### PR TITLE
feat(319): add settings menu and delete trace button

### DIFF
--- a/src/common/composables/index.ts
+++ b/src/common/composables/index.ts
@@ -1,4 +1,5 @@
 export * from './use-infinite-pagination/use-infinite-pagination'
 export * from './use-language-switcher'
+export * from './use-modal/use-modal'
 export * from './use-navigation'
 export * from './use-toast/use-toast'

--- a/src/common/composables/use-modal/use-modal.test.ts
+++ b/src/common/composables/use-modal/use-modal.test.ts
@@ -1,0 +1,158 @@
+import { beforeEach, describe, expect } from 'vitest'
+import { useModal } from './use-modal'
+
+describe('useModal', () => {
+  describe('given a fresh modal instance', () => {
+    let useModalResult: ReturnType<typeof useModal>
+
+    beforeEach(() => {
+      useModalResult = useModal()
+    })
+
+    describe('when the composable is initialized', () => {
+      it('then the modal should be hidden by default', () => {
+        expect(useModalResult.showModal.value).toBe(false)
+      })
+
+      it('then all expected properties and methods should be returned', () => {
+        expect(useModalResult).toHaveProperty('showModal')
+        expect(useModalResult).toHaveProperty('displayModal')
+        expect(useModalResult).toHaveProperty('hideModal')
+
+        expect(typeof useModalResult.displayModal).toBe('function')
+        expect(typeof useModalResult.hideModal).toBe('function')
+        expect(typeof useModalResult.showModal.value).toBe('boolean')
+      })
+
+      it('then the showModal should be a reactive ref', () => {
+        const initialValue = useModalResult.showModal.value
+        expect(initialValue).toBe(false)
+        expect(typeof useModalResult.showModal.value).toBe('boolean')
+      })
+    })
+
+    describe('when displayModal is called', () => {
+      beforeEach(() => {
+        useModalResult.displayModal()
+      })
+
+      it('then the modal should be visible', () => {
+        expect(useModalResult.showModal.value).toBe(true)
+      })
+
+      it('then the ref should be reactive and changed from initial state', () => {
+        expect(useModalResult.showModal.value).not.toBe(false)
+        expect(useModalResult.showModal.value).toBe(true)
+      })
+
+      describe('when hideModal is called after displaying', () => {
+        beforeEach(() => {
+          useModalResult.hideModal()
+        })
+
+        it('then the modal should be hidden', () => {
+          expect(useModalResult.showModal.value).toBe(false)
+        })
+      })
+    })
+
+    describe('when hideModal is called on a hidden modal', () => {
+      beforeEach(() => {
+        useModalResult.hideModal()
+      })
+
+      it('then the modal should remain hidden', () => {
+        expect(useModalResult.showModal.value).toBe(false)
+      })
+    })
+  })
+
+  describe('given a modal instance with show/hide cycles', () => {
+    let modalInstance: ReturnType<typeof useModal>
+
+    beforeEach(() => {
+      modalInstance = useModal()
+    })
+
+    describe('when multiple show/hide operations are performed', () => {
+      beforeEach(() => {
+        modalInstance.displayModal()
+        modalInstance.hideModal()
+        modalInstance.displayModal()
+        modalInstance.hideModal()
+      })
+
+      it('then the modal should end in hidden state', () => {
+        expect(modalInstance.showModal.value).toBe(false)
+      })
+    })
+
+    describe('when alternating between show and hide states', () => {
+      it('then each state change should be correctly reflected', () => {
+        expect(modalInstance.showModal.value).toBe(false)
+
+        modalInstance.displayModal()
+        expect(modalInstance.showModal.value).toBe(true)
+
+        modalInstance.hideModal()
+        expect(modalInstance.showModal.value).toBe(false)
+
+        modalInstance.displayModal()
+        expect(modalInstance.showModal.value).toBe(true)
+
+        modalInstance.hideModal()
+        expect(modalInstance.showModal.value).toBe(false)
+      })
+    })
+  })
+
+  describe('given multiple independent modal instances', () => {
+    let modal1: ReturnType<typeof useModal>
+    let modal2: ReturnType<typeof useModal>
+
+    beforeEach(() => {
+      modal1 = useModal()
+      modal2 = useModal()
+    })
+
+    describe('when both instances are created', () => {
+      it('then both should be hidden initially', () => {
+        expect(modal1.showModal.value).toBe(false)
+        expect(modal2.showModal.value).toBe(false)
+      })
+    })
+
+    describe('when first modal is displayed', () => {
+      beforeEach(() => {
+        modal1.displayModal()
+      })
+
+      it('then only the first modal should be visible', () => {
+        expect(modal1.showModal.value).toBe(true)
+        expect(modal2.showModal.value).toBe(false)
+      })
+
+      describe('when second modal is also displayed', () => {
+        beforeEach(() => {
+          modal2.displayModal()
+        })
+
+        it('then both modals should be visible', () => {
+          expect(modal1.showModal.value).toBe(true)
+          expect(modal2.showModal.value).toBe(true)
+        })
+
+        describe('when first modal is hidden', () => {
+          beforeEach(() => {
+            modal1.hideModal()
+          })
+
+          it('then only the second modal should remain visible', () => {
+            expect(modal1.showModal.value).toBe(false)
+            expect(modal2.showModal.value).toBe(true)
+          })
+        })
+      })
+    })
+  })
+})

--- a/src/common/composables/use-modal/use-modal.ts
+++ b/src/common/composables/use-modal/use-modal.ts
@@ -1,0 +1,17 @@
+export function useModal () {
+  const showModal = ref(false)
+
+  function displayModal () {
+    showModal.value = true
+  }
+
+  function hideModal () {
+    showModal.value = false
+  }
+
+  return {
+    showModal,
+    displayModal,
+    hideModal
+  }
+}

--- a/src/features/student/components/widgets/StudentOverviewWidget/StudentOverviewWidget.test.ts
+++ b/src/features/student/components/widgets/StudentOverviewWidget/StudentOverviewWidget.test.ts
@@ -1,8 +1,8 @@
 import type { ProfileOverviewDTO } from '@/api/avenir-esr'
-import type { BaseApiException } from '@/common/exceptions'
 import type { UseQueryDefinedReturnType } from '@tanstack/vue-query'
 import profile_banner_placeholder from '@/assets/profile_banner_placeholder.png'
 import profile_picture_placeholder from '@/assets/profile_picture_placeholder.png'
+import { BaseApiException } from '@/common/exceptions'
 import { useStudentSummaryQuery } from '@/features/student/queries'
 import { mountWithRouter, testUseBaseApiExceptionToast } from 'tests/utils'
 import { capitalize, type Ref } from 'vue'
@@ -28,7 +28,7 @@ const mockedUseStudentSummaryQuery = vi.mocked(useStudentSummaryQuery)
 
 function mockUseStudentSummaryQuery (payload: ProfileOverviewDTO) {
   const mockData: Ref<ProfileOverviewDTO> = ref(payload)
-  const mockError: Ref<null | null> = ref(null)
+  const mockError: Ref<null> = ref(null)
   const queryMockedData = {
     data: mockData,
     error: mockError
@@ -39,7 +39,8 @@ function mockUseStudentSummaryQuery (payload: ProfileOverviewDTO) {
 function mockUseStudentSummaryQueryUndefined () {
   const mockData: Ref<ProfileOverviewDTO | undefined> = ref(undefined)
   mockedUseStudentSummaryQuery.mockReturnValue({
-    data: mockData
+    data: mockData,
+    error: toRef(new BaseApiException('Student summary not found'))
   } as unknown as UseQueryDefinedReturnType<ProfileOverviewDTO, BaseApiException>)
 }
 

--- a/src/features/student/locales/en.json
+++ b/src/features/student/locales/en.json
@@ -199,7 +199,11 @@
           "buttons": {
             "close": "Close"
           },
-          "title": "Detail of my trace - {trace}"
+          "title": "Detail of my trace - {trace}",
+          "settings": {
+            "ariaLabel": "open trace settings",
+            "delete": "Delete my trace"
+          }
         },
         "studentToolsTracesViewContainer": {
           "pagination": {

--- a/src/features/student/locales/fr.json
+++ b/src/features/student/locales/fr.json
@@ -199,7 +199,11 @@
           "buttons": {
             "close": "Fermer"
           },
-          "title": "Détail de ma trace - {trace}"
+          "title": "Détail de ma trace - {trace}",
+          "settings": {
+            "ariaLabel": "Paramètres de la trace",
+            "delete": "Supprimer ma trace"
+          }
         },
         "studentToolsTracesViewContainer": {
           "pagination": {

--- a/src/features/student/views/StudentToolsTracesView/components/StudentDetailedTraceCardSettingMenu/StudentDetailedTraceCardSettingMenu.test.ts
+++ b/src/features/student/views/StudentToolsTracesView/components/StudentDetailedTraceCardSettingMenu/StudentDetailedTraceCardSettingMenu.test.ts
@@ -1,0 +1,155 @@
+import { TraceStatus, type TraceViewDTO } from '@/api/avenir-esr'
+import { MDI_ICONS } from '@/ui'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { beforeEach, describe, expect, vi } from 'vitest'
+import StudentDetailedTraceCardSettingMenu from './StudentDetailedTraceCardSettingMenu.vue'
+
+describe('studentDetailedTraceCardSettingMenu', () => {
+  const stubs = {
+    AvButton: {
+      name: 'AvButton',
+      props: ['icon', 'variant', 'size', 'theme', 'label', 'iconScale'],
+      template: `<button class="av-button" @click="$emit('click', $event)">
+        <slot>{{ label }}</slot>
+      </button>`,
+      emits: ['click']
+    }
+  }
+
+  const mockedTrace: TraceViewDTO = {
+    id: 'trace1',
+    title: 'Ma super trace',
+    status: TraceStatus.UNASSOCIATED,
+    createdAt: '2025-06-16T10:42:00.000Z',
+    updatedAt: '2025-06-17T15:18:00.000Z',
+    deletionDate: '2025-07-16T10:42:00.000Z'
+  }
+
+  const differentTrace: TraceViewDTO = {
+    id: 'trace2',
+    title: 'Another trace',
+    status: TraceStatus.ASSOCIATED,
+    createdAt: '2025-06-15T10:42:00.000Z',
+    updatedAt: '2025-06-16T15:18:00.000Z',
+    deletionDate: '2025-07-15T10:42:00.000Z'
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('given a settings menu with show prop set to true', () => {
+    let wrapper: VueWrapper
+
+    beforeEach(() => {
+      wrapper = mount(StudentDetailedTraceCardSettingMenu, {
+        props: {
+          trace: mockedTrace,
+          show: true
+        },
+        global: {
+          stubs,
+        },
+      })
+    })
+
+    describe('when the component is rendered', () => {
+      it('then the menu should be visible', () => {
+        expect(wrapper.find('.student-detailed-trace-card-setting-menu').exists()).toBe(true)
+      })
+
+      it('then the delete button should be present', () => {
+        expect(wrapper.findComponent({ name: 'AvButton' }).exists()).toBe(true)
+      })
+
+      it('then the correct delete text should be displayed', () => {
+        expect(wrapper.text()).toContain('Supprimer ma trace')
+      })
+
+      it('then the correct CSS classes should be applied', () => {
+        expect(wrapper.find('.student-detailed-trace-card-setting-menu').exists()).toBe(true)
+        expect(wrapper.find('.student-detailed-trace-card-setting-menu__item').exists()).toBe(true)
+      })
+
+      it('then the delete button should have correct props', () => {
+        const deleteButton = wrapper.findComponent({ name: 'AvButton' })
+
+        expect(deleteButton.props()).toMatchObject({
+          size: 'sm',
+          theme: 'SECONDARY',
+          label: 'Supprimer ma trace',
+          iconScale: 1.3
+        })
+        expect(deleteButton.props('icon')).toEqual(MDI_ICONS.TRASH_CAN_OUTLINE)
+      })
+    })
+
+    describe('when the delete button is clicked', () => {
+      beforeEach(async () => {
+        const deleteButton = wrapper.findComponent({ name: 'AvButton' })
+        await deleteButton.trigger('click')
+      })
+
+      it('then the onTraceDelete event should be emitted', () => {
+        expect(wrapper.emitted('onTraceDelete')).toBeTruthy()
+      })
+
+      it('then the onTraceDelete event should contain the correct trace data', () => {
+        expect(wrapper.emitted('onTraceDelete')?.[0]).toEqual([mockedTrace])
+      })
+
+      it('then the close event should be emitted', () => {
+        expect(wrapper.emitted('close')).toBeTruthy()
+      })
+    })
+  })
+
+  describe('given a settings menu with show prop set to false', () => {
+    let wrapper: VueWrapper
+
+    beforeEach(() => {
+      wrapper = mount(StudentDetailedTraceCardSettingMenu, {
+        props: {
+          trace: mockedTrace,
+          show: false
+        },
+        global: {
+          stubs,
+        },
+      })
+    })
+
+    describe('when the component is rendered', () => {
+      it('then the menu should not be visible', () => {
+        expect(wrapper.find('.student-detailed-trace-card-setting-menu').exists()).toBe(false)
+      })
+    })
+  })
+
+  describe('given a settings menu with a different trace object', () => {
+    let wrapper: VueWrapper
+
+    beforeEach(() => {
+      wrapper = mount(StudentDetailedTraceCardSettingMenu, {
+        props: {
+          trace: differentTrace,
+          show: true
+        },
+        global: {
+          stubs,
+        },
+      })
+    })
+
+    describe('when the delete button is clicked', () => {
+      beforeEach(async () => {
+        const deleteButton = wrapper.findComponent({ name: 'AvButton' })
+        await deleteButton.trigger('click')
+      })
+
+      it('then the onTraceDelete event should contain the different trace object', () => {
+        expect(wrapper.emitted('onTraceDelete')?.[0]).toEqual([differentTrace])
+      })
+    })
+  })
+})

--- a/src/features/student/views/StudentToolsTracesView/components/StudentDetailedTraceCardSettingMenu/StudentDetailedTraceCardSettingMenu.vue
+++ b/src/features/student/views/StudentToolsTracesView/components/StudentDetailedTraceCardSettingMenu/StudentDetailedTraceCardSettingMenu.vue
@@ -1,0 +1,65 @@
+<script lang="ts" setup>
+import type { TraceViewDTO } from '@/api/avenir-esr'
+import { AvButton, MDI_ICONS } from '@/ui'
+import { useI18n } from 'vue-i18n'
+
+const props = defineProps<{
+  trace: TraceViewDTO
+  show: boolean
+}>()
+const emit = defineEmits<{
+  (e: 'onTraceDelete', trace: TraceViewDTO): void
+  (e: 'close'): void
+}>()
+
+const { t } = useI18n()
+
+function onClickDelete () {
+  emit('onTraceDelete', props.trace)
+  emit('close')
+}
+</script>
+
+<template>
+  <div
+    v-if="show"
+    class="student-detailed-trace-card-setting-menu"
+  >
+    <AvButton
+      class="student-detailed-trace-card-setting-menu__item"
+      :icon="MDI_ICONS.TRASH_CAN_OUTLINE"
+      size="sm"
+      theme="SECONDARY"
+      :label="t('student.views.studentToolsTracesView.studentDetailedTraceModal.settings.delete')"
+      :icon-scale="1.3"
+      no-radius
+      @click="onClickDelete"
+    />
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.student-detailed-trace-card-setting-menu {
+  position: absolute;
+  top: 6rem;
+  right: 0.25rem;
+  background: var(--background-dialog);
+  border: 0.06rem solid var(--dark-background-primary2);
+  border-radius: var(--radius-lg);
+  box-shadow: 0 var(--spacing-xxs) var(--spacing-xs) rgba(0, 0, 0, 0.15);
+  z-index: 20000;
+  min-width: 14.688rem;
+  padding:  var(--spacing-xs) 0.04rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  align-items: flex-end;
+}
+
+.student-detailed-trace-card-setting-menu__item {
+  display: flex;
+  width: 100% !important;
+  align-items: center;
+  align-self: stretch;
+}
+</style>

--- a/src/features/student/views/StudentToolsTracesView/components/StudentDetailedTraceModal/StudentDetailedTraceModal.test.ts
+++ b/src/features/student/views/StudentToolsTracesView/components/StudentDetailedTraceModal/StudentDetailedTraceModal.test.ts
@@ -1,6 +1,7 @@
 import { TraceStatus, type TraceViewDTO } from '@/api/avenir-esr'
-import { mount } from '@vue/test-utils'
-import { describe, it, vi } from 'vitest'
+import { MDI_ICONS } from '@/ui'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { beforeEach, describe, expect, vi } from 'vitest'
 import StudentDetailedTraceModal from './StudentDetailedTraceModal.vue'
 
 const navigateToStudentMailbox = vi.fn()
@@ -30,6 +31,32 @@ vi.mock('@/ui', async () => {
   }
 })
 
+const stubs = {
+  AvVIcon: {
+    name: 'AvVIcon',
+    props: ['name', 'color', 'size'],
+    template: `<div class="av-vicon" />`,
+  },
+  AvModal: {
+    name: 'AvModal',
+    props: ['title'],
+    template: `<div><slot /><slot name="footer" /></div>`,
+    emits: ['close'],
+  },
+  AvButton: {
+    name: 'AvButton',
+    props: ['icon', 'iconOnly', 'size'],
+    template: '<button class="av-button" @click="$emit(\'click\', $event)"><slot></slot></button>',
+    emits: ['click']
+  },
+  StudentDetailedTraceCardSettingMenu: {
+    name: 'StudentDetailedTraceCardSettingMenu',
+    props: ['trace', 'show'],
+    template: '<div v-if="show" class="settings-menu" @click="$emit(\'onTraceDelete\', trace); $emit(\'close\')">Settings Menu</div>',
+    emits: ['onTraceDelete', 'close']
+  }
+}
+
 describe('studentDetailedTraceModal', () => {
   const nextMonthDate = new Date()
   nextMonthDate.setDate(nextMonthDate.getDate() + 30)
@@ -49,21 +76,162 @@ describe('studentDetailedTraceModal', () => {
     vi.clearAllMocks()
   })
 
-  it('should render correct content', () => {
-    const wrapper = mount(StudentDetailedTraceModal, {
-      props: { trace: mockedTrace, showModal: true, onClose },
-    })
-    const avModal = wrapper.getComponent({ name: 'AvModal' })
+  describe('given a trace modal is rendered with showModal true', () => {
+    let wrapper: VueWrapper
 
-    expect(avModal.props('title')).toBe(`Détail de ma trace - ${mockedTrace.title}`)
+    beforeEach(() => {
+      wrapper = mount(StudentDetailedTraceModal, {
+        props: { trace: mockedTrace, showModal: true, onClose },
+        global: { stubs }
+      })
+    })
+
+    describe('when the component is rendered', () => {
+      it('then the modal should have empty title prop', () => {
+        const avModal = wrapper.getComponent({ name: 'AvModal' })
+        expect(avModal.props('title')).toBe('')
+      })
+
+      it('then the modal title should contain trace details', () => {
+        const modalTitle = wrapper.find('.student-detailed-trace-modal__title')
+        expect(modalTitle.exists()).toBe(true)
+        expect(modalTitle.text()).toContain(`Détail de ma trace - ${mockedTrace.title}`)
+      })
+
+      it('then the settings button should be present', () => {
+        const settingsButton = wrapper.findComponent({
+          name: 'AvButton',
+          props: {
+            icon: MDI_ICONS.DOTS_VERTICAL,
+            iconOnly: true,
+          }
+        })
+        expect(settingsButton.exists()).toBe(true)
+      })
+    })
+
+    describe('when the modal close event is emitted', () => {
+      beforeEach(async () => {
+        await wrapper.findComponent({ name: 'AvModal' }).vm.$emit('close')
+      })
+
+      it('then the onClose callback should be called', () => {
+        expect(onClose).toHaveBeenCalled()
+      })
+    })
   })
 
-  it('should call onClose when modal is closed', async () => {
-    const wrapper = mount(StudentDetailedTraceModal, {
-      props: { trace: mockedTrace, showModal: true, onClose },
+  describe('given a trace modal with settings functionality', () => {
+    let wrapper: VueWrapper
+
+    beforeEach(() => {
+      wrapper = mount(StudentDetailedTraceModal, {
+        props: { trace: mockedTrace, showModal: true, onClose },
+        global: { stubs }
+      })
     })
 
-    await wrapper.findComponent({ name: 'AvModal' }).vm.$emit('close')
-    expect(onClose).toHaveBeenCalled()
+    describe('when the settings button is clicked', () => {
+      beforeEach(async () => {
+        const settingsButton = wrapper.findComponent({
+          name: 'AvButton',
+          props: {
+            icon: MDI_ICONS.DOTS_VERTICAL,
+            iconOnly: true,
+          }
+        })
+        await settingsButton.trigger('click')
+      })
+
+      it('then the settings menu should be visible', () => {
+        expect(wrapper.find('.settings-menu').exists()).toBe(true)
+      })
+
+      describe('when a click event is dispatched on the document', () => {
+        beforeEach(async () => {
+          document.dispatchEvent(new Event('click'))
+          await wrapper.vm.$nextTick()
+        })
+
+        it('then the settings menu should be hidden', () => {
+          expect(wrapper.find('.settings-menu').exists()).toBe(false)
+        })
+      })
+
+      describe('when the settings menu emits close event', () => {
+        beforeEach(async () => {
+          const settingsMenu = wrapper.findComponent({ name: 'StudentDetailedTraceCardSettingMenu' })
+          await settingsMenu.vm.$emit('close')
+          await wrapper.vm.$nextTick()
+        })
+
+        it('then the settings menu should be hidden', () => {
+          expect(wrapper.find('.settings-menu').exists()).toBe(false)
+        })
+      })
+    })
+  })
+
+  describe('given a trace modal with different trace data', () => {
+    const differentTrace: TraceViewDTO = {
+      id: 'trace2',
+      title: 'Another trace',
+      status: TraceStatus.ASSOCIATED,
+      createdAt: '2025-06-15T10:42:00.000Z',
+      updatedAt: '2025-06-16T15:18:00.000Z',
+      deletionDate: nextMonthDateIsoString
+    }
+
+    let wrapper: VueWrapper
+
+    beforeEach(() => {
+      wrapper = mount(StudentDetailedTraceModal, {
+        props: { trace: differentTrace, showModal: true, onClose },
+        global: { stubs }
+      })
+    })
+
+    describe('when the component is rendered', () => {
+      it('then the modal title should contain the different trace title', () => {
+        const modalTitle = wrapper.find('.student-detailed-trace-modal__title')
+        expect(modalTitle.text()).toContain(`Détail de ma trace - ${differentTrace.title}`)
+      })
+    })
+
+    describe('when the settings button is clicked', () => {
+      beforeEach(async () => {
+        const settingsButton = wrapper.findComponent({
+          name: 'AvButton',
+          props: {
+            icon: MDI_ICONS.DOTS_VERTICAL,
+            iconOnly: true,
+          }
+        })
+        await settingsButton.trigger('click')
+      })
+
+      it('then the settings menu should receive the correct trace data', () => {
+        const settingsMenu = wrapper.findComponent({ name: 'StudentDetailedTraceCardSettingMenu' })
+        expect(settingsMenu.props('trace')).toEqual(differentTrace)
+      })
+    })
+  })
+
+  describe('given a trace modal with showModal false', () => {
+    let wrapper: VueWrapper
+
+    beforeEach(() => {
+      wrapper = mount(StudentDetailedTraceModal, {
+        props: { trace: mockedTrace, showModal: false, onClose },
+        global: { stubs }
+      })
+    })
+
+    describe('when the component is rendered', () => {
+      it('then the modal component should exist', () => {
+        const avModal = wrapper.findComponent({ name: 'AvModal' })
+        expect(avModal.exists()).toBe(true)
+      })
+    })
   })
 })

--- a/src/features/student/views/StudentToolsTracesView/components/StudentDetailedTraceModal/StudentDetailedTraceModal.vue
+++ b/src/features/student/views/StudentToolsTracesView/components/StudentDetailedTraceModal/StudentDetailedTraceModal.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import type { TraceViewDTO } from '@/api/avenir-esr'
-import { AvModal } from '@/ui'
+import StudentDetailedTraceCardSettingMenu
+  from '@/features/student/views/StudentToolsTracesView/components/StudentDetailedTraceCardSettingMenu/StudentDetailedTraceCardSettingMenu.vue'
+import { AvButton, AvModal, MDI_ICONS } from '@/ui'
 import { useI18n } from 'vue-i18n'
 
 const {
@@ -10,20 +12,98 @@ const {
 } = defineProps<{ trace: TraceViewDTO, showModal: boolean, onClose: () => void }>()
 
 const { t } = useI18n()
+const { showSettingsMenu, toggleSettingsMenu, closeSettingsMenu } = useSettingsMenu()
+
+// TODO: Implement the delete trace functionality
+// eslint-disable-next-line unused-imports/no-unused-vars
+function handleDeleteTrace (trace: TraceViewDTO) {
+
+}
+
+/**
+ * composable that manages and organize the settings menu for the trace card
+ */
+function useSettingsMenu () {
+  const showSettingsMenu = ref(false)
+
+  function toggleSettingsMenu (event: Event) {
+    event.stopPropagation()
+    showSettingsMenu.value = !showSettingsMenu.value
+  }
+
+  function closeSettingsMenu () {
+    showSettingsMenu.value = false
+  }
+
+  onMounted(() => {
+    document.addEventListener('click', closeSettingsMenu)
+  })
+
+  onUnmounted(() => {
+    document.removeEventListener('click', closeSettingsMenu)
+  })
+
+  return {
+    showSettingsMenu,
+    toggleSettingsMenu,
+    closeSettingsMenu
+  }
+}
 </script>
 
 <template>
   <AvModal
-    :title="t('student.views.studentToolsTracesView.studentDetailedTraceModal.title', { trace: trace.title })"
+    title=""
     :opened="showModal"
     :close-button-label="t('student.views.studentToolsTracesView.studentDetailedTraceModal.buttons.close')"
     :close-button-title="t('student.views.studentToolsTracesView.studentDetailedTraceModal.buttons.close')"
+    size="lg"
     @close="onClose"
   >
-    <div>
-      Placeholder...
+    <div class="student-detailed-trace-modal__container">
+      <div class="student-detailed-trace-modal__header">
+        <h1 class="student-detailed-trace-modal__title fr-modal__title">
+          {{ t('student.views.studentToolsTracesView.studentDetailedTraceModal.title') }}{{ trace.title }}
+        </h1>
+        <AvButton
+          class="student-detailed-trace-modal__settings-btn"
+          :icon="{ name: MDI_ICONS.DOTS_VERTICAL }"
+          icon-only
+          variant="OUTLINED"
+          size="sm"
+          :aria-label="t('student.views.studentToolsTracesView.studentDetailedTraceModal.settings.ariaLabel')"
+          @click="toggleSettingsMenu"
+        />
+        <StudentDetailedTraceCardSettingMenu
+          :trace="trace"
+          :show="showSettingsMenu"
+          @close="closeSettingsMenu"
+          @on-trace-delete="handleDeleteTrace"
+        />
+      </div>
+      <div class="student-detailed-trace-modal__content">
+        Placeholder...
+      </div>
     </div>
   </AvModal>
 </template>
 
-<style lang="scss" scoped></style>
+<style lang="scss" scoped>
+.student-detailed-trace-modal__container {
+  display: flex;
+  flex-direction: column;
+  flex-wrap: nowrap;
+}
+
+.student-detailed-trace-modal__content {
+  flex: 1;
+  overflow-y: auto;
+}
+
+.student-detailed-trace-modal__header {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+}
+</style>

--- a/src/features/student/views/StudentToolsTracesView/components/StudentDetailedTracesCard/StudentDetailedTraceCard.vue
+++ b/src/features/student/views/StudentToolsTracesView/components/StudentDetailedTracesCard/StudentDetailedTraceCard.vue
@@ -1,5 +1,6 @@
 <script lang="ts" setup>
 import { TraceStatus, type TraceViewDTO } from '@/api/avenir-esr'
+import { useModal } from '@/common/composables'
 import { getDaysUntil, parseDateISO } from '@/common/utils'
 import { AvCard, AvIconText, AvVIcon, MDI_ICONS } from '@/ui'
 import { useI18n } from 'vue-i18n'
@@ -14,13 +15,7 @@ const getDaysUntilDeletion = computed(() => status === TraceStatus.UNASSOCIATED
 
 const { t } = useI18n()
 
-const showModal = ref(false)
-function displayModal () {
-  showModal.value = true
-}
-function hideModal () {
-  showModal.value = false
-}
+const { showModal, displayModal, hideModal } = useModal()
 
 const hoverBorderColor = ref('var(--dark-background-primary1)')
 </script>
@@ -95,12 +90,12 @@ const hoverBorderColor = ref('var(--dark-background-primary1)')
 }
 
 .student-detailed-trace-card__body {
-  padding-top: 1.5rem;
+  padding-top: var(--spacing-md);
   justify-content: flex-end;
 }
 
 .student-detailed-trace-card__title {
-  position: relative
+  position: relative;
 }
 
 .student-detailed-trace-card__titlecontent {
@@ -128,7 +123,7 @@ const hoverBorderColor = ref('var(--dark-background-primary1)')
   position: absolute;
   width: 2.75rem;
   height: 2.75rem;
-  border-radius: 0.75rem;
+  border-radius: var(--radius-lg);
   border: 1px solid var(--other-border-skill-card);
   right: 0.75rem;
   top: 2rem;

--- a/src/ui/interaction/buttons/AvButton/AvButton.types.ts
+++ b/src/ui/interaction/buttons/AvButton/AvButton.types.ts
@@ -5,4 +5,5 @@ export type AvButtonProps = {
   theme?: 'PRIMARY' | 'SECONDARY'
   isLoading?: boolean
   iconScale?: number
+  noRadius?: boolean
 } & Pick<DsfrButtonProps, 'label' | 'disabled' | 'size' | 'icon' | 'iconRight' | 'iconOnly' | 'onClick'>

--- a/src/ui/interaction/buttons/AvButton/AvButton.types.ts
+++ b/src/ui/interaction/buttons/AvButton/AvButton.types.ts
@@ -4,4 +4,5 @@ export type AvButtonProps = {
   variant?: 'DEFAULT' | 'OUTLINED'
   theme?: 'PRIMARY' | 'SECONDARY'
   isLoading?: boolean
+  iconScale?: number
 } & Pick<DsfrButtonProps, 'label' | 'disabled' | 'size' | 'icon' | 'iconRight' | 'iconOnly' | 'onClick'>

--- a/src/ui/interaction/buttons/AvButton/AvButton.vue
+++ b/src/ui/interaction/buttons/AvButton/AvButton.vue
@@ -11,12 +11,15 @@ const props = withDefaults(defineProps<AvButtonProps>(), {
   iconRight: false,
   disabled: false,
   isLoading: false,
+  noRadius: false
 })
 
 const loadingIcon: InstanceType<typeof VIcon>['$props'] = { name: MDI_ICONS.LOADING, animation: 'spin' }
 const iconToRender = computed(() => props.isLoading ? loadingIcon : props.icon)
 const variantClass = computed(() => `av-button--variant-${props.variant.toLowerCase()}`)
 const themeClass = computed(() => `av-button--theme-${props.theme.toLowerCase()}`)
+const radiusClass = computed(() => props.noRadius ? 'av-button--no-radius' : '')
+
 const computedSvgScale = computed(() => {
   if (props.iconScale && !Number.isNaN(props.iconScale)) {
     return props.iconScale
@@ -43,7 +46,7 @@ defineExpose({ computedSvgScale })
   <DsfrButton
     v-bind="props"
     class="av-button"
-    :class="[variantClass, themeClass]"
+    :class="[variantClass, themeClass, radiusClass]"
     :disabled="props.disabled || isLoading"
     :icon="iconToRender"
     :no-outline="props.variant === 'DEFAULT'"
@@ -84,7 +87,10 @@ defineExpose({ computedSvgScale })
 }
 
 .av-button--theme-secondary:hover {
-  background-color: var(--foreground-text1) !important;
-  color: white !important;
+  background-color: var(--light-background-neutral) !important;
+}
+
+.fr-btn.av-button--no-radius {
+  border-radius: 0 !important;
 }
 </style>

--- a/src/ui/interaction/buttons/AvButton/AvButton.vue
+++ b/src/ui/interaction/buttons/AvButton/AvButton.vue
@@ -18,6 +18,9 @@ const iconToRender = computed(() => props.isLoading ? loadingIcon : props.icon)
 const variantClass = computed(() => `av-button--variant-${props.variant.toLowerCase()}`)
 const themeClass = computed(() => `av-button--theme-${props.theme.toLowerCase()}`)
 const computedSvgScale = computed(() => {
+  if (props.iconScale && !Number.isNaN(props.iconScale)) {
+    return props.iconScale
+  }
   switch (props.size) {
     case 'small':
     case 'sm':

--- a/src/ui/styles/main.scss
+++ b/src/ui/styles/main.scss
@@ -3,3 +3,5 @@
 @use './buttons.scss' as *;
 @use './links.scss' as *;
 @use './texts.scss' as *;
+@use './spacing.scss' as *;
+@use './radius.scss' as *;

--- a/src/ui/styles/palette.scss
+++ b/src/ui/styles/palette.scss
@@ -26,7 +26,8 @@
   --light-background-primary2: #C4D6FF;
   --light-background-success: #BDDECA;
   --light-background-warn: #F4CEB8;
-
+  --light-background-hover: #0000000A;
+  
   --light-foreground-error: #800108;
   --light-foreground-primary1: #2929A2;
   --light-foreground-success: #0F4625;

--- a/src/ui/styles/radius.scss
+++ b/src/ui/styles/radius.scss
@@ -1,0 +1,11 @@
+:root {
+  --radius-none: 0;
+  --radius-xxs: 0.0625rem;  /* 1px */
+  --radius-xs: 0.125rem;    /* 2px */
+  --radius-sm: 0.25rem;     /* 4px */
+  --radius-md: 0.5rem;      /* 8px */
+  --radius-lg: 0.75rem;     /* 12px */
+  --radius-xl: 1rem;        /* 16px */
+  --radius-hg: 2rem;        /* 32px */
+  --radius-full: 62.5rem;   /* 1000px */
+}

--- a/src/ui/styles/spacing.scss
+++ b/src/ui/styles/spacing.scss
@@ -1,0 +1,13 @@
+:root {
+  --spacing-none: 0;
+  --spacing-xxxs: 0.125rem;   /* 2px */
+  --spacing-xxs: 0.25rem;     /* 4px */
+  --spacing-xs: 0.5rem;       /* 8px */
+  --spacing-sm: 1rem;         /* 16px */
+  --spacing-md: 1.5rem;       /* 24px */
+  --spacing-lg: 2rem;         /* 32px */
+  --spacing-xl: 2.5rem;       /* 40px */
+  --spacing-2xl: 3rem;        /* 48px */
+  --spacing-4xl: 4rem;        /* 64px */
+  --spacing-5xl: 5rem;        /* 80px */
+}

--- a/src/ui/tokens/icons.ts
+++ b/src/ui/tokens/icons.ts
@@ -35,7 +35,9 @@ export const MDI_ICONS = {
   SWAP_HORIZONTAL: 'mdi:swap-horizontal',
   SWAP_VERTICAL_VARIANT: 'mdi:swap-vertical-variant',
   TEST_TUBE_EMPTY: 'mdi:test-tube-empty',
-  WARNING: 'mdi:warning-outline'
+  WARNING: 'mdi:warning-outline',
+  DOTS_VERTICAL: 'mdi:dots-vertical',
+  TRASH_CAN_OUTLINE: 'mdi:trash-can-outline',
 }
 
 export const RI_ICONS = {


### PR DESCRIPTION
# feat: add settings menu and delete trace button

## 📋 Summary

Adds settings menu component with delete trace button for unassociated traces. Button is functional but delete action not yet implemented.

Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/319

## 🚀 Features Added
![image](https://github.com/user-attachments/assets/37295318-5fde-4c39-9734-775e5c1ccd10)
### Settings Menu Component
- ✅ **Settings dropdown menu** with three-dots button
- ✅ **Delete trace button** (UI only, no action yet)

### Design System Enhancement
- ✅ **radius.scss** - Border radius design tokens
- ✅ **spacing.scss** - Spacing design tokens

### Internationalization
- ✅ **i18n keys** for delete button text
- ✅ **Multilingual support** (FR/EN)

