### PR TITLE
feat(419): create AvDrawer component with storybook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -356,3 +356,5 @@ a11y/reports
 src/api/**/generated/
 !src/api/fetch-instance/
 !src/api/index.ts
+
+storybook-static/

--- a/src/ui/overlay/drawers/AvDrawer/AvDrawer.md
+++ b/src/ui/overlay/drawers/AvDrawer/AvDrawer.md
@@ -1,0 +1,129 @@
+# Drawers - `AvDrawer`
+
+## 🌟 Introduction
+
+The drawer is a panel that slides in from the edge of the screen, providing additional content or navigation options without leaving the current page. This component is designed to display contextual information, actions, or secondary navigation in a non-intrusive way.
+
+The `AvDrawer` component offers flexible positioning (left or right), customizable dimensions, and an optional backdrop overlay. It provides a clean, accessible way to present supplementary content while maintaining focus on the primary interface.
+
+It features smooth animations, proper z-index management, and integrates seamlessly with the design system's styling tokens.
+
+## 📐 Structure
+
+The drawer consists of the following elements:
+- **Container**: The main drawer panel that slides in from the specified edge
+- **Backdrop** (optional): Semi-transparent overlay that dims the background content
+- **Content Area**: Flexible content container that accepts any slotted content
+
+The drawer integrates:
+- Fixed positioning for consistent placement
+- Conditional backdrop for modal-like behavior
+- Position-specific styling (left/right rounded corners and shadows)
+- Responsive width and padding customization
+
+## 🛠️ Props
+
+| Name | Type | Default | Mandatory | Description |
+| --- | --- | --- | --- | --- |
+| `show` | `boolean` | | ✅ | Controls drawer visibility (open/closed state). |
+| `position` | `'left' \| 'right'` | `'right'` | | Position from which drawer slides in. |
+| `width` | `string` | `'35rem'` | | Width of the drawer panel. |
+| `backdrop` | `boolean` | `true` | | Whether to show backdrop overlay behind drawer. |
+| `padding` | `string` | `'var(--spacing-md)'` | | Internal padding of drawer content area. |
+
+## 🧩 Slots
+
+| Name | Description |
+| --- | --- |
+| `default` | Slot for drawer content. Can contain any HTML or Vue components. |
+
+## 📝 Examples of use
+
+### Basic Usage
+
+```vue
+<script setup lang="ts">
+const isDrawerOpen = ref(false)
+</script>
+
+<template>
+  <div>
+    <AvButton
+      label="Open Drawer"
+      @click="isDrawerOpen = true"
+    />
+
+    <AvDrawer :show="isDrawerOpen">
+      <h3>Drawer Content</h3>
+      <p>This is the drawer content area.</p>
+    </AvDrawer>
+  </div>
+</template>
+```
+
+### Left Position with Custom Width
+
+```vue
+<template>
+  <AvDrawer
+    :show="isDrawerOpen"
+    position="left"
+    width="25rem"
+  >
+    <div class="navigation">
+      <h3>Navigation</h3>
+      <ul>
+        <li><a href="/home">Home</a></li>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+      </ul>
+    </div>
+  </AvDrawer>
+</template>
+```
+
+### Without Backdrop
+
+```vue
+<template>
+  <AvDrawer
+    :show="isDrawerOpen"
+    :backdrop="false"
+    width="20rem"
+  >
+    <div class="sidebar">
+      <h3>Sidebar Content</h3>
+      <p>This drawer appears without dimming the background.</p>
+    </div>
+  </AvDrawer>
+</template>
+```
+
+### Custom Padding
+
+```vue
+<template>
+  <AvDrawer
+    :show="isDrawerOpen"
+    padding="var(--spacing-lg)"
+  >
+    <div class="content">
+      <h3>Spacious Content</h3>
+      <p>This drawer has larger internal padding.</p>
+    </div>
+  </AvDrawer>
+</template>
+```
+
+## 🎨 Styling
+
+The drawer uses the following design tokens:
+- `--dialog` for background color
+- `--surface-background` for border color
+- `--radius-hg` for rounded corners
+- `--spacing-md` for default padding
+- Position-specific box shadows for depth
+
+The component automatically applies appropriate border radius and shadows based on the position prop:
+- **Left position**: Rounded on the right side with left-side shadow
+- **Right position**: Rounded on the left side with right-side shadow

--- a/src/ui/overlay/drawers/AvDrawer/AvDrawer.stories.ts
+++ b/src/ui/overlay/drawers/AvDrawer/AvDrawer.stories.ts
@@ -1,0 +1,168 @@
+import type { Meta, StoryFn } from '@storybook/vue3'
+import AvButton from '@/ui/interaction/buttons/AvButton/AvButton.vue'
+import AvDrawer, { type AvDrawerProps } from '@/ui/overlay/drawers/AvDrawer/AvDrawer.vue'
+
+/**
+ * <h1 class="n1">Drawers - <code>AvDrawer</code></h1>
+ *
+ * <h2 class="n2">🌟 Introduction</h2>
+ *
+ * <p>
+ *   <span class="b2-regular">
+ *     The drawer is a panel that slides in from the edge of the screen, providing additional content or navigation options without leaving the current page.
+ *     This component is designed to display contextual information, actions, or secondary navigation in a non-intrusive way.
+ *   </span>
+ * </p>
+ *
+ * <p>
+ *   <span class="b2-regular">
+ *     The <code>AvDrawer</code> component offers flexible positioning (left or right), customizable dimensions, and an optional backdrop overlay.
+ *     It provides a clean, accessible way to present supplementary content while maintaining focus on the primary interface.
+ *   </span>
+ * </p>
+ *
+ * <p>
+ *   <span class="b2-regular">
+ *     It features smooth animations, proper z-index management, and integrates seamlessly with the design system's styling tokens.
+ *   </span>
+ * </p>
+ *
+ * <h2 class="n2">📐 Structure</h2>
+ *
+ * <p><span class="b2-regular">The drawer consists of the following elements:</span></p>
+ *
+ * <ul>
+ *   <li><span class="b2-regular"><strong>Container:</strong> The main drawer panel that slides in from the specified edge</span></li>
+ *   <li><span class="b2-regular"><strong>Backdrop:</strong> (optional) Semi-transparent overlay that dims the background content</span></li>
+ *   <li><span class="b2-regular"><strong>Content Area:</strong> Flexible content container that accepts any slotted content</span></li>
+ * </ul>
+ *
+ * <p><span class="b2-regular">The drawer integrates:</span></p>
+ *
+ * <ul>
+ *   <li><span class="b2-regular">Fixed positioning for consistent placement</span></li>
+ *   <li><span class="b2-regular">Conditional backdrop for modal-like behavior</span></li>
+ *   <li><span class="b2-regular">Position-specific styling (left/right rounded corners and shadows)</span></li>
+ *   <li><span class="b2-regular">Responsive width and padding customization</span></li>
+ * </ul>
+ */
+const meta: Meta<AvDrawerProps> = {
+  title: 'Components/Overlay/Drawers/AvDrawer',
+  component: AvDrawer,
+  tags: ['autodocs'],
+  argTypes: {
+    show: { control: 'boolean' },
+    position: {
+      control: 'select',
+      options: ['left', 'right']
+    },
+    width: { control: 'text' },
+    backdrop: { control: 'boolean' },
+    padding: { control: 'text' },
+  },
+  args: {
+    show: true,
+    position: 'right',
+    width: '35rem',
+    backdrop: true,
+    padding: 'var(--spacing-md)',
+  },
+  parameters: {
+    docs: {
+      story: {
+        height: '20rem',
+      },
+    },
+  }
+}
+
+export default meta
+
+const Template: StoryFn<AvDrawerProps> = args => ({
+  components: { AvDrawer, AvButton },
+  setup () {
+    const isDrawerOpen = ref(args.show)
+
+    const toggleDrawer = () => {
+      isDrawerOpen.value = !isDrawerOpen.value
+    }
+
+    const closeDrawer = () => {
+      isDrawerOpen.value = false
+    }
+
+    return {
+      args,
+      isDrawerOpen,
+      toggleDrawer,
+      closeDrawer
+    }
+  },
+  template: `
+    <div>
+      <AvButton
+        label="Toggle Drawer"
+        @click="toggleDrawer"
+      />
+      
+      <AvDrawer 
+        :show="isDrawerOpen"
+        :position="args.position"
+        :width="args.width"
+        :backdrop="args.backdrop"
+        :padding="args.padding"
+      >
+        <div style="display: flex; flex-direction: column; gap: 1rem;">
+          <h3 style="margin: 0; color: var(--title);">Drawer Content</h3>
+          <p style="margin: 0; color: var(--text1);">
+            This is the drawer content area. You can put any content here like navigation, 
+            actions, or additional information.
+          </p>
+          
+          <div style="display: flex; flex-direction: column; gap: 0.5rem;">
+            <AvButton
+              label="Action 1"
+              variant="DEFAULT"
+              theme="PRIMARY"
+              size="sm"
+            />
+            <AvButton
+              label="Action 2"
+              variant="OUTLINED"
+              theme="SECONDARY"
+              size="sm"
+            />
+          </div>
+          
+          <div style="margin-top: auto; padding-top: 2rem;">
+            <AvButton
+              label="Close Drawer"
+              @click="closeDrawer"
+              variant="OUTLINED"
+              theme="SECONDARY"
+              size="sm"
+            />
+          </div>
+        </div>
+      </AvDrawer>
+    </div>
+  `,
+})
+
+export const Default = Template.bind({})
+Default.args = {}
+
+export const LeftPosition = Template.bind({})
+LeftPosition.args = {
+  position: 'left',
+}
+
+export const WithoutBackdrop = Template.bind({})
+WithoutBackdrop.args = {
+  backdrop: false,
+}
+
+export const CustomWidth = Template.bind({})
+CustomWidth.args = {
+  width: '25rem',
+}

--- a/src/ui/overlay/drawers/AvDrawer/AvDrawer.test.ts
+++ b/src/ui/overlay/drawers/AvDrawer/AvDrawer.test.ts
@@ -1,0 +1,181 @@
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it } from 'vitest'
+import AvDrawer from './AvDrawer.vue'
+
+describe('avDrawer', () => {
+  describe('given a drawer component', () => {
+    let wrapper: ReturnType<typeof mount<typeof AvDrawer>>
+
+    beforeEach(() => {
+      wrapper = mount(AvDrawer, {
+        props: {
+          show: true,
+        },
+      })
+    })
+
+    describe('when the drawer is mounted with default props', () => {
+      it('then it should render the drawer', () => {
+        expect(wrapper.find('.av-drawer').exists()).toBe(true)
+      })
+
+      it('then it should have right position by default', () => {
+        expect(wrapper.find('.av-drawer--right').exists()).toBe(true)
+      })
+
+      it('then it should show backdrop by default', () => {
+        expect(wrapper.find('.av-drawer-backdrop').exists()).toBe(true)
+      })
+
+      it('then it should render the drawer content', () => {
+        expect(wrapper.find('.av-drawer__content').exists()).toBe(true)
+      })
+    })
+
+    describe('when the drawer is closed', () => {
+      beforeEach(() => {
+        wrapper = mount(AvDrawer, {
+          props: {
+            show: false,
+          },
+        })
+      })
+
+      it('then it should not render the drawer', () => {
+        expect(wrapper.find('.av-drawer').exists()).toBe(false)
+      })
+
+      it('then it should not render the backdrop', () => {
+        expect(wrapper.find('.av-drawer-backdrop').exists()).toBe(false)
+      })
+    })
+
+    describe('when the drawer has left position', () => {
+      beforeEach(() => {
+        wrapper = mount(AvDrawer, {
+          props: {
+            show: true,
+            position: 'left',
+          },
+        })
+      })
+
+      it('then it should have left position class', () => {
+        expect(wrapper.find('.av-drawer--left').exists()).toBe(true)
+      })
+
+      it('then it should not have right position class', () => {
+        expect(wrapper.find('.av-drawer--right').exists()).toBe(false)
+      })
+    })
+
+    describe('when the drawer has custom width', () => {
+      beforeEach(() => {
+        wrapper = mount(AvDrawer, {
+          props: {
+            show: true,
+            width: '31.25rem',
+          },
+        })
+      })
+
+      it('then it should render the drawer with custom width prop', () => {
+        expect(wrapper.find('.av-drawer').exists()).toBe(true)
+        expect(wrapper.vm.width).toBe('31.25rem')
+      })
+    })
+
+    describe('when the drawer has custom padding', () => {
+      beforeEach(() => {
+        wrapper = mount(AvDrawer, {
+          props: {
+            show: true,
+            padding: '2rem',
+          },
+        })
+      })
+
+      it('then it should render the drawer with custom padding prop', () => {
+        expect(wrapper.find('.av-drawer__content').exists()).toBe(true)
+        expect(wrapper.vm.padding).toBe('2rem')
+      })
+    })
+
+    describe('when backdrop is disabled', () => {
+      beforeEach(() => {
+        wrapper = mount(AvDrawer, {
+          props: {
+            show: true,
+            backdrop: false,
+          },
+        })
+      })
+
+      it('then it should not render the backdrop', () => {
+        expect(wrapper.find('.av-drawer-backdrop').exists()).toBe(false)
+      })
+
+      it('then it should still render the drawer', () => {
+        expect(wrapper.find('.av-drawer').exists()).toBe(true)
+      })
+    })
+
+    describe('when backdrop is enabled', () => {
+      beforeEach(() => {
+        wrapper = mount(AvDrawer, {
+          props: {
+            show: true,
+            backdrop: true,
+          },
+        })
+      })
+
+      it('then it should render the backdrop', () => {
+        expect(wrapper.find('.av-drawer-backdrop').exists()).toBe(true)
+      })
+    })
+
+    describe('when slot content is provided', () => {
+      beforeEach(() => {
+        wrapper = mount(AvDrawer, {
+          props: {
+            show: true,
+          },
+          slots: {
+            default: '<div class="test-content">Test Content</div>',
+          },
+        })
+      })
+
+      it('then it should render the slot content', () => {
+        expect(wrapper.find('.test-content').exists()).toBe(true)
+        expect(wrapper.find('.test-content').text()).toBe('Test Content')
+      })
+    })
+
+    describe('when all props are provided', () => {
+      beforeEach(() => {
+        wrapper = mount(AvDrawer, {
+          props: {
+            show: true,
+            position: 'left',
+            width: '25rem',
+            backdrop: false,
+            padding: '1rem',
+          },
+        })
+      })
+
+      it('then it should apply all props correctly', () => {
+        expect(wrapper.find('.av-drawer--left').exists()).toBe(true)
+        expect(wrapper.find('.av-drawer-backdrop').exists()).toBe(false)
+        expect(wrapper.find('.av-drawer').exists()).toBe(true)
+        expect(wrapper.find('.av-drawer__content').exists()).toBe(true)
+        expect(wrapper.vm.width).toBe('25rem')
+        expect(wrapper.vm.padding).toBe('1rem')
+        expect(wrapper.vm.position).toBe('left')
+        expect(wrapper.vm.backdrop).toBe(false)
+      })
+    })
+  })
+})

--- a/src/ui/overlay/drawers/AvDrawer/AvDrawer.vue
+++ b/src/ui/overlay/drawers/AvDrawer/AvDrawer.vue
@@ -1,0 +1,95 @@
+<script setup lang="ts">
+export interface AvDrawerProps {
+  /**
+   * Controls the visibility of the drawer
+   */
+  show: boolean
+  /**
+   * Position of the drawer on the screen
+   */
+  position?: 'left' | 'right'
+  /**
+   * Width of the drawer panel
+   */
+  width?: string
+  /**
+   * Whether to show the backdrop overlay, default true
+   */
+  backdrop?: boolean
+  /**
+   * Padding inside the drawer content area
+   */
+  padding?: string
+}
+
+const props = withDefaults(defineProps<AvDrawerProps>(), {
+  position: 'right',
+  width: '35rem',
+  backdrop: true,
+  padding: 'var(--spacing-md)'
+})
+
+const { position, width, padding } = toRefs(props)
+</script>
+
+<template>
+  <div v-if="show">
+    <div
+      v-if="backdrop"
+      class="av-drawer-backdrop"
+    />
+    <div
+      class="av-drawer"
+      :class="`av-drawer--${position}`"
+    >
+      <div class="av-drawer__content">
+        <slot />
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.av-drawer-backdrop {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: var(--transparency);
+  z-index: 999;
+}
+
+.av-drawer {
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  background-color: var(--dialog);
+  border: 0.06rem solid var(--surface-background);
+  overflow: hidden;
+  z-index: 1000;
+  padding: var(--spacing-xl);
+  width: v-bind('width')
+}
+
+.av-drawer--left {
+  left: 0;
+  border-radius: 0 var(--radius-hg) var(--radius-hg) 0;
+  box-shadow: -0.125rem 0 0.625rem 0 #0000001A;
+}
+
+.av-drawer--right {
+  right: 0;
+  border-radius: var(--radius-hg) 0 0 var(--radius-hg);
+  box-shadow: 0.125rem 0 0.625rem 0 #0000001A;
+}
+
+.av-drawer__content {
+  padding: v-bind('padding');
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  overflow-y: auto;
+}
+</style>

--- a/src/ui/overlay/index.ts
+++ b/src/ui/overlay/index.ts
@@ -1,2 +1,3 @@
+export { default as AvDrawer } from './drawers/AvDrawer/AvDrawer.vue'
 export { default as AvModal } from './modals/AvModal/AvModal.vue'
 export { default as AvPopover } from './popovers/AvPopover/AvPopover.vue'


### PR DESCRIPTION
  ## Brief description of changes applied
  This PR implements a new **AvDrawer** component in the design system, providing a slide-out panel interface that can be positioned on the left or right side
   of the screen. The drawer includes configurable backdrop, width, padding, and positioning options.

  ## Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/419
closes https://github.com/avenirs-esr/AVENIRS-Project/issues/101 (duplicate)

  ## Documentation
  - Added comprehensive Storybook documentation with interactive examples
  - Included unit tests for the AvDrawer component
  - Added markdown documentation file with usage examples
  - Updated UI overlay exports to include the new drawer component

  ## Target Branch
  `develop`

  ## Additional Notes
  The AvDrawer component follows the existing design system patterns and includes:
  - v-model support for open/close state
  - Configurable position (left/right), width, backdrop, and padding
  - Proper z-index layering for overlay behavior