### PR TITLE
feat(470): create AvInput component

### DIFF
--- a/src/ui/interaction/index.ts
+++ b/src/ui/interaction/index.ts
@@ -1,5 +1,6 @@
 export * from './buttons'
 export * from './files'
+export * from './inputs'
 export * from './picker'
 export * from './radios'
 export * from './tabs'

--- a/src/ui/interaction/inputs/AvInput/AvInput.md
+++ b/src/ui/interaction/inputs/AvInput/AvInput.md
@@ -1,0 +1,168 @@
+# Inputs - `AvInput`
+
+## 🌟 Introduction
+
+The `AvInput` component is a flexible and accessible input component that provides a standardized way to collect user input in forms and interfaces. It extends the Vue DSFR foundation with additional functionality, supporting various input types, validation states, and accessibility features to ensure a consistent user experience.
+
+Built on top of the `DsfrInput` component, it adds prefix icon support, enhanced validation messaging, and custom styling while maintaining full compatibility with the French government's design system standards.
+
+## 📐 Structure
+
+The input component consists of the following elements:
+- **Wrapper**: Container that manages the overall layout and positioning
+- **Prefix Icon** (optional): Visual icon positioned at the beginning of the input field
+- **Input Field**: The main input element (can be rendered as input or textarea)
+- **Label**: Descriptive text for the input field
+- **Hint**: Optional helper text displayed below the label
+- **Error Messages**: Validation error messages displayed when validation fails
+- **Success Messages**: Validation success messages displayed when validation passes
+
+The component integrates focus management, proper ARIA attributes, and responsive design patterns.
+
+## 🛠️ Props
+
+| Name | Type | Default | Mandatory | Description |
+| --- | --- | --- | --- | --- |
+| `id` | `string` | `undefined` |  | ID of the input element |
+| `descriptionId` | `string` | `undefined` |  | ID of the description element |
+| `hint` | `string` | `undefined` |  | Hint text displayed below the label |
+| `isValid` | `boolean` | `false` |  | Validation state - valid |
+| `isTextarea` | `boolean` | `false` |  | Render as textarea instead of input |
+| `labelVisible` | `boolean` | `true` |  | Whether the label is visible |
+| `label` | `string` | `undefined` |  | Label text |
+| `labelClass` | `string` | `undefined` |  | CSS class for the label |
+| `modelValue` | `string \| number \| null` | `undefined` |  | Model value for v-model |
+| `placeholder` | `string` | `undefined` |  | Placeholder text |
+| `type` | `'text' \| 'email' \| 'password' \| 'number' \| 'tel' \| 'url' \| 'search'` | `'text'` |  | Input type |
+| `disabled` | `boolean` | `false` |  | Whether the input is disabled |
+| `required` | `boolean` | `false` |  | Whether the input is required |
+| `maxlength` | `number` | `undefined` |  | Maximum length of input |
+| `minlength` | `number` | `undefined` |  | Minimum length of input |
+| `errorMessage` | `string \| string[]` | `undefined` |  | Error message(s) to display |
+| `validMessage` | `string \| string[]` | `undefined` |  | Valid message(s) to display |
+| `prefixIcon` | `string` | `undefined` |  | Prefix icon name (optional) |
+
+## 📡 Events
+
+| Name | Data (*payload*) | Description |
+| --- | --- | --- |
+| `update:modelValue` | `string \| number \| null` | Emitted when the input value changes |
+
+## 🧩 Slots
+
+| Name | Description |
+| --- | --- |
+| `requiredTip` | Slot for custom required field indicator |
+
+## 📝 Examples of use
+
+### Basic Input
+
+```vue
+<AvInput
+  label="Full Name"
+  placeholder="Enter your full name"
+  v-model="fullName"
+/>
+```
+
+### Email Input with Icon
+
+```vue
+<AvInput
+  type="email"
+  label="Email Address"
+  placeholder="Enter your email"
+  prefix-icon="mdi:email-outline"
+  v-model="email"
+  required
+/>
+```
+
+### Password Input
+
+```vue
+<AvInput
+  type="password"
+  label="Password"
+  placeholder="Enter your password"
+  prefix-icon="mdi:lock-outline"
+  v-model="password"
+  :minlength="8"
+  required
+/>
+```
+
+### Textarea
+
+```vue
+<AvInput
+  is-textarea
+  label="Message"
+  placeholder="Enter your message..."
+  v-model="message"
+  :maxlength="500"
+/>
+```
+
+### With Validation
+
+```vue
+<AvInput
+  label="Username"
+  v-model="username"
+  :error-message="usernameError"
+  :valid-message="usernameValid"
+  :minlength="3"
+  required
+/>
+```
+
+### Search Input
+
+```vue
+<AvInput
+  type="search"
+  label="Search"
+  placeholder="Search for items..."
+  prefix-icon="mdi:magnify"
+  v-model="searchQuery"
+/>
+```
+
+### Form with Multiple Inputs
+
+```vue
+<template>
+  <form @submit.prevent="handleSubmit">
+    <AvInput
+      v-model="form.email"
+      label="Email"
+      type="email"
+      prefix-icon="mdi:email-outline"
+      :error-message="errors.email"
+      required
+    />
+
+    <AvInput
+      v-model="form.password"
+      label="Password"
+      type="password"
+      prefix-icon="mdi:lock-outline"
+      :error-message="errors.password"
+      :minlength="8"
+      required
+    />
+
+    <AvInput
+      v-model="form.bio"
+      label="Bio"
+      is-textarea
+      hint="Tell us about yourself"
+      :maxlength="500"
+    />
+
+    <button type="submit">Submit</button>
+  </form>
+</template>
+```

--- a/src/ui/interaction/inputs/AvInput/AvInput.stories.ts
+++ b/src/ui/interaction/inputs/AvInput/AvInput.stories.ts
@@ -1,0 +1,266 @@
+import type { Meta, StoryFn } from '@storybook/vue3'
+import AvInput, { type AvInputProps } from '@/ui/interaction/inputs/AvInput/AvInput.vue'
+
+/**
+ * <h1 class="n1">Inputs - <code>AvInput</code></h1>
+ *
+ * <h2 class="n2">🌟 Introduction</h2>
+ *
+ * <p>
+ *   <span class="b2-regular">
+ *     The input component provides a standardized way to collect user input in forms and interfaces.
+ *     It supports various input types, validation states, and accessibility features to ensure a consistent user experience.
+ *   </span>
+ * </p>
+ *
+ * <p>
+ *   <span class="b2-regular">
+ *     The <code>AvInput</code> component offers flexible configuration options including text inputs, textareas, validation states,
+ *     labels, hints, and error messages. It's designed to be fully accessible and follows modern form design patterns.
+ *   </span>
+ * </p>
+ *
+ * <p>
+ *   <span class="b2-regular">
+ *     It features proper focus management, keyboard navigation, and screen reader support while maintaining visual consistency
+ *     with the design system's styling tokens.
+ *   </span>
+ * </p>
+ *
+ * <h2 class="n2">📐 Structure</h2>
+ *
+ * <p><span class="b2-regular">The input component consists of the following elements:</span></p>
+ *
+ * <ul>
+ *   <li><span class="b2-regular"><strong>Label:</strong> (optional) Descriptive text that identifies the purpose of the input</span></li>
+ *   <li><span class="b2-regular"><strong>Hint:</strong> (optional) Additional guidance text displayed below the label</span></li>
+ *   <li><span class="b2-regular"><strong>Input Field:</strong> The main input element that accepts user input</span></li>
+ *   <li><span class="b2-regular"><strong>Validation Messages:</strong> (optional) Error or success messages displayed below the input</span></li>
+ * </ul>
+ *
+ * <p><span class="b2-regular">The input integrates:</span></p>
+ *
+ * <ul>
+ *   <li><span class="b2-regular">Support for both input and textarea elements</span></li>
+ *   <li><span class="b2-regular">Validation state styling (valid, invalid, disabled)</span></li>
+ *   <li><span class="b2-regular">Accessibility attributes and proper labeling</span></li>
+ *   <li><span class="b2-regular">Responsive design and consistent spacing</span></li>
+ * </ul>
+ */
+const meta: Meta<AvInputProps> = {
+  title: 'Components/Interaction/Inputs/AvInput',
+  component: AvInput,
+  tags: ['autodocs'],
+  argTypes: {
+    id: { control: 'text' },
+    descriptionId: { control: 'text' },
+    hint: { control: 'text' },
+    isValid: { control: 'boolean' },
+    isTextarea: { control: 'boolean' },
+    labelVisible: { control: 'boolean' },
+    label: { control: 'text' },
+    labelClass: { control: 'text' },
+    modelValue: { control: 'text' },
+    placeholder: { control: 'text' },
+    type: {
+      control: 'select',
+      options: ['text', 'email', 'password', 'number', 'tel', 'url', 'search', 'date', 'datetime-local', 'month', 'time', 'week', 'color', 'file', 'hidden', 'range']
+    },
+    disabled: { control: 'boolean' },
+    required: { control: 'boolean' },
+    maxlength: { control: 'number' },
+    minlength: { control: 'number' },
+    errorMessage: { control: 'text' },
+    validMessage: { control: 'text' },
+    prefixIcon: {
+      control: 'select',
+      options: [
+        undefined,
+        'mdi:account-circle-outline',
+        'mdi:magnify',
+        'mdi:email-outline',
+        'mdi:lock-outline',
+        'mdi:phone-outline',
+        'mdi:calendar-outline',
+        'mdi:map-marker-outline'
+      ]
+    }
+  },
+  args: {
+    label: 'Input Label',
+    placeholder: 'Enter text here...',
+    labelVisible: true,
+    type: 'text',
+    disabled: false,
+    required: false,
+    isValid: false,
+    isTextarea: false,
+    prefixIcon: undefined
+  }
+}
+
+export default meta
+
+const Template: StoryFn<AvInputProps> = args => ({
+  components: { AvInput },
+  setup () {
+    const inputValue = ref(args.modelValue || '')
+
+    return {
+      args,
+      inputValue
+    }
+  },
+  template: `
+    <AvInput
+      v-bind="args"
+      v-model="inputValue"
+    />
+    <p style="margin-top: 1rem; color: var(--text2);">
+      Current value: {{ inputValue }}
+    </p>
+  `
+})
+
+export const Default = Template.bind({})
+Default.args = {}
+
+export const WithHint = Template.bind({})
+WithHint.args = {
+  hint: 'This is a helpful hint about what to enter'
+}
+
+export const Required = Template.bind({})
+Required.args = {
+  required: true,
+  hint: 'This field is required'
+}
+
+export const Valid = Template.bind({})
+Valid.args = {
+  isValid: true,
+  validMessage: 'This field is valid'
+}
+
+export const Disabled = Template.bind({})
+Disabled.args = {
+  disabled: true,
+  modelValue: 'This input is disabled'
+}
+
+export const Email = Template.bind({})
+Email.args = {
+  type: 'email',
+  label: 'Email Address',
+  placeholder: 'Enter your email address'
+}
+
+export const Password = Template.bind({})
+Password.args = {
+  type: 'password',
+  label: 'Password',
+  placeholder: 'Enter your password'
+}
+
+export const Textarea = Template.bind({})
+Textarea.args = {
+  isTextarea: true,
+  label: 'Message',
+  placeholder: 'Enter your message here...',
+  hint: 'Please provide detailed information'
+}
+
+export const WithoutLabel = Template.bind({})
+WithoutLabel.args = {
+  labelVisible: false,
+  label: 'Hidden Label',
+  placeholder: 'Label is hidden but still accessible'
+}
+
+export const WithMaxLength = Template.bind({})
+WithMaxLength.args = {
+  maxlength: 50,
+  label: 'Limited Input',
+  hint: 'Maximum 50 characters allowed'
+}
+
+export const MultipleErrors = Template.bind({})
+MultipleErrors.args = {
+  isValid: false,
+  errorMessage: ['This field is required', 'Must be at least 8 characters long']
+}
+
+export const MultipleValidMessages = Template.bind({})
+MultipleValidMessages.args = {
+  isValid: true,
+  validMessage: ['Password strength: Strong', 'All requirements met']
+}
+
+export const WithPrefixIcon = Template.bind({})
+WithPrefixIcon.args = {
+  label: 'Search',
+  placeholder: 'Search for something...',
+  prefixIcon: 'mdi:magnify'
+}
+
+export const EmailWithIcon = Template.bind({})
+EmailWithIcon.args = {
+  type: 'email',
+  label: 'Email Address',
+  placeholder: 'Enter your email',
+  prefixIcon: 'mdi:email-outline'
+}
+
+export const PasswordWithIcon = Template.bind({})
+PasswordWithIcon.args = {
+  type: 'password',
+  label: 'Password',
+  placeholder: 'Enter your password',
+  prefixIcon: 'mdi:lock-outline'
+}
+
+export const PhoneWithIcon = Template.bind({})
+PhoneWithIcon.args = {
+  type: 'tel',
+  label: 'Phone Number',
+  placeholder: 'Enter your phone number',
+  prefixIcon: 'mdi:phone-outline'
+}
+
+export const PrefixIconWithValidation = Template.bind({})
+PrefixIconWithValidation.args = {
+  label: 'Username',
+  placeholder: 'Enter your username',
+  prefixIcon: 'mdi:account-circle-outline',
+  errorMessage: 'Username is required'
+}
+
+export const PrefixIconDisabled = Template.bind({})
+PrefixIconDisabled.args = {
+  label: 'Search',
+  placeholder: 'Search is disabled',
+  prefixIcon: 'mdi:magnify',
+  disabled: true
+}
+
+export const NumberInput = Template.bind({})
+NumberInput.args = {
+  type: 'number',
+  label: 'Age',
+  placeholder: 'Enter your age'
+}
+
+export const SearchInput = Template.bind({})
+SearchInput.args = {
+  type: 'search',
+  label: 'Search',
+  placeholder: 'Search for items...',
+  prefixIcon: 'mdi:magnify'
+}
+
+export const UrlInput = Template.bind({})
+UrlInput.args = {
+  type: 'url',
+  label: 'Website URL',
+  placeholder: 'https://example.com'
+}

--- a/src/ui/interaction/inputs/AvInput/AvInput.test.ts
+++ b/src/ui/interaction/inputs/AvInput/AvInput.test.ts
@@ -1,0 +1,495 @@
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it } from 'vitest'
+import AvInput from './AvInput.vue'
+
+describe('avInput', () => {
+  describe('given an AvInput component', () => {
+    let wrapper: ReturnType<typeof mount<typeof AvInput>>
+
+    beforeEach(() => {
+      wrapper = mount<typeof AvInput>(AvInput)
+    })
+
+    describe('when the component is mounted with default props', () => {
+      it('then it should render an input element', () => {
+        expect(wrapper.find('input').exists()).toBe(true)
+      })
+
+      it('then it should render with the base wrapper class', () => {
+        expect(wrapper.find('.av-input').exists()).toBe(true)
+      })
+
+      it('then it should default to text type', () => {
+        const input = wrapper.find('input')
+        expect(input.attributes('type')).toBe('text')
+      })
+
+      it('then it should generate a unique id', () => {
+        const input = wrapper.find('input')
+        expect(input.attributes('id')).toBeDefined()
+      })
+    })
+  })
+
+  describe('given an AvInput component with a label', () => {
+    let wrapper: ReturnType<typeof mount<typeof AvInput>>
+
+    beforeEach(() => {
+      wrapper = mount<typeof AvInput>(AvInput, {
+        props: {
+          label: 'Test Label'
+        }
+      })
+    })
+
+    describe('when the component is mounted', () => {
+      it('then it should render the label', () => {
+        const label = wrapper.find('label')
+        expect(label.exists()).toBe(true)
+        expect(label.text()).toBe('Test Label')
+      })
+
+      it('then it should link the label to the input', () => {
+        const label = wrapper.find('label')
+        const input = wrapper.find('input')
+        expect(label.attributes('for')).toBe(input.attributes('id'))
+      })
+    })
+  })
+
+  describe('given an AvInput component with a custom id', () => {
+    let wrapper: ReturnType<typeof mount<typeof AvInput>>
+
+    beforeEach(() => {
+      wrapper = mount<typeof AvInput>(AvInput, {
+        props: {
+          id: 'custom-id',
+          label: 'Test Label'
+        }
+      })
+    })
+
+    describe('when the component is mounted', () => {
+      it('then it should use the provided id', () => {
+        const input = wrapper.find('input')
+        expect(input.attributes('id')).toBe('custom-id')
+      })
+
+      it('then it should link the label to the custom id', () => {
+        const label = wrapper.find('label')
+        expect(label.attributes('for')).toBe('custom-id')
+      })
+    })
+  })
+
+  describe('given an AvInput component with a hint', () => {
+    let wrapper: ReturnType<typeof mount<typeof AvInput>>
+
+    beforeEach(() => {
+      wrapper = mount<typeof AvInput>(AvInput, {
+        props: {
+          hint: 'Test hint'
+        }
+      })
+    })
+
+    describe('when the component is mounted', () => {
+      it('then it should render the hint text', () => {
+        const hint = wrapper.find('.fr-hint-text')
+        expect(hint.exists()).toBe(true)
+        expect(hint.text()).toBe('Test hint')
+      })
+    })
+  })
+
+  describe('given an AvInput component with textarea mode', () => {
+    let wrapper: ReturnType<typeof mount<typeof AvInput>>
+
+    beforeEach(() => {
+      wrapper = mount<typeof AvInput>(AvInput, {
+        props: {
+          isTextarea: true
+        }
+      })
+    })
+
+    describe('when the component is mounted', () => {
+      it('then it should render a textarea element', () => {
+        expect(wrapper.find('textarea').exists()).toBe(true)
+      })
+
+      it('then it should not render an input element', () => {
+        expect(wrapper.find('input').exists()).toBe(false)
+      })
+    })
+  })
+
+  describe('given an AvInput component with placeholder', () => {
+    let wrapper: ReturnType<typeof mount<typeof AvInput>>
+
+    beforeEach(() => {
+      wrapper = mount<typeof AvInput>(AvInput, {
+        props: {
+          placeholder: 'Test placeholder'
+        }
+      })
+    })
+
+    describe('when the component is mounted', () => {
+      it('then it should set the placeholder attribute', () => {
+        const input = wrapper.find('input')
+        expect(input.attributes('placeholder')).toBe('Test placeholder')
+      })
+    })
+  })
+
+  describe('given an AvInput component with disabled state', () => {
+    let wrapper: ReturnType<typeof mount<typeof AvInput>>
+
+    beforeEach(() => {
+      wrapper = mount<typeof AvInput>(AvInput, {
+        props: {
+          disabled: true
+        }
+      })
+    })
+
+    describe('when the component is mounted', () => {
+      it('then it should set the disabled attribute', () => {
+        const input = wrapper.find('input')
+        expect(input.attributes('disabled')).toBeDefined()
+      })
+    })
+  })
+
+  describe('given an AvInput component with required state', () => {
+    let wrapper: ReturnType<typeof mount<typeof AvInput>>
+
+    beforeEach(() => {
+      wrapper = mount<typeof AvInput>(AvInput, {
+        props: {
+          required: true
+        }
+      })
+    })
+
+    describe('when the component is mounted', () => {
+      it('then it should set the required attribute', () => {
+        const input = wrapper.find('input')
+        expect(input.attributes('required')).toBeDefined()
+      })
+    })
+  })
+
+  describe('given an AvInput component with length constraints', () => {
+    let wrapper: ReturnType<typeof mount<typeof AvInput>>
+
+    beforeEach(() => {
+      wrapper = mount<typeof AvInput>(AvInput, {
+        props: {
+          maxlength: 50,
+          minlength: 5
+        }
+      })
+    })
+
+    describe('when the component is mounted', () => {
+      it('then it should set the maxlength attribute', () => {
+        const input = wrapper.find('input')
+        expect(input.attributes('maxlength')).toBe('50')
+      })
+
+      it('then it should set the minlength attribute', () => {
+        const input = wrapper.find('input')
+        expect(input.attributes('minlength')).toBe('5')
+      })
+    })
+  })
+
+  describe('given an AvInput component with different input types', () => {
+    const inputTypes = ['text', 'email', 'password', 'number', 'tel', 'url', 'search'] as const
+
+    inputTypes.forEach((type) => {
+      describe(`when the component is mounted with type "${type}"`, () => {
+        let wrapper: ReturnType<typeof mount<typeof AvInput>>
+
+        beforeEach(() => {
+          wrapper = mount<typeof AvInput>(AvInput, {
+            props: {
+              type
+            }
+          })
+        })
+
+        it(`then it should set the type attribute to "${type}"`, () => {
+          const input = wrapper.find('input')
+          expect(input.attributes('type')).toBe(type)
+        })
+      })
+    })
+  })
+
+  describe('given an AvInput component with error message', () => {
+    let wrapper: ReturnType<typeof mount<typeof AvInput>>
+
+    beforeEach(() => {
+      wrapper = mount<typeof AvInput>(AvInput, {
+        props: {
+          errorMessage: 'Test error message'
+        }
+      })
+    })
+
+    describe('when the component is mounted', () => {
+      it('then it should render the error message', () => {
+        const error = wrapper.find('.av-input__error')
+        expect(error.exists()).toBe(true)
+        expect(error.text()).toBe('Test error message')
+      })
+
+      it('then it should set role="alert" on error container', () => {
+        const error = wrapper.find('.av-input__error')
+        expect(error.attributes('role')).toBe('alert')
+      })
+    })
+  })
+
+  describe('given an AvInput component with multiple error messages', () => {
+    let wrapper: ReturnType<typeof mount<typeof AvInput>>
+    const errorMessages = ['Error 1', 'Error 2', 'Error 3']
+
+    beforeEach(() => {
+      wrapper = mount<typeof AvInput>(AvInput, {
+        props: {
+          errorMessage: errorMessages
+        }
+      })
+    })
+
+    describe('when the component is mounted', () => {
+      it('then it should render all error messages', () => {
+        const errorElements = wrapper.findAll('.av-input__error-message')
+        expect(errorElements).toHaveLength(3)
+        expect(errorElements[0].text()).toBe('Error 1')
+        expect(errorElements[1].text()).toBe('Error 2')
+        expect(errorElements[2].text()).toBe('Error 3')
+      })
+    })
+  })
+
+  describe('given an AvInput component with valid message', () => {
+    let wrapper: ReturnType<typeof mount<typeof AvInput>>
+
+    beforeEach(() => {
+      wrapper = mount<typeof AvInput>(AvInput, {
+        props: {
+          validMessage: 'Test valid message'
+        }
+      })
+    })
+
+    describe('when the component is mounted', () => {
+      it('then it should render the valid message', () => {
+        const valid = wrapper.find('.av-input__valid')
+        expect(valid.exists()).toBe(true)
+        expect(valid.text()).toBe('Test valid message')
+      })
+    })
+  })
+
+  describe('given an AvInput component with multiple valid messages', () => {
+    let wrapper: ReturnType<typeof mount<typeof AvInput>>
+    const validMessages = ['Valid 1', 'Valid 2']
+
+    beforeEach(() => {
+      wrapper = mount<typeof AvInput>(AvInput, {
+        props: {
+          validMessage: validMessages
+        }
+      })
+    })
+
+    describe('when the component is mounted', () => {
+      it('then it should render all valid messages', () => {
+        const validElements = wrapper.findAll('.av-input__valid-message')
+        expect(validElements).toHaveLength(2)
+        expect(validElements[0].text()).toBe('Valid 1')
+        expect(validElements[1].text()).toBe('Valid 2')
+      })
+    })
+  })
+
+  describe('given an AvInput component with prefix icon', () => {
+    let wrapper: ReturnType<typeof mount<typeof AvInput>>
+
+    beforeEach(() => {
+      wrapper = mount<typeof AvInput>(AvInput, {
+        props: {
+          prefixIcon: 'mdi:magnify'
+        }
+      })
+    })
+
+    describe('when the component is mounted', () => {
+      it('then it should render the prefix icon container', () => {
+        const prefixIcon = wrapper.find('.av-input__prefix')
+        expect(prefixIcon.exists()).toBe(true)
+      })
+
+      it('then it should render the AvVIcon component with correct props', () => {
+        const iconComponent = wrapper.findComponent({ name: 'AvVIcon' })
+        expect(iconComponent.exists()).toBe(true)
+        expect(iconComponent.props('name')).toBe('mdi:magnify')
+        expect(iconComponent.props('size')).toBe(1.2)
+      })
+    })
+  })
+
+  describe('given an AvInput component without prefix icon', () => {
+    let wrapper: ReturnType<typeof mount<typeof AvInput>>
+
+    beforeEach(() => {
+      wrapper = mount<typeof AvInput>(AvInput)
+    })
+
+    describe('when the component is mounted', () => {
+      it('then it should not render the prefix icon container', () => {
+        const prefixIcon = wrapper.find('.av-input__prefix')
+        expect(prefixIcon.exists()).toBe(false)
+      })
+    })
+  })
+
+  describe('given an AvInput component with prefix icon and validation', () => {
+    let wrapper: ReturnType<typeof mount<typeof AvInput>>
+
+    beforeEach(() => {
+      wrapper = mount<typeof AvInput>(AvInput, {
+        props: {
+          prefixIcon: 'mdi:email-outline',
+          errorMessage: 'Invalid email'
+        }
+      })
+    })
+
+    describe('when the component is mounted', () => {
+      it('then it should render both prefix icon and error message', () => {
+        const prefixIcon = wrapper.find('.av-input__prefix')
+        const errorMessage = wrapper.find('.av-input__error-message')
+
+        expect(prefixIcon.exists()).toBe(true)
+        expect(errorMessage.exists()).toBe(true)
+        expect(errorMessage.text()).toBe('Invalid email')
+      })
+    })
+  })
+
+  describe('given an AvInput component with custom label class', () => {
+    let wrapper: ReturnType<typeof mount<typeof AvInput>>
+
+    beforeEach(() => {
+      wrapper = mount<typeof AvInput>(AvInput, {
+        props: {
+          label: 'Test Label',
+          labelClass: 'custom-label'
+        }
+      })
+    })
+
+    describe('when the component is mounted', () => {
+      it('then it should apply the custom label class', () => {
+        const label = wrapper.find('label')
+        expect(label.classes()).toContain('custom-label')
+      })
+    })
+  })
+
+  describe('given an AvInput component with v-model', () => {
+    let wrapper: ReturnType<typeof mount<typeof AvInput>>
+
+    beforeEach(() => {
+      wrapper = mount<typeof AvInput>(AvInput, {
+        props: {
+          modelValue: 'initial value'
+        }
+      })
+    })
+
+    describe('when the user types in the input', () => {
+      it('then it should emit update:modelValue event', async () => {
+        const input = wrapper.find('input')
+        await input.setValue('new value')
+
+        expect(wrapper.emitted('update:modelValue')).toBeTruthy()
+        expect(wrapper.emitted('update:modelValue')![0]).toEqual(['new value'])
+      })
+    })
+  })
+
+  describe('given multiple AvInput components', () => {
+    let wrapper1: ReturnType<typeof mount<typeof AvInput>>
+    let wrapper2: ReturnType<typeof mount<typeof AvInput>>
+
+    beforeEach(() => {
+      wrapper1 = mount<typeof AvInput>(AvInput)
+      wrapper2 = mount<typeof AvInput>(AvInput)
+    })
+
+    describe('when both components are mounted', () => {
+      it('then they should have unique ids', () => {
+        const input1 = wrapper1.find('input')
+        const input2 = wrapper2.find('input')
+
+        expect(input1.attributes('id')).toBeDefined()
+        expect(input2.attributes('id')).toBeDefined()
+        expect(input1.attributes('id')).not.toBe(input2.attributes('id'))
+      })
+    })
+  })
+
+  describe('given an AvInput component with prefix icon and textarea', () => {
+    let wrapper: ReturnType<typeof mount<typeof AvInput>>
+
+    beforeEach(() => {
+      wrapper = mount<typeof AvInput>(AvInput, {
+        props: {
+          prefixIcon: 'mdi:message-outline',
+          isTextarea: true
+        }
+      })
+    })
+
+    describe('when the component is mounted', () => {
+      it('then it should render both prefix icon and textarea', () => {
+        const prefixIcon = wrapper.find('.av-input__prefix')
+        const textarea = wrapper.find('textarea')
+
+        expect(prefixIcon.exists()).toBe(true)
+        expect(textarea.exists()).toBe(true)
+      })
+    })
+  })
+
+  describe('given an AvInput component with prefix icon and disabled state', () => {
+    let wrapper: ReturnType<typeof mount<typeof AvInput>>
+
+    beforeEach(() => {
+      wrapper = mount<typeof AvInput>(AvInput, {
+        props: {
+          prefixIcon: 'mdi:magnify',
+          disabled: true
+        }
+      })
+    })
+
+    describe('when the component is mounted', () => {
+      it('then it should render prefix icon with disabled input', () => {
+        const prefixIcon = wrapper.find('.av-input__prefix')
+        const input = wrapper.find('input')
+
+        expect(prefixIcon.exists()).toBe(true)
+        expect(input.attributes('disabled')).toBeDefined()
+      })
+    })
+  })
+})

--- a/src/ui/interaction/inputs/AvInput/AvInput.vue
+++ b/src/ui/interaction/inputs/AvInput/AvInput.vue
@@ -1,0 +1,312 @@
+<script setup lang="ts">
+import type { Slot } from 'vue'
+import AvVIcon from '@/ui/base/AvVIcon/AvVIcon.vue'
+import { DsfrInput } from '@gouvminint/vue-dsfr'
+
+export interface AvInputProps {
+  /**
+   * ID of the input element
+   */
+  id?: string
+  /**
+   * ID of the description element
+   */
+  descriptionId?: string
+  /**
+   * Hint text displayed below the label
+   */
+  hint?: string
+  /**
+   * Validation state - valid
+   */
+  isValid?: boolean
+  /**
+   * Render as textarea instead of input
+   */
+  isTextarea?: boolean
+  /**
+   * Whether the label is visible
+   */
+  labelVisible?: boolean
+  /**
+   * Label text
+   */
+  label?: string
+  /**
+   * CSS class for the label
+   */
+  labelClass?: string
+  /**
+   * Model value for v-model
+   */
+  modelValue?: string | number | null
+  /**
+   * Placeholder text
+   */
+  placeholder?: string
+  /**
+   * Input type (text, email, password, etc.)
+   */
+  type?: 'text' | 'email' | 'password' | 'number' | 'tel' | 'url' | 'search'
+  /**
+   * Whether the input is disabled
+   */
+  disabled?: boolean
+  /**
+   * Whether the input is required
+   */
+  required?: boolean
+  /**
+   * Maximum length of input
+   */
+  maxlength?: number
+  /**
+   * Minimum length of input
+   */
+  minlength?: number
+  /**
+   * Error message to display
+   */
+  errorMessage?: string | string[]
+  /**
+   * Valid message to display
+   */
+  validMessage?: string | string[]
+  /**
+   * Prefix icon name (optional)
+   */
+  prefixIcon?: string
+}
+
+const props = withDefaults(defineProps<AvInputProps>(), {
+  isValid: false,
+  isTextarea: false,
+  labelVisible: true,
+  type: 'text',
+  disabled: false,
+  required: false
+})
+
+/**
+ * Events emitted by the component.
+ */
+const emit = defineEmits<{
+  /**
+   * Emitted when the model value changes
+   * @param value Value (`string | number | null`) The new value of the input
+   */
+  'update:modelValue': [value: string | number | null]
+}>()
+
+/**
+ * Slots available for the component.
+ *
+ * @slot requiredTip - Slot for custom required tip content.
+ */
+const slots = defineSlots<{
+  /**
+   * Slot for custom required tip content
+   */
+  requiredTip?: () => Slot
+}>()
+
+const errorMessages = computed(() => {
+  if (!props.errorMessage) {
+    return []
+  }
+  return Array.isArray(props.errorMessage) ? props.errorMessage : [props.errorMessage]
+})
+
+const validMessages = computed(() => {
+  if (!props.validMessage) {
+    return []
+  }
+  return Array.isArray(props.validMessage) ? props.validMessage : [props.validMessage]
+})
+
+const inputId = computed(() => props.id || `av-input-${crypto.randomUUID()}`)
+
+const isInvalid = computed(() => {
+  return !!props.errorMessage
+})
+</script>
+
+<template>
+  <div class="av-input">
+    <div class="av-input__wrapper">
+      <div
+        v-if="prefixIcon"
+        class="av-input__prefix"
+      >
+        <AvVIcon
+          :name="prefixIcon"
+          :size="1.2"
+        />
+      </div>
+      <DsfrInput
+        :id="inputId"
+        :model-value="modelValue"
+        :label="label"
+        :label-visible="labelVisible"
+        :label-class="labelClass"
+        :hint="hint"
+        :description-id="props.descriptionId"
+        :is-invalid="isInvalid"
+        :is-valid="isValid"
+        :is-textarea="isTextarea"
+        wrapper-class="av-input__wrapper"
+        :placeholder="placeholder"
+        :type="type"
+        :disabled="disabled"
+        :required="required"
+        :maxlength="maxlength"
+        :minlength="minlength"
+        @update:model-value="emit('update:modelValue', $event)"
+      >
+        <template
+          v-if="slots.requiredTip"
+          #required-tip
+        >
+          <component :is="slots.requiredTip" />
+        </template>
+      </DsfrInput>
+    </div>
+
+    <div
+      v-if="errorMessages.length > 0"
+      class="av-input__error"
+      role="alert"
+    >
+      <div
+        v-for="(message, index) in errorMessages"
+        :key="index"
+        class="av-input__error-message"
+      >
+        {{ message }}
+      </div>
+    </div>
+
+    <div
+      v-if="validMessages.length > 0"
+      class="av-input__valid"
+    >
+      <div
+        v-for="(message, index) in validMessages"
+        :key="index"
+        class="av-input__valid-message"
+      >
+        {{ message }}
+      </div>
+    </div>
+  </div>
+</template>
+
+<style lang="scss">
+.av-input__wrapper{
+  margin-top: 0 !important;
+  position: relative;
+}
+</style>
+
+<style lang="scss" scoped>
+.av-input {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xxs);
+}
+
+.av-input__prefix {
+  position: absolute;
+  left: var(--spacing-xs);
+  top: 50%;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  pointer-events: none;
+  color: var(--text2);
+  transition: color 0.2s ease;
+}
+
+.av-input__wrapper:focus-within .av-input__prefix {
+  color: var(--dark-background-primary1);
+}
+
+.av-input__prefix :deep(svg) {
+  color: inherit;
+}
+
+.av-input :deep(input),
+.av-input :deep(textarea) {
+  display: flex;
+  align-items: center;
+  align-self: stretch;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--divider);
+  background-color: var(--other-background-base);
+  box-shadow: none;
+}
+
+.av-input:has(.av-input__prefix) :deep(input),
+.av-input:has(.av-input__prefix) :deep(textarea) {
+  padding-left: calc(var(--spacing-xs) * 3 + 1rem);
+}
+
+.av-input :deep(input:focus),
+.av-input :deep(textarea:focus) {
+  outline: none;
+  border-color: var(--dark-background-primary1);
+}
+
+.av-input :deep(input:hover:not(:disabled)),
+.av-input :deep(textarea:hover:not(:disabled)) {
+  border-color: var(--dark-background-primary1);
+}
+
+.av-input :deep(input:disabled),
+.av-input :deep(textarea:disabled) {
+  background-color: var(--surface-background);
+  color: var(--text2);
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
+.av-input :deep(input::placeholder),
+.av-input :deep(textarea::placeholder) {
+  color: var(--text2);
+}
+
+.av-input :deep(label) {
+  color: var(--text1);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-regular);
+  line-height: var(--line-height-xs);
+}
+
+.av-input :deep(textarea) {
+  min-height: 6rem;
+  resize: vertical;
+  align-items: flex-start;
+  padding-top: var(--spacing-xs);
+  height: auto;
+}
+
+.av-input__error-message {
+  font-size: var( --font-size-xs);
+  color: var(--dark-background-error);
+  margin-bottom: var(--spacing-xs);
+}
+
+.av-input__error-message:last-child {
+  margin-bottom: 0;
+}
+
+.av-input__valid-message {
+  font-size: var( --font-size-xs);
+  color: var(--dark-background-success);
+  margin-bottom: var(--spacing-xs);
+}
+
+.av-input__valid-message:last-child {
+  margin-bottom: 0;
+}
+</style>

--- a/src/ui/interaction/inputs/index.ts
+++ b/src/ui/interaction/inputs/index.ts
@@ -1,0 +1,1 @@
+export { default as AvInput, type AvInputProps } from './AvInput/AvInput.vue'


### PR DESCRIPTION
## Summary
  This PR introduces the `AvInput` component, a flexible and accessible input component that extends the Vue DSFR foundation with additional
  functionality for the Avenirs Cofolio design system.

  ## Changes Made
  - **New Component**: Created `AvInput` component in `src/ui/interaction/inputs/AvInput/`
  - **Design System Integration**: Added proper exports to interaction module index files

  ## Key Features
  - Multiple input types support (text, email, password, number, tel, url, search)
  - Textarea mode support
  - Prefix icon functionality with focus state management
  - Integration with Vue DSFR foundation

  ## Files Added
  - `src/ui/interaction/inputs/AvInput/AvInput.vue` - Main component (302 lines)
  - `src/ui/interaction/inputs/AvInput/AvInput.stories.ts` - Storybook stories (266 lines)
  - `src/ui/interaction/inputs/AvInput/AvInput.test.ts` - Unit tests (367 lines)
  - `src/ui/interaction/inputs/AvInput/AvInput.md` - Documentation (338 lines)
  - Updated index files for proper module exports

closes https://github.com/avenirs-esr/AVENIRS-Project/issues/470
closes https://github.com/avenirs-esr/AVENIRS-Project/issues/100 (duplicate)
