### PR TITLE
feat(373): add TraceDeletionConfirmationModal

### DIFF
--- a/src/features/student/locales/en.json
+++ b/src/features/student/locales/en.json
@@ -214,14 +214,8 @@
         "title": "(placeholder) All my resumes"
       },
       "studentToolsTracesView": {
-        "warningMessage": {
-          "unassociated": "You have an unassociated trace. | You have {unassociatedTracesCount} unassociated traces.",
-          "delete": {
-            "loneTrace": "Please note that the trace will be deleted",
-            "traces": "Please note that **1 of them** will be deleted. | Please note that **{tracesToDeleteCount} of them** will be deleted.",
-            "days": "tomorrow | in the coming {daysWarning} days."
-          },
-          "reminder": "As a reminder, without any action on your part, unassociated traces are deleted within {maxDayBeforeDeletion} days."
+        "errors": {
+          "delete": "An error occurred while deleting the trace"
         },
         "studentDetailedTraceCard": {
           "getDaysUntilDeletion": "Deletion in 1 day | Deletion {count} days"
@@ -247,8 +241,18 @@
           }
         },
         "title": "My collection of traces",
-        "errors": {
-          "delete": "An error occurred while deleting the trace"
+        "traceDeletionConfirmationModal": {
+          "description": "Are you sure you want to delete your trace?",
+          "subdescription": "Any deletion action is definitive. It results in the loss of the data entered for this trace, as well as the deletion of the association links it contains."
+        },
+        "warningMessage": {
+          "delete": {
+            "days": "tomorrow | in the coming {daysWarning} days.",
+            "loneTrace": "Please note that the trace will be deleted",
+            "traces": "Please note that **1 of them** will be deleted. | Please note that **{tracesToDeleteCount} of them** will be deleted."
+          },
+          "reminder": "As a reminder, without any action on your part, unassociated traces are deleted within {maxDayBeforeDeletion} days.",
+          "unassociated": "You have an unassociated trace. | You have {unassociatedTracesCount} unassociated traces."
         }
       }
     },

--- a/src/features/student/locales/fr.json
+++ b/src/features/student/locales/fr.json
@@ -214,14 +214,8 @@
         "title": "(placeholder) Tous mes CV"
       },
       "studentToolsTracesView": {
-        "warningMessage": {
-          "unassociated": "Vous avez une trace non associée. | Vous avez {count} traces non associées.",
-          "delete": {
-            "loneTrace": "Attention, la trace sera supprimée",
-            "traces": "Attention, **1 d'entre elles** sera supprimée | Attention, **{count} d'entre elles** seront supprimées",
-            "days": "demain. | dans les {count} jours à venir."
-          },
-          "reminder": "Pour rappel, sans aucune action de votre part, les traces non associées sont supprimées sous {count} jours."
+        "errors": {
+          "delete": "Une erreur est survenue lors de la suppression de la trace."
         },
         "studentDetailedTraceCard": {
           "getDaysUntilDeletion": "Suppression dans 1 jour | Suppression dans {count} jours"
@@ -247,8 +241,18 @@
           }
         },
         "title": "Ma bibliothèque de traces",
-        "errors": {
-          "delete": "Une erreur est survenue lors de la suppression de la trace."
+        "traceDeletionConfirmationModal": {
+          "description": "Êtes-vous certain(e) de vouloir supprimer votre trace ?",
+          "subdescription": "Toute action de suppression est définitive. Elle entraine la perte des données renseignées pour cette trace ainsi que la suppression des liens d'association qu'elle comporte."
+        },
+        "warningMessage": {
+          "delete": {
+            "days": "demain. | dans les {count} jours à venir.",
+            "loneTrace": "Attention, la trace sera supprimée",
+            "traces": "Attention, **1 d'entre elles** sera supprimée | Attention, **{count} d'entre elles** seront supprimées"
+          },
+          "reminder": "Pour rappel, sans aucune action de votre part, les traces non associées sont supprimées sous {count} jours.",
+          "unassociated": "Vous avez une trace non associée. | Vous avez {count} traces non associées."
         }
       }
     },

--- a/src/features/student/views/StudentToolsTracesView/components/StudentDetailedTraceCardSettingMenu/StudentDetailedTraceCardSettingMenu.test.ts
+++ b/src/features/student/views/StudentToolsTracesView/components/StudentDetailedTraceCardSettingMenu/StudentDetailedTraceCardSettingMenu.test.ts
@@ -36,9 +36,9 @@ describe('studentDetailedTraceCardSettingMenu', () => {
     },
     TraceDeletionConfirmationModal: {
       name: 'TraceDeletionConfirmationModal',
-      props: ['trace', 'show', 'onSuccess', 'onClose'],
+      props: ['trace', 'show', 'onConfirmDelete', 'onClose'],
       template: `<div class="trace-deletion-modal" v-if="show">
-        <button class="success" @click="onSuccess()">confirm</button>
+        <button class="success" @click="onConfirmDelete()">confirm</button>
         <button class="close" @click="onClose()">close</button>
       </div>`
     }

--- a/src/features/student/views/StudentToolsTracesView/components/StudentDetailedTraceCardSettingMenu/StudentDetailedTraceCardSettingMenu.test.ts
+++ b/src/features/student/views/StudentToolsTracesView/components/StudentDetailedTraceCardSettingMenu/StudentDetailedTraceCardSettingMenu.test.ts
@@ -1,51 +1,22 @@
 import { TraceStatus, type TraceViewDTO } from '@/api/avenir-esr'
-import { BaseApiErrorCode, type BaseApiException } from '@/common/exceptions'
-import { useDeleteTraceMutation } from '@/features/student/queries'
 import StudentDetailedTraceCardSettingMenu from '@/features/student/views/StudentToolsTracesView/components/StudentDetailedTraceCardSettingMenu/StudentDetailedTraceCardSettingMenu.vue'
-import { useToasterStore } from '@/store'
 import { MDI_ICONS } from '@/ui/tokens/icons'
 import { mount, type VueWrapper } from '@vue/test-utils'
-import { beforeEach, describe, expect, it, type MockedFunction, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-vi.mock('@/features/student/queries', async (importActual) => {
-  const actual = await importActual<typeof import('@/features/student/queries')>()
-  return {
-    ...actual,
-    useDeleteTraceMutation: vi.fn()
-  }
-})
+const displayModalMock = vi.fn()
+const hideModalMock = vi.fn()
 
-vi.mock('@/store', () => {
-  return {
-    useToasterStore: vi.fn()
-  }
-})
+vi.mock('@/common/composables', () => ({
+  useModal: () => ({
+    showModal: true,
+    displayModal: displayModalMock,
+    hideModal: hideModalMock
+  })
+}))
 
 describe('studentDetailedTraceCardSettingMenu', () => {
   let wrapper: VueWrapper
-  let onErrorCallback: (error: BaseApiException) => void
-  let onSuccessCallback: () => void
-  const mockedUseDeleteTraceMutation: MockedFunction<typeof useDeleteTraceMutation> = vi.mocked(useDeleteTraceMutation)
-  const mockedUseToasterStore: MockedFunction<typeof useToasterStore> = vi.mocked(useToasterStore)
-
-  const mockMutate = vi.fn()
-  const mockIsPending = ref(false)
-  const mockAddErrorMessage = vi.fn()
-
-  const stubs = {
-    AvButton: {
-      name: 'AvButton',
-      props: ['icon', 'variant', 'size', 'theme', 'label', 'iconScale', 'disabled', 'noRadius'],
-      template: `<button 
-        class="av-button" 
-        :disabled="disabled"
-        @click="$emit('click', $event)"
-      >
-        <slot>{{ label }}</slot>
-      </button>`,
-      emits: ['click']
-    }
-  }
 
   const mockedTrace: TraceViewDTO = {
     id: 'trace1',
@@ -56,191 +27,107 @@ describe('studentDetailedTraceCardSettingMenu', () => {
     deletedAt: '2025-07-16T10:42:00.000Z'
   }
 
-  beforeEach(() => {
-    vi.clearAllMocks()
-    mockIsPending.value = false
-    setActivePinia(createPinia())
-
-    mockedUseToasterStore.mockReturnValue({
-      addErrorMessage: mockAddErrorMessage
-    } as unknown as ReturnType<typeof useToasterStore>)
-
-    mockedUseDeleteTraceMutation.mockImplementation(({ onError, onSuccess } = {}) => {
-      if (onError) {
-        onErrorCallback = onError
-      }
-      if (onSuccess) {
-        onSuccessCallback = onSuccess
-      }
-      return {
-        mutate: mockMutate,
-        isPending: mockIsPending
-      } as unknown as ReturnType<typeof useDeleteTraceMutation>
-    })
-  })
+  const stubs = {
+    AvButton: {
+      name: 'AvButton',
+      props: ['icon', 'variant', 'size', 'theme', 'label', 'iconScale', 'disabled', 'noRadius', 'onClick'],
+      emits: ['click'],
+      template: `<button class="av-button" @click="$emit('click')"><slot>{{ label }}</slot></button>`
+    },
+    TraceDeletionConfirmationModal: {
+      name: 'TraceDeletionConfirmationModal',
+      props: ['trace', 'show', 'onSuccess', 'onClose'],
+      template: `<div class="trace-deletion-modal" v-if="show">
+        <button class="success" @click="onSuccess()">confirm</button>
+        <button class="close" @click="onClose()">close</button>
+      </div>`
+    }
+  }
 
   describe('given a settings menu with show prop set to true', () => {
     beforeEach(() => {
+      vi.clearAllMocks()
+
       wrapper = mount(StudentDetailedTraceCardSettingMenu, {
         props: {
           trace: mockedTrace,
           show: true
         },
-        global: { stubs }
+        global: {
+          stubs
+        }
       })
     })
 
     describe('when the component is rendered', () => {
-      it('then the menu should be visible', () => {
+      it('then it should display the setting menu and the delete button', () => {
         expect(wrapper.find('.student-detailed-trace-card-setting-menu').exists()).toBe(true)
         expect(wrapper.find('.student-detailed-trace-card-setting-menu__item').exists()).toBe(true)
       })
 
-      it('then the delete button should have correct props', () => {
-        const deleteButton = wrapper.findComponent({ name: 'AvButton' })
-
-        expect(deleteButton.props()).toMatchObject({
-          size: 'sm',
-          theme: 'SECONDARY',
-          label: 'Supprimer ma trace',
-          iconScale: 1.3,
-          noRadius: ''
-        })
-        expect(deleteButton.props('icon')).toEqual(MDI_ICONS.TRASH_CAN_OUTLINE)
+      it('then it should display the modal when showModal is true', () => {
+        expect(wrapper.findComponent({ name: 'TraceDeletionConfirmationModal' }).exists()).toBe(true)
       })
 
-      it('then useDeleteTraceMutation should be called with onError and onSuccess callbacks', () => {
-        expect(mockedUseDeleteTraceMutation).toHaveBeenCalledWith({
-          onError: expect.any(Function),
-          onSuccess: expect.any(Function)
-        })
+      it('then it should pass the correct props to AvButton', () => {
+        const button = wrapper.findComponent({ name: 'AvButton' })
+        expect(button.props('icon')).toBe(MDI_ICONS.TRASH_CAN_OUTLINE)
+        expect(button.props('size')).toBe('sm')
       })
     })
 
-    describe('when the delete button is clicked', () => {
-      beforeEach(async () => {
-        const deleteButton = wrapper.findComponent({ name: 'AvButton' })
-        await deleteButton.trigger('click')
-      })
+    describe('when deletion modal emits success', () => {
+      it('then it should emit onTraceDelete and close', async () => {
+        await wrapper.find('.success').trigger('click')
+        await new Promise(resolve => setTimeout(resolve, 0))
 
-      it('then the onTraceDelete and close events should not be emitted immediately', () => {
-        expect(wrapper.emitted('onTraceDelete')).toBeFalsy()
-        expect(wrapper.emitted('close')).toBeFalsy()
-      })
-    })
-
-    describe('when the mutation succeeds', () => {
-      beforeEach(() => {
-        onSuccessCallback()
-      })
-
-      it('then the onTraceDelete event should be emitted with correct trace', () => {
-        expect(wrapper.emitted('onTraceDelete')).toBeTruthy()
         expect(wrapper.emitted('onTraceDelete')?.[0]).toEqual([mockedTrace])
-      })
-
-      it('then the close event should be emitted', () => {
         expect(wrapper.emitted('close')).toBeTruthy()
       })
     })
 
-    describe('when the mutation fails', () => {
-      beforeEach(() => {
-        const error: BaseApiException = {
-          message: 'Failed to delete trace',
-          name: 'DeleteTraceError',
-          status: 400,
-          code: BaseApiErrorCode.BAD_REQUEST
-        }
-
-        onErrorCallback(error)
-      })
-
-      it('then an error message should be added to toaster', () => {
-        expect(mockAddErrorMessage).toHaveBeenCalledWith({
-          title: 'Une erreur est survenue lors de la suppression de la trace.',
-          description: 'Failed to delete trace',
-          type: 'error'
+    describe('when deletion modal emits close', () => {
+      it('then it should hide the modal', async () => {
+        const localWrapper = mount(StudentDetailedTraceCardSettingMenu, {
+          props: {
+            trace: mockedTrace,
+            show: true
+          },
+          global: { stubs }
         })
-      })
 
-      it('then no events should be emitted', () => {
-        expect(wrapper.emitted('onTraceDelete')).toBeFalsy()
-        expect(wrapper.emitted('close')).toBeFalsy()
-      })
-    })
-
-    describe('when the mutation fails without error message', () => {
-      beforeEach(() => {
-        const error: BaseApiException = {
-          message: '',
-          name: 'DeleteTraceError',
-          status: 500,
-          code: BaseApiErrorCode.UNKNOWN
-        }
-
-        onErrorCallback(error)
-      })
-
-      it('then an error message should be added with empty description', () => {
-        expect(mockAddErrorMessage).toHaveBeenCalledWith({
-          title: 'Une erreur est survenue lors de la suppression de la trace.',
-          description: '',
-          type: 'error'
-        })
+        await localWrapper.find('.close').trigger('click')
+        expect(hideModalMock).toHaveBeenCalled()
       })
     })
   })
 
   describe('given a settings menu with show prop set to false', () => {
     beforeEach(() => {
+      vi.clearAllMocks()
+
       wrapper = mount(StudentDetailedTraceCardSettingMenu, {
         props: {
           trace: mockedTrace,
           show: false
         },
-        global: { stubs }
+        global: {
+          stubs
+        }
       })
     })
 
-    describe('when the component is rendered', () => {
-      it('then the menu should not be visible', () => {
+    describe('when the component is rendered with show=false', () => {
+      it('then it should not display anything', () => {
+        wrapper = mount(StudentDetailedTraceCardSettingMenu, {
+          props: {
+            trace: mockedTrace,
+            show: false
+          },
+          global: { stubs }
+        })
+
         expect(wrapper.find('.student-detailed-trace-card-setting-menu').exists()).toBe(false)
-      })
-
-      it('then the useDeleteTraceMutation should still be called during setup', () => {
-        expect(mockedUseDeleteTraceMutation).toHaveBeenCalled()
-      })
-    })
-  })
-
-  describe('given a settings menu with different trace object', () => {
-    const differentTrace: TraceViewDTO = {
-      id: 'trace2',
-      title: 'Another trace',
-      status: TraceStatus.ASSOCIATED,
-      createdAt: '2025-06-15T10:42:00.000Z',
-      updatedAt: '2025-06-16T15:18:00.000Z',
-      deletedAt: '2025-07-15T10:42:00.000Z'
-    }
-
-    beforeEach(() => {
-      wrapper = mount(StudentDetailedTraceCardSettingMenu, {
-        props: {
-          trace: differentTrace,
-          show: true
-        },
-        global: { stubs }
-      })
-    })
-
-    describe('when the mutation succeeds with different trace', () => {
-      beforeEach(() => {
-        onSuccessCallback()
-      })
-
-      it('then the onTraceDelete event should contain the different trace object', () => {
-        expect(wrapper.emitted('onTraceDelete')?.[0]).toEqual([differentTrace])
       })
     })
   })

--- a/src/features/student/views/StudentToolsTracesView/components/StudentDetailedTraceCardSettingMenu/StudentDetailedTraceCardSettingMenu.vue
+++ b/src/features/student/views/StudentToolsTracesView/components/StudentDetailedTraceCardSettingMenu/StudentDetailedTraceCardSettingMenu.vue
@@ -47,7 +47,7 @@ function onDeleteTraceSuccess () {
   <TraceDeletionConfirmationModal
     :trace="trace"
     :show="showModal"
-    :on-success="() => onDeleteTraceSuccess()"
+    :on-confirm-delete="() => onDeleteTraceSuccess()"
     :on-close="() => hideModal()"
   />
 </template>

--- a/src/features/student/views/StudentToolsTracesView/components/StudentDetailedTraceModal/StudentDetailedTraceModal.vue
+++ b/src/features/student/views/StudentToolsTracesView/components/StudentDetailedTraceModal/StudentDetailedTraceModal.vue
@@ -67,6 +67,7 @@ function useSettingsMenu () {
           :trace="trace"
           :show="showSettingsMenu"
           @close="closeSettingsMenu"
+          @on-trace-delete="onClose"
         />
       </div>
       <div class="student-detailed-trace-modal__content">

--- a/src/features/student/views/StudentToolsTracesView/components/TraceDeletionConfirmationModal/TraceDeletionConfirmationModal.test.ts
+++ b/src/features/student/views/StudentToolsTracesView/components/TraceDeletionConfirmationModal/TraceDeletionConfirmationModal.test.ts
@@ -1,0 +1,227 @@
+import { TraceStatus, type TraceViewDTO } from '@/api/avenir-esr'
+import { BaseApiErrorCode, type BaseApiException } from '@/common/exceptions'
+import { useDeleteTraceMutation } from '@/features/student/queries'
+import TraceDeletionConfirmationModal from '@/features/student/views/StudentToolsTracesView/components/TraceDeletionConfirmationModal/TraceDeletionConfirmationModal.vue'
+import { useToasterStore } from '@/store'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, type MockedFunction, vi } from 'vitest'
+
+vi.mock('@/features/student/queries', async (importActual) => {
+  const actual = await importActual<typeof import('@/features/student/queries')>()
+  return {
+    ...actual,
+    useDeleteTraceMutation: vi.fn()
+  }
+})
+
+vi.mock('@/store', () => ({
+  useToasterStore: vi.fn()
+}))
+
+describe('traceDeletionConfirmationModal', () => {
+  let wrapper: VueWrapper
+  let onSuccessMock: () => void
+  let onCloseMock: () => void
+  let onErrorCallback: (error: BaseApiException) => void
+
+  const mockedUseDeleteTraceMutation: MockedFunction<typeof useDeleteTraceMutation> = vi.mocked(useDeleteTraceMutation)
+  const mockedUseToasterStore: MockedFunction<typeof useToasterStore> = vi.mocked(useToasterStore)
+
+  const mockMutate = vi.fn()
+  const mockIsPending = ref(false)
+  const mockAddErrorMessage = vi.fn()
+
+  const mockedTrace: TraceViewDTO = {
+    id: 'trace1',
+    title: 'Ma trace',
+    status: TraceStatus.UNASSOCIATED,
+    createdAt: '2025-06-16T10:42:00.000Z',
+    updatedAt: '2025-06-17T15:18:00.000Z',
+    deletedAt: '2025-07-16T10:42:00.000Z'
+  }
+
+  const stubs = {
+    AvButton: {
+      name: 'AvButton',
+      props: ['isLoading', 'onClick'],
+      template: `
+        <button
+          data-testid="confirm-button"
+          :disabled="isLoading"
+          @click="onClick && onClick()"
+        >
+          <slot />
+        </button>
+      `
+    },
+    AvModal: {
+      name: 'AvModal',
+      props: ['opened', 'closeButtonLabel'],
+      emits: ['close'],
+      template: `
+        <div v-if="opened" data-testid="av-modal">
+          <slot name="header"></slot>
+          <div class="content-container">
+            <slot></slot>
+          </div>
+          <slot name="footer"></slot>
+        </div>
+      `
+    }
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockIsPending.value = false
+
+    onSuccessMock = vi.fn()
+    onCloseMock = vi.fn()
+
+    mockedUseToasterStore.mockReturnValue({
+      addErrorMessage: mockAddErrorMessage
+    } as unknown as ReturnType<typeof useToasterStore>)
+
+    mockedUseDeleteTraceMutation.mockImplementation(({ onError, onSuccess } = {}) => {
+      if (onError) {
+        onErrorCallback = onError
+      }
+      if (onSuccess) {
+        onSuccessMock = onSuccess
+      }
+      return {
+        mutate: mockMutate,
+        isPending: mockIsPending
+      } as unknown as ReturnType<typeof useDeleteTraceMutation>
+    })
+  })
+
+  describe('given TraceDeletionConfirmationModal with show=true', () => {
+    beforeEach(() => {
+      wrapper = mount(TraceDeletionConfirmationModal, {
+        props: {
+          trace: mockedTrace,
+          show: true,
+          onSuccess: onSuccessMock,
+          onClose: onCloseMock
+        },
+        global: { stubs }
+      })
+    })
+
+    it('then it should render the modal', () => {
+      expect(wrapper.findComponent({ name: 'AvModal' }).exists()).toBe(true)
+    })
+
+    it('then the modal close event should call onClose callback', async () => {
+      await wrapper.findComponent({ name: 'AvModal' }).vm.$emit('close')
+      expect(onCloseMock).toHaveBeenCalled()
+    })
+
+    it('then clicking confirm button should call mutate with traceId', async () => {
+      await wrapper.find('[data-testid="confirm-button"]').trigger('click')
+      expect(mockMutate).toHaveBeenCalledWith({ traceId: mockedTrace.id })
+    })
+  })
+
+  describe('given TraceDeletionConfirmationModal with show=false', () => {
+    beforeEach(() => {
+      wrapper = mount(TraceDeletionConfirmationModal, {
+        props: {
+          trace: mockedTrace,
+          show: false,
+          onSuccess: onSuccessMock,
+          onClose: onCloseMock
+        },
+        global: { stubs }
+      })
+    })
+
+    it('then it should not render modal content', () => {
+      expect(wrapper.find('.content-container').exists()).toBe(false)
+    })
+  })
+
+  describe('when the mutation fails', () => {
+    const error: BaseApiException = {
+      message: 'Failed to delete trace',
+      name: 'DeleteTraceError',
+      status: 500,
+      code: BaseApiErrorCode.UNKNOWN
+    }
+
+    beforeEach(() => {
+      wrapper = mount(TraceDeletionConfirmationModal, {
+        props: {
+          trace: mockedTrace,
+          show: true,
+          onSuccess: onSuccessMock,
+          onClose: onCloseMock
+        },
+        global: { stubs }
+      })
+      onErrorCallback(error)
+    })
+
+    it('then an error message should be added with empty description', () => {
+      expect(mockAddErrorMessage).toHaveBeenCalledWith({
+        title: 'Une erreur est survenue lors de la suppression de la trace.',
+        description: 'Failed to delete trace',
+        type: 'error'
+      })
+    })
+
+    it('then no events should be emitted', () => {
+      expect(wrapper.emitted('onTraceDelete')).toBeFalsy()
+      expect(wrapper.emitted('close')).toBeFalsy()
+    })
+  })
+
+  describe('when the mutation fails without error message', () => {
+    const error: BaseApiException = {
+      message: '',
+      name: 'DeleteTraceError',
+      status: 500,
+      code: BaseApiErrorCode.UNKNOWN
+    }
+
+    beforeEach(() => {
+      wrapper = mount(TraceDeletionConfirmationModal, {
+        props: {
+          trace: mockedTrace,
+          show: true,
+          onSuccess: onSuccessMock,
+          onClose: onCloseMock
+        },
+        global: { stubs }
+      })
+      onErrorCallback(error)
+    })
+
+    it('then an error message should be added with empty description', () => {
+      expect(mockAddErrorMessage).toHaveBeenCalledWith({
+        title: 'Une erreur est survenue lors de la suppression de la trace.',
+        description: '',
+        type: 'error'
+      })
+    })
+  })
+
+  describe('when mutation onSuccess callback is called', () => {
+    beforeEach(() => {
+      wrapper = mount(TraceDeletionConfirmationModal, {
+        props: {
+          trace: mockedTrace,
+          show: true,
+          onSuccess: onSuccessMock,
+          onClose: onCloseMock
+        },
+        global: { stubs }
+      })
+    })
+
+    it('then it should call onSuccess callback', () => {
+      onSuccessMock()
+      expect(onSuccessMock).toHaveBeenCalled()
+    })
+  })
+})

--- a/src/features/student/views/StudentToolsTracesView/components/TraceDeletionConfirmationModal/TraceDeletionConfirmationModal.test.ts
+++ b/src/features/student/views/StudentToolsTracesView/components/TraceDeletionConfirmationModal/TraceDeletionConfirmationModal.test.ts
@@ -20,7 +20,7 @@ vi.mock('@/store', () => ({
 
 describe('traceDeletionConfirmationModal', () => {
   let wrapper: VueWrapper
-  let onSuccessMock: () => void
+  let onConfirmDeleteMock: () => void
   let onCloseMock: () => void
   let onErrorCallback: (error: BaseApiException) => void
 
@@ -74,7 +74,7 @@ describe('traceDeletionConfirmationModal', () => {
     vi.clearAllMocks()
     mockIsPending.value = false
 
-    onSuccessMock = vi.fn()
+    onConfirmDeleteMock = vi.fn()
     onCloseMock = vi.fn()
 
     mockedUseToasterStore.mockReturnValue({
@@ -86,7 +86,7 @@ describe('traceDeletionConfirmationModal', () => {
         onErrorCallback = onError
       }
       if (onSuccess) {
-        onSuccessMock = onSuccess
+        onConfirmDeleteMock = onSuccess
       }
       return {
         mutate: mockMutate,
@@ -101,7 +101,7 @@ describe('traceDeletionConfirmationModal', () => {
         props: {
           trace: mockedTrace,
           show: true,
-          onSuccess: onSuccessMock,
+          onConfirmDelete: onConfirmDeleteMock,
           onClose: onCloseMock
         },
         global: { stubs }
@@ -129,7 +129,7 @@ describe('traceDeletionConfirmationModal', () => {
         props: {
           trace: mockedTrace,
           show: false,
-          onSuccess: onSuccessMock,
+          onConfirmDelete: onConfirmDeleteMock,
           onClose: onCloseMock
         },
         global: { stubs }
@@ -154,7 +154,7 @@ describe('traceDeletionConfirmationModal', () => {
         props: {
           trace: mockedTrace,
           show: true,
-          onSuccess: onSuccessMock,
+          onConfirmDelete: onConfirmDeleteMock,
           onClose: onCloseMock
         },
         global: { stubs }
@@ -189,7 +189,7 @@ describe('traceDeletionConfirmationModal', () => {
         props: {
           trace: mockedTrace,
           show: true,
-          onSuccess: onSuccessMock,
+          onConfirmDelete: onConfirmDeleteMock,
           onClose: onCloseMock
         },
         global: { stubs }
@@ -206,22 +206,22 @@ describe('traceDeletionConfirmationModal', () => {
     })
   })
 
-  describe('when mutation onSuccess callback is called', () => {
+  describe('when mutation onConfirmDelete callback is called', () => {
     beforeEach(() => {
       wrapper = mount(TraceDeletionConfirmationModal, {
         props: {
           trace: mockedTrace,
           show: true,
-          onSuccess: onSuccessMock,
+          onConfirmDelete: onConfirmDeleteMock,
           onClose: onCloseMock
         },
         global: { stubs }
       })
     })
 
-    it('then it should call onSuccess callback', () => {
-      onSuccessMock()
-      expect(onSuccessMock).toHaveBeenCalled()
+    it('then it should call onConfirmDelete callback', () => {
+      onConfirmDeleteMock()
+      expect(onConfirmDeleteMock).toHaveBeenCalled()
     })
   })
 })

--- a/src/features/student/views/StudentToolsTracesView/components/TraceDeletionConfirmationModal/TraceDeletionConfirmationModal.vue
+++ b/src/features/student/views/StudentToolsTracesView/components/TraceDeletionConfirmationModal/TraceDeletionConfirmationModal.vue
@@ -8,10 +8,10 @@ import AvIconText from '@/ui/base/AvIconText/AvIconText.vue'
 import AvModal from '@/ui/overlay/modals/AvModal/AvModal.vue'
 import { useI18n } from 'vue-i18n'
 
-const { trace, show, onSuccess, onClose } = defineProps<{
+const { trace, show, onConfirmDelete, onClose } = defineProps<{
   trace: TraceViewDTO
   show: boolean
-  onSuccess: () => void
+  onConfirmDelete: () => void
   onClose: () => void
 }>()
 
@@ -30,7 +30,7 @@ function useDeleteTrace () {
 
   const deleteTraceMutation = useDeleteTraceMutation({
     onError: onDeleteTraceError,
-    onSuccess
+    onSuccess: onConfirmDelete
   })
 
   function onConfirmDeleteTrace () {

--- a/src/features/student/views/StudentToolsTracesView/components/TraceDeletionConfirmationModal/TraceDeletionConfirmationModal.vue
+++ b/src/features/student/views/StudentToolsTracesView/components/TraceDeletionConfirmationModal/TraceDeletionConfirmationModal.vue
@@ -1,0 +1,89 @@
+<script lang="ts" setup>
+import type { TraceViewDTO } from '@/api/avenir-esr'
+import type { BaseApiException } from '@/common/exceptions'
+import { useDeleteTraceMutation } from '@/features/student/queries'
+import { useToasterStore } from '@/store'
+import { AvButton, MDI_ICONS } from '@/ui'
+import AvIconText from '@/ui/base/AvIconText/AvIconText.vue'
+import AvModal from '@/ui/overlay/modals/AvModal/AvModal.vue'
+import { useI18n } from 'vue-i18n'
+
+const { trace, show, onSuccess, onClose } = defineProps<{
+  trace: TraceViewDTO
+  show: boolean
+  onSuccess: () => void
+  onClose: () => void
+}>()
+
+const { t } = useI18n()
+const { addErrorMessage } = useToasterStore()
+const { onConfirmDeleteTrace, isDeleteTracePending } = useDeleteTrace()
+
+function useDeleteTrace () {
+  function onDeleteTraceError (error: BaseApiException) {
+    addErrorMessage({
+      title: t('student.views.studentToolsTracesView.errors.delete'),
+      description: error.message,
+      type: 'error',
+    })
+  }
+
+  const deleteTraceMutation = useDeleteTraceMutation({
+    onError: onDeleteTraceError,
+    onSuccess
+  })
+
+  function onConfirmDeleteTrace () {
+    deleteTraceMutation.mutate({ traceId: trace.id })
+  }
+
+  return {
+    onConfirmDeleteTrace,
+    isDeleteTracePending: deleteTraceMutation.isPending,
+  }
+}
+</script>
+
+<template>
+  <AvModal
+    :opened="show"
+    :close-button-label="t('global.buttons.cancel')"
+    @close="onClose"
+  >
+    <template #header>
+      <AvIconText
+        :icon="MDI_ICONS.ATTACH_FILE"
+        icon-color="var(--icon)"
+        :text="trace.title"
+        typography-class="n6"
+      />
+    </template>
+    <div class="content-container">
+      <span class="b2-bold">{{ t('student.views.studentToolsTracesView.traceDeletionConfirmationModal.description') }}</span>
+      <span class="b2-light">{{ t('student.views.studentToolsTracesView.traceDeletionConfirmationModal.subdescription') }}</span>
+    </div>
+    <template #footer>
+      <AvButton
+        variant="DEFAULT"
+        theme="PRIMARY"
+        :label="t('global.buttons.confirm')"
+        :icon="MDI_ICONS.ARROW_RIGHT"
+        :is-loading="isDeleteTracePending"
+        size="sm"
+        :on-click="() => onConfirmDeleteTrace()"
+      />
+    </template>
+  </AvModal>
+</template>
+
+<style lang="scss" scoped>
+.content-container {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
+.b2-bold, .b2-light {
+  color: var(--text2);
+}
+</style>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -9,7 +9,9 @@
       "prevPageTitle": "Last page"
     },
     "buttons": {
+      "cancel": "Cancel",
       "close": "Close",
+      "confirm": "Confirm",
       "exit": "Exit",
       "goBack": "Go back"
     },

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -9,7 +9,9 @@
       "prevPageTitle": "Page précédente"
     },
     "buttons": {
+      "cancel": "Annuler",
       "close": "Fermer",
+      "confirm": "Confirmer",
       "exit": "Quitter",
       "goBack": "Retour"
     },

--- a/src/ui/feedback/AvToaster/AvToaster.vue
+++ b/src/ui/feedback/AvToaster/AvToaster.vue
@@ -128,7 +128,7 @@ function getToasterStyleVars (type: Message['type']) {
   position: fixed;
   bottom: var(--spacing-sm);
   width: 100%;
-  z-index: 1750;
+  z-index: 9999;
 }
 
 .toasters {

--- a/src/ui/interaction/inputs/AvInput/AvInput.md
+++ b/src/ui/interaction/inputs/AvInput/AvInput.md
@@ -162,7 +162,9 @@ The component integrates focus management, proper ARIA attributes, and responsiv
       :maxlength="500"
     />
 
-    <button type="submit">Submit</button>
+    <button type="submit">
+      Submit
+    </button>
   </form>
 </template>
 ```

--- a/src/ui/overlay/modals/AvModal/AvModal.vue
+++ b/src/ui/overlay/modals/AvModal/AvModal.vue
@@ -76,7 +76,7 @@ const emit = defineEmits<{
  * @slot header - Slot for modal title.
  * @slot footer - Slot for modal footer.
  */
-defineSlots<{
+const slots = defineSlots<{
   default?: Slot
   header?: Slot
   footer?: Slot
@@ -89,30 +89,35 @@ const closeButtonVariant = computed(() => props.closeButtonVariant ?? 'DEFAULT')
 </script>
 
 <template>
-  <DsfrModal
-    v-bind="props"
-    title=""
-  >
-    <template #default>
-      <div class="av-modal__header">
-        <slot name="header" />
-      </div>
-      <slot />
-    </template>
-    <template #footer>
-      <div class="footer">
-        <AvButton
-          :icon="MDI_ICONS.CLOSE_CIRCLE_OUTLINE"
-          :label="closeButtonLabel"
-          :title="closeButtonLabel"
-          :variant="closeButtonVariant"
-          size="sm"
-          :on-click="() => emit('close')"
-        />
-        <slot name="footer" />
-      </div>
-    </template>
-  </DsfrModal>
+  <Teleport to="body">
+    <DsfrModal
+      v-bind="props"
+      title=""
+    >
+      <template #default>
+        <div
+          v-if="slots.header"
+          class="header"
+        >
+          <slot name="header" />
+        </div>
+        <slot />
+      </template>
+      <template #footer>
+        <div class="footer">
+          <AvButton
+            :icon="MDI_ICONS.CLOSE_CIRCLE_OUTLINE"
+            :label="closeButtonLabel"
+            :title="closeButtonLabel"
+            :variant="closeButtonVariant"
+            size="sm"
+            :on-click="() => emit('close')"
+          />
+          <slot name="footer" />
+        </div>
+      </template>
+    </DsfrModal>
+  </Teleport>
 </template>
 
 <style lang="scss" scoped>
@@ -122,8 +127,16 @@ const closeButtonVariant = computed(() => props.closeButtonVariant ?? 'DEFAULT')
   background: var(--dialog) !important;
 }
 
+:deep(.fr-modal__body) {
+  border-radius: var(--radius-lg) !important;
+}
+
 :deep(.fr-btn--close) {
   display: none !important;
+}
+
+.header {
+  padding-bottom: var(--spacing-md);
 }
 
 .footer {

--- a/src/ui/tokens/icons.ts
+++ b/src/ui/tokens/icons.ts
@@ -3,6 +3,7 @@ export const MDI_ICONS = {
   ALERT_CIRCLE_OUTLINE: 'mdi:alert-circle-outline',
   ARROW_DECISION: 'mdi:arrow-decision',
   ARROW_LEFT_THIN: 'mdi:arrow-left-thin',
+  ARROW_RIGHT: 'mdi:arrow-right',
   ARROW_RIGHT_THIN: 'mdi:arrow-right-thin',
   ARROW_TOP_RIGHT_THICK: 'mdi:arrow-top-right-thick',
   ATTACHMENT_PLUS: 'mdi:attachment-plus',


### PR DESCRIPTION
---

## 📝 Pull Request Description

### Brief description of changes applied
> _Describe the changes introduced by this pull request._

- :sparkles: add TraceDeletionConfirmationModal
- :recycle: add Teleport to body in AvModal to prevent strange behaviour when piling modals and popovers
- :recycle: increase AvToaster z-index to display it above modals
- :lipstick: add radius to modals and padding under header slot
- :speech_balloon: update translations
- :bug: fix lint in AvInput.md
- :bento: add icons

---

### Reference to an Issue, Feature, Task, User Story or another PR
> _Mention related issue numbers or links (e.g. Closes #123, Implements #456)._

- closes https://github.com/avenirs-esr/AVENIRS-Project/issues/373

---

### Target Branch
> _Which branch is this PR targeting (e.g. `main`, `develop`)?_

- develop

---

### Additional Notes
> _Include any relevant context, technical details, or reasons behind certain decisions._

#### Demo

[Capture vidéo du 2025-07-21 15-33-45.webm](https://github.com/user-attachments/assets/df4232ca-11f1-44e5-94e1-b69e153a0845)

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [ ] No unnecessary code (e.g., debug logs, commented code)
- [ ] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and detaiils for the update process

---

# Remember

**DO NOT** keep this template as is when you submit. Please remove or adjust the description when you submit your pull request.

Please do not submit a pull request to ask questions.

Do not submit pull requests without tests that verify or reproduce your intended use case. The pull request will
most likely be automatically closed immediately, unless the change is extremely trivial. 

