### PR TITLE
feat(439): use StudentLastCompletedLevelBadge component

### DIFF
--- a/src/__mocks__/fixtures/student/program-progress.fixtures.ts
+++ b/src/__mocks__/fixtures/student/program-progress.fixtures.ts
@@ -1,4 +1,20 @@
-import { SkillLevelStatus, type StudentProgressOverviewDTO, type StudentProgressViewDTO, TrainingPathDTODurationUnit } from '@/api/avenir-esr'
+import {
+  SkillLevelStatus,
+  type SkillLevelViewDTO,
+  type StudentProgressOverviewDTO,
+  type StudentProgressViewDTO,
+  TrainingPathDTODurationUnit
+} from '@/api/avenir-esr'
+
+function getMockedAchievedSkillLevels (currentLevel: SkillLevelViewDTO) {
+  const isLevelOne = currentLevel.name.includes('Niveau 1')
+  return !isLevelOne
+    ? {
+        ...currentLevel,
+        status: [SkillLevelStatus.VALIDATED, SkillLevelStatus.FAILED][Math.floor(Math.random() * 2)],
+      }
+    : undefined
+}
 
 export const mockedProgramsProgressOverview: StudentProgressOverviewDTO[] = [
   {
@@ -99,6 +115,10 @@ export const mockedProgramsProgressView: StudentProgressViewDTO[] = mockedProgra
       'skill-2-4': 'Formuler précisément les besoins utilisateurs et les traduire en exigences techniques',
     }[skill.id] ?? `Description courte de ${currentLevel.name}`
 
+    const currentSkillLevel = {
+      ...currentLevel,
+      shortDescription,
+    }
     return {
       id: skill.id,
       name: skill.name,
@@ -106,10 +126,8 @@ export const mockedProgramsProgressView: StudentProgressViewDTO[] = mockedProgra
       activityCount: skill.activityCount,
       isProgramFinished: false,
       levelCount,
-      currentSkillLevel: {
-        ...currentLevel,
-        shortDescription,
-      },
+      currentSkillLevel,
+      achievedSkillLevels: getMockedAchievedSkillLevels(currentSkillLevel)
     }
   }),
 }))

--- a/src/features/student/components/badges/index.ts
+++ b/src/features/student/components/badges/index.ts
@@ -1,2 +1,3 @@
 export { default as StudentAmsStatusBadge } from './StudentAmsStatusBadge/StudentAmsStatusBadge.vue'
+export { default as StudentLastCompletedLevelBadge } from './StudentLastCompletedLevelBadge/StudentLastCompletedLevelBadge.vue'
 export { default as StudentLevelBadge } from './StudentLevelBadge/StudentLevelBadge.vue'

--- a/src/features/student/components/cards/StudentDetailedEducationalSkillCard/StudentDetailedEducationalSkillCard.test.ts
+++ b/src/features/student/components/cards/StudentDetailedEducationalSkillCard/StudentDetailedEducationalSkillCard.test.ts
@@ -15,6 +15,12 @@ const baseSkill: SkillDTO = {
     name: 'Niveau 1',
     status: SkillLevelStatus.TO_BE_EVALUATED,
     shortDescription: 'Une description courte'
+  },
+  achievedSkillLevels: {
+    id: 'level-0',
+    name: 'Niveau 0',
+    shortDescription: 'Niveau 0 description',
+    status: SkillLevelStatus.VALIDATED
   }
 }
 
@@ -52,6 +58,11 @@ function createWrapper (skill: SkillDTO = baseSkill) {
           name: 'AvBadge',
           props: ['label', 'color', 'backgroundColor', 'iconPath', 'small', 'ellipsis'],
           template: `<div class="badge">{{ label }}</div>`
+        },
+        StudentLastCompletedLevelBadge: {
+          name: 'StudentLastCompletedLevelBadge',
+          props: ['level'],
+          template: `<div class="last-completed-badge">{{ level.name }}</div>`
         }
       }
     }
@@ -104,6 +115,19 @@ describe('given a student detailed educationnal skill card with valid props', ()
       const skill = { ...baseSkill, currentSkillLevel: { ...baseSkill.currentSkillLevel, status: SkillLevelStatus.VALIDATED } }
       wrapper = createWrapper(skill)
       const badge = wrapper.find('.student-level-badge')
+      expect(badge.exists()).toBe(false)
+    })
+
+    it('then it should render the StudentLastCompletedLevelBadge when achievedSkillLevels is present', () => {
+      const badge = wrapper.find('.last-completed-badge')
+      expect(badge.exists()).toBe(true)
+      expect(badge.text()).toContain('Niveau 0')
+    })
+
+    it('then it should not render the StudentLastCompletedLevelBadge when achievedSkillLevels is undefined', () => {
+      const skill = { ...baseSkill, achievedSkillLevels: undefined }
+      wrapper = createWrapper(skill)
+      const badge = wrapper.find('.last-completed-badge')
       expect(badge.exists()).toBe(false)
     })
   })

--- a/src/features/student/components/cards/StudentDetailedEducationalSkillCard/StudentDetailedEducationalSkillCard.vue
+++ b/src/features/student/components/cards/StudentDetailedEducationalSkillCard/StudentDetailedEducationalSkillCard.vue
@@ -1,15 +1,16 @@
 <script lang="ts" setup>
-import { type SkillDTO, SkillLevelStatus } from '@/api/avenir-esr'
-import { StudentCountAmsIconText, StudentCountTracesIconText, StudentLevelBadge } from '@/features/student/components/'
+import type { ComputedRef } from 'vue'
+import { type SkillDTO, SkillLevelStatus, type SkillLevelViewDTO } from '@/api/avenir-esr'
+import { StudentCountAmsIconText, StudentCountTracesIconText, StudentLastCompletedLevelBadge, StudentLevelBadge } from '@/features/student/components/'
 import { StudentDetailedSkillCard } from '@/features/student/components/cards'
 import { AvBadge, MDI_ICONS } from '@/ui'
 
-export interface StudentDetailedEducationaSkillCardProps {
+export interface StudentDetailedEducationalSkillCardProps {
   skill: SkillDTO
   skillColor: string
 }
 
-const { skill, skillColor } = defineProps<StudentDetailedEducationaSkillCardProps>()
+const { skill, skillColor } = defineProps<StudentDetailedEducationalSkillCardProps>()
 const { traceCount, activityCount, levelCount, currentSkillLevel } = skill
 
 const showLevelBadge = computed((): boolean => {
@@ -19,6 +20,8 @@ const showLevelBadge = computed((): boolean => {
   ]
   return badgeVisibleStatuses.includes(currentSkillLevel.status)
 })
+
+const lastAchievedSkillLevel: ComputedRef< SkillLevelViewDTO | undefined> = computed(() => skill.achievedSkillLevels)
 const basePath = import.meta.env.BASE_URL
 </script>
 
@@ -46,6 +49,10 @@ const basePath = import.meta.env.BASE_URL
             :icon-path="`${basePath}assets/icons/text-box-check-outline.svg`"
             small
             ellipsis
+          />
+          <StudentLastCompletedLevelBadge
+            v-if="lastAchievedSkillLevel"
+            :level="lastAchievedSkillLevel"
           />
         </div>
       </div>


### PR DESCRIPTION
 This PR implements the integration of a new badge component `StudentLastCompletedLevelBadge` that displays the status of the last completed skill
  level within educational skill cards. The component shows validated or failed skill levels with appropriate styling and icons.

<img width="1359" height="504" alt="image" src="https://github.com/user-attachments/assets/2edfc61c-70f9-4b19-a9b9-9a57637c349d" />

  ---

  ### Reference to an Issue, Feature, Task, User Story or another PR
  Closes [#439](https://github.com/avenirs-esr/AVENIRS-Project/issues/439) - [FE] Intégrer le composant StudentLastCompletedLevelBadge dans StudentDetailedEducationalSkillCard
  Closes [#440 ](https://github.com/avenirs-esr/AVENIRS-Project/issues/440)- [FE] Récupérer la donnée depuis le back correspondant au dernier niveau complété (validé ou échoué)

  ---

  ### Documentation
  - Added comprehensive unit tests for the new `StudentLastCompletedLevelBadge` component
  - Updated existing unit tests for `StudentDetailedEducationalSkillCard` to include the new badge functionality
  - Component follows existing architecture patterns and design system conventions

  ---

  ### Target Branch
  This PR is targeting the `develop` branch.

  ---

  ### Additional Notes
  The implementation includes:
  - A new reusable badge component that displays skill level completion status
  - Integration within the educational skill card to show the last achieved level
  - Conditional rendering based on the presence of `achievedSkillLevels` data

  The component displays:
  - "Niveau X Validé" with green styling and check icon for validated levels
  - "Niveau X Non validé" with red styling and close icon for failed levels
  - No badge rendered for levels that are neither validated nor failed

  ---

  ## ✅ Checklist

  Please make sure you have addressed the following before submitting:

  - [x] a11y tested (if the PR includes frontend changes)
  - [x] Tests provided (including unit and integration tests for both frontend and backend)
  - [x] i18n handled (texts are translated)
  - [ ] Performance tests
  - [x] No unnecessary code (e.g., debug logs, commented code)
  - [x] Code style and formatting rules respected (linting, conventions, etc.)
  - [ ] Semantic Versioning respected
  - [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process