### PR TITLE
fix(layout): fix global layout to match figma designs

### DIFF
--- a/src/features/student/layouts/StudentLayout/StudentLayout.vue
+++ b/src/features/student/layouts/StudentLayout/StudentLayout.vue
@@ -59,7 +59,7 @@ defineExpose({ searchQuery })
   </AvHeader>
 
   <main>
-    <div class="fr-container  fr-mt-3w  fr-mt-md-5w  fr-mb-5w">
+    <div class="container fr-mt-3w  fr-mt-md-5w  fr-mb-5w">
       <router-view />
     </div>
   </main>
@@ -81,5 +81,12 @@ defineExpose({ searchQuery })
 
 :deep(.fr-btns-group .fr-btn) {
   margin-bottom: var(--spacing-none);
+}
+
+.container {
+  max-width: 90rem;
+  margin: 0 auto;
+  padding-left: 1rem;
+  padding-right: 1rem;
 }
 </style>


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
Fix global layout to match the Figma design.  

We were using a DSFR container that enforced a maximum width too small to match the Figma designs. As a result, the container could only hold 2 cards instead of 3.  

#### Proposal
Use a custom container in order to better align with the expected design.  

#### Figma Design:
<img width="989" height="726" alt="Screenshot 2025-08-25 at 16 20 28" src="https://github.com/user-attachments/assets/1364335a-7836-497a-aa33-2593348d9ecf" />

#### What we had before: 
<img width="1500" height="857" alt="Screenshot 2025-08-25 at 16 12 36" src="https://github.com/user-attachments/assets/d0ce9a72-c44d-421a-8baf-38a0027cf975" />

#### What we have after the fix: 
<img width="1504" height="853" alt="Screenshot 2025-08-25 at 16 12 48" src="https://github.com/user-attachments/assets/051e8ec7-f45a-490d-94e1-c8450931e71d" />
---

### Target Branch
develop

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [ ] No unnecessary code (e.g., debug logs, commented code)
- [ ] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and detaiils for the update process
