### PR TITLE
feat(550): make AvUploadFile component support deletion

### DIFF
--- a/api-specs/avenir-esr.swagger.json
+++ b/api-specs/avenir-esr.swagger.json
@@ -1246,6 +1246,24 @@
           "label"
         ]
       },
+      "PictureDTO": {
+        "type": "object",
+        "properties": {
+          "fileId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "fileName": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "url"
+        ]
+      },
       "ProfileOverviewDTO": {
         "type": "object",
         "properties": {
@@ -1262,10 +1280,10 @@
             "type": "string"
           },
           "profilePicture": {
-            "type": "string"
+            "$ref": "#/components/schemas/PictureDTO"
           },
           "coverPicture": {
-            "type": "string"
+            "$ref": "#/components/schemas/PictureDTO"
           }
         },
         "required": [

--- a/src/__mocks__/fixtures/student/overviews.fixtures.ts
+++ b/src/__mocks__/fixtures/student/overviews.fixtures.ts
@@ -13,8 +13,16 @@ export const mockedProfileOverview: ProfileOverviewDTO = {
   firstname: 'Jeanne',
   lastname: 'Moulin',
   email: 'j.moulin@example.com',
-  profilePicture: profile_picture_placeholder,
-  coverPicture: profile_banner_placeholder,
+  profilePicture: {
+    fileId: undefined,
+    fileName: undefined,
+    url: profile_picture_placeholder,
+  },
+  coverPicture: {
+    fileId: undefined,
+    fileName: undefined,
+    url: profile_banner_placeholder,
+  },
   bio: 'Je suis étudiante en chimie et écologie. Passionnée par l’innovation durable, je souhaite utiliser la science pour protéger l’environnement et bâtir un avenir plus respectueux de la planète.'
 }
 

--- a/src/common/components/ImageUpload/ImageUpload.test.ts
+++ b/src/common/components/ImageUpload/ImageUpload.test.ts
@@ -11,14 +11,15 @@ vi.mock('@/common/composables', () => ({
     error,
     valid,
     name: { value: 'test.jpg' },
-    previewUrl: { value: undefined }
+    previewUrl: { value: 'exemple.com/image.png' }
   })
 }))
 
 function createWrapper (props = {}) {
   return mount<typeof ImageUpload>(ImageUpload, {
     props: {
-      defaultImage: 'default.jpg',
+      defaultImageName: 'default.jpg',
+      defaultImageLink: 'exemple.com/image.png',
       imageAlt: 'alt text',
       onUpdate: vi.fn(),
       ...props
@@ -81,7 +82,7 @@ describe('imageUpload', () => {
       it('then it should render the default image with correct alt', () => {
         const img = wrapper.find('img')
         expect(img.exists()).toBe(true)
-        expect(img.attributes('src')).toBe('default.jpg')
+        expect(img.attributes('src')).toBe('exemple.com/image.png')
         expect(img.attributes('alt')).toBe('alt text')
       })
     })

--- a/src/common/components/ImageUpload/ImageUpload.vue
+++ b/src/common/components/ImageUpload/ImageUpload.vue
@@ -8,9 +8,14 @@ import { useI18n } from 'vue-i18n'
  */
 interface ImageUploadProps {
   /**
-   * Default image displayed in the left part of the file upload (before any upload)
+   * Default image name displayed in the left part of the file upload (before any upload)
    */
-  defaultImage: string
+  defaultImageName?: string
+
+  /**
+   * Default image link displayed in the left part of the file upload (before any upload)
+   */
+  defaultImageUrl?: string
 
   /**
    * Alt text for the image
@@ -22,9 +27,15 @@ interface ImageUploadProps {
    * @param file
    */
   onUpdate: (file: File) => void
+
+  /**
+   * Method executed on delete image button click.
+   * @default undefined
+   */
+  onDeleteImage?: () => void
 }
 
-const { defaultImage, imageAlt, onUpdate } = defineProps<ImageUploadProps>()
+const { defaultImageName, imageAlt, onUpdate } = defineProps<ImageUploadProps>()
 
 const { t } = useI18n()
 const imageUpload = useImageUpload()
@@ -41,7 +52,7 @@ const describedBy = computed(() => {
 })
 
 /**
- * Method exectuted on file update
+ * Method executed on file update
  * We only keep the first file if a list is provided
  * @param files
  */
@@ -51,40 +62,45 @@ async function onUpdateImage (files: FileList) {
     onUpdate(files[0])
   }
 }
+const modelValue = defineModel<File | null>()
 </script>
 
 <template>
   <AvFileUpload
+    v-model:error="imageUpload.error.value"
+    v-model:valid-message="imageUpload.valid.value"
+    :title="t('global.information.fileUpload.title')"
+    :description="t('global.information.fileUpload.dragAndDrop')"
+    :delete-button-label="t('global.buttons.delete')"
+    :model-value="modelValue"
+    :file-name="defaultImageName"
     :aria-describedby="describedBy"
-    :error="imageUpload.error.value"
-    :valid-message="imageUpload.valid.value"
     :accept="ACCEPTED_FILE_TYPES"
+    :on-delete-file="onDeleteImage"
+    @update:model-value="(value) => modelValue = value"
     @change="onUpdateImage"
     @on-drop-accept-type-error="() => { imageUpload.error.value = t('global.error.file.acceptType') }"
   >
-    <template #left>
+    <template
+      v-if="defaultImageName || imageUpload.previewUrl.value"
+      #left
+    >
       <img
-        :src="imageUpload.previewUrl.value ?? defaultImage"
+        :src="defaultImageUrl ?? imageUpload.previewUrl.value!"
         :alt="imageAlt"
       >
     </template>
-    <span class="b2-bold">{{ imageUpload.name.value }}</span>
-    <template #hint>
-      <span
-        :id="hintId"
-        class="caption-light"
-      >
-        {{ t('global.information.imageUpload.filesIndication') }}
-        <span class="caption-bold">
-          {{ t('global.information.imageUpload.filesTypes') }}
-        </span>
-        {{ t('global.information.imageUpload.sizeIndication') }}
-        <span class="caption-bold">
-          {{ t('global.information.imageUpload.size') }}
-        </span>
-      </span>
-    </template>
   </AvFileUpload>
+  <span class="caption-light">
+    {{ t('global.information.fileUpload.filesIndication') }}
+    <span class="caption-bold">
+      {{ t('global.information.fileUpload.filesTypes') }}
+    </span>
+    {{ t('global.information.fileUpload.sizeIndication') }}
+    <span class="caption-bold">
+      {{ t('global.information.fileUpload.size') }}
+    </span>
+  </span>
   <template v-if="imageUpload.error.value">
     <span
       :id="errorId"
@@ -108,5 +124,28 @@ img {
   height: 100%;
   width: 100%;
   object-fit: cover;
+}
+
+.file-upload-container {
+  border: 1px solid var(--divider);
+  border-radius: var(--radius-lg);
+  padding: var(--spacing-xs);
+}
+
+.left-content-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: var(--dimension-4xl);
+  width: var(--dimension-4xl);
+  overflow: hidden;
+  border-radius: var(--radius-md);
+}
+
+.file-upload-content {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: var(--spacing-xs);
 }
 </style>

--- a/src/common/composables/use-image-upload/use-image-upload.ts
+++ b/src/common/composables/use-image-upload/use-image-upload.ts
@@ -31,6 +31,7 @@ export function useImageUpload () {
   async function update (files: FileList) {
     const file = files[0]
     if (!file) {
+      clear()
       return
     }
 

--- a/src/features/student/components/widgets/StudentOverviewWidget/StudentOverviewWidget.test.ts
+++ b/src/features/student/components/widgets/StudentOverviewWidget/StudentOverviewWidget.test.ts
@@ -77,8 +77,16 @@ describe('studentOverviewWidget', () => {
     firstname: 'Jeanne',
     lastname: 'Moulin',
     email: 'j.moulin@example.com',
-    profilePicture: profile_picture_placeholder,
-    coverPicture: profile_banner_placeholder,
+    profilePicture: {
+      id: null,
+      name: null,
+      url: profile_picture_placeholder,
+    },
+    coverPicture: {
+      id: null,
+      name: null,
+      url: profile_banner_placeholder,
+    },
     bio: 'Je suis étudiante en chimie et écologie. Passionnée par l’innovation durable, je souhaite utiliser la science pour protéger l’environnement et bâtir un avenir plus respectueux de la planète.'
   }
 
@@ -110,8 +118,8 @@ describe('studentOverviewWidget', () => {
 
       it('then it should show profile and cover images with correct src', async () => {
         const images = wrapper.findAll('img')
-        expect(images[0].attributes('src')).toBe(studentSummary.coverPicture)
-        expect(images[1].attributes('src')).toBe(studentSummary.profilePicture)
+        expect(images[0].attributes('src')).toBe(studentSummary.coverPicture.url)
+        expect(images[1].attributes('src')).toBe(studentSummary.profilePicture.url)
       })
 
       it('then it should emit click on AvRichButtons', async () => {

--- a/src/features/student/components/widgets/StudentOverviewWidget/StudentOverviewWidget.vue
+++ b/src/features/student/components/widgets/StudentOverviewWidget/StudentOverviewWidget.vue
@@ -31,7 +31,7 @@ defineExpose({ fullName })
     <template #title>
       <div class="student-overview-widget__title">
         <img
-          :src="studentSummary.coverPicture"
+          :src="studentSummary.coverPicture.url"
           :alt="t('student.widgets.overview.bannerAlt')"
           class="student-overview-widget__banner"
         >
@@ -39,7 +39,7 @@ defineExpose({ fullName })
           class="student-overview-widget__icon"
         >
           <img
-            :src="studentSummary.profilePicture"
+            :src="studentSummary.profilePicture.url"
             :alt="t('student.widgets.overview.pictureAlt')"
             class="student-overview-widget__picture"
           >

--- a/src/features/student/components/widgets/StudentOverviewWidget/components/UpdateProfileDrawer/UpdateProfileDrawer.test.ts
+++ b/src/features/student/components/widgets/StudentOverviewWidget/components/UpdateProfileDrawer/UpdateProfileDrawer.test.ts
@@ -1,9 +1,10 @@
-import type { UpdateProfileDrawerForm } from '@/features/student/components/widgets/StudentOverviewWidget/components/UpdateProfileDrawer/types'
+import type { PictureDTO, ProfileOverviewDTO } from '@/api/avenir-esr'
 import type { SetupContext } from 'vue'
 import profile_banner_placeholder from '@/assets/profile_banner_placeholder.png'
 import profile_picture_placeholder from '@/assets/profile_picture_placeholder.png'
 import UpdateProfileDrawer from '@/features/student/components/widgets/StudentOverviewWidget/components/UpdateProfileDrawer/UpdateProfileDrawer.vue'
 import { useUpdateProfileForm } from '@/features/student/components/widgets/StudentOverviewWidget/components/UpdateProfileDrawer/use-update-profile-form'
+import { QueryClient, VueQueryPlugin } from '@tanstack/vue-query'
 import { mount, type VueWrapper } from '@vue/test-utils'
 import { createPinia } from 'pinia'
 import { mockAddErrorMessage, mockAddSuccessMessage } from 'tests/mocks'
@@ -92,8 +93,16 @@ describe('updateProfileDrawer', () => {
     firstname: 'Jeanne',
     lastname: 'Moulin',
     email: 'j.moulin@example.com',
-    profilePicture: profile_picture_placeholder,
-    coverPicture: profile_banner_placeholder,
+    profilePicture: {
+      fileId: undefined,
+      fileName: undefined,
+      url: profile_picture_placeholder
+    },
+    coverPicture: {
+      fileId: undefined,
+      fileName: undefined,
+      url: profile_banner_placeholder
+    },
     bio: 'Je suis étudiante en chimie et écologie. Passionnée par l’innovation durable, je souhaite utiliser la science pour protéger l’environnement et bâtir un avenir plus respectueux de la planète.'
   }
 
@@ -105,7 +114,7 @@ describe('updateProfileDrawer', () => {
     onClose: mockOnClose
   }
 
-  const fakeField = (initialValues: UpdateProfileDrawerForm) => {
+  const fakeField = (initialValues: ProfileOverviewDTO) => {
     return {
       props: ['name'],
       setup (props: Record<string, string>, context: SetupContext) {
@@ -154,7 +163,7 @@ describe('updateProfileDrawer', () => {
     }
   }
 
-  const store: Record<string, { value: string }> = {
+  const store: Record<string, { value: string | PictureDTO }> = {
     lastname: ref(studentSummary.lastname),
     firstname: ref(studentSummary.firstname),
     email: ref(studentSummary.email),
@@ -181,11 +190,11 @@ describe('updateProfileDrawer', () => {
     lastname: '',
     email: '',
     bio: '',
-    profilePicture: '',
-    coverPicture: ''
+    profilePicture: { fileId: undefined, fileName: undefined, url: '' },
+    coverPicture: { fileId: undefined, fileName: undefined, url: '' }
   }
 
-  const storeWithMissingFields: Record<string, { value: string }> = {
+  const storeWithMissingFields: Record<string, { value: string | PictureDTO }> = {
     lastname: ref(studentSummaryWithMissingFields.lastname),
     firstname: ref(studentSummaryWithMissingFields.firstname),
     email: ref(studentSummaryWithMissingFields.email),
@@ -219,13 +228,18 @@ describe('updateProfileDrawer', () => {
       onProfilePictureUpdate: vi.fn(),
       onUpdateProfileCoverSuccess: vi.fn(),
       onUpdateProfilePhotoSuccess: vi.fn(),
+      coverPictureFile: ref<File | null>(null),
+      profilePictureFile: ref<File | null>(null),
     }))
 
     wrapper = mount(UpdateProfileDrawer, {
       props: defaultProps,
       global: {
         stubs,
-        plugins: [createPinia()],
+        plugins: [
+          createPinia(),
+          [VueQueryPlugin, { queryClient: new QueryClient() }]
+        ],
       },
     })
   })
@@ -278,11 +292,16 @@ describe('updateProfileDrawer', () => {
           onProfilePictureUpdate: vi.fn(),
           onUpdateProfileCoverSuccess: vi.fn(),
           onUpdateProfilePhotoSuccess: vi.fn(),
+          coverPictureFile: ref<File | null>(null),
+          profilePictureFile: ref<File | null>(null),
         }))
 
         wrapper = mount(UpdateProfileDrawer, {
           props: { ...defaultProps, studentSummary: studentSummaryWithMissingFields },
-          global: { stubs, plugins: [createPinia()] }
+          global: { stubs, plugins: [
+            createPinia(),
+            [VueQueryPlugin, { queryClient: new QueryClient() }]
+          ], }
         })
       })
 
@@ -320,14 +339,16 @@ describe('updateProfileDrawer', () => {
           onProfilePictureUpdate: vi.fn(),
           onUpdateProfileCoverSuccess: vi.fn(),
           onUpdateProfilePhotoSuccess: vi.fn(),
+          coverPictureFile: ref<File | null>(null),
+          profilePictureFile: ref<File | null>(null),
         }))
 
         wrapper = mount(UpdateProfileDrawer, {
           props: defaultProps,
-          global: {
-            stubs,
-            plugins: [createPinia()],
-          },
+          global: { stubs, plugins: [
+            createPinia(),
+            [VueQueryPlugin, { queryClient: new QueryClient() }]
+          ], }
         })
       })
 
@@ -351,6 +372,8 @@ describe('updateProfileDrawer', () => {
           onProfilePictureUpdate: vi.fn(),
           onUpdateProfileCoverSuccess: vi.fn(),
           onUpdateProfilePhotoSuccess: vi.fn(),
+          coverPictureFile: ref<File | null>(null),
+          profilePictureFile: ref<File | null>(null),
         }))
       })
 
@@ -421,6 +444,8 @@ describe('updateProfileDrawer', () => {
             onProfilePictureUpdate: vi.fn(),
             onUpdateProfileCoverSuccess: vi.fn(),
             onUpdateProfilePhotoSuccess: vi.fn(),
+            coverPictureFile: ref<File | null>(null),
+            profilePictureFile: ref<File | null>(null),
             simulateSuccess: () => {
               onSuccess()
             }
@@ -431,10 +456,10 @@ describe('updateProfileDrawer', () => {
 
         wrapper = mount(UpdateProfileDrawer, {
           props: defaultProps,
-          global: {
-            stubs,
-            plugins: [createPinia()],
-          },
+          global: { stubs, plugins: [
+            createPinia(),
+            [VueQueryPlugin, { queryClient: new QueryClient() }]
+          ], }
         })
 
         useUpdateProfileFormReturn.simulateSuccess()

--- a/src/features/student/components/widgets/StudentOverviewWidget/components/UpdateProfileDrawer/UpdateProfileDrawer.vue
+++ b/src/features/student/components/widgets/StudentOverviewWidget/components/UpdateProfileDrawer/UpdateProfileDrawer.vue
@@ -1,19 +1,16 @@
 <script setup lang="ts">
 import type { ProfileOverviewDTO } from '@/api/avenir-esr'
+import type { BaseApiException } from '@/common/exceptions'
 import { ImageUpload } from '@/common/components'
 import { useModal } from '@/common/composables'
-import UpdateExitConfirmationModal from '@/features/student/components/widgets/StudentOverviewWidget/components/UpdateExitConfirmationModal/UpdateExitConfirmationModal.vue'
-import { useUpdateProfileForm } from '@/features/student/components/widgets/StudentOverviewWidget/components/UpdateProfileDrawer/use-update-profile-form'
-import { useToasterStore } from '@/store'
+import UpdateExitConfirmationModal
+  from '@/features/student/components/widgets/StudentOverviewWidget/components/UpdateExitConfirmationModal/UpdateExitConfirmationModal.vue'
 import {
-  AvAccordion,
-  AvAccordionsGroup,
-  AvButton,
-  AvDrawer,
-  AvIconText,
-  AvInput,
-  MDI_ICONS
-} from '@/ui'
+  useUpdateProfileForm
+} from '@/features/student/components/widgets/StudentOverviewWidget/components/UpdateProfileDrawer/use-update-profile-form'
+import { useDeletePhotoMutation } from '@/features/student/queries'
+import { useToasterStore } from '@/store'
+import { AvAccordion, AvAccordionsGroup, AvButton, AvDrawer, AvIconText, AvInput, MDI_ICONS } from '@/ui'
 import { useI18n } from 'vue-i18n'
 
 const { studentSummary, show, onClose } = defineProps<{
@@ -24,19 +21,57 @@ const { studentSummary, show, onClose } = defineProps<{
 
 const { t } = useI18n()
 const { showModal, displayModal, hideModal } = useModal()
-const { addSuccessMessage } = useToasterStore()
+const { addSuccessMessage, addErrorMessage } = useToasterStore()
 const {
   form,
   isPending,
   isModified,
+  coverPictureFile,
   onCoverPictureUpdate,
+  profilePictureFile,
   onProfilePictureUpdate,
   resetForm
 } = useUpdateProfileForm(studentSummary, onUpdateProfileSuccess)
+const { onConfirmDeleteCoverPhoto } = useDeleteCoverPhoto()
+const { onConfirmDeleteProfilePhoto } = useDeleteProfilePhoto()
 
 function onUpdateProfileSuccess () {
   addSuccessMessage(t('student.widgets.overview.updateProfileDrawer.onUpdate.success'))
   onClose()
+}
+
+function useDeleteCoverPhoto () {
+  function onDeleteCoverPhotoError (error: BaseApiException) {
+    addErrorMessage({ title: t('student.widgets.overview.updateProfileDrawer.onDelete.error'), description: error.message, type: 'error', })
+  }
+
+  const { mutate: deletePhotoMutation } = useDeletePhotoMutation({
+    onError: onDeleteCoverPhotoError,
+    onSuccess: onConfirmDeleteCoverPhoto
+  })
+
+  function onConfirmDeleteCoverPhoto () {
+    deletePhotoMutation({ fileId: studentSummary.coverPicture.fileId! })
+  }
+
+  return { onConfirmDeleteCoverPhoto }
+}
+
+function useDeleteProfilePhoto () {
+  function onDeleteProfilePhotoError (error: BaseApiException) {
+    addErrorMessage({ title: t('student.widgets.overview.updateProfileDrawer.onDelete.error'), description: error.message, type: 'error', })
+  }
+
+  const { mutate: deletePhotoMutation } = useDeletePhotoMutation({
+    onError: onDeleteProfilePhotoError,
+    onSuccess: onConfirmDeleteProfilePhoto
+  })
+
+  function onConfirmDeleteProfilePhoto () {
+    deletePhotoMutation({ fileId: studentSummary.profilePicture.fileId! })
+  }
+
+  return { onConfirmDeleteProfilePhoto }
 }
 
 watch(() => show, (newVal) => {
@@ -122,7 +157,10 @@ watch(() => show, (newVal) => {
             :icon="MDI_ICONS.IMAGE_OUTLINE"
           >
             <ImageUpload
-              :default-image="studentSummary.coverPicture"
+              v-model="coverPictureFile"
+              :on-delete-image="onConfirmDeleteCoverPhoto"
+              :default-image-url="studentSummary.coverPicture.fileName ? studentSummary.coverPicture.url : undefined"
+              :default-image-name="studentSummary.coverPicture.fileName ?? undefined"
               :image-alt="t('student.widgets.overview.updateProfileDrawer.pictures.banner')"
               :on-update="onCoverPictureUpdate"
             />
@@ -132,7 +170,9 @@ watch(() => show, (newVal) => {
             :icon="MDI_ICONS.IMAGE_OUTLINE"
           >
             <ImageUpload
-              :default-image="studentSummary.profilePicture"
+              v-model="profilePictureFile"
+              :on-delete-image="onConfirmDeleteProfilePhoto"
+              :default-image-name="studentSummary.profilePicture.fileName ?? undefined"
               :image-alt="t('student.widgets.overview.updateProfileDrawer.pictures.picture')"
               :on-update="onProfilePictureUpdate"
             />

--- a/src/features/student/components/widgets/StudentOverviewWidget/components/UpdateProfileDrawer/types.ts
+++ b/src/features/student/components/widgets/StudentOverviewWidget/components/UpdateProfileDrawer/types.ts
@@ -1,10 +1,12 @@
+import type { PictureDTO } from '@/api/avenir-esr'
+
 export interface UpdateProfileDrawerForm {
   email: string
   firstname: string
   lastname: string
   bio: string
-  coverPicture: string
-  profilePicture: string
+  coverPicture: PictureDTO
+  profilePicture: PictureDTO
 }
 
 export type FormKeys = keyof UpdateProfileDrawerForm

--- a/src/features/student/components/widgets/StudentOverviewWidget/components/UpdateProfileDrawer/use-update-profile-form.test.ts
+++ b/src/features/student/components/widgets/StudentOverviewWidget/components/UpdateProfileDrawer/use-update-profile-form.test.ts
@@ -64,8 +64,16 @@ describe('given a useUpdateProfileForm composable', () => {
     firstname: 'Jeanne',
     email: 'j.moulin@example.com',
     bio: 'Bio',
-    coverPicture: 'initialCover.jpg',
-    profilePicture: 'initialProfile.jpg',
+    coverPicture: {
+      id: 'random-id',
+      name: 'initialCover.jpg',
+      url: 'initialCover.jpg',
+    },
+    profilePicture: {
+      id: 'random-id-2',
+      name: 'initialProfile.jpg',
+      url: 'initialProfile.jpg',
+    }
   }
 
   const onSuccess = vi.fn()
@@ -100,7 +108,7 @@ describe('given a useUpdateProfileForm composable', () => {
 
       const newCoverUrl = 'https://example.com/new-cover.jpg'
       result.onUpdateProfileCoverSuccess(newCoverUrl)
-      expect(result.form.state.values.coverPicture).toBe(newCoverUrl)
+      expect(result.form.state.values.coverPicture).toStrictEqual({ id: 'random-id', name: 'initialCover.jpg', url: newCoverUrl })
     })
   })
 
@@ -112,7 +120,11 @@ describe('given a useUpdateProfileForm composable', () => {
 
       const newPhotoUrl = 'https://example.com/new-photo.jpg'
       result.onUpdateProfilePhotoSuccess(newPhotoUrl)
-      expect(result.form.state.values.profilePicture).toBe(newPhotoUrl)
+      expect(result.form.state.values.profilePicture).toStrictEqual({
+        id: 'random-id-2',
+        name: 'initialProfile.jpg',
+        url: newPhotoUrl
+      })
     })
   })
 

--- a/src/features/student/components/widgets/StudentOverviewWidget/components/UpdateProfileDrawer/use-update-profile-form.ts
+++ b/src/features/student/components/widgets/StudentOverviewWidget/components/UpdateProfileDrawer/use-update-profile-form.ts
@@ -1,12 +1,12 @@
+import type { ProfileOverviewDTO } from '@/api/avenir-esr'
 import type { BaseApiException } from '@/common/exceptions'
-import type { UpdateProfileDrawerForm } from './types'
 import { useUpdateProfile, useUpdateProfileCover, useUpdateProfilePhoto } from '@/features/student/components/widgets/StudentOverviewWidget/components/UpdateProfileDrawer/use-update-profile'
 import { useToasterStore } from '@/store'
 import { isValidEmail } from '@/ui/utils'
 import { useForm, useStore } from '@tanstack/vue-form'
 import { useI18n } from 'vue-i18n'
 
-export function useUpdateProfileForm (initialData: UpdateProfileDrawerForm, onSuccess: () => void) {
+export function useUpdateProfileForm (initialData: ProfileOverviewDTO, onSuccess: () => void) {
   const { t } = useI18n()
   const { addErrorMessage } = useToasterStore()
   const { onUpdateProfile, iseUpdateProfilePending } = useUpdateProfile(onSuccess)
@@ -58,11 +58,11 @@ export function useUpdateProfileForm (initialData: UpdateProfileDrawerForm, onSu
   })
 
   function onUpdateProfileCoverSuccess (url: string) {
-    form.setFieldValue('coverPicture', url)
+    form.setFieldValue('coverPicture.url', url)
   }
 
   function onUpdateProfilePhotoSuccess (url: string) {
-    form.setFieldValue('profilePicture', url)
+    form.setFieldValue('profilePicture.url', url)
   }
 
   function onCoverPictureUpdate (file: File | null) {
@@ -97,7 +97,9 @@ export function useUpdateProfileForm (initialData: UpdateProfileDrawerForm, onSu
     isPending,
     isModified,
     resetForm,
+    coverPictureFile,
     onCoverPictureUpdate,
+    profilePictureFile,
     onProfilePictureUpdate,
     onUpdateProfileCoverSuccess,
     onUpdateProfilePhotoSuccess

--- a/src/features/student/layouts/StudentLayout/StudentLayout.test.ts
+++ b/src/features/student/layouts/StudentLayout/StudentLayout.test.ts
@@ -111,8 +111,12 @@ describe('studentLayout', () => {
     firstname: 'Jeanne',
     lastname: 'Moulin',
     email: 'j.moulin@example.com',
-    profilePicture: profile_picture_placeholder,
-    coverPicture: profile_banner_placeholder,
+    profilePicture: {
+      url: profile_picture_placeholder
+    },
+    coverPicture: {
+      url: profile_banner_placeholder
+    },
     bio: 'Je suis étudiante en chimie et écologie. Passionnée par l’innovation durable, je souhaite utiliser la science pour protéger l’environnement et bâtir un avenir plus respectueux de la planète.'
   }
 

--- a/src/features/student/locales/en.json
+++ b/src/features/student/locales/en.json
@@ -407,6 +407,10 @@
         },
         "pictureAlt": "Profile picture",
         "updateProfileDrawer": {
+          "confirmDeletePhotoModal": {
+            "subtitle": "This action will permanently delete your profile picture. Confirm deletion?",
+            "title": "Are you sure you want to delete your photo?"
+          },
           "confirmModal": {
             "subtitle": "Any unsaved changes will be lost.",
             "title": "Are you sure you want to exit?"
@@ -417,6 +421,10 @@
             "lastname": "Last name",
             "mail": "Personal email address",
             "title": "Identity"
+          },
+          "onDelete": {
+            "error": "An error occurred while deleting the photo.",
+            "success": "Your photo has been deleted."
           },
           "onUpdate": {
             "error": "An error occurred while updating the profile.",

--- a/src/features/student/locales/fr.json
+++ b/src/features/student/locales/fr.json
@@ -407,6 +407,10 @@
         },
         "pictureAlt": "Photo de profil",
         "updateProfileDrawer": {
+          "confirmDeletePhotoModal": {
+            "subtitle": "Cette action supprimera définitivement votre photo de profil. Confirmer la suppression ?",
+            "title": "Êtes-vous sûr de vouloir supprimer votre photo?"
+          },
           "confirmModal": {
             "subtitle": "Toutes les modifications non enregistrées seront perdues.",
             "title": "Êtes-vous sûr de vouloir quitter ?"
@@ -417,6 +421,10 @@
             "lastname": "Nom",
             "mail": "Adresse mail personnelle",
             "title": "Identité"
+          },
+          "onDelete": {
+            "error": "Une erreur est survenue lors de la suppression de votre photo.",
+            "success": "Votre photo a été supprimée."
           },
           "onUpdate": {
             "error": "Une erreur est survenue lors de la mise à jour du profil.",

--- a/src/features/student/queries/use-student-summary.query/use-student-summary.query.test.ts
+++ b/src/features/student/queries/use-student-summary.query/use-student-summary.query.test.ts
@@ -45,7 +45,7 @@ describe('useStudentSummaryQuery', () => {
       })
 
       it('then it should return a profile object with required properties', () => {
-        expect(queryResult.data.value).toStrictEqual(mockedProfileOverview)
+        expect(queryResult.data.value).toEqual(mockedProfileOverview)
       })
     })
   })

--- a/src/features/student/queries/use-student-summary.query/use-student-summary.query.ts
+++ b/src/features/student/queries/use-student-summary.query/use-student-summary.query.ts
@@ -8,6 +8,7 @@ import {
   mockedResumesOverview
 } from '@/__mocks__/fixtures/student'
 import {
+  deleteUserPhoto,
   EUserCategory,
   EUserPhotoType,
   getProfile,
@@ -212,6 +213,29 @@ export function useUpdateProfilePhotoMutation ({ onError, onSuccess }: CommonMut
       return uploadedPhoto.id
     },
     onSuccess,
+    onError
+  })
+}
+
+interface DeleteUserPhotoVariables {
+  fileId: string
+}
+
+export interface UseDeletePhotoMutationArgs {
+  onSuccess?: () => void
+  onError?: (error: BaseApiException) => void
+}
+
+export function useDeletePhotoMutation ({ onError, onSuccess }: UseDeletePhotoMutationArgs = {}) {
+  const invalidateStudentSummaryQuery = useInvalidateQuery(studentSummaryQueryKeys)
+  return useMutation<string, BaseApiException, DeleteUserPhotoVariables>({
+    mutationFn: async ({ fileId }: DeleteUserPhotoVariables): Promise<string> => {
+      return await deleteUserPhoto(fileId)
+    },
+    onSuccess: async () => {
+      await invalidateStudentSummaryQuery()
+      onSuccess?.()
+    },
     onError
   })
 }

--- a/src/features/student/views/StudentToolsTracesView/components/StudentToolsTracesAddTraceDrawer/components/CreateTraceFormTraceDefinitionItems/CreateTraceFormTraceDefinitionItems.test.ts
+++ b/src/features/student/views/StudentToolsTracesView/components/StudentToolsTracesAddTraceDrawer/components/CreateTraceFormTraceDefinitionItems/CreateTraceFormTraceDefinitionItems.test.ts
@@ -115,7 +115,7 @@ describe('createTraceFormTraceDefinitionItems', () => {
         await fileInput.trigger('change')
 
         const fileUploadComponent = wrapper.findComponent({ name: 'AvFileUpload' })
-        expect(fileUploadComponent.props('validMessage')).toBe(`${mockFile.name} - Document chargé.`)
+        expect(fileUploadComponent.props('validMessage')).toBe(`Document chargé.`)
       })
     })
 
@@ -155,7 +155,7 @@ describe('createTraceFormTraceDefinitionItems', () => {
         await wrapper.vm.$nextTick()
 
         const fileUploadComponent = wrapper.findComponent({ name: 'AvFileUpload' })
-        expect(fileUploadComponent.props('validMessage')).toBe('test.pdf - Document chargé.')
+        expect(fileUploadComponent.props('validMessage')).toBe('Document chargé.')
       })
 
       it('then it should not show success message when no file is selected', () => {

--- a/src/features/student/views/StudentToolsTracesView/components/StudentToolsTracesAddTraceDrawer/components/CreateTraceFormTraceDefinitionItems/CreateTraceFormTraceDefinitionItems.vue
+++ b/src/features/student/views/StudentToolsTracesView/components/StudentToolsTracesAddTraceDrawer/components/CreateTraceFormTraceDefinitionItems/CreateTraceFormTraceDefinitionItems.vue
@@ -32,7 +32,7 @@ const filesTypesMaxSize = [
 const acceptedFileTypes = [...TRACE_ACCEPTED_FILE_TYPES]
 
 function getFileInputSuccessMessage (file: File | null) {
-  return file ? `${file.name} - ${t('global.success.file.loaded')}` : undefined
+  return file ? t('global.success.file.loaded') : undefined
 }
 </script>
 
@@ -44,37 +44,29 @@ function getFileInputSuccessMessage (file: File | null) {
           <template #default="{ field }">
             <AvFileUpload
               id="trace-file-upload"
-              :model-value="field.state.value?.name"
+              :title="t('global.information.fileUpload.title')"
+              :description="t('global.information.fileUpload.dragAndDrop')"
+              :delete-button-label="t('global.buttons.delete')"
+              :model-value="field.state.value"
               :accept="acceptedFileTypes"
               :aria-label="`${t('student.views.studentToolsTracesView.studentToolsTracesAddTraceDrawer.createTraceForm.fileUpload.title')} ${t('student.views.studentToolsTracesView.studentToolsTracesAddTraceDrawer.createTraceForm.fileUpload.subtitle')}`"
               :error="field.state.meta.errors.join(', ')"
               :valid-message="getFileInputSuccessMessage(field.state.value)"
               @change="(files) => handleFileChange(files, field.handleChange)"
-            >
-              <div class="file-upload-content">
-                <p class="b2-regular">
-                  {{ t('student.views.studentToolsTracesView.studentToolsTracesAddTraceDrawer.createTraceForm.fileUpload.title') }}
-                </p>
-                <p class="caption-light">
-                  {{ t('student.views.studentToolsTracesView.studentToolsTracesAddTraceDrawer.createTraceForm.fileUpload.subtitle') }}
-                </p>
-              </div>
-              <template #hint>
-                <p
-                  class="caption-light"
-                >
-                  <template
-                    v-for="(item, index) in filesTypesMaxSize"
-                    :key="item.type"
-                  >
-                    {{ $t(item.type) }} : <span class="file-upload-content__hint">{{ item.size }}</span>
-                    <span v-if="index < filesTypesMaxSize.length - 1"> • </span>
-                  </template>
-                </p>
-              </template>
-            </AvFileUpload>
+              @update:model-value="(value) => field.handleChange(value)"
+            />
           </template>
         </form.Field>
+        <div>
+          <span
+            v-for="(item, index) in filesTypesMaxSize"
+            :key="item.type"
+            class="caption-light"
+          >
+            {{ $t(item.type) }} : <span class="caption-bold">{{ item.size }}</span>
+            <span v-if="index < filesTypesMaxSize.length - 1"> • </span>
+          </span>
+        </div>
       </div>
 
       <div class="create-trace-form-trace-definition-items__field">
@@ -139,21 +131,5 @@ function getFileInputSuccessMessage (file: File | null) {
 .create-trace-form-trace-definition-items__field {
   display: flex;
   flex-direction: column;
-  gap: var(--spacing-xs);
-}
-
-.file-upload-content {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: var(--spacing-xxs);
-
-  &__hint {
-    font-weight: 700;
-  }
-}
-
-.file-upload-content p {
-  margin: 0;
 }
 </style>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -12,6 +12,7 @@
       "cancel": "Cancel",
       "close": "Close",
       "confirm": "Confirm",
+      "delete": "Delete",
       "exit": "Exit",
       "goBack": "Go back",
       "save": "Save"
@@ -39,11 +40,13 @@
       }
     },
     "information": {
-      "imageUpload": {
+      "fileUpload": {
+        "dragAndDrop": "or drag and drop here",
         "filesIndication": "Format: ",
         "filesTypes": "PDF, JPG, JPEG, PNG •",
         "sizeIndication": "Size : ",
-        "size": "10 Mo max"
+        "size": "10 Mo max",
+        "title": "Add a file"
       }
     },
     "error": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -12,6 +12,7 @@
       "cancel": "Annuler",
       "close": "Fermer",
       "confirm": "Confirmer",
+      "delete": "Supprimer",
       "exit": "Quitter",
       "goBack": "Retour",
       "save": "Enregistrer"
@@ -50,11 +51,13 @@
       }
     },
     "information": {
-      "imageUpload": {
+      "fileUpload": {
+        "dragAndDrop": "ou glisser et déposer ici",
         "filesIndication": "Format : ",
         "filesTypes": "PDF, JPG, JPEG, PNG •",
         "sizeIndication": "Poids : ",
-        "size": "10 Mo max"
+        "size": "10 Mo max",
+        "title": "Ajouter un fichier"
       }
     },
     "pageSizePicker": {

--- a/src/ui/interaction/files/AvFileUpload/AvFileUpload.md
+++ b/src/ui/interaction/files/AvFileUpload/AvFileUpload.md
@@ -8,30 +8,39 @@ The `AvFileUpload` component is an adaptation of the `DsfrFileUpload` code. This
 
 ## 🛠️ Props
 
-| Name | Type | Default | Mandatory | Description |
-| --- | --- | --- | --- | --- |
-| `id` | `Function` | `() => useRandomId(...)` | | Unique identifier for the file download component. If not specified, a random ID is generated. |
-| `ariaLabel` | `string` | `''` | | ARIA label for file download button. |
-| `accept` | `string \| string[]` | `undefined` | | Accepted file types, specified as a string (like HTML `accept` attribute) or an array of strings (which will be transformed into a string). |
-| `validMessage` | `string` | `''` | | Message indicating that the downloaded file is valid. |
-| `error` | `string` | `''` | | Error message to be displayed in case of download problem. |
-| `modelValue` | `string` | `''` | | Value linked to file upload input template. |
-| `maxWidth` | `string` | `'none'` | | Max width of the component. |
+| Name                 | Type                 | Default                  | Mandatory | Description                                                                                                                                 |
+|----------------------|----------------------|--------------------------|-----------|---------------------------------------------------------------------------------------------------------------------------------------------|
+| `id`                 | `Function`           | `() => useRandomId(...)` |           | Unique identifier for the file download component. If not specified, a random ID is generated.                                              |
+| `ariaLabel`          | `string`             | `''`                     |           | ARIA label for file download button.                                                                                                        |
+| `accept`             | `string \| string[]` | `undefined`              |           | Accepted file types, specified as a string (like HTML `accept` attribute) or an array of strings (which will be transformed into a string). |
+| `validMessage`       | `string`             | `''`                     |           | Message indicating that the downloaded file is valid.                                                                                       |
+| `error`              | `string`             | `''`                     |           | Error message to be displayed in case of download problem.                                                                                  |
+| `modelValue`         | `File \| null`       | `''`                     |           | Value linked to file upload input template.                                                                                                 |
+| `maxWidth`           | `string`             | `'none'`                 |           | Max width of the component.                                                                                                                 |
+| `fileName`           | `string`             | `'none'`                 |           | Name of actual file.                                                                                                                        |
+| `title`              | `string`             | `''`                     |           | Title of the file upload section.                                                                                                           |
+| `description`        | `string`             | `''`                     |           | Description of the file upload section.                                                                                                     |
+| `deleteButtonLabel`  | `string`             | `''`                     |           | delete button label.                                                                                                                        |
+| `onDeleteFile`       | `Function`           | `'none'`                 |           | Method executed on delete file button click.                                                                                                |
+| `enableMultiple`     | `boolean`            | `'none'`                 |           | Whether the file upload input enable multiple file selection or not.                                                                        |
 
 ## 📡 Events
 
-| Name | Data (*payload*) | Description |
-| --- | --- | --- |
-| `'update:modelValue'` | The updated model value (`string`) | Event emitted when the model value linked to the file is updated |
-| `'change'` | The new list of selected files (`FileList`) | Event emitted when the selected file is changed. |
-| `'onDropAcceptTypeError'` | | Event emitted when a file of wrong type is dropped. |
+| Name                      | Data (*payload*)                             | Description                                                      |
+|---------------------------|----------------------------------------------|------------------------------------------------------------------|
+| `'update:modelValue'`     | The updated model value (`File`)             | Event emitted when the model value linked to the file is updated |
+| `'update:validMessage'`   | The updated valide message (`string`)        | Event emitted when the validMessage is updated.                  |
+| `'update:error'`          | The updated error message (`string`)         | Event emitted when the error is updated.                         |
+| `'change'`                | The new list of selected files (`FileList`)  | Event emitted when the selected file is changed.                 |
+| `'onDropAcceptTypeError'` |                                              | Event emitted when a file of wrong type is dropped.              |
+| `'onDropAcceptTypeError'` |                                              | Event emitted when a file of wrong type is dropped.              |
 
 ## 🧩 Slots
 
-| Name | Description |
-| --- | --- |
-| `hint` | Slot for the hint description. |
-| `left` | Slot for the left content. |
+| Name      | Description                                                       |
+|-----------|-------------------------------------------------------------------|
+| `hint`    | Slot for the hint description.                                    |
+| `left`    | Slot for the left content.                                        |
 | `default` | Default slot for global content between the left and right icons. |
 
 ## 📝 Examples of use

--- a/src/ui/interaction/files/AvFileUpload/AvFileUpload.stories.ts
+++ b/src/ui/interaction/files/AvFileUpload/AvFileUpload.stories.ts
@@ -36,6 +36,12 @@ const meta: Meta<AvFileUploadProps> = {
     disabled: { control: 'boolean' },
     modelValue: { control: 'text' },
     maxWidth: { control: 'text' },
+    fileName: { control: 'text' },
+    title: { control: 'text' },
+    description: { control: 'text' },
+    deleteButtonLabel: { control: 'text' },
+    onDeleteFile: { type: { name: 'function' }, control: false, },
+    enableMultiple: { control: 'boolean' },
   },
   args: {
     id: 'test',
@@ -44,8 +50,14 @@ const meta: Meta<AvFileUploadProps> = {
     error: '',
     validMessage: '',
     disabled: false,
-    modelValue: '',
-    maxWidth: 'none'
+    modelValue: null,
+    maxWidth: 'none',
+    fileName: undefined,
+    title: 'Add a new',
+    description: 'or drag and drop here',
+    deleteButtonLabel: 'Delete',
+    onDeleteFile: undefined,
+    enableMultiple: false
   },
 }
 

--- a/src/ui/interaction/files/AvFileUpload/AvFileUpload.test.ts
+++ b/src/ui/interaction/files/AvFileUpload/AvFileUpload.test.ts
@@ -15,6 +15,9 @@ describe('avFileUpload', () => {
 
   const mountComponent = (props?: Partial<AvFileUploadProps>) => mount<typeof AvFileUpload>(AvFileUpload, {
     props: {
+      title: 'Ajouter un document',
+      description: 'ou glisser et déposer ici',
+      deleteButtonLabel: 'delete',
       ...props,
       global: { stubs }
     },
@@ -31,11 +34,8 @@ describe('avFileUpload', () => {
 
     describe('when the component is mounted', () => {
       it('then it should render the slot content', () => {
-        expect(wrapper.text()).toContain('Upload a file')
-      })
-
-      it('then it should render the hint slot', () => {
-        expect(wrapper.text()).toContain('Accepted files: .pdf, .jpg')
+        expect(wrapper.text()).toContain('Ajouter un document')
+        expect(wrapper.text()).toContain('ou glisser et déposer ici')
       })
     })
   })
@@ -108,7 +108,7 @@ describe('avFileUpload', () => {
         await input.element.dispatchEvent(event)
 
         expect(wrapper.emitted('update:modelValue')).toBeTruthy()
-        expect(wrapper.emitted('update:modelValue')?.[0]).toEqual(['C:\\fakepath\\hello.png'])
+        expect((wrapper.emitted('update:modelValue')?.[0][0] as File).name).toBe('hello.png')
 
         expect(wrapper.emitted('change')).toBeTruthy()
         expect(wrapper.emitted('change')?.[0][0]).toEqual(files)
@@ -143,7 +143,7 @@ describe('avFileUpload', () => {
         await label.element.dispatchEvent(dropEvent)
 
         expect(wrapper.emitted('update:modelValue')).toBeTruthy()
-        expect(wrapper.emitted('update:modelValue')?.[0]).toEqual(['dragged.pdf'])
+        expect((wrapper.emitted('update:modelValue')?.[0][0] as File).name).toBe('dragged.pdf')
 
         expect(wrapper.emitted('change')).toBeTruthy()
         expect(wrapper.emitted('change')?.[0][0]).toEqual(dataTransfer.files)
@@ -153,10 +153,8 @@ describe('avFileUpload', () => {
     describe('when a dragover event occurs', () => {
       it('then it should add drag-over class', async () => {
         const label = wrapper.find('label')
-        const dragEvent = new DragEvent('dragover')
-
-        await label.element.dispatchEvent(dragEvent)
-        expect(wrapper.classes()).toContain('drag-over')
+        await label.trigger('dragover')
+        expect(label.classes()).toContain('drag-over')
       })
     })
 
@@ -165,10 +163,10 @@ describe('avFileUpload', () => {
         const label = wrapper.find('label')
 
         await label.trigger('dragover')
-        expect(wrapper.classes()).toContain('drag-over')
+        expect(label.classes()).toContain('drag-over')
 
         await label.trigger('dragleave')
-        expect(wrapper.classes()).not.toContain('drag-over')
+        expect(label.classes()).not.toContain('drag-over')
       })
     })
   })
@@ -202,7 +200,7 @@ describe('avFileUpload', () => {
         await label.element.dispatchEvent(dropEvent)
 
         expect(wrapper.emitted('update:modelValue')).toBeTruthy()
-        expect(wrapper.emitted('update:modelValue')?.[0]).toEqual(['dragged.jpeg'])
+        expect((wrapper.emitted('update:modelValue')?.[0][0] as File).name).toBe('dragged.jpeg')
 
         expect(wrapper.emitted('change')).toBeTruthy()
         expect(wrapper.emitted('change')?.[0][0]).toEqual(dataTransfer.files)
@@ -220,7 +218,7 @@ describe('avFileUpload', () => {
         await label.element.dispatchEvent(dropEvent)
 
         expect(wrapper.emitted('update:modelValue')).toBeTruthy()
-        expect(wrapper.emitted('update:modelValue')?.[0]).toEqual(['dragged.png'])
+        expect((wrapper.emitted('update:modelValue')?.[0][0] as File).name).toBe('dragged.png')
 
         expect(wrapper.emitted('change')).toBeTruthy()
         expect(wrapper.emitted('change')?.[0][0]).toEqual(dataTransfer.files)
@@ -306,6 +304,85 @@ describe('avFileUpload', () => {
         expect(wrapper.emitted('update:modelValue')).toBeFalsy()
         expect(wrapper.emitted('change')).toBeFalsy()
         expect(wrapper.emitted('onDropAcceptTypeError')).toBeFalsy()
+      })
+    })
+  })
+
+  describe('given a file uploader with onClear button', () => {
+    beforeEach(() => {
+      wrapper = mountComponent({ modelValue: new File(['test'], 'test.txt') })
+    })
+
+    describe('when clicking on onClear button', () => {
+      it('then it should emit update:modelValue, update:validMessage, and update:error with null', async () => {
+        const onClearButton = wrapper.find('.av-button')
+        expect(onClearButton.exists()).toBe(true)
+
+        await onClearButton.trigger('click')
+
+        expect(wrapper.emitted('update:modelValue')).toBeTruthy()
+        expect(wrapper.emitted('update:modelValue')?.[0][0]).toBeNull()
+
+        expect(wrapper.emitted('update:validMessage')).toBeTruthy()
+        expect(wrapper.emitted('update:validMessage')?.[0][0]).toBeNull()
+
+        expect(wrapper.emitted('update:error')).toBeTruthy()
+        expect(wrapper.emitted('update:error')?.[0][0]).toBeNull()
+      })
+    })
+  })
+
+  describe('given a fileUpload rendering', () => {
+    describe('when enableMultiple = false', () => {
+      describe('and fileName is set', () => {
+        beforeEach(() => {
+          wrapper = mountComponent({ fileName: 'file.txt', modelValue: null, enableMultiple: false, deleteButtonLabel: 'delete', title: 'click here', description: 'or drag and drop' })
+        })
+
+        it('then it should render file info template', () => {
+          expect(wrapper.html()).toContain('file.txt')
+        })
+      })
+
+      describe('and modelValue is set (fileName not provided)', () => {
+        let file: File
+
+        beforeEach(() => {
+          file = new File(['content'], 'file.txt')
+          wrapper = mountComponent({ modelValue: file, enableMultiple: false, fileName: undefined })
+        })
+
+        it('then it should render file info template', () => {
+          expect(wrapper.html()).toContain('file.txt')
+        })
+
+        it('then it should render the delete button', () => {
+          const deleteBtn = wrapper.find('.av-button')
+          expect(deleteBtn.exists()).toBe(true)
+        })
+      })
+
+      describe('and neither fileName nor modelValue is set', () => {
+        beforeEach(() => {
+          wrapper = mountComponent({ modelValue: null, fileName: undefined, enableMultiple: false })
+        })
+
+        it('then it should render upload input template', () => {
+          expect(wrapper.find('input[type="file"]').exists()).toBe(true)
+        })
+      })
+    })
+
+    describe('when enableMultiple = true', () => {
+      let file: File
+
+      beforeEach(() => {
+        file = new File(['content'], 'file.txt')
+        wrapper = mountComponent({ modelValue: file, enableMultiple: true })
+      })
+
+      it('then it should render upload input template even if modelValue is set', () => {
+        expect(wrapper.find('input[type="file"]').exists()).toBe(true)
       })
     })
   })

--- a/src/ui/interaction/files/AvFileUpload/AvFileUpload.vue
+++ b/src/ui/interaction/files/AvFileUpload/AvFileUpload.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
-import AvIconText from '@/ui/base/AvIconText/AvIconText.vue'
-import AvVIcon from '@/ui/base/AvVIcon/AvVIcon.vue'
-import { MDI_ICONS } from '@/ui/tokens'
+import { AvButton, AvVIcon, MDI_ICONS } from '@/ui'
+import AvFileUploadAlert from '@/ui/interaction/files/AvFileUpload/AvFileUploadAlert.vue'
 import { useRandomId } from '@gouvminint/vue-dsfr'
 import { nextTick, type Slot } from 'vue'
 
@@ -56,9 +55,9 @@ export interface AvFileUploadProps {
   /**
    * Value linked to file upload input template.
    *
-   * @default ''
+   * @default null
    */
-  modelValue?: string
+  modelValue?: File | null
 
   /**
    * Max width of the component.
@@ -66,6 +65,44 @@ export interface AvFileUploadProps {
    * @default undefined
    */
   maxWidth?: string
+
+  /**
+   * Title of the file upload section.
+   */
+  title: string
+
+  /**
+   * Description of the file upload section.
+   * @default undefined
+   */
+  description: string
+
+  /**
+   * delete button label
+   *
+   */
+  deleteButtonLabel: string
+
+  /**
+   * Name of actual file.
+   *
+   * @default undefined
+   */
+  fileName?: string
+
+  /**
+   * Method executed on delete file button click.
+   *
+   * @default undefined
+   */
+  onDeleteFile?: () => void
+
+  /**
+   * Whether the file upload input enable multiple file selection or not.
+   *
+   * @default false
+   */
+  enableMultiple?: boolean
 }
 
 defineOptions({
@@ -78,25 +115,30 @@ const props = withDefaults(defineProps<AvFileUploadProps>(), {
   accept: undefined,
   validMessage: '',
   error: '',
-  modelValue: '',
-  maxWidth: 'none'
+  modelValue: null,
+  maxWidth: 'none',
+  disabled: false,
+  enableMultiple: false,
 })
 
-/**
- * Emits available for the AvFileUpload component.
- *
- * @emits update:modelValue - Event emitted when the model value linked to the file is updated.
- * @param payload - The updated model value (string).
- *
- * @emits change - Event emitted when the selected file is changed.
- * @param payload - The new list of selected files (FileList).
- */
 const emit = defineEmits<{
   /**
    * Event emitted when the model value linked to the file is updated.
-   * @param payload The updated model value (string).
+   * @param payload The updated model value (File or null).
    */
-  (e: 'update:modelValue', payload: string): void
+  (e: 'update:modelValue', payload: File | null): void
+
+  /**
+   * Event emitted when the validMessage is updated.
+   * @param payload The updated model value (string or null).
+   */
+  (e: 'update:validMessage', payload: string | null): void
+
+  /**
+   * Event emitted when the error is updated.
+   * @param payload The updated model value (string or null).
+   */
+  (e: 'update:error', payload: string | null): void
 
   /**
    * Event emitted when the selected file is changed.
@@ -168,7 +210,7 @@ async function onDrop (event: DragEvent) {
 
   if (files.length) {
     emit('change', files as unknown as FileList)
-    emit('update:modelValue', files[0]?.name ?? '')
+    emit('update:modelValue', files[0] ?? '')
   }
   else {
     emit('onDropAcceptTypeError')
@@ -187,33 +229,58 @@ function onDragLeave () {
 }
 
 function onChange ($event: InputEvent) {
-  emit('update:modelValue', ($event.target as HTMLInputElement)?.value)
-  emit('change', ($event.target as (InputEvent['target'] & { files: FileList }))?.files)
+  const files = ($event.target as HTMLInputElement).files
+  emit('change', files as FileList)
+  emit('update:modelValue', files?.[0] ?? null)
+}
+
+const isPreview = computed(() => props.fileName || (props.modelValue && !props.enableMultiple))
+
+const uploadLabelAttrs = computed(() => {
+  return {
+    'for':
+    props.id,
+    'class':
+    [
+      'fr-upload-group',
+      {
+        'fr-upload-group--error': props.error,
+        'fr-upload-group--valid': props.validMessage,
+        'fr-upload-group--disabled': props.disabled,
+        'drag-over': isDragging.value,
+      },
+    ],
+    'aria-label':
+    props.ariaLabel,
+    'onDragover':
+    onDragOver,
+    'onDragleave':
+    onDragLeave,
+    'onDrop':
+    onDrop,
+  }
+})
+
+function onClear (modelValue: File | null) {
+  if (modelValue) {
+    emit('update:modelValue', null)
+    emit('update:validMessage', null)
+    emit('update:error', null)
+    emit('change', [] as unknown as FileList)
+  }
+  else {
+    props.onDeleteFile?.()
+  }
 }
 </script>
 
 <template>
-  <label
-    :for="id"
-    class="fr-upload-group"
-    :class="{
-      'fr-upload-group--error': error,
-      'fr-upload-group--valid': validMessage,
-      'fr-upload-group--disabled': disabled,
-      'drag-over': isDragging,
-    }"
-    :aria-label="ariaLabel"
-    @dragover="onDragOver"
-    @dragleave="onDragLeave"
-    @drop="onDrop"
+  <component
+    :is="isPreview ? 'div' : 'label'"
+    v-bind="isPreview ? {} : uploadLabelAttrs"
+    :class="isPreview ? 'file-preview-container' : ''"
   >
-    <div
-      class="file-upload-container"
-      :class="{
-        'file-upload-container--error': error,
-        'file-upload-container--valid': validMessage,
-      }"
-    >
+    <div :class="isPreview ? '' : 'file-upload-container'">
       <div class="file-upload-content">
         <div class="left-content-container">
           <slot name="left">
@@ -225,29 +292,39 @@ function onChange ($event: InputEvent) {
           </slot>
         </div>
         <div class="content-container">
-          <slot />
-          <div
-            v-if="error || validMessage"
-            class="messages-group"
-            role="alert"
-          >
-            <AvIconText
-              :icon="error ? MDI_ICONS.CLOSE_CIRCLE_OUTLINE : MDI_ICONS.CHECK_CIRCLE_OUTLINE"
-              :icon-color="error ? 'var(--dark-background-error)' : 'var(--dark-background-success)'"
-              :text="error ? error : validMessage"
-              :text-color="error ? 'var(--dark-background-error)' : 'var(--dark-background-success)'"
-              typography-class="caption-regular"
-            />
+          <div v-if="isPreview">
+            <span class="b2-bold">{{ fileName || modelValue!.name }}</span>
           </div>
+          <div
+            v-else
+            class="title-container"
+          >
+            <span class="b2-regular">{{ title }}</span>
+            <span class="caption-light">{{ description }}</span>
+          </div>
+
+          <AvFileUploadAlert
+            :valid-message="validMessage"
+            :error="error"
+          />
         </div>
+
         <div class="right-icon-container">
+          <AvButton
+            v-if="isPreview"
+            :label="deleteButtonLabel"
+            theme="SECONDARY"
+            @click="() => onClear(modelValue)"
+          />
           <AvVIcon
+            v-else
             :size="1.5"
             :name="MDI_ICONS.TRAY_UPLOAD"
             color="var(--dark-background-primary1)"
           />
         </div>
         <input
+          v-if="!isPreview"
           :id="id"
           class="fr-upload"
           type="file"
@@ -260,16 +337,22 @@ function onChange ($event: InputEvent) {
         >
       </div>
     </div>
-    <span class="caption-light">
-      <slot name="hint" />
-    </span>
-  </label>
+  </component>
+  <span class="caption-light">
+    <slot name="hint" />
+  </span>
 </template>
 
 <style lang="scss" scoped>
 .file-upload-container:focus-within {
   outline: 2px solid #005fcc;
   outline-offset: 2px;
+}
+
+.title-container {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xxs);
 }
 
 .fr-upload {
@@ -282,7 +365,7 @@ function onChange ($event: InputEvent) {
   white-space: nowrap;
   border: 0;
   padding: 0;
-  margin: 0;
+  margin: 0 !important;
 }
 
 .fr-upload-group {
@@ -294,18 +377,16 @@ function onChange ($event: InputEvent) {
   cursor: not-allowed;
 }
 
-.file-upload-container {
-  border: 1px dashed var(--divider);
+.file-preview-container {
+  border: 1px solid var(--divider);
   border-radius: var(--radius-lg);
   padding: var(--spacing-xs);
 }
 
-.file-upload-container--error {
-  border: 1px solid var(--dark-background-error)
-}
-
-.file-upload-container--valid {
-  border: 1px solid var(--dark-background-success)
+.file-upload-container {
+  border: 1px dashed var(--divider);
+  border-radius: var(--radius-lg);
+  padding: var(--spacing-xs);
 }
 
 .drag-over .file-upload-container {
@@ -347,9 +428,5 @@ function onChange ($event: InputEvent) {
 
 .messages-group {
   padding-top: var(--spacing-xxs);
-}
-
-.fr-upload {
-  margin: 0 !important;
 }
 </style>

--- a/src/ui/interaction/files/AvFileUpload/AvFileUploadAlert.vue
+++ b/src/ui/interaction/files/AvFileUpload/AvFileUploadAlert.vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+import { MDI_ICONS } from '@/ui'
+import AvIconText from '@/ui/base/AvIconText/AvIconText.vue'
+
+export interface AvFileUploadAlertProps {
+  /**
+   * Error message to be displayed in case of upload problem.
+   *
+   * @default undefined
+   */
+  error?: string
+
+  /**
+   * Message indicating that the uploaded file is valid.
+   *
+   * @default undefined
+   */
+  validMessage?: string
+}
+
+withDefaults(defineProps<AvFileUploadAlertProps>(), {
+  error: undefined,
+  validMessage: undefined
+})
+</script>
+
+<template>
+  <div
+    v-if="error || validMessage"
+    class="messages-group"
+    role="alert"
+  >
+    <AvIconText
+      :icon="error ? MDI_ICONS.CLOSE_CIRCLE_OUTLINE : MDI_ICONS.CHECK_CIRCLE_OUTLINE"
+      :icon-color="error ? 'var(--dark-background-error)' : 'var(--dark-background-success)'"
+      :text="error ? error : validMessage"
+      :text-color="error ? 'var(--dark-background-error)' : 'var(--dark-background-success)'"
+      typography-class="caption-regular"
+    />
+  </div>
+</template>
+
+<style scoped lang="scss">
+
+</style>


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied

This PR introduces the ability to delete both the profile picture and the cover photo.  
Several improvements were made to the `avFileUpload` component:

- The component can no longer accept new files if this functionality is not intended to be supported.
- A new parameter `enableMultiple` has been introduced to allow multiple file uploads in the future.
- If `enableMultiple` is set to `false`, once a file is uploaded, the component becomes a simple `div` with an optional image preview and a "delete" CTA to cancel the upload.
- If a file already exists, the upload button now acts as a delete action for the existing photo.

---

### Reference to an Issue, Feature, Task, User Story or another PR

This change is linked to the backend PR: [avenirs-portfolio-api#106](https://github.com/avenirs-esr/avenirs-portfolio-api/pull/106)
closes https://github.com/avenirs-esr/AVENIRS-Project/issues/548
closes https://github.com/avenirs-esr/AVENIRS-Project/issues/549
closes https://github.com/avenirs-esr/AVENIRS-Project/issues/550
closes https://github.com/avenirs-esr/AVENIRS-Project/issues/551


---

### Target Branch
> develop

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [x] i18n handled (texts are translated)
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [x] Semantic Versioning respected

---
