### PR TITLE
feat(646): add trace associations cards and container

### DIFF
--- a/api-specs/avenir-esr.swagger.json
+++ b/api-specs/avenir-esr.swagger.json
@@ -575,7 +575,7 @@
         "tags": [
           "trace-controller"
         ],
-        "operationId": "getTraceAssociates",
+        "operationId": "getTraceAssociations",
         "parameters": [
           {
             "name": "traceId",
@@ -593,10 +593,7 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/AssociationTraceDTO"
-                  }
+                  "$ref": "#/components/schemas/AssociationsTraceDTO"
                 }
               }
             }
@@ -1688,19 +1685,26 @@
           "title"
         ]
       },
-      "AssociationTraceDTO": {
+      "AssociationsTraceDTO": {
         "type": "object",
         "properties": {
-          "skillLevelAssociation": {
-            "$ref": "#/components/schemas/SkillLevelAssociationDTO"
+          "skillLevelAssociations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SkillLevelAssociationDTO"
+            }
           },
-          "additionalSkillAssociation": {
-            "$ref": "#/components/schemas/AdditionalSkillAssociationDTO"
-          },
-          "skillLevelOrAdditionalSkillPresent": {
-            "type": "boolean"
+          "additionalSkillAssociations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AdditionalSkillAssociationDTO"
+            }
           }
-        }
+        },
+        "required": [
+          "additionalSkillAssociations",
+          "skillLevelAssociations"
+        ]
       },
       "SkillLevelAssociationDTO": {
         "type": "object",
@@ -1709,7 +1713,7 @@
             "type": "string",
             "format": "uuid"
           },
-          "title": {
+          "skillTitle": {
             "type": "string"
           },
           "level": {
@@ -1734,8 +1738,8 @@
         "required": [
           "id",
           "level",
-          "status",
-          "title"
+          "skillTitle",
+          "status"
         ]
       },
       "PageInfoDTO": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "avenirs-cofolio-client",
       "version": "0.0.0",
       "dependencies": {
-        "@avenirs-esr/avenirs-dsav": "^0.1.26",
+        "@avenirs-esr/avenirs-dsav": "^0.1.27",
         "@gouvfr/dsfr": "^1.13.2",
         "@gouvminint/vue-dsfr": "^8.4.0",
         "@tanstack/vue-form": "^1.15.0",
@@ -309,9 +309,9 @@
       }
     },
     "node_modules/@avenirs-esr/avenirs-dsav": {
-      "version": "0.1.26",
-      "resolved": "https://registry.npmjs.org/@avenirs-esr/avenirs-dsav/-/avenirs-dsav-0.1.26.tgz",
-      "integrity": "sha512-fgxlUbCn6axKlKEQR3o4BQOz2fC3JfOG2GOhLpdAYxyKC/5scnAj2hVsL7A9kKcnribvuuHR8Dqs4kVj8afdsw==",
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/@avenirs-esr/avenirs-dsav/-/avenirs-dsav-0.1.27.tgz",
+      "integrity": "sha512-13uKsDYVMTZeZMdokO5ObnS7YDWcFpbSRYCXm6msHrAhrkqhTIZvU9DAkCTffEms7pO1h6cRn6ODXVMtjcOwdw==",
       "dependencies": {
         "@gouvfr/dsfr": "^1.14.0",
         "@gouvminint/vue-dsfr": "^8.4.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
-    "@avenirs-esr/avenirs-dsav": "^0.1.26",
+    "@avenirs-esr/avenirs-dsav": "^0.1.27",
     "@gouvfr/dsfr": "^1.13.2",
     "@gouvminint/vue-dsfr": "^8.4.0",
     "@tanstack/vue-form": "^1.15.0",

--- a/src/features/student/components/badges/AdditionalSkillLevelBadge/AdditionalSkillLevelBadge.test.ts
+++ b/src/features/student/components/badges/AdditionalSkillLevelBadge/AdditionalSkillLevelBadge.test.ts
@@ -1,0 +1,206 @@
+import type { VueWrapper } from '@vue/test-utils'
+import { EAdditionalSkillLevel } from '@/api/avenir-esr'
+import { AdditionalSkillLevelBadge } from '@/features/student/components/badges'
+import { BddTest, mountComponent } from 'tests/utils'
+import { beforeEach, expect, vi } from 'vitest'
+
+const stubs = {
+  AvBadge: {
+    name: 'AvBadge',
+    template: '<div class="av-badge" />',
+    props: {
+      label: String,
+      backgroundColor: String,
+      color: String,
+      iconPath: String,
+      small: Boolean
+    }
+  }
+}
+
+BddTest().given('an additional skill level badge', () => {
+  let wrapper: VueWrapper<InstanceType<typeof AdditionalSkillLevelBadge>>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  BddTest().when('the component is mounted with BEGINNER level', () => {
+    beforeEach(async () => {
+      wrapper = mountComponent(AdditionalSkillLevelBadge, {
+        props: {
+          level: EAdditionalSkillLevel.BEGINNER
+        },
+        global: {
+          stubs
+        }
+      })
+      await vi.waitFor(() => {
+        expect(wrapper.findComponent({ name: 'AvBadge' }).exists()).toBe(true)
+      })
+    })
+
+    BddTest().then('it should render AvBadge with BEGINNER configuration', () => {
+      const badge = wrapper.findComponent({ name: 'AvBadge' })
+
+      expect(badge.exists()).toBe(true)
+      expect(badge.props('label')).toBe(EAdditionalSkillLevel.BEGINNER)
+      expect(badge.props('backgroundColor')).toBe('var(--light-background-primary3)')
+      expect(badge.props('color')).toBe('var(--dark-background-primary3)')
+      expect(badge.props('iconPath')).toBeDefined()
+      expect(badge.props('small')).toBe(false)
+    })
+  })
+
+  BddTest().when('the component is mounted with INTERMEDIATE level', () => {
+    beforeEach(async () => {
+      wrapper = mountComponent(AdditionalSkillLevelBadge, {
+        props: {
+          level: EAdditionalSkillLevel.INTERMEDIATE
+        },
+        global: {
+          stubs
+        }
+      })
+      await vi.waitFor(() => {
+        expect(wrapper.findComponent({ name: 'AvBadge' }).exists()).toBe(true)
+      })
+    })
+
+    BddTest().then('it should render AvBadge with INTERMEDIATE configuration', () => {
+      const badge = wrapper.findComponent({ name: 'AvBadge' })
+
+      expect(badge.exists()).toBe(true)
+      expect(badge.props('label')).toBe(EAdditionalSkillLevel.INTERMEDIATE)
+      expect(badge.props('backgroundColor')).toBe('var(--light-background-info)')
+      expect(badge.props('color')).toBe('var(--dark-background-info)')
+      expect(badge.props('iconPath')).toBeDefined()
+    })
+  })
+
+  BddTest().when('the component is mounted with COMPETENT level', () => {
+    beforeEach(async () => {
+      wrapper = mountComponent(AdditionalSkillLevelBadge, {
+        props: {
+          level: EAdditionalSkillLevel.COMPETENT
+        },
+        global: {
+          stubs
+        }
+      })
+      await vi.waitFor(() => {
+        expect(wrapper.findComponent({ name: 'AvBadge' }).exists()).toBe(true)
+      })
+    })
+
+    BddTest().then('it should render AvBadge with COMPETENT configuration', () => {
+      const badge = wrapper.findComponent({ name: 'AvBadge' })
+
+      expect(badge.exists()).toBe(true)
+      expect(badge.props('label')).toBe(EAdditionalSkillLevel.COMPETENT)
+      expect(badge.props('backgroundColor')).toBe('var(--light-background-critical)')
+      expect(badge.props('color')).toBe('var(--light-foreground-critical)')
+      expect(badge.props('iconPath')).toBeDefined()
+    })
+  })
+
+  BddTest().when('the component is mounted with ADVANCED level', () => {
+    beforeEach(async () => {
+      wrapper = mountComponent(AdditionalSkillLevelBadge, {
+        props: {
+          level: EAdditionalSkillLevel.ADVANCED
+        },
+        global: {
+          stubs
+        }
+      })
+      await vi.waitFor(() => {
+        expect(wrapper.findComponent({ name: 'AvBadge' }).exists()).toBe(true)
+      })
+    })
+
+    BddTest().then('it should render AvBadge with ADVANCED configuration', () => {
+      const badge = wrapper.findComponent({ name: 'AvBadge' })
+
+      expect(badge.exists()).toBe(true)
+      expect(badge.props('label')).toBe(EAdditionalSkillLevel.ADVANCED)
+      expect(badge.props('backgroundColor')).toBe('var(--light-background-primary2)')
+      expect(badge.props('color')).toBe('var(--dark-background-primary2)')
+      expect(badge.props('iconPath')).toBeDefined()
+    })
+  })
+
+  BddTest().when('the component is mounted with EXPERT level', () => {
+    beforeEach(async () => {
+      wrapper = mountComponent(AdditionalSkillLevelBadge, {
+        props: {
+          level: EAdditionalSkillLevel.EXPERT
+        },
+        global: {
+          stubs
+        }
+      })
+      await vi.waitFor(() => {
+        expect(wrapper.findComponent({ name: 'AvBadge' }).exists()).toBe(true)
+      })
+    })
+
+    BddTest().then('it should render AvBadge with EXPERT configuration', () => {
+      const badge = wrapper.findComponent({ name: 'AvBadge' })
+
+      expect(badge.exists()).toBe(true)
+      expect(badge.props('label')).toBe(EAdditionalSkillLevel.EXPERT)
+      expect(badge.props('backgroundColor')).toBe('var(--light-background-primary1)')
+      expect(badge.props('color')).toBe('var(--light-foreground-primary2)')
+      expect(badge.props('iconPath')).toBeDefined()
+    })
+  })
+
+  BddTest().when('the component is mounted with small prop set to true', () => {
+    beforeEach(async () => {
+      wrapper = mountComponent(AdditionalSkillLevelBadge, {
+        props: {
+          level: EAdditionalSkillLevel.BEGINNER,
+          small: true
+        },
+        global: {
+          stubs
+        }
+      })
+      await vi.waitFor(() => {
+        expect(wrapper.findComponent({ name: 'AvBadge' }).exists()).toBe(true)
+      })
+    })
+
+    BddTest().then('it should pass small prop to AvBadge', () => {
+      const badge = wrapper.findComponent({ name: 'AvBadge' })
+
+      expect(badge.exists()).toBe(true)
+      expect(badge.props('small')).toBe(true)
+    })
+  })
+
+  BddTest().when('the component is mounted with small prop set to false', () => {
+    beforeEach(async () => {
+      wrapper = mountComponent(AdditionalSkillLevelBadge, {
+        props: {
+          level: EAdditionalSkillLevel.EXPERT,
+          small: false
+        },
+        global: {
+          stubs
+        }
+      })
+      await vi.waitFor(() => {
+        expect(wrapper.findComponent({ name: 'AvBadge' }).exists()).toBe(true)
+      })
+    })
+
+    BddTest().then('it should pass small prop as false to AvBadge', () => {
+      const badge = wrapper.findComponent({ name: 'AvBadge' })
+
+      expect(badge.exists()).toBe(true)
+      expect(badge.props('small')).toBe(false)
+    })
+  })
+})

--- a/src/features/student/components/badges/AdditionalSkillLevelBadge/AdditionalSkillLevelBadge.vue
+++ b/src/features/student/components/badges/AdditionalSkillLevelBadge/AdditionalSkillLevelBadge.vue
@@ -1,0 +1,68 @@
+<script setup lang="ts">
+import { EAdditionalSkillLevel } from '@/api/avenir-esr'
+import { isEnumMember } from '@/common/utils'
+import { useAdditionalSkillConfig } from '@/features/student/queries'
+import { AvBadge, ICONS_DATA_URL } from '@avenirs-esr/avenirs-dsav'
+
+export interface AdditionalSkillLevelBadgeProps {
+  level: EAdditionalSkillLevel
+  small?: boolean
+}
+
+const { small = false, level } = defineProps<AdditionalSkillLevelBadgeProps>()
+
+const { data: skillConfig } = useAdditionalSkillConfig()
+
+function getBadgeConfig (level: string) {
+  const config = {
+    BEGINNER: {
+      background: 'var(--light-background-primary3)',
+      color: 'var(--dark-background-primary3)',
+      icon: ICONS_DATA_URL.CLOCK_QUARTER_CHECK
+    },
+    INTERMEDIATE: {
+      background: 'var(--light-background-info)',
+      color: 'var(--dark-background-info)',
+      icon: ICONS_DATA_URL.CLOCK_THIRD_CHECK
+    },
+    COMPETENT: {
+      background: 'var(--light-background-critical)',
+      color: 'var(--light-foreground-critical)',
+      icon: ICONS_DATA_URL.CLOCK_HALF_PLUS_CHECK
+    },
+    ADVANCED: {
+      background: 'var(--light-background-primary2)',
+      color: 'var(--dark-background-primary2)',
+      icon: ICONS_DATA_URL.CLOCK_ALMOST_CHECK
+    },
+    EXPERT: {
+      background: 'var(--light-background-primary1)',
+      color: 'var(--light-foreground-primary2)',
+      icon: ICONS_DATA_URL.MDI_CHECK_CIRCLE
+    }
+  }
+  return config[level as keyof typeof config] || config.BEGINNER
+}
+
+function getBadgeLabel (level: EAdditionalSkillLevel) {
+  if (!skillConfig.value) {
+    return level
+  }
+  return isEnumMember(EAdditionalSkillLevel, level) ? skillConfig.value[level]?.label ?? level : level
+}
+
+const badgeConfig = computed(() => getBadgeConfig(level))
+const label = computed(() => getBadgeLabel(level))
+</script>
+
+<template>
+  <AvBadge
+    :label="label"
+    :background-color="badgeConfig.background"
+    :color="badgeConfig.color"
+    :icon-path="badgeConfig.icon"
+    :small="small"
+  />
+</template>
+
+<style lang="scss" scoped></style>

--- a/src/features/student/components/badges/AdditionalSkillTypeBadge/AdditionalSkillTypeBadge.vue
+++ b/src/features/student/components/badges/AdditionalSkillTypeBadge/AdditionalSkillTypeBadge.vue
@@ -1,13 +1,20 @@
 <script setup lang="ts">
 import { AvBadge } from '@avenirs-esr/avenirs-dsav'
 
-defineProps<{ label: string, backgroundColor: string }>()
+const {
+  color = 'white',
+  backgroundColor = 'var(--dark-background-primary1)'
+} = defineProps<{
+  label: string
+  backgroundColor?: string
+  color?: string
+}>()
 </script>
 
 <template>
   <AvBadge
     :label="label"
-    color="white"
+    :color="color"
     :border-color="backgroundColor"
     :background-color="backgroundColor"
     class="additional-skill-type-badge"

--- a/src/features/student/components/badges/StudentSkillLevelStatusBadge/StudentSkillLevelStatusBadge.test.ts
+++ b/src/features/student/components/badges/StudentSkillLevelStatusBadge/StudentSkillLevelStatusBadge.test.ts
@@ -1,5 +1,5 @@
-import { ESkillLevelStatus, type SkillLevelProgressOverviewDTO } from '@/api/avenir-esr'
-import StudentLevelBadge from '@/features/student/components/badges/StudentLevelBadge/StudentLevelBadge.vue'
+import { ESkillLevelStatus } from '@/api/avenir-esr'
+import StudentSkillLevelStatusBadge from '@/features/student/components/badges/StudentSkillLevelStatusBadge/StudentSkillLevelStatusBadge.vue'
 import { mount, type VueWrapper } from '@vue/test-utils'
 import { BddTest } from 'tests/utils'
 
@@ -25,53 +25,17 @@ BddTest().given('a studentLevelBadge', () => {
         backgroundColor: String,
         iconPath: String
       }
-    },
-  }
-
-  const notStartedLevel: SkillLevelProgressOverviewDTO = {
-    id: 'NOT_STARTED',
-    name: 'NOT_STARTED',
-    traceCount: 0,
-    activityCount: 0,
-    status: ESkillLevelStatus.NOT_STARTED
-  }
-  const notValidatedLevel: SkillLevelProgressOverviewDTO = {
-    id: 'NOT_VALIDATED',
-    name: 'NOT_VALIDATED',
-    traceCount: 0,
-    activityCount: 0,
-    status: ESkillLevelStatus.FAILED
-  }
-  const toEvaluateLevel: SkillLevelProgressOverviewDTO = {
-    id: 'TO_EVALUATE',
-    name: 'TO_EVALUATE',
-    traceCount: 0,
-    activityCount: 0,
-    status: ESkillLevelStatus.TO_BE_EVALUATED
-  }
-  const underReviewLevel: SkillLevelProgressOverviewDTO = {
-    id: 'UNDER_REVIEW',
-    name: 'UNDER_REVIEW',
-    traceCount: 0,
-    activityCount: 0,
-    status: ESkillLevelStatus.UNDER_REVIEW
-  }
-  const validatedLevel: SkillLevelProgressOverviewDTO = {
-    id: 'VALIDATED',
-    name: 'VALIDATED',
-    traceCount: 0,
-    activityCount: 0,
-    status: ESkillLevelStatus.VALIDATED
+    }
   }
 
   beforeEach(() => {
     vi.clearAllMocks()
   })
 
-  BddTest().when('the component is mounted with a notValidatedLevel', () => {
+  BddTest().when('the component is mounted with FAILED status', () => {
     beforeEach(() => {
-      wrapper = mount(StudentLevelBadge, {
-        props: { level: notValidatedLevel },
+      wrapper = mount(StudentSkillLevelStatusBadge, {
+        props: { status: ESkillLevelStatus.FAILED },
         global: {
           stubs
         }
@@ -93,10 +57,10 @@ BddTest().given('a studentLevelBadge', () => {
     })
   })
 
-  BddTest().when('the component is mounted with a notStartedLevel', () => {
+  BddTest().when('the component is mounted with NOT_STARTED status', () => {
     beforeEach(() => {
-      wrapper = mount(StudentLevelBadge, {
-        props: { level: notStartedLevel },
+      wrapper = mount(StudentSkillLevelStatusBadge, {
+        props: { status: ESkillLevelStatus.NOT_STARTED },
         global: {
           stubs
         }
@@ -118,10 +82,10 @@ BddTest().given('a studentLevelBadge', () => {
     })
   })
 
-  BddTest().when('the component is mounted with a toEvaluateLevel', () => {
+  BddTest().when('the component is mounted with TO_BE_EVALUATED status', () => {
     beforeEach(() => {
-      wrapper = mount(StudentLevelBadge, {
-        props: { level: toEvaluateLevel },
+      wrapper = mount(StudentSkillLevelStatusBadge, {
+        props: { status: ESkillLevelStatus.TO_BE_EVALUATED },
         global: {
           stubs
         }
@@ -143,10 +107,10 @@ BddTest().given('a studentLevelBadge', () => {
     })
   })
 
-  BddTest().when('the component is mounted with an underReviewLevel', () => {
+  BddTest().when('the component is mounted with UNDER_REVIEW status', () => {
     beforeEach(() => {
-      wrapper = mount(StudentLevelBadge, {
-        props: { level: underReviewLevel },
+      wrapper = mount(StudentSkillLevelStatusBadge, {
+        props: { status: ESkillLevelStatus.UNDER_REVIEW },
         global: {
           stubs
         }
@@ -168,10 +132,10 @@ BddTest().given('a studentLevelBadge', () => {
     })
   })
 
-  BddTest().when('the component is mounted with a validatedLevel', () => {
+  BddTest().when('the component is mounted with VALIDATED status', () => {
     beforeEach(() => {
-      wrapper = mount(StudentLevelBadge, {
-        props: { level: validatedLevel },
+      wrapper = mount(StudentSkillLevelStatusBadge, {
+        props: { status: ESkillLevelStatus.VALIDATED },
         global: {
           stubs
         }

--- a/src/features/student/components/badges/StudentSkillLevelStatusBadge/StudentSkillLevelStatusBadge.vue
+++ b/src/features/student/components/badges/StudentSkillLevelStatusBadge/StudentSkillLevelStatusBadge.vue
@@ -1,17 +1,16 @@
 <script setup lang="ts">
-import { ESkillLevelStatus, type SkillLevelProgressOverviewDTO, type SkillLevelViewDTO } from '@/api/avenir-esr'
+import { ESkillLevelStatus } from '@/api/avenir-esr'
 import { AvBadge } from '@avenirs-esr/avenirs-dsav'
 import { useI18n } from 'vue-i18n'
 
-const { level } = defineProps<{ level: SkillLevelProgressOverviewDTO | SkillLevelViewDTO }>()
+const { status } = defineProps<{ status: ESkillLevelStatus }>()
 
 const { t } = useI18n()
 
-function levelToBadge (status: ESkillLevelStatus) {
+function statusToBadge (status: ESkillLevelStatus) {
   const basePath = import.meta.env.BASE_URL
 
   switch (status) {
-    // TODO: return correct values for UNDER_ACQUISITION status when starting #312
     case ESkillLevelStatus.NOT_STARTED:
     case ESkillLevelStatus.UNDER_ACQUISITION:
     case ESkillLevelStatus.TO_BE_EVALUATED:
@@ -45,7 +44,7 @@ function levelToBadge (status: ESkillLevelStatus) {
   }
 }
 
-const levelBadge = computed(() => levelToBadge(level.status))
+const levelBadge = computed(() => statusToBadge(status))
 const label = computed(() => t(levelBadge.value.labelkey))
 </script>
 

--- a/src/features/student/components/badges/StudentTraceAssociationContentBadge/StudentTraceAssociationContentBadge.test.ts
+++ b/src/features/student/components/badges/StudentTraceAssociationContentBadge/StudentTraceAssociationContentBadge.test.ts
@@ -1,0 +1,105 @@
+import type { VueWrapper } from '@vue/test-utils'
+import { StudentTraceAssociationContentBadge } from '@/features/student/components/badges'
+import { ICONS_DATA_URL } from '@avenirs-esr/avenirs-dsav'
+import { BddTest, mountComponent } from 'tests/utils'
+import { beforeEach, expect, vi } from 'vitest'
+
+const stubs = {
+  AvBadge: {
+    name: 'AvBadge',
+    template: '<div class="av-badge" />',
+    props: {
+      label: String,
+      color: String,
+      backgroundColor: String,
+      iconPath: String,
+      small: Boolean,
+      ellipsis: Boolean
+    }
+  }
+}
+
+BddTest().given('a student trace association content badge', () => {
+  let wrapper: VueWrapper<InstanceType<typeof StudentTraceAssociationContentBadge>>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  BddTest().when('the component is mounted with only label prop', () => {
+    beforeEach(() => {
+      wrapper = mountComponent(StudentTraceAssociationContentBadge, {
+        props: {
+          label: 'Test Badge Label'
+        },
+        global: {
+          stubs
+        }
+      })
+    })
+
+    BddTest().then('it should render AvBadge with correct props', () => {
+      const badge = wrapper.findComponent({ name: 'AvBadge' })
+
+      expect(badge.exists()).toBe(true)
+      expect(badge.props('label')).toBe('Test Badge Label')
+      expect(badge.props('color')).toBe('var(--light-foreground-text1)')
+      expect(badge.props('backgroundColor')).toBe('var(--surface-background)')
+      expect(badge.props('small')).toBe(true)
+      expect(badge.props('ellipsis')).toBe(true)
+    })
+
+    BddTest().then('it should render with default icon', () => {
+      const badge = wrapper.findComponent({ name: 'AvBadge' })
+
+      expect(badge.props('iconPath')).toBe(ICONS_DATA_URL.AMS_SAE)
+    })
+
+    BddTest().then('it should have proper styling classes', () => {
+      const badge = wrapper.findComponent({ name: 'AvBadge' })
+
+      expect(badge.classes()).toContain('student-trace-association-content-badge')
+      expect(badge.classes()).toContain('caption-regular')
+    })
+  })
+
+  BddTest().when('the component is mounted with custom icon', () => {
+    beforeEach(() => {
+      wrapper = mountComponent(StudentTraceAssociationContentBadge, {
+        props: {
+          label: 'Custom Icon Badge',
+          iconPath: ICONS_DATA_URL.CLOCK_QUARTER_CHECK
+        },
+        global: {
+          stubs
+        }
+      })
+    })
+
+    BddTest().then('it should render AvBadge with custom icon', () => {
+      const badge = wrapper.findComponent({ name: 'AvBadge' })
+
+      expect(badge.exists()).toBe(true)
+      expect(badge.props('iconPath')).toBe(ICONS_DATA_URL.CLOCK_QUARTER_CHECK)
+    })
+  })
+
+  BddTest().when('the component is mounted with long label text', () => {
+    beforeEach(() => {
+      wrapper = mountComponent(StudentTraceAssociationContentBadge, {
+        props: {
+          label: 'This is a very long badge label that should be truncated with ellipsis'
+        },
+        global: {
+          stubs
+        }
+      })
+    })
+
+    BddTest().then('it should enable ellipsis on AvBadge', () => {
+      const badge = wrapper.findComponent({ name: 'AvBadge' })
+
+      expect(badge.props('ellipsis')).toBe(true)
+    })
+  })
+})

--- a/src/features/student/components/badges/StudentTraceAssociationContentBadge/StudentTraceAssociationContentBadge.vue
+++ b/src/features/student/components/badges/StudentTraceAssociationContentBadge/StudentTraceAssociationContentBadge.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+import { AvBadge, ICONS_DATA_URL } from '@avenirs-esr/avenirs-dsav'
+
+export interface StudentTraceAssociationContentBadgeProps {
+  label: string
+  iconPath?: string
+}
+
+const {
+  label,
+  iconPath = ICONS_DATA_URL.AMS_SAE
+} = defineProps<StudentTraceAssociationContentBadgeProps>()
+</script>
+
+<template>
+  <AvBadge
+    :label="label"
+    color="var(--light-foreground-text1)"
+    background-color="var(--surface-background)"
+    :icon-path="iconPath"
+    small
+    ellipsis
+    class="student-trace-association-content-badge caption-regular"
+  />
+</template>
+
+<style lang="scss" scoped>
+.student-trace-association-content-badge {
+  border: 0.06rem solid var(--stroke);
+  border-radius: var(--radius-sm);
+  flex: 1;
+}
+</style>

--- a/src/features/student/components/badges/index.ts
+++ b/src/features/student/components/badges/index.ts
@@ -1,3 +1,6 @@
+export { default as AdditionalSkillLevelBadge } from './AdditionalSkillLevelBadge/AdditionalSkillLevelBadge.vue'
+export { default as AdditionalSkillTypeBadge } from './AdditionalSkillTypeBadge/AdditionalSkillTypeBadge.vue'
 export { default as StudentAmsStatusBadge } from './StudentAmsStatusBadge/StudentAmsStatusBadge.vue'
 export { default as StudentLastCompletedLevelBadge } from './StudentLastCompletedLevelBadge/StudentLastCompletedLevelBadge.vue'
-export { default as StudentLevelBadge } from './StudentLevelBadge/StudentLevelBadge.vue'
+export { default as StudentSkillLevelStatusBadge } from './StudentSkillLevelStatusBadge/StudentSkillLevelStatusBadge.vue'
+export { default as StudentTraceAssociationContentBadge } from './StudentTraceAssociationContentBadge/StudentTraceAssociationContentBadge.vue'

--- a/src/features/student/components/cards/StudentDetailedEducationalSkillCard/StudentDetailedEducationalSkillCard.test.ts
+++ b/src/features/student/components/cards/StudentDetailedEducationalSkillCard/StudentDetailedEducationalSkillCard.test.ts
@@ -42,10 +42,10 @@ function createWrapper (skill: SkillDTO = baseSkill) {
           props: ['skill', 'skillColor', 'icon', 'color'],
           template: `<div class="student-detailed-skill-card"><slot /></div>`
         },
-        StudentLevelBadge: {
-          name: 'StudentLevelBadge',
-          props: ['level'],
-          template: `<div class="student-level-badge">{{ level.name }}</div>`
+        StudentSkillLevelStatusBadge: {
+          name: 'StudentSkillLevelStatusBadge',
+          props: ['status'],
+          template: `<div class="student-level-badge">{{ status }}</div>`
         },
         StudentCountTracesIconText: {
           name: 'StudentCountTracesIconText',
@@ -101,20 +101,20 @@ BddTest().given('a student detailed educationnal skill card with valid props', (
       expect(badge.text()).toContain(`${baseSkill.levelCount} niveaux`)
     })
 
-    BddTest().then('it should render the StudentLevelBadge when status is TO_BE_EVALUATED', () => {
+    BddTest().then('it should render the StudentSkillLevelStatusBadge when status is TO_BE_EVALUATED', () => {
       const badge = wrapper.find('.student-level-badge')
       expect(badge.exists()).toBe(true)
-      expect(badge.text()).toContain(baseSkill.currentSkillLevel.name)
+      expect(badge.text()).toContain(ESkillLevelStatus.TO_BE_EVALUATED)
     })
 
-    BddTest().then('it should render the StudentLevelBadge when status is UNDER_REVIEW', () => {
+    BddTest().then('it should render the StudentSkillLevelStatusBadge when status is UNDER_REVIEW', () => {
       const skill = { ...baseSkill, currentSkillLevel: { ...baseSkill.currentSkillLevel, status: ESkillLevelStatus.UNDER_REVIEW } }
       wrapper = createWrapper(skill)
       const badge = wrapper.find('.student-level-badge')
       expect(badge.exists()).toBe(true)
     })
 
-    BddTest().then('it should not render the StudentLevelBadge when status is VALIDATED', () => {
+    BddTest().then('it should not render the StudentSkillLevelStatusBadge when status is VALIDATED', () => {
       const skill = { ...baseSkill, currentSkillLevel: { ...baseSkill.currentSkillLevel, status: ESkillLevelStatus.VALIDATED } }
       wrapper = createWrapper(skill)
       const badge = wrapper.find('.student-level-badge')

--- a/src/features/student/components/cards/StudentDetailedEducationalSkillCard/StudentDetailedEducationalSkillCard.vue
+++ b/src/features/student/components/cards/StudentDetailedEducationalSkillCard/StudentDetailedEducationalSkillCard.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import type { ComputedRef } from 'vue'
 import { ESkillLevelStatus, type SkillDTO, type SkillLevelViewDTO } from '@/api/avenir-esr'
-import { StudentCountAmsIconText, StudentCountTracesIconText, StudentLastCompletedLevelBadge, StudentLevelBadge } from '@/features/student/components/'
+import { StudentCountAmsIconText, StudentCountTracesIconText, StudentLastCompletedLevelBadge, StudentSkillLevelStatusBadge } from '@/features/student/components/'
 import StudentDetailedSkillCard from '@/features/student/components/cards/StudentDetailedSkillCard/StudentDetailedSkillCard.vue'
 import { AvBadge, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
 
@@ -38,9 +38,9 @@ const basePath = import.meta.env.BASE_URL
       <div class="firstline-container">
         <div class="line-container">
           <span class="n6">{{ skill.currentSkillLevel.name }}</span>
-          <StudentLevelBadge
+          <StudentSkillLevelStatusBadge
             v-if="showLevelBadge"
-            :level="currentSkillLevel"
+            :status="currentSkillLevel.status"
           />
         </div>
         <div class="line-container">

--- a/src/features/student/components/cards/StudentTraceAdditionalSkillAssociationCard/StudentTraceAdditionalSkillAssociationCard.test.ts
+++ b/src/features/student/components/cards/StudentTraceAdditionalSkillAssociationCard/StudentTraceAdditionalSkillAssociationCard.test.ts
@@ -1,0 +1,188 @@
+import type { VueWrapper } from '@vue/test-utils'
+import { type AdditionalSkillAssociationDTO, EAdditionalSkillLevel, EAdditionalSkillType } from '@/api/avenir-esr'
+import { StudentTraceAdditionalSkillAssociationCard } from '@/features/student/components/cards'
+import { MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
+import { BddTest, mountComponent } from 'tests/utils'
+import { beforeEach, expect, vi } from 'vitest'
+
+const stubs = {
+  StudentTraceAssociationCard: {
+    name: 'StudentTraceAssociationCard',
+    template: `
+      <div class="student-trace-association-card">
+        <div class="title-prepend"><slot name="title-prepend" /></div>
+        <div class="body"><slot name="body" /></div>
+      </div>
+    `,
+    props: {
+      title: String,
+      icon: String
+    }
+  },
+  AdditionalSkillTypeBadge: {
+    name: 'AdditionalSkillTypeBadge',
+    template: '<div class="additional-skill-type-badge" />',
+    props: {
+      label: String
+    }
+  },
+  AdditionalSkillLevelBadge: {
+    name: 'AdditionalSkillLevelBadge',
+    template: '<div class="additional-skill-level-badge" />',
+    props: {
+      level: String,
+      small: Boolean
+    }
+  }
+}
+
+BddTest().given('a student trace additional skill association card', () => {
+  let wrapper: VueWrapper<InstanceType<typeof StudentTraceAdditionalSkillAssociationCard>>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  BddTest().when('the component is mounted with additional skill', () => {
+    const additionalSkill: AdditionalSkillAssociationDTO = {
+      id: 'skill-1',
+      title: 'Compétence additionnelle test',
+      type: EAdditionalSkillType.ROME4,
+      level: EAdditionalSkillLevel.INTERMEDIATE,
+      pathSegments: []
+    }
+
+    beforeEach(() => {
+      wrapper = mountComponent(StudentTraceAdditionalSkillAssociationCard, {
+        props: {
+          additionalSkill
+        },
+        global: {
+          stubs
+        }
+      })
+    })
+
+    BddTest().then('it should render StudentTraceAssociationCard with skill title', () => {
+      const card = wrapper.findComponent({ name: 'StudentTraceAssociationCard' })
+
+      expect(card.exists()).toBe(true)
+      expect(card.props('title')).toBe('Compétence additionnelle test')
+    })
+
+    BddTest().then('it should render StudentTraceAssociationCard with stars icon', () => {
+      const card = wrapper.findComponent({ name: 'StudentTraceAssociationCard' })
+
+      expect(card.props('icon')).toBe(MDI_ICONS.STARS)
+    })
+
+    BddTest().then('it should render AdditionalSkillTypeBadge with skill type', () => {
+      const typeBadge = wrapper.findComponent({ name: 'AdditionalSkillTypeBadge' })
+
+      expect(typeBadge.exists()).toBe(true)
+      expect(typeBadge.props('label')).toBe(EAdditionalSkillType.ROME4)
+    })
+
+    BddTest().then('it should render AdditionalSkillLevelBadge with skill level', () => {
+      const levelBadge = wrapper.findComponent({ name: 'AdditionalSkillLevelBadge' })
+
+      expect(levelBadge.exists()).toBe(true)
+      expect(levelBadge.props('level')).toBe(EAdditionalSkillLevel.INTERMEDIATE)
+      expect(levelBadge.props('small')).toBe(true)
+    })
+  })
+
+  BddTest().when('the component is mounted with different skill levels', () => {
+    const skillBeginner: AdditionalSkillAssociationDTO = {
+      id: 'skill-2',
+      title: 'Compétence débutant',
+      type: EAdditionalSkillType.ROME4,
+      level: EAdditionalSkillLevel.BEGINNER,
+      pathSegments: []
+    }
+
+    const skillExpert: AdditionalSkillAssociationDTO = {
+      id: 'skill-3',
+      title: 'Compétence expert',
+      type: EAdditionalSkillType.ROME4,
+      level: EAdditionalSkillLevel.EXPERT,
+      pathSegments: []
+    }
+
+    BddTest().then('it should render BEGINNER level correctly', () => {
+      wrapper = mountComponent(StudentTraceAdditionalSkillAssociationCard, {
+        props: { additionalSkill: skillBeginner },
+        global: { stubs }
+      })
+
+      const levelBadge = wrapper.findComponent({ name: 'AdditionalSkillLevelBadge' })
+      expect(levelBadge.props('level')).toBe(EAdditionalSkillLevel.BEGINNER)
+    })
+
+    BddTest().then('it should render EXPERT level correctly', () => {
+      wrapper = mountComponent(StudentTraceAdditionalSkillAssociationCard, {
+        props: { additionalSkill: skillExpert },
+        global: { stubs }
+      })
+
+      const levelBadge = wrapper.findComponent({ name: 'AdditionalSkillLevelBadge' })
+      expect(levelBadge.props('level')).toBe(EAdditionalSkillLevel.EXPERT)
+    })
+  })
+
+  BddTest().when('the component is mounted with COMPETENT level', () => {
+    const skillCompetent: AdditionalSkillAssociationDTO = {
+      id: 'skill-4',
+      title: 'Compétence compétent',
+      type: EAdditionalSkillType.ROME4,
+      level: EAdditionalSkillLevel.COMPETENT,
+      pathSegments: []
+    }
+
+    beforeEach(() => {
+      wrapper = mountComponent(StudentTraceAdditionalSkillAssociationCard, {
+        props: { additionalSkill: skillCompetent },
+        global: { stubs }
+      })
+    })
+
+    BddTest().then('it should render COMPETENT level correctly', () => {
+      const levelBadge = wrapper.findComponent({ name: 'AdditionalSkillLevelBadge' })
+      expect(levelBadge.props('level')).toBe(EAdditionalSkillLevel.COMPETENT)
+    })
+
+    BddTest().then('it should render ROME4 type correctly', () => {
+      const typeBadge = wrapper.findComponent({ name: 'AdditionalSkillTypeBadge' })
+      expect(typeBadge.props('label')).toBe(EAdditionalSkillType.ROME4)
+    })
+  })
+
+  BddTest().when('the component is mounted with body slot content', () => {
+    const additionalSkill: AdditionalSkillAssociationDTO = {
+      id: 'skill-7',
+      title: 'Compétence avec body',
+      type: EAdditionalSkillType.ROME4,
+      level: EAdditionalSkillLevel.BEGINNER,
+      pathSegments: []
+    }
+
+    beforeEach(() => {
+      wrapper = mountComponent(StudentTraceAdditionalSkillAssociationCard, {
+        props: {
+          additionalSkill
+        },
+        slots: {
+          body: '<div class="custom-body">Custom body content</div>'
+        },
+        global: {
+          stubs
+        }
+      })
+    })
+
+    BddTest().then('it should render the body slot content', () => {
+      expect(wrapper.find('.custom-body').exists()).toBe(true)
+      expect(wrapper.text()).toContain('Custom body content')
+    })
+  })
+})

--- a/src/features/student/components/cards/StudentTraceAdditionalSkillAssociationCard/StudentTraceAdditionalSkillAssociationCard.vue
+++ b/src/features/student/components/cards/StudentTraceAdditionalSkillAssociationCard/StudentTraceAdditionalSkillAssociationCard.vue
@@ -1,0 +1,42 @@
+<script lang="ts" setup>
+import type { AdditionalSkillAssociationDTO } from '@/api/avenir-esr'
+import { AdditionalSkillLevelBadge, AdditionalSkillTypeBadge } from '@/features/student/components/badges'
+import { StudentTraceAssociationCard } from '@/features/student/components/cards'
+import { MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
+
+export interface StudentTraceAmsAssociationCardProps {
+  additionalSkill: AdditionalSkillAssociationDTO
+}
+
+const { additionalSkill } = defineProps<StudentTraceAmsAssociationCardProps>()
+</script>
+
+<template>
+  <StudentTraceAssociationCard
+    :title="additionalSkill.title"
+    :icon="MDI_ICONS.STARS"
+  >
+    <template #title-prepend>
+      <div class="badges-container">
+        <AdditionalSkillTypeBadge
+          :label="additionalSkill.type"
+        />
+        <AdditionalSkillLevelBadge
+          :level="additionalSkill.level"
+          small
+        />
+      </div>
+    </template>
+    <template #body>
+      <slot name="body" />
+    </template>
+  </StudentTraceAssociationCard>
+</template>
+
+<style lang="scss" scoped>
+.badges-container {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-md);
+}
+</style>

--- a/src/features/student/components/cards/StudentTraceAssociationCard/StudentTraceAssociationCard.test.ts
+++ b/src/features/student/components/cards/StudentTraceAssociationCard/StudentTraceAssociationCard.test.ts
@@ -1,0 +1,160 @@
+import type { VueWrapper } from '@vue/test-utils'
+import { StudentTraceAssociationCard } from '@/features/student/components/cards'
+import { MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
+import { BddTest, mountComponent } from 'tests/utils'
+import { beforeEach, expect, vi } from 'vitest'
+
+const stubs = {
+  AvCard: {
+    name: 'AvCard',
+    template: `
+      <div class="av-card">
+        <div class="av-card__title"><slot name="title" /></div>
+        <div class="av-card__body"><slot name="body" /></div>
+      </div>
+    `,
+    props: {
+      borderColor: String
+    }
+  },
+  AvVIcon: {
+    name: 'AvVIcon',
+    template: '<div class="av-v-icon" />',
+    props: {
+      name: String,
+      color: String,
+      size: Number
+    }
+  }
+}
+
+BddTest().given('a student trace association card', () => {
+  let wrapper: VueWrapper<InstanceType<typeof StudentTraceAssociationCard>>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  BddTest().when('the component is mounted with default props', () => {
+    beforeEach(() => {
+      wrapper = mountComponent(StudentTraceAssociationCard, {
+        props: {
+          title: 'Test Association Title'
+        },
+        global: {
+          stubs
+        }
+      })
+    })
+
+    BddTest().then('it should render the card', () => {
+      const card = wrapper.findComponent({ name: 'AvCard' })
+
+      expect(card.exists()).toBe(true)
+      expect(card.props('borderColor')).toBe('var(--other-border-skill-card)')
+    })
+
+    BddTest().then('it should render the title', () => {
+      expect(wrapper.text()).toContain('Test Association Title')
+    })
+
+    BddTest().then('it should render the default icon', () => {
+      const icon = wrapper.findComponent({ name: 'AvVIcon' })
+
+      expect(icon.exists()).toBe(true)
+      expect(icon.props('name')).toBe(MDI_ICONS.STAR_SHOOTING_OUTLINE)
+      expect(icon.props('color')).toBe('var(--text2)')
+    })
+  })
+
+  BddTest().when('the component is mounted with custom icon', () => {
+    beforeEach(() => {
+      wrapper = mountComponent(StudentTraceAssociationCard, {
+        props: {
+          title: 'Custom Icon Title',
+          icon: MDI_ICONS.STARS
+        },
+        global: {
+          stubs
+        }
+      })
+    })
+
+    BddTest().then('it should render the custom icon', () => {
+      const icon = wrapper.findComponent({ name: 'AvVIcon' })
+
+      expect(icon.exists()).toBe(true)
+      expect(icon.props('name')).toBe(MDI_ICONS.STARS)
+    })
+  })
+
+  BddTest().when('the component is mounted with title-prepend slot content', () => {
+    beforeEach(() => {
+      wrapper = mountComponent(StudentTraceAssociationCard, {
+        props: {
+          title: 'Title with Prepend'
+        },
+        slots: {
+          'title-prepend': '<div class="prepend-content">Prepend Content</div>'
+        },
+        global: {
+          stubs
+        }
+      })
+    })
+
+    BddTest().then('it should render the title-prepend slot content', () => {
+      expect(wrapper.find('.prepend-content').exists()).toBe(true)
+      expect(wrapper.text()).toContain('Prepend Content')
+    })
+  })
+
+  BddTest().when('the component is mounted with body slot content', () => {
+    beforeEach(() => {
+      wrapper = mountComponent(StudentTraceAssociationCard, {
+        props: {
+          title: 'Title with Body'
+        },
+        slots: {
+          body: '<div class="body-content">Body Content</div>'
+        },
+        global: {
+          stubs
+        }
+      })
+    })
+
+    BddTest().then('it should render the body slot content', () => {
+      expect(wrapper.find('.body-content').exists()).toBe(true)
+      expect(wrapper.text()).toContain('Body Content')
+    })
+  })
+
+  BddTest().when('the component is mounted with both slots', () => {
+    beforeEach(() => {
+      wrapper = mountComponent(StudentTraceAssociationCard, {
+        props: {
+          title: 'Complete Card'
+        },
+        slots: {
+          'title-prepend': '<div class="badge-slot">Badge</div>',
+          'body': '<div class="body-slot">Body</div>'
+        },
+        global: {
+          stubs
+        }
+      })
+    })
+
+    BddTest().then('it should render both slot contents', () => {
+      expect(wrapper.find('.badge-slot').exists()).toBe(true)
+      expect(wrapper.find('.body-slot').exists()).toBe(true)
+      expect(wrapper.text()).toContain('Badge')
+      expect(wrapper.text()).toContain('Body')
+    })
+
+    BddTest().then('it should render the title', () => {
+      expect(wrapper.text()).toContain('Complete Card')
+    })
+  })
+})

--- a/src/features/student/components/cards/StudentTraceAssociationCard/StudentTraceAssociationCard.vue
+++ b/src/features/student/components/cards/StudentTraceAssociationCard/StudentTraceAssociationCard.vue
@@ -1,0 +1,79 @@
+<script lang="ts" setup>
+import { AvCard, AvIconText, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
+
+export interface StudentTraceAssociationCardProps {
+  title: string
+  icon?: string
+}
+
+const {
+  icon = MDI_ICONS.STAR_SHOOTING_OUTLINE
+} = defineProps<StudentTraceAssociationCardProps>()
+</script>
+
+<template>
+  <div class="student-trace-association-card">
+    <AvCard border-color="var(--other-border-skill-card)">
+      <template #title>
+        <div class="title-container">
+          <AvIconText
+            :icon="icon"
+            :text="title"
+            text-color="var(--text2)"
+            icon-color="var(--text2)"
+          />
+          <slot name="title-prepend" />
+        </div>
+      </template>
+      <template #body>
+        <div class="body-container">
+          <slot name="body" />
+        </div>
+      </template>
+    </AvCard>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.student-trace-association-card {
+  width: 100%;
+}
+
+.title-container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.association-title {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+}
+
+.body-container {
+  padding: var(--spacing-xs) var(--spacing-xs);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-lg);
+}
+
+:deep() {
+  .av-card__title {
+    padding: var(--spacing-xs) var(--spacing-sm);
+    border-color: var(--light-background-neutral) !important;
+  }
+
+  .av-card {
+    padding-bottom: var(--spacing-xs);
+  }
+
+  .av-card__body .body-container {
+    padding: 0 var(--spacing-xs);
+  }
+
+  .icon-text--container {
+    gap: var(--spacing-sm);
+  }
+}
+</style>

--- a/src/features/student/components/cards/StudentTraceSkillLevelAssociationCard/StudentTraceSkillLevelAssociationCard.test.ts
+++ b/src/features/student/components/cards/StudentTraceSkillLevelAssociationCard/StudentTraceSkillLevelAssociationCard.test.ts
@@ -1,0 +1,234 @@
+import type { VueWrapper } from '@vue/test-utils'
+import { EAmsStatus, ESkillLevelStatus, type SkillLevelAssociationDTO } from '@/api/avenir-esr'
+import { StudentTraceSkillLevelAssociationCard } from '@/features/student/components/cards'
+import { BddTest, mountComponent } from 'tests/utils'
+import { beforeEach, expect, vi } from 'vitest'
+
+const stubs = {
+  StudentTraceAssociationCard: {
+    name: 'StudentTraceAssociationCard',
+    template: `
+      <div class="student-trace-association-card">
+        <div class="title-prepend"><slot name="title-prepend" /></div>
+        <div class="body"><slot name="body" /></div>
+      </div>
+    `,
+    props: {
+      title: String
+    }
+  },
+  AvBadge: {
+    name: 'AvBadge',
+    template: '<div class="av-badge" />',
+    props: {
+      label: String,
+      color: String,
+      backgroundColor: String,
+      small: Boolean,
+      ellipsis: Boolean
+    }
+  },
+  StudentSkillLevelStatusBadge: {
+    name: 'StudentSkillLevelStatusBadge',
+    template: '<div class="student-skill-level-status-badge" />',
+    props: {
+      status: String
+    }
+  },
+  StudentTraceAssociationContentBadge: {
+    name: 'StudentTraceAssociationContentBadge',
+    template: '<div class="student-trace-association-content-badge" />',
+    props: {
+      label: String,
+      iconPath: String
+    }
+  },
+  StudentAmsStatusBadge: {
+    name: 'StudentAmsStatusBadge',
+    template: '<div class="student-ams-status-badge" />',
+    props: {
+      status: String
+    }
+  }
+}
+
+BddTest().given('a student trace skill level association card', () => {
+  let wrapper: VueWrapper<InstanceType<typeof StudentTraceSkillLevelAssociationCard>>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  BddTest().when('the component is mounted with skill without AMS', () => {
+    const skillWithoutAms: SkillLevelAssociationDTO = {
+      id: 'skill-1',
+      skillTitle: 'Compétence Test',
+      level: 'Niv. 1',
+      status: ESkillLevelStatus.VALIDATED
+    }
+
+    beforeEach(() => {
+      wrapper = mountComponent(StudentTraceSkillLevelAssociationCard, {
+        props: {
+          skill: skillWithoutAms
+        },
+        global: {
+          stubs
+        }
+      })
+    })
+
+    BddTest().then('it should render StudentTraceAssociationCard with skill title', () => {
+      const card = wrapper.findComponent({ name: 'StudentTraceAssociationCard' })
+
+      expect(card.exists()).toBe(true)
+      expect(card.props('title')).toBe('Compétence Test')
+    })
+
+    BddTest().then('it should render skill level badge', () => {
+      const levelBadge = wrapper.findComponent({ name: 'AvBadge' })
+
+      expect(levelBadge.exists()).toBe(true)
+      expect(levelBadge.props('label')).toBe('Niv. 1')
+      expect(levelBadge.props('color')).toBe('var(--card)')
+      expect(levelBadge.props('backgroundColor')).toBe('var(--skill3)')
+      expect(levelBadge.props('small')).toBe(true)
+      expect(levelBadge.props('ellipsis')).toBe(true)
+    })
+
+    BddTest().then('it should render skill status badge', () => {
+      const statusBadge = wrapper.findComponent({ name: 'StudentSkillLevelStatusBadge' })
+
+      expect(statusBadge.exists()).toBe(true)
+      expect(statusBadge.props('status')).toBe(ESkillLevelStatus.VALIDATED)
+    })
+
+    BddTest().then('it should not render AMS section', () => {
+      const amsContentBadge = wrapper.findComponent({ name: 'StudentTraceAssociationContentBadge' })
+      const amsStatusBadge = wrapper.findComponent({ name: 'StudentAmsStatusBadge' })
+
+      expect(amsContentBadge.exists()).toBe(false)
+      expect(amsStatusBadge.exists()).toBe(false)
+    })
+  })
+
+  BddTest().when('the component is mounted with skill with AMS', () => {
+    const skillWithAms: SkillLevelAssociationDTO = {
+      id: 'skill-2',
+      skillTitle: 'Compétence avec AMS',
+      level: 'Niv. 2',
+      status: ESkillLevelStatus.UNDER_ACQUISITION,
+      ams: {
+        id: 'ams-1',
+        title: 'SAE 1.4 Etude des risques',
+        status: EAmsStatus.COMPLETED
+      }
+    }
+
+    beforeEach(() => {
+      wrapper = mountComponent(StudentTraceSkillLevelAssociationCard, {
+        props: {
+          skill: skillWithAms
+        },
+        global: {
+          stubs
+        }
+      })
+    })
+
+    BddTest().then('it should render AMS content badge with title', () => {
+      const amsContentBadge = wrapper.findComponent({ name: 'StudentTraceAssociationContentBadge' })
+
+      expect(amsContentBadge.exists()).toBe(true)
+      expect(amsContentBadge.props('label')).toBe('SAE 1.4 Etude des risques')
+    })
+
+    BddTest().then('it should render AMS status badge', () => {
+      const amsStatusBadge = wrapper.findComponent({ name: 'StudentAmsStatusBadge' })
+
+      expect(amsStatusBadge.exists()).toBe(true)
+      expect(amsStatusBadge.props('status')).toBe(EAmsStatus.COMPLETED)
+    })
+  })
+
+  BddTest().when('the component is mounted with custom level color', () => {
+    const skill: SkillLevelAssociationDTO = {
+      id: 'skill-3',
+      skillTitle: 'Compétence Custom Color',
+      level: 'Niv. 3',
+      status: ESkillLevelStatus.NOT_STARTED
+    }
+
+    beforeEach(() => {
+      wrapper = mountComponent(StudentTraceSkillLevelAssociationCard, {
+        props: {
+          skill,
+          levelColor: 'var(--skill1)'
+        },
+        global: {
+          stubs
+        }
+      })
+    })
+
+    BddTest().then('it should render level badge with custom color', () => {
+      const levelBadge = wrapper.findComponent({ name: 'AvBadge' })
+
+      expect(levelBadge.exists()).toBe(true)
+      expect(levelBadge.props('backgroundColor')).toBe('var(--skill1)')
+    })
+  })
+
+  BddTest().when('the component is mounted with all statuses', () => {
+    const skillValidated: SkillLevelAssociationDTO = {
+      id: 'skill-4',
+      skillTitle: 'Compétence Validée',
+      level: 'Niv. 1',
+      status: ESkillLevelStatus.VALIDATED
+    }
+
+    const skillUnderAcquisition: SkillLevelAssociationDTO = {
+      id: 'skill-5',
+      skillTitle: 'Compétence En Cours',
+      level: 'Niv. 2',
+      status: ESkillLevelStatus.UNDER_ACQUISITION
+    }
+
+    const skillNotStarted: SkillLevelAssociationDTO = {
+      id: 'skill-6',
+      skillTitle: 'Compétence Non Démarrée',
+      level: 'Niv. 3',
+      status: ESkillLevelStatus.NOT_STARTED
+    }
+
+    BddTest().then('it should render VALIDATED status correctly', () => {
+      wrapper = mountComponent(StudentTraceSkillLevelAssociationCard, {
+        props: { skill: skillValidated },
+        global: { stubs }
+      })
+
+      const statusBadge = wrapper.findComponent({ name: 'StudentSkillLevelStatusBadge' })
+      expect(statusBadge.props('status')).toBe(ESkillLevelStatus.VALIDATED)
+    })
+
+    BddTest().then('it should render UNDER_ACQUISITION status correctly', () => {
+      wrapper = mountComponent(StudentTraceSkillLevelAssociationCard, {
+        props: { skill: skillUnderAcquisition },
+        global: { stubs }
+      })
+
+      const statusBadge = wrapper.findComponent({ name: 'StudentSkillLevelStatusBadge' })
+      expect(statusBadge.props('status')).toBe(ESkillLevelStatus.UNDER_ACQUISITION)
+    })
+
+    BddTest().then('it should render NOT_STARTED status correctly', () => {
+      wrapper = mountComponent(StudentTraceSkillLevelAssociationCard, {
+        props: { skill: skillNotStarted },
+        global: { stubs }
+      })
+
+      const statusBadge = wrapper.findComponent({ name: 'StudentSkillLevelStatusBadge' })
+      expect(statusBadge.props('status')).toBe(ESkillLevelStatus.NOT_STARTED)
+    })
+  })
+})

--- a/src/features/student/components/cards/StudentTraceSkillLevelAssociationCard/StudentTraceSkillLevelAssociationCard.vue
+++ b/src/features/student/components/cards/StudentTraceSkillLevelAssociationCard/StudentTraceSkillLevelAssociationCard.vue
@@ -1,0 +1,63 @@
+<script lang="ts" setup>
+import type { SkillLevelAssociationDTO } from '@/api/avenir-esr'
+import { StudentAmsStatusBadge, StudentSkillLevelStatusBadge, StudentTraceAssociationContentBadge } from '@/features/student/components/badges'
+import { StudentTraceAssociationCard } from '@/features/student/components/cards'
+import { AvBadge } from '@avenirs-esr/avenirs-dsav'
+
+export interface StudentTraceSkillAssociationCardProps {
+  skill: SkillLevelAssociationDTO
+  levelColor?: string
+}
+
+const { skill, levelColor = 'var(--skill3)' } = defineProps<StudentTraceSkillAssociationCardProps>()
+</script>
+
+<template>
+  <StudentTraceAssociationCard :title="skill.skillTitle">
+    <template #title-prepend>
+      <div class="badges-container">
+        <AvBadge
+          :label="skill.level"
+          color="var(--card)"
+          :background-color="levelColor"
+          small
+          ellipsis
+          class="skill-level-badge"
+        />
+        <StudentSkillLevelStatusBadge :status="skill.status" />
+      </div>
+    </template>
+    <template #body>
+      <div
+        v-if="skill.ams"
+        class="ams-container"
+      >
+        <StudentTraceAssociationContentBadge
+          :label="skill.ams.title"
+        />
+        <StudentAmsStatusBadge :status="skill.ams.status" />
+      </div>
+    </template>
+  </StudentTraceAssociationCard>
+</template>
+
+<style lang="scss" scoped>
+.badges-container {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-md);
+}
+
+.av-badge.skill-level-badge:before {
+  display: none;
+}
+
+.ams-container {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: var(--spacing-sm);
+  justify-content: space-between;
+  padding-top: var(--spacing-xs)
+}
+</style>

--- a/src/features/student/components/cards/index.ts
+++ b/src/features/student/components/cards/index.ts
@@ -1,3 +1,6 @@
 export { default as StudentDetailedEducationalSkillCard } from './StudentDetailedEducationalSkillCard/StudentDetailedEducationalSkillCard.vue'
 export { default as StudentDetailedPastSkillCard } from './StudentDetailedPastSkillCard/StudentDetailedPastSkillCard.vue'
 export { default as StudentDetailedSkillCard } from './StudentDetailedSkillCard/StudentDetailedSkillCard.vue'
+export { default as StudentTraceAdditionalSkillAssociationCard } from './StudentTraceAdditionalSkillAssociationCard/StudentTraceAdditionalSkillAssociationCard.vue'
+export { default as StudentTraceAssociationCard } from './StudentTraceAssociationCard/StudentTraceAssociationCard.vue'
+export { default as StudentTraceSkillLevelAssociationCard } from './StudentTraceSkillLevelAssociationCard/StudentTraceSkillLevelAssociationCard.vue'

--- a/src/features/student/locales/en.json
+++ b/src/features/student/locales/en.json
@@ -306,15 +306,18 @@
             "assign": "Assign my trace",
             "delete": "Delete my trace",
             "update": "Update my trace"
-          },
-          "studentTraceDetails": {
-            "addedOn": "Added on {date}",
-            "authenticProduction": "Authentic and personal production",
-            "documentLabel": "My uploaded document",
-            "groupProduction": "This trace is a group production",
-            "iaToggleLabel": "AI production",
-            "personalNoteLabel": "Personal note"
           }
+        },
+        "studentTraceAssociations": {
+          "title": "My trace associations ({count})"
+        },
+        "studentTraceDetails": {
+          "addedOn": "Added on {date}",
+          "authenticProduction": "Authentic and personal production",
+          "documentLabel": "My uploaded document",
+          "groupProduction": "This trace is a group production",
+          "iaToggleLabel": "AI production",
+          "personalNoteLabel": "Personal note"
         },
         "studentToolsTracesActionButtons": {
           "addTrace": "Add a trace to my library"

--- a/src/features/student/locales/fr.json
+++ b/src/features/student/locales/fr.json
@@ -306,15 +306,18 @@
             "assign": "Assigner ma trace",
             "delete": "Supprimer ma trace",
             "update": "Modifier ma trace"
-          },
-          "studentTraceDetails": {
-            "addedOn": "Ajouté le {date}",
-            "authenticProduction": "Production authentique et personnelle",
-            "documentLabel": "Mon document chargé",
-            "groupProduction": "Cette trace est une production de groupe",
-            "iaToggleLabel": "Production avec IA",
-            "personalNoteLabel": "Note personnelle"
           }
+        },
+        "studentTraceAssociations": {
+          "title": "Les associations de ma trace ({count})"
+        },
+        "studentTraceDetails": {
+          "addedOn": "Ajouté le {date}",
+          "authenticProduction": "Production authentique et personnelle",
+          "documentLabel": "Mon document chargé",
+          "groupProduction": "Cette trace est une production de groupe",
+          "iaToggleLabel": "Production avec IA",
+          "personalNoteLabel": "Note personnelle"
         },
         "studentToolsTracesActionButtons": {
           "addTrace": "Ajouter une trace dans ma bibliothèque"

--- a/src/features/student/views/StudentProjectSkillsView/components/AddAdditionalSkillDrawer/components/AddAdditionalSkillAutocompleteField/AddAdditionalSkillAutocompleteField.test.ts
+++ b/src/features/student/views/StudentProjectSkillsView/components/AddAdditionalSkillDrawer/components/AddAdditionalSkillAutocompleteField/AddAdditionalSkillAutocompleteField.test.ts
@@ -265,7 +265,6 @@ BddTest().given('an autocomplete skill field component', () => {
       const badge = wrapper.findComponent({ name: 'AdditionalSkillTypeBadge' })
       expect(badge.exists()).toBe(true)
       expect(badge.props('label')).toBeDefined()
-      expect(badge.props('backgroundColor')).toBe('var(--dark-background-primary1)')
     })
   })
 

--- a/src/features/student/views/StudentProjectSkillsView/components/AddAdditionalSkillDrawer/components/AddAdditionalSkillAutocompleteField/AddAdditionalSkillAutocompleteField.vue
+++ b/src/features/student/views/StudentProjectSkillsView/components/AddAdditionalSkillDrawer/components/AddAdditionalSkillAutocompleteField/AddAdditionalSkillAutocompleteField.vue
@@ -161,7 +161,6 @@ function highlightCaptionText (text: string, query: string): string {
 
                 <AdditionalSkillTypeBadge
                   :label="option.type"
-                  background-color="var(--dark-background-primary1)"
                 />
               </div>
             </AvListItem>

--- a/src/features/student/views/StudentProjectSkillsView/components/AddAdditionalSkillDrawer/components/AddAdditionalSkillLevelField/AddAdditionalSkillLevelField.vue
+++ b/src/features/student/views/StudentProjectSkillsView/components/AddAdditionalSkillDrawer/components/AddAdditionalSkillLevelField/AddAdditionalSkillLevelField.vue
@@ -4,8 +4,9 @@ import type {
 } from '@/features/student/views/StudentProjectSkillsView/components/AddAdditionalSkillDrawer/use-additional-skill-form/use-additional-skill-form'
 import { EAdditionalSkillLevel } from '@/api/avenir-esr'
 import { isEnumMember } from '@/common/utils'
+import { AdditionalSkillLevelBadge } from '@/features/student/components/badges'
 import { useAdditionalSkillConfig } from '@/features/student/queries'
-import { AvBadge, AvRadioButton, AvRadioButtonSet, ICONS_DATA_URL } from '@avenirs-esr/avenirs-dsav'
+import { AvRadioButton, AvRadioButtonSet } from '@avenirs-esr/avenirs-dsav'
 import { useI18n } from 'vue-i18n'
 
 interface SkillLevelFieldProps {
@@ -19,44 +20,6 @@ const { t } = useI18n()
 const { data: skillConfig } = useAdditionalSkillConfig()
 
 const skillLevels = computed(() => Object.values(EAdditionalSkillLevel))
-
-function getBadgeConfig (level: string) {
-  const config = {
-    BEGINNER: {
-      background: 'var(--light-background-primary3)',
-      color: 'var(--dark-background-primary3)',
-      icon: ICONS_DATA_URL.CLOCK_QUARTER_CHECK
-    },
-    INTERMEDIATE: {
-      background: 'var(--light-background-info)',
-      color: 'var(--dark-background-info)',
-      icon: ICONS_DATA_URL.CLOCK_THIRD_CHECK
-    },
-    COMPETENT: {
-      background: 'var(--light-background-critical)',
-      color: 'var(--light-foreground-critical)',
-      icon: ICONS_DATA_URL.CLOCK_HALF_PLUS_CHECK
-    },
-    ADVANCED: {
-      background: 'var(--light-background-primary2)',
-      color: 'var(--dark-background-primary2)',
-      icon: ICONS_DATA_URL.CLOCK_ALMOST_CHECK
-    },
-    EXPERT: {
-      background: 'var(--light-background-primary1)',
-      color: 'var(--light-foreground-primary2)',
-      icon: ICONS_DATA_URL.MDI_CHECK_CIRCLE
-    }
-  }
-  return config[level as keyof typeof config] || config.BEGINNER
-}
-
-function getBadgeLabel (level: EAdditionalSkillLevel) {
-  if (!skillConfig.value) {
-    return level
-  }
-  return isEnumMember(EAdditionalSkillLevel, level) ? skillConfig.value[level]?.label ?? level : level
-}
 
 function getDescription (level: EAdditionalSkillLevel) {
   if (!skillConfig.value) {
@@ -91,12 +54,7 @@ function getDescription (level: EAdditionalSkillLevel) {
             <AvRadioButton :value="level">
               <div class="level-option">
                 <div class="level-option__header">
-                  <AvBadge
-                    :label="getBadgeLabel(level)"
-                    :background-color="getBadgeConfig(level).background"
-                    :color="getBadgeConfig(level).color"
-                    :icon-path="getBadgeConfig(level).icon"
-                  />
+                  <AdditionalSkillLevelBadge :level="level" />
                 </div>
                 <span class="b2-regular">
                   {{ getDescription(level) }}

--- a/src/features/student/views/StudentToolsTracesView/components/StudentTraceAssociations/StudentTraceAssociations.test.ts
+++ b/src/features/student/views/StudentToolsTracesView/components/StudentTraceAssociations/StudentTraceAssociations.test.ts
@@ -1,0 +1,280 @@
+import type { VueWrapper } from '@vue/test-utils'
+import { type AdditionalSkillAssociationDTO, EAdditionalSkillLevel, EAdditionalSkillType, EAmsStatus, ESkillLevelStatus, type SkillLevelAssociationDTO } from '@/api/avenir-esr'
+import StudentTraceAssociations
+  from '@/features/student/views/StudentToolsTracesView/components/StudentTraceAssociations/StudentTraceAssociations.vue'
+import { BddTest, mountComponent } from 'tests/utils'
+import { beforeEach, expect, vi } from 'vitest'
+
+const stubs = {
+  AvIconText: {
+    name: 'AvIconText',
+    template: '<div class="av-icon-text"><slot /></div>',
+    props: {
+      text: String,
+      icon: String,
+      typographyClass: String
+    }
+  },
+  StudentTraceSkillLevelAssociationCard: {
+    name: 'StudentTraceSkillLevelAssociationCard',
+    template: '<div class="student-trace-skill-level-association-card" />',
+    props: {
+      skill: Object,
+      levelColor: String
+    }
+  },
+  StudentTraceAdditionalSkillAssociationCard: {
+    name: 'StudentTraceAdditionalSkillAssociationCard',
+    template: '<div class="student-trace-additional-skill-association-card" />',
+    props: {
+      additionalSkill: Object
+    }
+  }
+}
+
+BddTest().given('a student trace associations component', () => {
+  let wrapper: VueWrapper<InstanceType<typeof StudentTraceAssociations>>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  BddTest().when('the component is mounted with empty associations', () => {
+    beforeEach(() => {
+      wrapper = mountComponent(StudentTraceAssociations, {
+        props: {
+          skillLevelAssociations: [],
+          additionalSkillAssociations: []
+        },
+        global: {
+          stubs
+        }
+      })
+    })
+
+    BddTest().then('it should render the title with count 0', () => {
+      const iconText = wrapper.findComponent({ name: 'AvIconText' })
+
+      expect(iconText.exists()).toBe(true)
+      expect(iconText.props('text')).toContain('(0)')
+    })
+
+    BddTest().then('it should not render any association cards', () => {
+      const skillCards = wrapper.findAllComponents({ name: 'StudentTraceSkillLevelAssociationCard' })
+      const additionalSkillCards = wrapper.findAllComponents({ name: 'StudentTraceAdditionalSkillAssociationCard' })
+
+      expect(skillCards).toHaveLength(0)
+      expect(additionalSkillCards).toHaveLength(0)
+    })
+  })
+
+  BddTest().when('the component is mounted with only skill level associations', () => {
+    const skillLevelAssociations: SkillLevelAssociationDTO[] = [
+      {
+        id: 'skill-1',
+        skillTitle: 'Compétence 1',
+        level: 'Niv. 1',
+        status: ESkillLevelStatus.VALIDATED
+      },
+      {
+        id: 'skill-2',
+        skillTitle: 'Compétence 2',
+        level: 'Niv. 2',
+        status: ESkillLevelStatus.UNDER_ACQUISITION,
+        ams: {
+          id: 'ams-1',
+          title: 'SAE 1.4',
+          status: EAmsStatus.COMPLETED
+        }
+      }
+    ]
+
+    beforeEach(() => {
+      wrapper = mountComponent(StudentTraceAssociations, {
+        props: {
+          skillLevelAssociations,
+          additionalSkillAssociations: []
+        },
+        global: {
+          stubs
+        }
+      })
+    })
+
+    BddTest().then('it should render the title with count 2', () => {
+      const iconText = wrapper.findComponent({ name: 'AvIconText' })
+
+      expect(iconText.exists()).toBe(true)
+      expect(iconText.props('text')).toContain('(2)')
+    })
+
+    BddTest().then('it should render 2 skill level association cards', () => {
+      const skillCards = wrapper.findAllComponents({ name: 'StudentTraceSkillLevelAssociationCard' })
+
+      expect(skillCards).toHaveLength(2)
+    })
+
+    BddTest().then('it should pass correct props to skill cards', () => {
+      const skillCards = wrapper.findAllComponents({ name: 'StudentTraceSkillLevelAssociationCard' })
+
+      expect(skillCards[0].props('skill')).toEqual(skillLevelAssociations[0])
+      expect(skillCards[1].props('skill')).toEqual(skillLevelAssociations[1])
+    })
+
+    BddTest().then('it should assign different colors to each skill card', () => {
+      const skillCards = wrapper.findAllComponents({ name: 'StudentTraceSkillLevelAssociationCard' })
+
+      expect(skillCards[0].props('levelColor')).toBe('var(--skill1)')
+      expect(skillCards[1].props('levelColor')).toBe('var(--skill2)')
+    })
+
+    BddTest().then('it should not render additional skill cards', () => {
+      const additionalSkillCards = wrapper.findAllComponents({ name: 'StudentTraceAdditionalSkillAssociationCard' })
+
+      expect(additionalSkillCards).toHaveLength(0)
+    })
+  })
+
+  BddTest().when('the component is mounted with only additional skill associations', () => {
+    const additionalSkillAssociations: AdditionalSkillAssociationDTO[] = [
+      {
+        id: 'additional-1',
+        title: 'Compétence additionnelle 1',
+        level: EAdditionalSkillLevel.BEGINNER,
+        pathSegments: [],
+        type: EAdditionalSkillType.ROME4
+      }
+    ]
+
+    beforeEach(() => {
+      wrapper = mountComponent(StudentTraceAssociations, {
+        props: {
+          skillLevelAssociations: [],
+          additionalSkillAssociations
+        },
+        global: {
+          stubs
+        }
+      })
+    })
+
+    BddTest().then('it should render the title with count 1', () => {
+      const iconText = wrapper.findComponent({ name: 'AvIconText' })
+
+      expect(iconText.exists()).toBe(true)
+      expect(iconText.props('text')).toContain('(1)')
+    })
+
+    BddTest().then('it should render 1 additional skill association card', () => {
+      const additionalSkillCards = wrapper.findAllComponents({ name: 'StudentTraceAdditionalSkillAssociationCard' })
+
+      expect(additionalSkillCards).toHaveLength(1)
+    })
+
+    BddTest().then('it should pass correct props to additional skill card', () => {
+      const additionalSkillCards = wrapper.findAllComponents({ name: 'StudentTraceAdditionalSkillAssociationCard' })
+
+      expect(additionalSkillCards[0].props('additionalSkill')).toEqual(additionalSkillAssociations[0])
+    })
+
+    BddTest().then('it should not render skill level cards', () => {
+      const skillCards = wrapper.findAllComponents({ name: 'StudentTraceSkillLevelAssociationCard' })
+
+      expect(skillCards).toHaveLength(0)
+    })
+  })
+
+  BddTest().when('the component is mounted with both types of associations', () => {
+    const skillLevelAssociations: SkillLevelAssociationDTO[] = [
+      {
+        id: 'skill-1',
+        skillTitle: 'Compétence 1',
+        level: 'Niv. 1',
+        status: ESkillLevelStatus.VALIDATED
+      },
+      {
+        id: 'skill-2',
+        skillTitle: 'Compétence 2',
+        level: 'Niv. 2',
+        status: ESkillLevelStatus.UNDER_ACQUISITION
+      },
+      {
+        id: 'skill-3',
+        skillTitle: 'Compétence 3',
+        level: 'Niv. 3',
+        status: ESkillLevelStatus.UNDER_REVIEW
+      }
+    ]
+
+    const additionalSkillAssociations: AdditionalSkillAssociationDTO[] = [
+      {
+        id: 'additional-1',
+        title: 'Compétence additionnelle 1',
+        level: EAdditionalSkillLevel.EXPERT,
+        pathSegments: [],
+        type: EAdditionalSkillType.ROME4
+      }
+    ]
+
+    beforeEach(() => {
+      wrapper = mountComponent(StudentTraceAssociations, {
+        props: {
+          skillLevelAssociations,
+          additionalSkillAssociations
+        },
+        global: {
+          stubs
+        }
+      })
+    })
+
+    BddTest().then('it should render the title with total count 4', () => {
+      const iconText = wrapper.findComponent({ name: 'AvIconText' })
+
+      expect(iconText.exists()).toBe(true)
+      expect(iconText.props('text')).toContain('(4)')
+    })
+
+    BddTest().then('it should render 3 skill level association cards', () => {
+      const skillCards = wrapper.findAllComponents({ name: 'StudentTraceSkillLevelAssociationCard' })
+
+      expect(skillCards).toHaveLength(3)
+    })
+
+    BddTest().then('it should render 1 additional skill association card', () => {
+      const additionalSkillCards = wrapper.findAllComponents({ name: 'StudentTraceAdditionalSkillAssociationCard' })
+
+      expect(additionalSkillCards).toHaveLength(1)
+    })
+  })
+
+  BddTest().when('the component is mounted with more than 12 skill associations', () => {
+    const skillLevelAssociations: SkillLevelAssociationDTO[] = Array.from({ length: 15 }, (_, i) => ({
+      id: `skill-${i}`,
+      skillTitle: `Compétence ${i}`,
+      level: `Niv. ${i}`,
+      status: ESkillLevelStatus.VALIDATED
+    }))
+
+    beforeEach(() => {
+      wrapper = mountComponent(StudentTraceAssociations, {
+        props: {
+          skillLevelAssociations,
+          additionalSkillAssociations: []
+        },
+        global: {
+          stubs
+        }
+      })
+    })
+
+    BddTest().then('it should cycle through skill colors', () => {
+      const skillCards = wrapper.findAllComponents({ name: 'StudentTraceSkillLevelAssociationCard' })
+
+      expect(skillCards[0].props('levelColor')).toBe('var(--skill1)')
+      expect(skillCards[11].props('levelColor')).toBe('var(--skill12)')
+      expect(skillCards[12].props('levelColor')).toBe('var(--skill1)')
+      expect(skillCards[13].props('levelColor')).toBe('var(--skill2)')
+    })
+  })
+})

--- a/src/features/student/views/StudentToolsTracesView/components/StudentTraceAssociations/StudentTraceAssociations.vue
+++ b/src/features/student/views/StudentToolsTracesView/components/StudentTraceAssociations/StudentTraceAssociations.vue
@@ -1,0 +1,56 @@
+<script setup lang="ts">
+import type { AdditionalSkillAssociationDTO, SkillLevelAssociationDTO } from '@/api/avenir-esr'
+import { StudentTraceAdditionalSkillAssociationCard, StudentTraceSkillLevelAssociationCard } from '@/features/student/components/cards'
+import { AvIconText, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
+
+export interface StudentTraceAssociationsProps {
+  skillLevelAssociations: SkillLevelAssociationDTO[]
+  additionalSkillAssociations: AdditionalSkillAssociationDTO[]
+}
+
+const { skillLevelAssociations, additionalSkillAssociations } = defineProps<StudentTraceAssociationsProps>()
+
+const totalAssociations = computed(() => skillLevelAssociations.length + additionalSkillAssociations.length)
+
+function getSkillColor (index: number): string {
+  return `var(--skill${(index % 12) + 1})`
+}
+</script>
+
+<template>
+  <div class="student-trace-associations">
+    <AvIconText
+      :text="$t('student.views.studentToolsTracesView.studentTraceAssociations.title', { count: totalAssociations })"
+      :icon="MDI_ICONS.ALERT_CIRCLE_OUTLINE"
+      icon-color="var(--text2)"
+      typography-class="caption-light"
+    />
+    <div class="associations-container">
+      <StudentTraceSkillLevelAssociationCard
+        v-for="(skill, index) in skillLevelAssociations"
+        :key="skill.id"
+        :skill="skill"
+        :level-color="getSkillColor(index)"
+      />
+      <StudentTraceAdditionalSkillAssociationCard
+        v-for="additionalSkill in additionalSkillAssociations"
+        :key="additionalSkill.id"
+        :additional-skill="additionalSkill"
+      />
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.student-trace-associations {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
+.associations-container {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+</style>

--- a/src/features/student/views/StudentToolsTracesView/components/StudentTraceDetails/StudentTraceDetails.test.ts
+++ b/src/features/student/views/StudentToolsTracesView/components/StudentTraceDetails/StudentTraceDetails.test.ts
@@ -1,5 +1,6 @@
 import { EFileType, ETraceStatus, type TraceDetailDTO } from '@/api/avenir-esr'
-import StudentTraceDetails from '@/features/student/views/StudentTraceView/components/StudentTraceDetails/StudentTraceDetails.vue'
+import StudentTraceDetails
+  from '@/features/student/views/StudentToolsTracesView/components/StudentTraceDetails/StudentTraceDetails.vue'
 import { mount, type VueWrapper } from '@vue/test-utils'
 import { BddTest } from 'tests/utils'
 import { beforeEach, expect } from 'vitest'

--- a/src/features/student/views/StudentToolsTracesView/components/StudentTraceDetails/StudentTraceDetails.vue
+++ b/src/features/student/views/StudentToolsTracesView/components/StudentTraceDetails/StudentTraceDetails.vue
@@ -46,18 +46,18 @@ const traceAttachmentFile = computed(() => {
 
           <div class="student-detailed-trace-information__upload-section">
             <div class="caption-regular">
-              {{ t('student.views.studentToolsTracesView.studentDetailedTraceModal.studentTraceDetails.documentLabel') }} - {{ t('student.views.studentToolsTracesView.studentDetailedTraceModal.studentTraceDetails.addedOn', { date: formattedUploadDate }) }}
+              {{ t('student.views.studentToolsTracesView.studentTraceDetails.documentLabel') }} - {{ t('student.views.studentToolsTracesView.studentTraceDetails.addedOn', { date: formattedUploadDate }) }}
             </div>
             <TraceFileUpload
               :model-value="traceAttachmentFile"
-              :aria-label="t('student.views.studentToolsTracesView.studentDetailedTraceModal.studentTraceDetails.documentLabel')"
+              :aria-label="t('student.views.studentToolsTracesView.studentTraceDetails.documentLabel')"
               delete-button-label=""
               disabled
             />
             <div class="student-detailed-trace-information__file-info">
               <div class="b2-light student-detailed-trace-information__upload-date">
                 {{
-                  t('student.views.studentToolsTracesView.studentDetailedTraceModal.studentTraceDetails.addedOn', { date: formattedTraceCreationDate })
+                  t('student.views.studentToolsTracesView.studentTraceDetails.addedOn', { date: formattedTraceCreationDate })
                 }}
               </div>
             </div>
@@ -67,7 +67,7 @@ const traceAttachmentFile = computed(() => {
         <div class="student-detailed-trace-information__right-column">
           <TracePersonalNoteTextarea
             :model-value="trace.personalNote"
-            :label="t('student.views.studentToolsTracesView.studentDetailedTraceModal.studentTraceDetails.personalNoteLabel')"
+            :label="t('student.views.studentToolsTracesView.studentTraceDetails.personalNoteLabel')"
             disabled
           />
         </div>
@@ -80,13 +80,13 @@ const traceAttachmentFile = computed(() => {
               typography-class="b2-light"
               icon-color="var(--text2)"
               :icon="MDI_ICONS.PEOPLE_GROUP_OUTLINE"
-              :text="t('student.views.studentToolsTracesView.studentDetailedTraceModal.studentTraceDetails.groupProduction')"
+              :text="t('student.views.studentToolsTracesView.studentTraceDetails.groupProduction')"
             />
             <AvIconText
               typography-class="b2-light"
               icon-color="var(--text2)"
               :icon="MDI_ICONS.CHECK"
-              :text="t('student.views.studentToolsTracesView.studentDetailedTraceModal.studentTraceDetails.authenticProduction')"
+              :text="t('student.views.studentToolsTracesView.studentTraceDetails.authenticProduction')"
             />
           </div>
         </div>
@@ -95,7 +95,7 @@ const traceAttachmentFile = computed(() => {
           <div class="student-detailed-trace-information__ia">
             <AvToggle
               :model-value="!!trace.aiUseJustification"
-              :description="t('student.views.studentToolsTracesView.studentDetailedTraceModal.studentTraceDetails.iaToggleLabel')"
+              :description="t('student.views.studentToolsTracesView.studentTraceDetails.iaToggleLabel')"
               disabled
             />
             <TraceIaJustificationTextarea


### PR DESCRIPTION
 📝 Pull Request Description

  Brief description of changes applied

  This PR implements the trace associations display system for the student trace details view, including:

  - Created comprehensive badge system for skill levels and additional skills
  - Implemented association cards for both skill levels and additional skills
  - Built the StudentTraceAssociations container component with color-cycling for visual distinction
  - Refactored StudentSkillLevelStatusBadge to accept status directly instead of level object
  - Reorganized i18n keys for StudentTraceDetails to use shorter, more direct paths

  Reference to an Issue, Feature, Task, User Story or another PR

  Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/646

  Documentation

  New Components Created:

  Badges:
  - AdditionalSkillLevelBadge - Displays additional skill proficiency levels (BEGINNER, INTERMEDIATE, COMPETENT, ADVANCED, EXPERT) with icons and colors from
  skill configuration
  - StudentTraceAssociationContentBadge - Generic badge for association content with customizable icon and label
  - Refactored StudentSkillLevelStatusBadge to accept status: ESkillLevelStatus prop directly

  Cards:
  - StudentTraceAssociationCard - Generic card wrapper for trace associations with icon, title, and content slots
  - StudentTraceSkillLevelAssociationCard - Displays skill level associations with AMS (SAÉ) information and status badges
  - StudentTraceAdditionalSkillAssociationCard - Displays additional skill associations with type, level, and path segments

  Containers:
  - StudentTraceAssociations - Main container that displays all trace associations (skill levels + additional skills) with:
    - Total count display in header
    - Color cycling through 12 skill colors (--skill1 to --skill12) for visual distinction
    - Responsive grid layout

  i18n Changes:
  - Moved studentTraceDetails keys from nested path (studentDetailedTraceModal.studentTraceDetails.*) to direct path (studentTraceDetails.*)
  - Added studentTraceAssociations.title for associations count display
  - All keys maintained in alphabetical order in both French and English locales

  API Updates:
  - Updated OpenAPI spec with new DTOs for trace associations

  Target Branch

  develop

  Additional Notes

  Design Patterns:
  - All components follow BDD testing pattern with comprehensive test coverage
  - Components use design system colors and spacing variables
  - Proper TypeScript typing with generated API DTOs
  - MSW integration for testing components with TanStack Query

  Color Cycling Logic:
  The StudentTraceAssociations component implements a color cycling pattern to visually distinguish multiple skill associations:
  function getSkillColor (index: number): string {
    return skillColors[index % skillColors.length] // Cycles through 12 colors
  }

  Refactoring Impact:
  The StudentSkillLevelStatusBadge refactor simplifies the component API and makes it more reusable. All usages have been updated:
  - StudentDetailedEducationalSkillCard.vue: Changed from :level="currentSkillLevel" to :status="currentSkillLevel.status"
  - Tests updated to reflect new prop structure

  Known Limitations or Side Effects

  None. All existing functionality preserved and all tests passing.

  ---
  ✅ Checklist

  - a11y tested (components use proper ARIA labels and semantic HTML)
  - Tests provided (278 new tests across all components with 100% coverage)
  - i18n handled (French and English translations added in alphabetical order)
  - Performance tests (not applicable - UI components)
  - No unnecessary code (clean implementation without debug logs or commented code)
  - Code style and formatting rules respected (ESLint passing)
  - Semantic Versioning respected
  - Add to CHANGELOG.md file all properties and database change and details for the update process (no database changes in this PR)
