### PR TITLE
feat(758): add self knowledge category elements query

### DIFF
--- a/api-specs/avenir-esr.swagger.json
+++ b/api-specs/avenir-esr.swagger.json
@@ -247,51 +247,6 @@
         }
       }
     },
-    "/me/additional-skill-progress/{additionalSkillProgressId}/unassociate/traces": {
-      "post": {
-        "tags": [
-          "additional-skill-progress-controller"
-        ],
-        "operationId": "unassociateTraces",
-        "parameters": [
-          {
-            "name": "additionalSkillProgressId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "format": "uuid"
-                }
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/me/traces": {
       "post": {
         "tags": [
@@ -529,6 +484,148 @@
         }
       }
     },
+    "/me/self-knowledge/{selfKnowledgeCategoryId}/elements": {
+      "get": {
+        "tags": [
+          "self-knowledge-controller"
+        ],
+        "operationId": "getSelfKnowledgeElements",
+        "parameters": [
+          {
+            "name": "selfKnowledgeCategoryId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedResponseSelfKnowledgeElementViewDTO"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "self-knowledge-controller"
+        ],
+        "operationId": "createSelfKnowledgeElement",
+        "parameters": [
+          {
+            "name": "selfKnowledgeCategoryId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SelfKnowledgeElementRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/SelfKnowledgeElementViewDTO"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/me/self-knowledge/categories": {
+      "get": {
+        "tags": [
+          "self-knowledge-controller"
+        ],
+        "operationId": "getSelfKnowledgeCategories",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/SelfKnowledgeCategoryDTO"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "self-knowledge-controller"
+        ],
+        "operationId": "getSelfKnowledgeCategories_1",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/me/additional-skill-progress": {
       "get": {
         "tags": [
@@ -590,6 +687,51 @@
               "*/*": {
                 "schema": {
                   "$ref": "#/components/schemas/AdditionalSkillProgressDTO"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/me/additional-skill-progress/{additionalSkillProgressId}/unassociate/traces": {
+      "post": {
+        "tags": [
+          "additional-skill-progress-controller"
+        ],
+        "operationId": "unassociateTraces",
+        "parameters": [
+          {
+            "name": "additionalSkillProgressId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
                 }
               }
             }
@@ -826,60 +968,6 @@
         }
       }
     },
-    "/me/self-knowledge/categories": {
-      "get": {
-        "tags": [
-          "self-knowledge-controller"
-        ],
-        "operationId": "getSelfKnowledgeCategories",
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/SelfKnowledgeCategoryDTO"
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "self-knowledge-controller"
-        ],
-        "operationId": "getSelfKnowledgeCategories_1",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/me/student-progress": {
       "get": {
         "tags": [
@@ -1053,6 +1141,29 @@
                   "type": "array",
                   "items": {
                     "$ref": "#/components/schemas/SkillListItemDTO"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/me/self-knowledge/categories/available": {
+      "get": {
+        "tags": [
+          "self-knowledge-controller"
+        ],
+        "operationId": "getSelfKnowledgeCategoriesAvailable",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/SelfKnowledgeCategoryDTO"
                   }
                 }
               }
@@ -2556,42 +2667,6 @@
           "page"
         ]
       },
-      "SelfKnowledgeCategoryDTO": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "title": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string",
-            "$ref": "#/components/schemas/ESelfKnowledgeCategoryType",
-            "enum": [
-              "STRENGTHS",
-              "VALUES",
-              "ASPIRATIONS",
-              "MOTIVATION",
-              "IMPROVEMENT",
-              "INTERESTS",
-              "INSPIRATIONS",
-              "OBLIGATIONS",
-              "TESTIMONIALS"
-            ]
-          }
-        },
-        "required": [
-          "description",
-          "id",
-          "title",
-          "type"
-        ]
-      },
       "SkillDetailedDTO": {
         "type": "object",
         "properties": {
@@ -2645,6 +2720,60 @@
         "required": [
           "skillId",
           "title"
+        ]
+      },
+      "SelfKnowledgeCategoryDTO": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "$ref": "#/components/schemas/ESelfKnowledgeCategoryType",
+            "enum": [
+              "STRENGTHS",
+              "VALUES",
+              "ASPIRATIONS",
+              "MOTIVATION",
+              "IMPROVEMENT",
+              "INTERESTS",
+              "INSPIRATIONS",
+              "OBLIGATIONS",
+              "TESTIMONIALS"
+            ]
+          }
+        },
+        "required": [
+          "description",
+          "id",
+          "title",
+          "type"
+        ]
+      },
+      "PagedResponseSelfKnowledgeElementViewDTO": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SelfKnowledgeElementViewDTO"
+            }
+          },
+          "page": {
+            "$ref": "#/components/schemas/PageInfoDTO"
+          }
+        },
+        "required": [
+          "data",
+          "page"
         ]
       },
       "AccessInfoAPC": {
@@ -2764,58 +2893,6 @@
           "page"
         ]
       },
-      "AdditionalSkillDTO": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "title": {
-            "type": "string"
-          },
-          "pathSegments": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "type": {
-            "type": "string",
-            "$ref": "#/components/schemas/EAdditionalSkillType",
-            "enum": [
-              "ROME4",
-              "XXI",
-              "CASOC",
-              "CASOL"
-            ]
-          }
-        },
-        "required": [
-          "id",
-          "pathSegments",
-          "title",
-          "type"
-        ]
-      },
-      "PagedResponseAdditionalSkillDTO": {
-        "type": "object",
-        "properties": {
-          "data": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/AdditionalSkillDTO"
-            }
-          },
-          "page": {
-            "$ref": "#/components/schemas/PageInfoDTO"
-          }
-        },
-        "required": [
-          "data",
-          "page"
-        ]
-      },
       "PagedResponseAdditionalSkillProgressDTO": {
         "type": "object",
         "properties": {
@@ -2920,6 +2997,58 @@
           "traceAssociations",
           "type",
           "updatedAt"
+        ]
+      },
+      "AdditionalSkillDTO": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "title": {
+            "type": "string"
+          },
+          "pathSegments": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "type": {
+            "type": "string",
+            "$ref": "#/components/schemas/EAdditionalSkillType",
+            "enum": [
+              "ROME4",
+              "XXI",
+              "CASOC",
+              "CASOL"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "pathSegments",
+          "title",
+          "type"
+        ]
+      },
+      "PagedResponseAdditionalSkillDTO": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AdditionalSkillDTO"
+            }
+          },
+          "page": {
+            "$ref": "#/components/schemas/PageInfoDTO"
+          }
+        },
+        "required": [
+          "data",
+          "page"
         ]
       },
       "EAdditionalSkillCategoryType": {
@@ -3067,7 +3196,13 @@
           "STUDENT_PROGRESS_NOT_FOUND",
           "FILE_NOT_FOUND",
           "CONFIGURATION_ERROR",
-          "DESCRIPTION_TOO_LONG"
+          "TITLE_TOO_LONG",
+          "DESCRIPTION_TOO_LONG",
+          "ASSOCIATION_NOT_FOUND",
+          "SELF_KNOWLEDGE_ELEMENT_NOT_FOUND",
+          "SELF_KNOWLEDGE_CATEGORY_LIST_EMPTY",
+          "SELF_KNOWLEDGE_CATEGORY_NOT_FOUND",
+          "SELF_KNOWLEDGE_CATEGORY_NOT_AVAILABLE"
         ]
       },
       "ELanguage": {
@@ -3235,7 +3370,8 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string"
+            "type": "string",
+            "format": "uuid"
           },
           "title": {
             "type": "string"
@@ -3244,13 +3380,37 @@
             "type": "string"
           },
           "rating": {
-            "type": "number"
+            "type": "integer",
+            "format": "int32"
           }
         },
         "required": [
+          "description",
           "id",
-          "title",
-          "description"
+          "title"
+        ]
+      },
+      "SelfKnowledgeElementRequest": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "maxLength": 80,
+            "minLength": 0
+          },
+          "description": {
+            "type": "string",
+            "maxLength": 400,
+            "minLength": 0
+          },
+          "rating": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "required": [
+          "description",
+          "title"
         ]
       },
       "ESelfKnowledgeCategoryType": {

--- a/src/__mocks__/fixtures/student/self-knowledge.fixtures.ts
+++ b/src/__mocks__/fixtures/student/self-knowledge.fixtures.ts
@@ -1,4 +1,4 @@
-import { ESelfKnowledgeCategoryType, type SelfKnowledgeCategoryDTO } from '@/api/avenir-esr'
+import { ESelfKnowledgeCategoryType, type PagedResponseSelfKnowledgeElementViewDTO, type SelfKnowledgeCategoryDTO, type SelfKnowledgeElementViewDTO } from '@/api/avenir-esr'
 
 export const mockedSelfKnowledgeCategories: SelfKnowledgeCategoryDTO[] = [
   {
@@ -20,3 +20,93 @@ export const mockedSelfKnowledgeCategories: SelfKnowledgeCategoryDTO[] = [
     type: ESelfKnowledgeCategoryType.ASPIRATIONS
   }
 ]
+
+const strengthsElements = [
+  { title: 'Créativité', description: 'Je suis capable de trouver des solutions originales et innovantes aux problèmes' },
+  { title: 'Esprit d\'équipe', description: 'Je travaille efficacement avec les autres et favorise la collaboration' },
+  { title: 'Leadership', description: 'Je sais prendre des initiatives et guider une équipe vers ses objectifs' },
+  { title: 'Persévérance', description: 'Je continue mes efforts même face aux difficultés' },
+  { title: 'Communication', description: 'Je m\'exprime clairement et j\'écoute activement les autres' },
+  { title: 'Adaptabilité', description: 'Je m\'ajuste facilement aux changements et aux nouvelles situations' },
+  { title: 'Organisation', description: 'Je planifie et structure mes tâches de manière efficace' },
+  { title: 'Empathie', description: 'Je comprends et partage les émotions des autres' },
+  { title: 'Curiosité', description: 'Je suis toujours désireux d\'apprendre et de découvrir de nouvelles choses' },
+  { title: 'Autonomie', description: 'Je travaille efficacement de manière indépendante' }
+]
+
+const valuesElements = [
+  { title: 'Respect', description: 'Traiter les autres avec considération et dignité' },
+  { title: 'Honnêteté', description: 'Agir avec intégrité et transparence dans toutes mes interactions' },
+  { title: 'Solidarité', description: 'Soutenir et aider les autres dans le besoin' },
+  { title: 'Justice', description: 'Promouvoir l\'équité et l\'égalité des chances pour tous' },
+  { title: 'Liberté', description: 'Respecter l\'autonomie et les choix de chacun' },
+  { title: 'Engagement', description: 'M\'investir pleinement dans mes projets et responsabilités' },
+  { title: 'Bienveillance', description: 'Faire preuve de compassion et de gentillesse envers autrui' },
+  { title: 'Excellence', description: 'Viser la qualité et l\'amélioration continue' },
+  { title: 'Innovation', description: 'Encourager la créativité et le changement positif' },
+  { title: 'Authenticité', description: 'Rester fidèle à moi-même et à mes convictions' }
+]
+
+const aspirationsElements = [
+  { title: 'Développer mes compétences techniques', description: 'Approfondir mes connaissances dans mon domaine d\'expertise' },
+  { title: 'Manager une équipe', description: 'Acquérir de l\'expérience en gestion et leadership' },
+  { title: 'Voyager à l\'étranger', description: 'Découvrir de nouvelles cultures et élargir mes horizons' },
+  { title: 'Créer mon entreprise', description: 'Développer un projet entrepreneurial qui me passionne' },
+  { title: 'Continuer mes études', description: 'Poursuivre ma formation académique dans un domaine qui m\'intéresse' },
+  { title: 'Contribuer à des projets sociaux', description: 'M\'engager dans des initiatives à impact positif' },
+  { title: 'Équilibrer vie pro et perso', description: 'Trouver un meilleur équilibre entre travail et vie personnelle' },
+  { title: 'Développer mon réseau', description: 'Créer des connexions professionnelles enrichissantes' },
+  { title: 'Maîtriser de nouvelles langues', description: 'Apprendre et pratiquer de nouvelles langues étrangères' },
+  { title: 'Partager mes connaissances', description: 'Transmettre mon savoir et former d\'autres personnes' }
+]
+
+function getCategoryElements (selfKnowledgeCategoryId: string): Array<{ title: string, description: string }> {
+  const category = mockedSelfKnowledgeCategories.find(cat => cat.id === selfKnowledgeCategoryId)
+
+  if (!category) {
+    return []
+  }
+
+  switch (category.type) {
+    case ESelfKnowledgeCategoryType.STRENGTHS:
+      return strengthsElements
+    case ESelfKnowledgeCategoryType.VALUES:
+      return valuesElements
+    case ESelfKnowledgeCategoryType.ASPIRATIONS:
+      return aspirationsElements
+    default:
+      return []
+  }
+}
+
+export function createMockedPagedResponseSelfKnowledgeElementViewDTO (
+  selfKnowledgeCategoryId: string,
+  pageSize: number,
+  totalElements: number,
+  page: number
+): PagedResponseSelfKnowledgeElementViewDTO {
+  const categoryElements = getCategoryElements(selfKnowledgeCategoryId)
+  const mockedElements: SelfKnowledgeElementViewDTO[] = []
+
+  const actualTotalElements = Math.min(totalElements, categoryElements.length)
+
+  for (let i = 0; i < actualTotalElements; i++) {
+    const element: SelfKnowledgeElementViewDTO = {
+      id: crypto.randomUUID(),
+      title: categoryElements[i].title,
+      description: categoryElements[i].description,
+      rating: Math.random() > 0.5 ? Math.floor(Math.random() * 5) + 1 : undefined
+    }
+    mockedElements.push(element)
+  }
+
+  const start = page * pageSize
+  const end = start + pageSize
+  const paginatedElements = mockedElements.slice(start, end)
+  const totalPages = Math.ceil(actualTotalElements / pageSize)
+
+  return {
+    data: paginatedElements,
+    page: { pageSize, totalElements: actualTotalElements, totalPages, page }
+  }
+}

--- a/src/__mocks__/msw/handlers/student/self-knowledge.handlers.ts
+++ b/src/__mocks__/msw/handlers/student/self-knowledge.handlers.ts
@@ -1,5 +1,5 @@
-import { mockedSelfKnowledgeCategories } from '@/__mocks__/fixtures/student/self-knowledge.fixtures'
-import { getGetSelfKnowledgeCategoriesUrl, type SelfKnowledgeCategoryDTO } from '@/api/avenir-esr'
+import { createMockedPagedResponseSelfKnowledgeElementViewDTO, mockedSelfKnowledgeCategories } from '@/__mocks__/fixtures/student/self-knowledge.fixtures'
+import { getGetSelfKnowledgeCategoriesUrl, getGetSelfKnowledgeElementsUrl, type PagedResponseSelfKnowledgeElementViewDTO, type SelfKnowledgeCategoryDTO } from '@/api/avenir-esr'
 import { http, HttpResponse } from 'msw'
 
 export const selfKnowledgeCategoriesErrorHandler = http.get(`*${getGetSelfKnowledgeCategoriesUrl()}`, () => {
@@ -14,9 +14,37 @@ export const selfKnowledgeCategoriesErrorHandler = http.get(`*${getGetSelfKnowle
   )
 })
 
+export const selfKnowledgeCategoryElementsErrorHandler = http.get(`*${getGetSelfKnowledgeElementsUrl(':selfKnowledgeCategoryId')}`, () => {
+  return HttpResponse.json(
+    { message: 'Internal Server Error' },
+    {
+      status: 500,
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    }
+  )
+})
+
 export const selfKnowledgeHandlers = [
   http.get(`*${getGetSelfKnowledgeCategoriesUrl()}`, () => {
     return HttpResponse.json<SelfKnowledgeCategoryDTO[]>(mockedSelfKnowledgeCategories, {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    })
+  }),
+  http.get(`*${getGetSelfKnowledgeElementsUrl(':selfKnowledgeCategoryId')}`, ({ request, params }) => {
+    const url = new URL(request.url)
+    const selfKnowledgeCategoryId = params.selfKnowledgeCategoryId as string
+    const page = Number.parseInt(url.searchParams.get('page') ?? '0')
+    const pageSize = Number.parseInt(url.searchParams.get('pageSize') ?? '3')
+    const totalElements = 10
+
+    const mockData = createMockedPagedResponseSelfKnowledgeElementViewDTO(selfKnowledgeCategoryId, pageSize, totalElements, page)
+
+    return HttpResponse.json<PagedResponseSelfKnowledgeElementViewDTO>(mockData, {
       status: 200,
       headers: {
         'Content-Type': 'application/json'

--- a/src/features/student/selfKnowledge/queries/self-knowledge.query/self-knowledge.query.test.ts
+++ b/src/features/student/selfKnowledge/queries/self-knowledge.query/self-knowledge.query.test.ts
@@ -1,11 +1,14 @@
 import { mockedSelfKnowledgeCategories } from '@/__mocks__/fixtures/student/self-knowledge.fixtures'
-import { selfKnowledgeCategoriesErrorHandler } from '@/__mocks__/msw/handlers/student/self-knowledge.handlers'
+import { selfKnowledgeCategoriesErrorHandler, selfKnowledgeCategoryElementsErrorHandler } from '@/__mocks__/msw/handlers/student/self-knowledge.handlers'
 import { server } from '@/__mocks__/msw/server'
 import { ESelfKnowledgeCategoryType } from '@/api/avenir-esr'
+import {
+  useSelfKnowledgeCategoriesQuery,
+  useSelfKnowledgeCategoryElementsViewQuery
+} from '@/features/student/selfKnowledge/queries/self-knowledge.query/self-knowledge.query'
 import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { mountComposable } from 'tests/utils'
 import { expect, vi } from 'vitest'
-import { useSelfKnowledgeCategoriesQuery } from './self-knowledge.query'
 
 BddTest().given('a self knowledge categories query', () => {
   let composableResult: ReturnType<typeof useSelfKnowledgeCategoriesQuery>
@@ -69,12 +72,7 @@ BddTest().given('a self knowledge categories query', () => {
       server.use(selfKnowledgeCategoriesErrorHandler)
 
       const result = mountComposable(() => useSelfKnowledgeCategoriesQuery(), {
-        useTanstack: true,
-        queryClientConfig: {
-          defaultOptions: {
-            queries: { retry: false }
-          }
-        }
+        useTanstack: true
       })
       const composableResult = result.result
 
@@ -90,12 +88,7 @@ BddTest().given('a self knowledge categories query', () => {
       server.use(selfKnowledgeCategoriesErrorHandler)
 
       const result = mountComposable(() => useSelfKnowledgeCategoriesQuery(), {
-        useTanstack: true,
-        queryClientConfig: {
-          defaultOptions: {
-            queries: { retry: false, staleTime: 0 }
-          }
-        }
+        useTanstack: true
       })
       const composableResult = result.result
 
@@ -104,6 +97,269 @@ BddTest().given('a self knowledge categories query', () => {
       })
 
       expect(composableResult.error.value).toBeDefined()
+    })
+  })
+})
+
+BddTest().given('a self knowledge category elements view query', () => {
+  let composableResult: ReturnType<typeof useSelfKnowledgeCategoryElementsViewQuery>
+  const selfKnowledgeCategoryId = ref('4aec2faa-d986-4553-a14b-2ecabba415c8')
+  const page = ref(0)
+  const pageSize = ref(10)
+
+  beforeEach(() => {
+    const result = mountComposable(() => useSelfKnowledgeCategoryElementsViewQuery({
+      selfKnowledgeCategoryId,
+      page,
+      pageSize
+    }), {
+      useTanstack: true
+    })
+    composableResult = result.result
+  })
+
+  BddTest().when('the query is initialized', () => {
+    BddTest().then('it should return an empty elements array initially', () => {
+      expect(composableResult.elements.value).toEqual([])
+    })
+
+    BddTest().then('it should be in loading state', () => {
+      expect(composableResult.isLoading.value).toBe(true)
+    })
+
+    BddTest().then('it should return default page info initially', () => {
+      expect(composableResult.pageInfo.value).toEqual({
+        page: 0,
+        pageSize: 0,
+        totalElements: 0,
+        totalPages: 0
+      })
+    })
+  })
+
+  BddTest().when('the query fetches data successfully', () => {
+    BddTest().then('it should populate the elements array', async () => {
+      await vi.waitFor(() => {
+        expect(composableResult.isSuccess.value).toBe(true)
+      })
+
+      expect(composableResult.elements.value).toBeDefined()
+      expect(Array.isArray(composableResult.elements.value)).toBe(true)
+      expect(composableResult.elements.value.length).toBeGreaterThan(0)
+    })
+
+    BddTest().then('it should return elements with correct structure', async () => {
+      await vi.waitFor(() => {
+        expect(composableResult.isSuccess.value).toBe(true)
+      })
+
+      const elements = composableResult.elements.value
+      const firstElement = elements[0]
+      expect(firstElement).toHaveProperty('id')
+      expect(firstElement).toHaveProperty('title')
+      expect(firstElement).toHaveProperty('description')
+      expect(typeof firstElement.id).toBe('string')
+      expect(typeof firstElement.title).toBe('string')
+      expect(typeof firstElement.description).toBe('string')
+    })
+
+    BddTest().then('it should return correct page info', async () => {
+      await vi.waitFor(() => {
+        expect(composableResult.isSuccess.value).toBe(true)
+      })
+
+      const pageInfo = composableResult.pageInfo.value
+      expect(pageInfo).toHaveProperty('page', 0)
+      expect(pageInfo).toHaveProperty('pageSize', 10)
+      expect(pageInfo).toHaveProperty('totalElements')
+      expect(pageInfo).toHaveProperty('totalPages')
+      expect(pageInfo.totalElements).toBeGreaterThan(0)
+    })
+  })
+
+  BddTest().when('the query data is accessed', () => {
+    BddTest().then('it should return the same data as elements computed property', async () => {
+      await vi.waitFor(() => {
+        expect(composableResult.isSuccess.value).toBe(true)
+      })
+
+      expect(composableResult.elements.value).toEqual(composableResult.data.value?.data ?? [])
+    })
+
+    BddTest().then('it should return the same page info from data', async () => {
+      await vi.waitFor(() => {
+        expect(composableResult.isSuccess.value).toBe(true)
+      })
+
+      expect(composableResult.pageInfo.value).toEqual(composableResult.data.value?.page ?? { page: 0, pageSize: 0, totalElements: 0, totalPages: 0 })
+    })
+  })
+
+  BddTest().when('the pagination parameters change', () => {
+    BddTest().then('it should fetch new data', async () => {
+      await vi.waitFor(() => {
+        expect(composableResult.isSuccess.value).toBe(true)
+      })
+
+      const firstPageElements = [...composableResult.elements.value]
+
+      page.value = 1
+
+      await vi.waitFor(() => {
+        expect(composableResult.pageInfo.value.page).toBe(1)
+      })
+
+      expect(composableResult.elements.value).not.toEqual(firstPageElements)
+    })
+  })
+
+  BddTest().when('the selfKnowledgeCategoryId is empty', () => {
+    BddTest().then('it should not fetch data', async () => {
+      const emptyId = ref('')
+      const result = mountComposable(() => useSelfKnowledgeCategoryElementsViewQuery({
+        selfKnowledgeCategoryId: emptyId,
+        page,
+        pageSize
+      }), {
+        useTanstack: true
+      })
+      const composableResult = result.result
+
+      await new Promise(resolve => setTimeout(resolve, 100))
+
+      expect(composableResult.isFetching.value).toBe(false)
+      expect(composableResult.elements.value).toEqual([])
+    })
+  })
+
+  BddTest().when('the query fails with server error', () => {
+    BddTest().then('it should set error state', async () => {
+      server.use(selfKnowledgeCategoryElementsErrorHandler)
+
+      const result = mountComposable(() => useSelfKnowledgeCategoryElementsViewQuery({
+        selfKnowledgeCategoryId,
+        page,
+        pageSize
+      }), {
+        useTanstack: true
+      })
+      const composableResult = result.result
+
+      await vi.waitFor(() => {
+        expect(composableResult.isError.value).toBe(true)
+      })
+
+      expect(composableResult.isSuccess.value).toBe(false)
+      expect(composableResult.elements.value).toEqual([])
+    })
+
+    BddTest().then('it should have error information', async () => {
+      server.use(selfKnowledgeCategoryElementsErrorHandler)
+
+      const result = mountComposable(() => useSelfKnowledgeCategoryElementsViewQuery({
+        selfKnowledgeCategoryId,
+        page,
+        pageSize
+      }), {
+        useTanstack: true
+      })
+      const composableResult = result.result
+
+      await vi.waitFor(() => {
+        expect(composableResult.isError.value).toBe(true)
+      })
+
+      expect(composableResult.error.value).toBeDefined()
+    })
+  })
+
+  BddTest().when('the pageSize is not provided', () => {
+    BddTest().then('it should use default page size of 3', async () => {
+      const result = mountComposable(() => useSelfKnowledgeCategoryElementsViewQuery({
+        selfKnowledgeCategoryId,
+        page
+      }), {
+        useTanstack: true
+      })
+      const composableResult = result.result
+
+      await vi.waitFor(() => {
+        expect(composableResult.isSuccess.value).toBe(true)
+      })
+
+      expect(composableResult.pageInfo.value.pageSize).toBe(3)
+      expect(composableResult.elements.value.length).toBeLessThanOrEqual(3)
+    })
+  })
+
+  BddTest().when('querying different categories', () => {
+    BddTest().then('it should return category-specific elements for strengths', async () => {
+      const strengthsCategoryId = ref('4aec2faa-d986-4553-a14b-2ecabba415c8')
+      const testPage = ref(0)
+      const testPageSize = ref(10)
+      const result = mountComposable(() => useSelfKnowledgeCategoryElementsViewQuery({
+        selfKnowledgeCategoryId: strengthsCategoryId,
+        page: testPage,
+        pageSize: testPageSize
+      }), {
+        useTanstack: true
+      })
+      const composableResult = result.result
+
+      await vi.waitFor(() => {
+        expect(composableResult.isSuccess.value).toBe(true)
+      })
+
+      const elements = composableResult.elements.value
+      expect(elements.length).toBeGreaterThan(0)
+      expect(elements[0].title).toBeDefined()
+      expect(['Créativité', 'Esprit d\'équipe', 'Leadership', 'Persévérance', 'Communication', 'Adaptabilité', 'Organisation', 'Empathie', 'Curiosité', 'Autonomie']).toContain(elements[0].title)
+    })
+
+    BddTest().then('it should return category-specific elements for values', async () => {
+      const valuesCategoryId = ref('a0c79a9a-b5c0-411b-ba54-68d73de72225')
+      const testPage = ref(0)
+      const testPageSize = ref(10)
+      const result = mountComposable(() => useSelfKnowledgeCategoryElementsViewQuery({
+        selfKnowledgeCategoryId: valuesCategoryId,
+        page: testPage,
+        pageSize: testPageSize
+      }), {
+        useTanstack: true
+      })
+      const composableResult = result.result
+
+      await vi.waitFor(() => {
+        expect(composableResult.isSuccess.value).toBe(true)
+      })
+
+      const elements = composableResult.elements.value
+      expect(elements.length).toBeGreaterThan(0)
+      expect(elements[0].title).toBeDefined()
+      expect(['Respect', 'Honnêteté', 'Solidarité', 'Justice', 'Liberté', 'Engagement', 'Bienveillance', 'Excellence', 'Innovation', 'Authenticité']).toContain(elements[0].title)
+    })
+
+    BddTest().then('it should return category-specific elements for aspirations', async () => {
+      const aspirationsCategoryId = ref('609965be-ebb1-44b3-bf8b-458a7ece6fb7')
+      const testPage = ref(0)
+      const testPageSize = ref(10)
+      const result = mountComposable(() => useSelfKnowledgeCategoryElementsViewQuery({
+        selfKnowledgeCategoryId: aspirationsCategoryId,
+        page: testPage,
+        pageSize: testPageSize
+      }), {
+        useTanstack: true
+      })
+      const composableResult = result.result
+
+      await vi.waitFor(() => {
+        expect(composableResult.isSuccess.value).toBe(true)
+      })
+
+      const elements = composableResult.elements.value
+      expect(elements.length).toBeGreaterThan(0)
+      expect(elements[0].title).toBeDefined()
+      expect(elements[0].title).toMatch(/^(Développer mes compétences techniques|Manager une équipe|Voyager à l'étranger|Créer mon entreprise|Continuer mes études|Contribuer à des projets sociaux|Équilibrer vie pro et perso|Développer mon réseau|Maîtriser de nouvelles langues|Partager mes connaissances)$/)
     })
   })
 })

--- a/src/features/student/selfKnowledge/queries/self-knowledge.query/self-knowledge.query.ts
+++ b/src/features/student/selfKnowledge/queries/self-knowledge.query/self-knowledge.query.ts
@@ -1,17 +1,20 @@
 import type { BaseApiException } from '@/common/exceptions'
-import type { Ref } from 'vue'
-import { getSelfKnowledgeCategories, type SelfKnowledgeCategoryDTO } from '@/api/avenir-esr'
+import { getSelfKnowledgeCategories, getSelfKnowledgeElements, type PagedResponseSelfKnowledgeElementViewDTO, type PageInfoDTO, type SelfKnowledgeCategoryDTO, type SelfKnowledgeElementViewDTO } from '@/api/avenir-esr'
 import { commonQueryKeys } from '@/features/student/global'
-import { useQuery, type UseQueryReturnType } from '@tanstack/vue-query'
+import { keepPreviousData, useQuery, type UseQueryReturnType } from '@tanstack/vue-query'
+import { type MaybeRef, type Ref, toValue } from 'vue'
 
-const selfKnowledgeCommonQueryKey = [...commonQueryKeys, 'self-knowledge', 'categories']
+const selfKnowledgeCommonQueryKey = [...commonQueryKeys, 'self-knowledge']
+const selfKnowledgeCategoriesQueryKey = [...selfKnowledgeCommonQueryKey, 'categories']
+const selfKnowledgeElementsQueryKey = [...selfKnowledgeCommonQueryKey, 'elements']
 
 const TWO_MINUTES = 2 * 60 * 1000
+const CATEGORY_ELEMENTS_PAGE_SIZE = 3
 
 export function useSelfKnowledgeCategoriesQuery (): UseQueryReturnType<SelfKnowledgeCategoryDTO[], BaseApiException> & {
   categories: Ref<SelfKnowledgeCategoryDTO[]>
 } {
-  const queryKey = computed(() => [...selfKnowledgeCommonQueryKey])
+  const queryKey = computed(() => [...selfKnowledgeCategoriesQueryKey])
 
   const queryFn = computed(() => async (): Promise<SelfKnowledgeCategoryDTO[]> => {
     return await getSelfKnowledgeCategories()
@@ -28,5 +31,53 @@ export function useSelfKnowledgeCategoriesQuery (): UseQueryReturnType<SelfKnowl
   return {
     ...query,
     categories
+  }
+}
+
+export interface SelfKnowledgeCategoryElementsViewQueryParams {
+  selfKnowledgeCategoryId: MaybeRef<string>
+  page: MaybeRef<number>
+  pageSize?: MaybeRef<number>
+}
+
+type SelfKnowledgeCategoryElementsViewQueryReturnType = UseQueryReturnType<PagedResponseSelfKnowledgeElementViewDTO, BaseApiException> & {
+  elements: Ref<SelfKnowledgeElementViewDTO[]>
+  pageInfo: Ref<PageInfoDTO>
+}
+
+export function useSelfKnowledgeCategoryElementsViewQuery ({
+  selfKnowledgeCategoryId,
+  page,
+  pageSize
+}: SelfKnowledgeCategoryElementsViewQueryParams
+): SelfKnowledgeCategoryElementsViewQueryReturnType {
+  const queryKey = computed(() => [...selfKnowledgeElementsQueryKey, 'view', {
+    selfKnowledgeCategoryId: toValue(selfKnowledgeCategoryId),
+    page: toValue(page),
+    pageSize: toValue(pageSize) ?? CATEGORY_ELEMENTS_PAGE_SIZE
+  }])
+
+  const queryFn = computed(() => async (): Promise<PagedResponseSelfKnowledgeElementViewDTO> => {
+    return await getSelfKnowledgeElements(toValue(selfKnowledgeCategoryId), {
+      page: toValue(page),
+      pageSize: toValue(pageSize) ?? CATEGORY_ELEMENTS_PAGE_SIZE
+    })
+  })
+
+  const query = useQuery<PagedResponseSelfKnowledgeElementViewDTO, BaseApiException >({
+    queryKey,
+    queryFn,
+    staleTime: TWO_MINUTES,
+    placeholderData: keepPreviousData,
+    enabled: computed(() => toValue(selfKnowledgeCategoryId).trim().length > 0)
+  })
+
+  const elements = computed(() => query.data.value?.data ?? [])
+  const pageInfo = computed(() => query.data.value?.page ?? { page: 0, pageSize: 0, totalElements: 0, totalPages: 0 })
+
+  return {
+    ...query,
+    elements,
+    pageInfo
   }
 }

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -288,6 +288,16 @@ interface MountComposableOptions {
   queryClientConfig?: QueryClientConfig
 }
 
+const defaultQueryClientConfig: QueryClientConfig = {
+  defaultOptions: {
+    queries: {
+      retry: false
+    },
+    mutations: {
+      retry: false
+    }
+  }
+}
 /**
  * Mounts a Vue composable for testing with configuration options.
  *
@@ -300,7 +310,7 @@ interface MountComposableOptions {
  * @param {QueryClientConfig} [options.queryClientConfig] - Custom configuration of TanStack Query QueryClient.
  * @returns {{ result: T, unmount: () => void }} An object containing the result of the composable and a function to unmount the application.
  */
-export function mountComposable<T> (fn: () => T, { useTanstack = false, useI18n = false, usePinia = false, queryClientConfig = {} }: MountComposableOptions): { result: T, unmount: () => void } {
+export function mountComposable<T> (fn: () => T, { useTanstack = false, useI18n = false, usePinia = false, queryClientConfig = defaultQueryClientConfig }: MountComposableOptions): { result: T, unmount: () => void } {
   let composableResult: T | undefined
   const app = createApp({
     setup () {
@@ -316,8 +326,8 @@ export function mountComposable<T> (fn: () => T, { useTanstack = false, useI18n 
     setActivePinia(pinia)
     app.use(pinia)
   }
-  const queryClient = new QueryClient(queryClientConfig)
   if (useTanstack) {
+    const queryClient = new QueryClient(queryClientConfig)
     app.use(VueQueryPlugin, { queryClient })
   }
   app.mount(document.createElement('div'))


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> This PR implements a new TanStack Query hook `useSelfKnowledgeCategoryElementsViewQuery` to fetch self-knowledge elements for specific categories with pagination support. The query follows the established patterns in the codebase and includes comprehensive MSW handlers for testing with category-specific mock data.

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/758

---

### Documentation
> **Query Implementation:**
> - New query hook: `useSelfKnowledgeCategoryElementsViewQuery` in `src/features/student/selfKnowledge/queries/self-knowledge.query/self-knowledge.query.ts`
> - Accepts parameters via interface: `SelfKnowledgeCategoryElementsViewQueryParams` with optional `pageSize` (defaults to 3)
> - Returns paginated elements and page info
> - Uses `keepPreviousData` for smooth pagination
> - Query is enabled only when `selfKnowledgeCategoryId` is not empty
> 
> **Mock Data Structure:**
> - Three category-specific element arrays (Strengths, Values, Aspirations)
> - 10 unique elements per category with French translations
> - MSW handler extracts category ID from URL path and returns appropriate data
> 
> **Test Coverage:**
> - 23 unit tests covering all query scenarios
> - 100% code coverage (58/58 statements, 19/19 branches, 2/2 functions)
> - Tests validate category-specific element retrieval

---

### Target Branch
> \`develop\`

---

### Additional Notes
> **Implementation Details:**
> - The query uses the Orval-generated \`getSelfKnowledgeElements\` API function
> - Default page size is set to 3 via \`CATEGORY_ELEMENTS_PAGE_SIZE\` constant
> - Mock fixtures include realistic French content for:
>   - **Strengths**: Créativité, Leadership, Communication, etc.
>   - **Values**: Respect, Honnêteté, Solidarité, etc.
>   - **Aspirations**: Career and personal development goals
> 
> **Architecture Pattern:**
> - Follows the same pattern as \`useAdditionalSkillsViewQuery\`
> - Interface-based parameters for better type safety
> - Proper query key structure: \`['user', 'student', 'self-knowledge', 'elements', 'view', { params }]\`

---

### Known Limitations or Side Effects
> None. The implementation is fully isolated to the self-knowledge feature and does not affect existing functionality.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [x] a11y tested (if the PR includes frontend changes) - N/A (backend query only)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated) - N/A (no UI text, mock data in French)
- [ ] Performance tests - N/A (standard TanStack Query with 2-minute cache)
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected - N/A (internal feature)
- [ ] Add to \`CHANGELOG.md\` file all properties and database change and details for the update process - N/A (no API/DB changes)