### PR TITLE
feat(765): create SelfKnowledgeElementsDropdown

### DIFF
--- a/src/features/student/global/locales/en.json
+++ b/src/features/student/global/locales/en.json
@@ -347,6 +347,11 @@
           "buttons": {
             "addCategory": "Add category"
           },
+          "categoryElementsPaginator": {
+            "buttons": {
+              "deleteCategory": "Delete category"
+            }
+          },
           "modals": {
             "addSelfKnowledgeCategories": {
               "success": "{count} category added successfully | {count} categories added successfully",
@@ -409,7 +414,6 @@
           },
           "title": "Detail of my trace",
           "settings": {
-            "ariaLabel": "More actions",
             "associate": "Associate my trace",
             "delete": "Delete my trace",
             "update": "Update my trace"
@@ -543,7 +547,6 @@
           "delete": "An error occurred while deleting the trace"
         },
         "settings": {
-          "ariaLabel": "More actions",
           "associate": "Associate my trace",
           "delete": "Delete my trace",
           "update": "Update my trace"

--- a/src/features/student/global/locales/fr.json
+++ b/src/features/student/global/locales/fr.json
@@ -347,6 +347,11 @@
           "buttons": {
             "addCategory": "Ajouter une catégorie"
           },
+          "categoryElementsPaginator": {
+            "buttons": {
+              "deleteCategory": "Supprimer la catégorie"
+            }
+          },
           "modals": {
             "addSelfKnowledgeCategories": {
               "success": "{count} catégorie ajoutée avec succès | {count} catégories ajoutées avec succès",
@@ -409,7 +414,6 @@
           },
           "title": "Détail de ma trace",
           "settings": {
-            "ariaLabel": "Plus d'actions",
             "associate": "Associer ma trace",
             "delete": "Supprimer ma trace",
             "update": "Modifier ma trace"
@@ -539,7 +543,6 @@
           "delete": "Une erreur est survenue lors de la suppression de la trace."
         },
         "settings": {
-          "ariaLabel": "Plus d'actions",
           "associate": "Associer ma trace",
           "delete": "Supprimer ma trace",
           "update": "Modifier ma trace"

--- a/src/features/student/selfKnowledge/components/dropdowns/SelfKnowledgeElementsDropdown/SelfKnowledgeElementsDropdown.test.ts
+++ b/src/features/student/selfKnowledge/components/dropdowns/SelfKnowledgeElementsDropdown/SelfKnowledgeElementsDropdown.test.ts
@@ -1,0 +1,112 @@
+import SelfKnowledgeElementsDropdown, { type SelfKnowledgeElementsDropdownProps } from '@/features/student/selfKnowledge/components/dropdowns/SelfKnowledgeElementsDropdown/SelfKnowledgeElementsDropdown.vue'
+import { MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
+import { AvDropdownStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { beforeEach, expect } from 'vitest'
+
+const stubs = {
+  AvDropdown: AvDropdownStub,
+}
+
+BddTest().given('a self knowledge elements dropdown', () => {
+  let wrapper: VueWrapper<InstanceType<typeof SelfKnowledgeElementsDropdown>>
+
+  function mountDropdown (props: SelfKnowledgeElementsDropdownProps): VueWrapper<InstanceType<typeof SelfKnowledgeElementsDropdown>> {
+    return mount(SelfKnowledgeElementsDropdown, { props, global: { stubs } })
+  }
+
+  BddTest().and('the category is deletable', () => {
+    const props: SelfKnowledgeElementsDropdownProps = {
+      addLabel: 'Add an improvement',
+      deleteLabel: 'Delete an improvement',
+      shareLabel: 'Share my improvements',
+      isCategoryDeletable: true
+    }
+
+    BddTest().when('the component is mounted', () => {
+      beforeEach(() => {
+        wrapper = mountDropdown(props)
+      })
+
+      BddTest().then('it should render the AvDropdown with correct props', () => {
+        const dropdown = wrapper.findComponent(AvDropdownStub)
+        expect(dropdown.exists()).toBe(true)
+        expect(dropdown.props('items')).toEqual([
+          { name: 'add', label: 'Add an improvement', icon: MDI_ICONS.PLUS_CIRCLE_OUTLINE },
+          { name: 'delete', label: 'Delete an improvement', icon: MDI_ICONS.TRASH_CAN_OUTLINE },
+          { name: 'share', label: 'Share my improvements', icon: MDI_ICONS.SHARE_VARIANT_OUTLINE },
+          { name: 'deleteCategory', label: 'Supprimer la catégorie', icon: MDI_ICONS.TRASH_CAN_OUTLINE }
+        ])
+      })
+
+      BddTest().and('the add item is selected', () => {
+        beforeEach(async () => {
+          const dropdown = wrapper.findComponent(AvDropdownStub)
+          await dropdown.vm.$emit('itemSelected', 'add')
+        })
+
+        BddTest().then('it should emit the addSelected event', () => {
+          expect(wrapper.emitted()).toHaveProperty('addSelected')
+        })
+      })
+
+      BddTest().and('the delete item is selected', () => {
+        beforeEach(async () => {
+          const dropdown = wrapper.findComponent(AvDropdownStub)
+          await dropdown.vm.$emit('itemSelected', 'delete')
+        })
+
+        BddTest().then('it should emit the deleteSelected event', () => {
+          expect(wrapper.emitted()).toHaveProperty('deleteSelected')
+        })
+      })
+
+      BddTest().and('the share item is selected', () => {
+        beforeEach(async () => {
+          const dropdown = wrapper.findComponent(AvDropdownStub)
+          await dropdown.vm.$emit('itemSelected', 'share')
+        })
+
+        BddTest().then('it should emit the shareSelected event', () => {
+          expect(wrapper.emitted()).toHaveProperty('shareSelected')
+        })
+      })
+
+      BddTest().and('the deleteCategory item is selected', () => {
+        beforeEach(async () => {
+          const dropdown = wrapper.findComponent(AvDropdownStub)
+          await dropdown.vm.$emit('itemSelected', 'deleteCategory')
+        })
+
+        BddTest().then('it should emit the deleteCategorySelected event', () => {
+          expect(wrapper.emitted()).toHaveProperty('deleteCategorySelected')
+        })
+      })
+    })
+  })
+
+  BddTest().and('the category is not deletable', () => {
+    const props: SelfKnowledgeElementsDropdownProps = {
+      addLabel: 'Add a strength',
+      deleteLabel: 'Delete an strength',
+      shareLabel: 'Share my strengths',
+      isCategoryDeletable: false
+    }
+
+    BddTest().when('the component is mounted', () => {
+      beforeEach(() => {
+        wrapper = mountDropdown(props)
+      })
+
+      BddTest().then('it should render the AvDropdown with correct props', () => {
+        const dropdown = wrapper.findComponent(AvDropdownStub)
+        expect(dropdown.exists()).toBe(true)
+        expect(dropdown.props('items')).toEqual([
+          { name: 'add', label: 'Add a strength', icon: MDI_ICONS.PLUS_CIRCLE_OUTLINE },
+          { name: 'delete', label: 'Delete an strength', icon: MDI_ICONS.TRASH_CAN_OUTLINE },
+          { name: 'share', label: 'Share my strengths', icon: MDI_ICONS.SHARE_VARIANT_OUTLINE }
+        ])
+      })
+    })
+  })
+})

--- a/src/features/student/selfKnowledge/components/dropdowns/SelfKnowledgeElementsDropdown/SelfKnowledgeElementsDropdown.vue
+++ b/src/features/student/selfKnowledge/components/dropdowns/SelfKnowledgeElementsDropdown/SelfKnowledgeElementsDropdown.vue
@@ -1,0 +1,89 @@
+<script lang="ts" setup>
+import { AvDropdown, type AvDropdownItem, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
+import { useI18n } from 'vue-i18n'
+
+export interface SelfKnowledgeElementsDropdownProps {
+  addLabel: string
+  deleteLabel: string
+  shareLabel: string
+  isCategoryDeletable: boolean
+}
+
+const { addLabel, deleteLabel, shareLabel, isCategoryDeletable } = defineProps<SelfKnowledgeElementsDropdownProps>()
+
+const emit = defineEmits<{
+  (e: 'addSelected'): void
+  (e: 'deleteSelected'): void
+  (e: 'shareSelected'): void
+  (e: 'deleteCategorySelected'): void
+}>()
+
+const { t } = useI18n()
+
+enum SelfKnowledgeElementsDropdownEvents {
+  ADD = 'add',
+  DELETE = 'delete',
+  SHARE = 'share',
+  DELETE_CATEGORY = 'deleteCategory'
+}
+
+const menuItems = computed<AvDropdownItem[]>(() => {
+  const items = [
+    {
+      name: SelfKnowledgeElementsDropdownEvents.ADD,
+      icon: MDI_ICONS.PLUS_CIRCLE_OUTLINE,
+      label: addLabel
+    },
+    {
+      name: SelfKnowledgeElementsDropdownEvents.DELETE,
+      icon: MDI_ICONS.TRASH_CAN_OUTLINE,
+      label: deleteLabel
+    },
+    {
+      name: SelfKnowledgeElementsDropdownEvents.SHARE,
+      icon: MDI_ICONS.SHARE_VARIANT_OUTLINE,
+      label: shareLabel
+    }
+  ]
+
+  if (isCategoryDeletable) {
+    items.push({
+      name: SelfKnowledgeElementsDropdownEvents.DELETE_CATEGORY,
+      icon: MDI_ICONS.TRASH_CAN_OUTLINE,
+      label: t('student.views.studentProjectTrajectoriesView.selfKnowledge.categoryElementsPaginator.buttons.deleteCategory')
+    })
+  }
+
+  return items
+})
+
+function handleItemSelected (itemName: string) {
+  switch (itemName) {
+    case SelfKnowledgeElementsDropdownEvents.ADD:
+      emit('addSelected')
+      break
+    case SelfKnowledgeElementsDropdownEvents.DELETE:
+      emit('deleteSelected')
+      break
+    case SelfKnowledgeElementsDropdownEvents.SHARE:
+      emit('shareSelected')
+      break
+    case SelfKnowledgeElementsDropdownEvents.DELETE_CATEGORY:
+      emit('deleteCategorySelected')
+      break
+  }
+}
+</script>
+
+<template>
+  <AvDropdown
+    :items="menuItems"
+    :trigger-aria-label="t('global.buttons.moreActions')"
+    :trigger-label="t('global.buttons.moreActions')"
+    width="max-content"
+    @item-selected="handleItemSelected"
+  />
+</template>
+
+<style lang="scss" scoped>
+</style>

--- a/src/features/student/traces/views/StudentTraceView/components/TraceSettingsDropdown/TraceSettingsDropdown.vue
+++ b/src/features/student/traces/views/StudentTraceView/components/TraceSettingsDropdown/TraceSettingsDropdown.vue
@@ -52,8 +52,8 @@ function handleItemSelected (itemName: string) {
 <template>
   <AvDropdown
     :items="menuItems"
-    :trigger-aria-label="t('student.views.studentTraceView.settings.ariaLabel')"
-    :trigger-label="t('student.views.studentTraceView.settings.ariaLabel')"
+    :trigger-aria-label="t('global.buttons.moreActions')"
+    :trigger-label="t('global.buttons.moreActions')"
     @item-selected="handleItemSelected"
   />
 </template>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -22,6 +22,7 @@
       "delete": "Delete",
       "exit": "Exit",
       "goBack": "Go back",
+      "moreActions": "More actions",
       "save": "Save"
     },
     "colon": "{before}:",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -22,6 +22,7 @@
       "delete": "Supprimer",
       "exit": "Quitter",
       "goBack": "Retour",
+      "moreActions": "Plus d'actions",
       "save": "Enregistrer"
     },
     "colon": "{before} :",


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> _Describe the changes introduced by this pull request._

:sparkles: create SelfKnowledgeElementsDropdown
💬 put "More actions" translation in globals

---

### Reference to an Issue, Feature, Task, User Story or another PR
> _Mention related issue numbers or links (e.g. Closes #123, Implements #456)._

Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/765

---

### Target Branch
> _Which branch is this PR targeting (e.g. `main`, `develop`)?_

develop

---

### Additional Notes
> _Include any relevant context, technical details, or reasons behind certain decisions._

<img width="339" height="243" alt="image" src="https://github.com/user-attachments/assets/bc705d04-6d38-49c7-8718-4d9a7e3220ca" />

<img width="339" height="243" alt="image" src="https://github.com/user-attachments/assets/07c8cc09-e743-413b-8018-eb53184d8c2d" />


---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [x] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and detaiils for the update process

---