### PR TITLE
feat(766): create DeleteSelfKnowledgeCategoryModal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "avenirs-cofolio-client",
       "version": "0.0.0",
       "dependencies": {
-        "@avenirs-esr/avenirs-dsav": "^0.1.82",
+        "@avenirs-esr/avenirs-dsav": "^0.1.83",
         "@tanstack/vue-form": "^1.15.0",
         "@tanstack/vue-query": "^5.74.9",
         "@vueuse/core": "^13.7.0",
@@ -308,9 +308,9 @@
       }
     },
     "node_modules/@avenirs-esr/avenirs-dsav": {
-      "version": "0.1.82",
-      "resolved": "https://registry.npmjs.org/@avenirs-esr/avenirs-dsav/-/avenirs-dsav-0.1.82.tgz",
-      "integrity": "sha512-XRrqrUNoMeSL6Dh4bK+J3gBE3kPwmbt/6+AcQnb+V7Kl1sbyzm9jm06682WVEHHudFzwG32LCHMIol+gzzMiQw==",
+      "version": "0.1.83",
+      "resolved": "https://registry.npmjs.org/@avenirs-esr/avenirs-dsav/-/avenirs-dsav-0.1.83.tgz",
+      "integrity": "sha512-nlwNvthn9XL6YhJJcZbw7yg2FUjteLB0u+GacB1rDVZKhOson5Ond5mQAkzXOQdAkTMhogV8aa8XMzDgulQBXg==",
       "dependencies": {
         "@vueuse/core": "^13.9.0",
         "date-fns": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
-    "@avenirs-esr/avenirs-dsav": "^0.1.82",
+    "@avenirs-esr/avenirs-dsav": "^0.1.83",
     "@tanstack/vue-form": "^1.15.0",
     "@tanstack/vue-query": "^5.74.9",
     "@vueuse/core": "^13.7.0",

--- a/src/features/student/global/locales/en.json
+++ b/src/features/student/global/locales/en.json
@@ -349,7 +349,40 @@
           },
           "categoryElementsPaginator": {
             "buttons": {
-              "deleteCategory": "Delete category"
+              "add": {
+                "aspirations": "Add an aspiration",
+                "improvement": "Add an area for improvement",
+                "inspirations": "Add an inspiration",
+                "interests": "Add an area of interest",
+                "motivation": "Add a professional motivation",
+                "obligations": "Add an obligation",
+                "strengths": "Add a strength",
+                "testimonials": "Add a testimonial",
+                "values": "Add a value"
+              },
+              "delete": {
+                "aspirations": "Delete an aspiration",
+                "category": "Delete category",
+                "improvement": "Delete an area for improvement",
+                "inspirations": "Delete an inspiration",
+                "interests": "Delete an area of interest",
+                "motivation": "Delete a professional motivation",
+                "obligations": "Delete an obligation",
+                "strengths": "Delete a strength",
+                "testimonials": "Delete a testimonial",
+                "values": "Delete a value"
+              },
+              "share": {
+                "aspirations": "Share my aspirations",
+                "improvement": "Share my areas for improvement",
+                "inspirations": "Share my inspirations",
+                "interests": "Share my areas of interest",
+                "motivation": "Share my professional motivations",
+                "obligations": "Share my obligations",
+                "strengths": "Share my strengths",
+                "testimonials": "Share my testimonials",
+                "values": "Share my values"
+              }
             }
           },
           "modals": {

--- a/src/features/student/global/locales/en.json
+++ b/src/features/student/global/locales/en.json
@@ -356,6 +356,10 @@
             "addSelfKnowledgeCategories": {
               "success": "{count} category added successfully | {count} categories added successfully",
               "title": "You have added all the categories currently available on COFOLIO. | Which category would you like to add? | Which categories would you like to add?"
+            },
+            "deleteSelfKnowledgeCategory": {
+              "title": "Are you sure you want to delete the category {category}?",
+              "description": "The item entered in this category will be permanently deleted. | {count} items entered in this category will be permanently deleted."
             }
           },
           "title": {

--- a/src/features/student/global/locales/fr.json
+++ b/src/features/student/global/locales/fr.json
@@ -349,7 +349,40 @@
           },
           "categoryElementsPaginator": {
             "buttons": {
-              "deleteCategory": "Supprimer la catégorie"
+              "add": {
+                "aspirations": "Ajouter une envie",
+                "improvement": "Ajouter un axe d'amélioration",
+                "inspirations": "Ajouter une inspiration",
+                "interests": "Ajouter un centre d'intérêt",
+                "motivation": "Ajouter une motivation professionnelle",
+                "obligations": "Ajouter une obligation",
+                "strengths": "Ajouter un point fort",
+                "testimonials": "Ajouter un témoignage",
+                "values": "Ajouter une valeur"
+              },
+              "delete": {
+                "aspirations": "Supprimer une envie",
+                "category": "Supprimer la catégorie",
+                "improvement": "Supprimer un axe d'amélioration",
+                "inspirations": "Supprimer une inspiration",
+                "interests": "Supprimer un centre d'intérêt",
+                "motivation": "Supprimer une motivation professionnelle",
+                "obligations": "Supprimer une obligation",
+                "strengths": "Supprimer un point fort",
+                "testimonials": "Supprimer un témoignage",
+                "values": "Supprimer une valeur"
+              },
+              "share": {
+                "aspirations": "Partager mes envies",
+                "improvement": "Partager mes axes d'amélioration",
+                "inspirations": "Partager mes inspirations",
+                "interests": "Partager mes centres d'intérêt",
+                "motivation": "Partager mes motivations professionnelles",
+                "obligations": "Partager mes obligations",
+                "strengths": "Partager mes points forts",
+                "testimonials": "Partager mes témoignages",
+                "values": "Partager mes valeurs"
+              }
             }
           },
           "modals": {

--- a/src/features/student/global/locales/fr.json
+++ b/src/features/student/global/locales/fr.json
@@ -356,6 +356,10 @@
             "addSelfKnowledgeCategories": {
               "success": "{count} catégorie ajoutée avec succès | {count} catégories ajoutées avec succès",
               "title": "Vous avez ajouté toutes les catégories actuellement disponible sur COFOLIO. | Quelle catégorie souhaitez-vous ajouter ? | Quelles catégories souhaitez-vous ajouter ?"
+            },
+            "deleteSelfKnowledgeCategory": {
+              "title": "Êtes-vous certain(e) de vouloir supprimer la catégorie {category} ?",
+              "description": "L'élément renseigné dans cette catégorie sera définitivement supprimé. | {count} éléments renseignés dans cette catégorie seront définitivement supprimés."
             }
           },
           "title": {

--- a/src/features/student/selfKnowledge/components/dropdowns/SelfKnowledgeElementsDropdown/SelfKnowledgeElementsDropdown.test.ts
+++ b/src/features/student/selfKnowledge/components/dropdowns/SelfKnowledgeElementsDropdown/SelfKnowledgeElementsDropdown.test.ts
@@ -1,5 +1,5 @@
+import { ESelfKnowledgeCategoryType } from '@/api/avenir-esr'
 import SelfKnowledgeElementsDropdown, { type SelfKnowledgeElementsDropdownProps } from '@/features/student/selfKnowledge/components/dropdowns/SelfKnowledgeElementsDropdown/SelfKnowledgeElementsDropdown.vue'
-import { MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
 import { AvDropdownStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { mount, type VueWrapper } from '@vue/test-utils'
 import { beforeEach, expect } from 'vitest'
@@ -15,98 +15,75 @@ BddTest().given('a self knowledge elements dropdown', () => {
     return mount(SelfKnowledgeElementsDropdown, { props, global: { stubs } })
   }
 
-  BddTest().and('the category is deletable', () => {
-    const props: SelfKnowledgeElementsDropdownProps = {
-      addLabel: 'Add an improvement',
-      deleteLabel: 'Delete an improvement',
-      shareLabel: 'Share my improvements',
-      isCategoryDeletable: true
-    }
+  function isCategoryDeletable (categoryType: ESelfKnowledgeCategoryType) {
+    return (![
+      ESelfKnowledgeCategoryType.VALUES,
+      ESelfKnowledgeCategoryType.STRENGTHS,
+      ESelfKnowledgeCategoryType.ASPIRATIONS
+    ].includes(categoryType))
+  }
 
-    BddTest().when('the component is mounted', () => {
-      beforeEach(() => {
-        wrapper = mountDropdown(props)
-      })
+  for (const category of Object.values(ESelfKnowledgeCategoryType)) {
+    BddTest().and(`the category type is ${category}`, () => {
+      BddTest().when('the component is mounted', () => {
+        beforeEach(() => {
+          wrapper = mountDropdown({
+            categoryType: category
+          })
+        })
 
-      BddTest().then('it should render the AvDropdown with correct props', () => {
-        const dropdown = wrapper.findComponent(AvDropdownStub)
-        expect(dropdown.exists()).toBe(true)
-        expect(dropdown.props('items')).toEqual([
-          { name: 'add', label: 'Add an improvement', icon: MDI_ICONS.PLUS_CIRCLE_OUTLINE },
-          { name: 'delete', label: 'Delete an improvement', icon: MDI_ICONS.TRASH_CAN_OUTLINE },
-          { name: 'share', label: 'Share my improvements', icon: MDI_ICONS.SHARE_VARIANT_OUTLINE },
-          { name: 'deleteCategory', label: 'Supprimer la catégorie', icon: MDI_ICONS.TRASH_CAN_OUTLINE }
-        ])
-      })
-
-      BddTest().and('the add item is selected', () => {
-        beforeEach(async () => {
+        BddTest().then(isCategoryDeletable(category) ? 'the category should be deletable' : 'the category should not be deletable', () => {
           const dropdown = wrapper.findComponent(AvDropdownStub)
-          await dropdown.vm.$emit('itemSelected', 'add')
+          expect(dropdown.exists()).toBe(true)
+          expect(dropdown.findAll('button')).toHaveLength(isCategoryDeletable(category) ? 4 : 3)
         })
 
-        BddTest().then('it should emit the addSelected event', () => {
-          expect(wrapper.emitted()).toHaveProperty('addSelected')
-        })
-      })
+        BddTest().and('the add item is selected', () => {
+          beforeEach(async () => {
+            const dropdown = wrapper.findComponent(AvDropdownStub)
+            await dropdown.vm.$emit('itemSelected', 'add')
+          })
 
-      BddTest().and('the delete item is selected', () => {
-        beforeEach(async () => {
-          const dropdown = wrapper.findComponent(AvDropdownStub)
-          await dropdown.vm.$emit('itemSelected', 'delete')
-        })
-
-        BddTest().then('it should emit the deleteSelected event', () => {
-          expect(wrapper.emitted()).toHaveProperty('deleteSelected')
-        })
-      })
-
-      BddTest().and('the share item is selected', () => {
-        beforeEach(async () => {
-          const dropdown = wrapper.findComponent(AvDropdownStub)
-          await dropdown.vm.$emit('itemSelected', 'share')
+          BddTest().then('it should emit the addSelected event', () => {
+            expect(wrapper.emitted()).toHaveProperty('addSelected')
+          })
         })
 
-        BddTest().then('it should emit the shareSelected event', () => {
-          expect(wrapper.emitted()).toHaveProperty('shareSelected')
-        })
-      })
+        BddTest().and('the delete item is selected', () => {
+          beforeEach(async () => {
+            const dropdown = wrapper.findComponent(AvDropdownStub)
+            await dropdown.vm.$emit('itemSelected', 'delete')
+          })
 
-      BddTest().and('the deleteCategory item is selected', () => {
-        beforeEach(async () => {
-          const dropdown = wrapper.findComponent(AvDropdownStub)
-          await dropdown.vm.$emit('itemSelected', 'deleteCategory')
+          BddTest().then('it should emit the deleteSelected event', () => {
+            expect(wrapper.emitted()).toHaveProperty('deleteSelected')
+          })
         })
 
-        BddTest().then('it should emit the deleteCategorySelected event', () => {
-          expect(wrapper.emitted()).toHaveProperty('deleteCategorySelected')
+        BddTest().and('the share item is selected', () => {
+          beforeEach(async () => {
+            const dropdown = wrapper.findComponent(AvDropdownStub)
+            await dropdown.vm.$emit('itemSelected', 'share')
+          })
+
+          BddTest().then('it should emit the shareSelected event', () => {
+            expect(wrapper.emitted()).toHaveProperty('shareSelected')
+          })
         })
+
+        if (isCategoryDeletable(category)) {
+          BddTest().and('the delete category item is selected', () => {
+            beforeEach(async () => {
+              const dropdown = wrapper.findComponent(AvDropdownStub)
+              await dropdown.vm.$emit('itemSelected', 'deleteCategory')
+            })
+
+            BddTest().then('it should emit the deleteCategorySelected event', () => {
+              expect(wrapper.emitted()).toHaveProperty('deleteCategorySelected')
+            })
+          })
+        }
       })
     })
-  })
-
-  BddTest().and('the category is not deletable', () => {
-    const props: SelfKnowledgeElementsDropdownProps = {
-      addLabel: 'Add a strength',
-      deleteLabel: 'Delete an strength',
-      shareLabel: 'Share my strengths',
-      isCategoryDeletable: false
-    }
-
-    BddTest().when('the component is mounted', () => {
-      beforeEach(() => {
-        wrapper = mountDropdown(props)
-      })
-
-      BddTest().then('it should render the AvDropdown with correct props', () => {
-        const dropdown = wrapper.findComponent(AvDropdownStub)
-        expect(dropdown.exists()).toBe(true)
-        expect(dropdown.props('items')).toEqual([
-          { name: 'add', label: 'Add a strength', icon: MDI_ICONS.PLUS_CIRCLE_OUTLINE },
-          { name: 'delete', label: 'Delete an strength', icon: MDI_ICONS.TRASH_CAN_OUTLINE },
-          { name: 'share', label: 'Share my strengths', icon: MDI_ICONS.SHARE_VARIANT_OUTLINE }
-        ])
-      })
-    })
-  })
+  }
 })

--- a/src/features/student/selfKnowledge/components/dropdowns/SelfKnowledgeElementsDropdown/SelfKnowledgeElementsDropdown.vue
+++ b/src/features/student/selfKnowledge/components/dropdowns/SelfKnowledgeElementsDropdown/SelfKnowledgeElementsDropdown.vue
@@ -1,15 +1,13 @@
 <script lang="ts" setup>
+import { ESelfKnowledgeCategoryType } from '@/api/avenir-esr'
 import { AvDropdown, type AvDropdownItem, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
 import { useI18n } from 'vue-i18n'
 
 export interface SelfKnowledgeElementsDropdownProps {
-  addLabel: string
-  deleteLabel: string
-  shareLabel: string
-  isCategoryDeletable: boolean
+  categoryType: ESelfKnowledgeCategoryType
 }
 
-const { addLabel, deleteLabel, shareLabel, isCategoryDeletable } = defineProps<SelfKnowledgeElementsDropdownProps>()
+const { categoryType } = defineProps<SelfKnowledgeElementsDropdownProps>()
 
 const emit = defineEmits<{
   (e: 'addSelected'): void
@@ -19,6 +17,12 @@ const emit = defineEmits<{
 }>()
 
 const { t } = useI18n()
+
+const isCategoryDeletable = computed(() => ![
+  ESelfKnowledgeCategoryType.VALUES,
+  ESelfKnowledgeCategoryType.STRENGTHS,
+  ESelfKnowledgeCategoryType.ASPIRATIONS
+].includes(categoryType))
 
 enum SelfKnowledgeElementsDropdownEvents {
   ADD = 'add',
@@ -32,25 +36,25 @@ const menuItems = computed<AvDropdownItem[]>(() => {
     {
       name: SelfKnowledgeElementsDropdownEvents.ADD,
       icon: MDI_ICONS.PLUS_CIRCLE_OUTLINE,
-      label: addLabel
+      label: t(`student.views.studentProjectTrajectoriesView.selfKnowledge.categoryElementsPaginator.buttons.add.${categoryType.toLowerCase()}`)
     },
     {
       name: SelfKnowledgeElementsDropdownEvents.DELETE,
       icon: MDI_ICONS.TRASH_CAN_OUTLINE,
-      label: deleteLabel
+      label: t(`student.views.studentProjectTrajectoriesView.selfKnowledge.categoryElementsPaginator.buttons.delete.${categoryType.toLowerCase()}`)
     },
     {
       name: SelfKnowledgeElementsDropdownEvents.SHARE,
       icon: MDI_ICONS.SHARE_VARIANT_OUTLINE,
-      label: shareLabel
+      label: t(`student.views.studentProjectTrajectoriesView.selfKnowledge.categoryElementsPaginator.buttons.share.${categoryType.toLowerCase()}`)
     }
   ]
 
-  if (isCategoryDeletable) {
+  if (isCategoryDeletable.value) {
     items.push({
       name: SelfKnowledgeElementsDropdownEvents.DELETE_CATEGORY,
       icon: MDI_ICONS.TRASH_CAN_OUTLINE,
-      label: t('student.views.studentProjectTrajectoriesView.selfKnowledge.categoryElementsPaginator.buttons.deleteCategory')
+      label: t('student.views.studentProjectTrajectoriesView.selfKnowledge.categoryElementsPaginator.buttons.delete.category')
     })
   }
 

--- a/src/features/student/selfKnowledge/components/modals/DeleteSelfKnowledgeCategoryModal/DeleteSelfKnowledgeCategoryModal.test.ts
+++ b/src/features/student/selfKnowledge/components/modals/DeleteSelfKnowledgeCategoryModal/DeleteSelfKnowledgeCategoryModal.test.ts
@@ -1,0 +1,126 @@
+import DeleteSelfKnowledgeCategoryModal, { type DeleteSelfKnowledgeCategoryModalProps } from '@/features/student/selfKnowledge/components/modals/DeleteSelfKnowledgeCategoryModal/DeleteSelfKnowledgeCategoryModal.vue'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { beforeEach, expect } from 'vitest'
+
+const AvModalStub = defineComponent({
+  name: 'AvModal',
+  template: `
+    <div class="av-modal-stub">
+      <slot name="header" />
+      <slot />
+    </div>
+  `,
+  props: ['opened', 'id', 'closeButtonLabel', 'confirmButtonLabel'],
+  emits: ['close', 'confirm']
+})
+
+BddTest().given('the DeleteSelfKnowledgeCategoryModal component', () => {
+  let wrapper: VueWrapper<InstanceType<typeof DeleteSelfKnowledgeCategoryModal>>
+
+  const stubs = { AvModal: AvModalStub }
+
+  BddTest().when('the component is mounted with many elements', () => {
+    const props: DeleteSelfKnowledgeCategoryModalProps = {
+      show: true,
+      categoryTitle: 'Category with 3 elements',
+      elementsCount: 3,
+    }
+
+    beforeEach(() => {
+      wrapper = mount(DeleteSelfKnowledgeCategoryModal, {
+        props,
+        global: { stubs }
+      })
+    })
+
+    BddTest().then('it should render the AvModal with correct props', () => {
+      const modal = wrapper.findComponent(AvModalStub)
+      expect(modal.exists()).toBe(true)
+      expect(modal.props('opened')).toBe(true)
+      expect(modal.props('closeButtonLabel')).toBe('Annuler')
+      expect(modal.props('confirmButtonLabel')).toBe('Confirmer')
+    })
+
+    BddTest().then('it should render the correct title', () => {
+      const title = wrapper.find('.delete-self-knowledge-category-modal__header')
+      expect(title.exists()).toBe(true)
+      expect(title.text()).toBe('Êtes-vous certain(e) de vouloir supprimer la catégorie Category with 3 elements ?')
+    })
+
+    BddTest().then('it should render the description with elements count in plural', () => {
+      const description = wrapper.find('.delete-self-knowledge-category-modal__body')
+      expect(description.exists()).toBe(true)
+      expect(description.text()).toBe(`${props.elementsCount} éléments renseignés dans cette catégorie seront définitivement supprimés.`)
+    })
+
+    BddTest().and('the user clicks on the cancel button', () => {
+      BddTest().then('it should emit the cancel event', () => {
+        const modal = wrapper.findComponent(AvModalStub)
+        modal.vm.$emit('close')
+        expect(wrapper.emitted()).toHaveProperty('cancel')
+      })
+    })
+
+    BddTest().and('the user clicks on the confirm button', () => {
+      BddTest().then('it should emit the confirm event', () => {
+        const modal = wrapper.findComponent(AvModalStub)
+        modal.vm.$emit('confirm')
+        expect(wrapper.emitted()).toHaveProperty('confirm')
+      })
+    })
+  })
+
+  BddTest().when('the component is mounted with one element', () => {
+    const props: DeleteSelfKnowledgeCategoryModalProps = {
+      show: true,
+      categoryTitle: 'Category with 1 element',
+      elementsCount: 1,
+    }
+
+    beforeEach(() => {
+      wrapper = mount(DeleteSelfKnowledgeCategoryModal, {
+        props,
+        global: { stubs }
+      })
+    })
+
+    BddTest().then('it should render the correct title', () => {
+      const title = wrapper.find('.delete-self-knowledge-category-modal__header')
+      expect(title.exists()).toBe(true)
+      expect(title.text()).toBe('Êtes-vous certain(e) de vouloir supprimer la catégorie Category with 1 element ?')
+    })
+
+    BddTest().then('it should render the description with element count in singular', () => {
+      const description = wrapper.find('.delete-self-knowledge-category-modal__body')
+      expect(description.exists()).toBe(true)
+      expect(description.text()).toBe(`L'élément renseigné dans cette catégorie sera définitivement supprimé.`)
+    })
+  })
+
+  BddTest().when('the component is mounted without elements', () => {
+    const props: DeleteSelfKnowledgeCategoryModalProps = {
+      show: true,
+      categoryTitle: 'Empty Category',
+      elementsCount: 0,
+    }
+
+    beforeEach(() => {
+      wrapper = mount(DeleteSelfKnowledgeCategoryModal, {
+        props,
+        global: { stubs }
+      })
+    })
+
+    BddTest().then('it should render the correct title', () => {
+      const title = wrapper.find('.delete-self-knowledge-category-modal__header')
+      expect(title.exists()).toBe(true)
+      expect(title.text()).toBe('Êtes-vous certain(e) de vouloir supprimer la catégorie Empty Category ?')
+    })
+
+    BddTest().then('it should not render a description', () => {
+      const description = wrapper.find('.delete-self-knowledge-category-modal__body')
+      expect(description.exists()).toBe(false)
+    })
+  })
+})

--- a/src/features/student/selfKnowledge/components/modals/DeleteSelfKnowledgeCategoryModal/DeleteSelfKnowledgeCategoryModal.vue
+++ b/src/features/student/selfKnowledge/components/modals/DeleteSelfKnowledgeCategoryModal/DeleteSelfKnowledgeCategoryModal.vue
@@ -1,0 +1,64 @@
+<script lang="ts" setup>
+import { AvModal, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
+import { useI18n } from 'vue-i18n'
+
+export interface DeleteSelfKnowledgeCategoryModalProps {
+  show: boolean
+  categoryTitle: string
+  elementsCount: number
+}
+
+defineProps<DeleteSelfKnowledgeCategoryModalProps>()
+
+const emit = defineEmits<{
+  (e: 'cancel'): void
+  (e: 'confirm'): void
+}>()
+
+const { t } = useI18n()
+
+function onConfirm () {
+  // TODO: implement this when backend is ready
+  emit('confirm')
+}
+</script>
+
+<template>
+  <AvModal
+    :opened="show"
+    :close-button-label="t('global.buttons.cancel')"
+    :confirm-button-label="t('global.buttons.confirm')"
+    :confirm-button-icon="MDI_ICONS.CHECK_CIRCLE"
+    @close="$emit('cancel')"
+    @confirm="onConfirm"
+  >
+    <template #header>
+      <div class="delete-self-knowledge-category-modal__header">
+        <span class="b2-bold">
+          {{ t('student.views.studentProjectTrajectoriesView.selfKnowledge.modals.deleteSelfKnowledgeCategory.title', { category: categoryTitle }) }}
+        </span>
+      </div>
+    </template>
+
+    <div
+      v-if="elementsCount > 0"
+      class="delete-self-knowledge-category-modal__body"
+    >
+      {{ t('student.views.studentProjectTrajectoriesView.selfKnowledge.modals.deleteSelfKnowledgeCategory.description', { count: elementsCount }) }}
+    </div>
+  </AvModal>
+</template>
+
+<style lang="scss" scoped>
+.delete-self-knowledge-category-modal {
+  &__header {
+    display: flex;
+    flex: 1;
+  }
+}
+
+.b2-bold,
+.b2-regular {
+  color: var(--text1);
+}
+</style>


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> _Describe the changes introduced by this pull request._

:sparkles: create DeleteSelfKnowledgeCategoryModal
:recycle: only give categoryType as prop to SelfKnowledgeElementsDropdown

---

### Reference to an Issue, Feature, Task, User Story or another PR
> _Mention related issue numbers or links (e.g. Closes #123, Implements #456)._

Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/766

---

### Target Branch
> _Which branch is this PR targeting (e.g. `main`, `develop`)?_

develop

---

### Demo

#### All dropdowns available

https://github.com/user-attachments/assets/d732da0d-3da8-44a2-bc43-04bedf721ba7

#### Delete modal with linked elements

https://github.com/user-attachments/assets/62d1086e-b001-4749-bb8c-428b200d54ab

#### Delete modal without linked elements

https://github.com/user-attachments/assets/c3716623-0976-4e47-acdb-b1ccfe389e2f



---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [x] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and detaiils for the update process

---