### PR TITLE
feat(781): add SelfKnowledgeElementUpdateView

### DIFF
--- a/api-specs/avenir-esr.swagger.json
+++ b/api-specs/avenir-esr.swagger.json
@@ -177,6 +177,105 @@
         }
       }
     },
+    "/me/self-knowledge/element/{selfKnowledgeElementId}": {
+      "get": {
+        "tags": [
+          "self-knowledge-controller"
+        ],
+        "operationId": "getSelfKnowledgeElementDetails",
+        "parameters": [
+          {
+            "name": "selfKnowledgeElementId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/SelfKnowledgeElementDetailsDTO"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "self-knowledge-controller"
+        ],
+        "operationId": "updateSelfKnowledgeElement",
+        "parameters": [
+          {
+            "name": "selfKnowledgeElementId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SelfKnowledgeElementRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/SelfKnowledgeElementViewDTO"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "self-knowledge-controller"
+        ],
+        "operationId": "deleteSelfKnowledgeElement",
+        "parameters": [
+          {
+            "name": "selfKnowledgeElementId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/me/additional-skill-progress/{additionalSkillProgressId}": {
       "get": {
         "tags": [
@@ -1931,6 +2030,55 @@
           "version"
         ]
       },
+      "SelfKnowledgeElementRequest": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "maxLength": 80,
+            "minLength": 0
+          },
+          "description": {
+            "type": "string",
+            "maxLength": 400,
+            "minLength": 0
+          },
+          "rating": {
+            "type": "integer",
+            "format": "int32",
+            "maximum": 5,
+            "minimum": 1
+          }
+        },
+        "required": [
+          "description",
+          "title"
+        ]
+      },
+      "SelfKnowledgeElementViewDTO": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "rating": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "required": [
+          "description",
+          "id",
+          "title"
+        ]
+      },
       "AdditionalSkillProgressRequest": {
         "type": "object",
         "properties": {
@@ -2753,6 +2901,40 @@
           "title"
         ]
       },
+      "SelfKnowledgeElementDetailsDTO": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "rating": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "createdAt",
+          "description",
+          "id",
+          "title",
+          "updatedAt"
+        ]
+      },
       "SelfKnowledgeCategoryDTO": {
         "type": "object",
         "properties": {
@@ -3398,53 +3580,6 @@
         "required": [
           "description",
           "label"
-        ]
-      },
-      "SelfKnowledgeElementViewDTO": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "title": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "rating": {
-            "type": "integer",
-            "format": "int32"
-          }
-        },
-        "required": [
-          "description",
-          "id",
-          "title"
-        ]
-      },
-      "SelfKnowledgeElementRequest": {
-        "type": "object",
-        "properties": {
-          "title": {
-            "type": "string",
-            "maxLength": 80,
-            "minLength": 0
-          },
-          "description": {
-            "type": "string",
-            "maxLength": 400,
-            "minLength": 0
-          },
-          "rating": {
-            "type": "integer",
-            "format": "int32"
-          }
-        },
-        "required": [
-          "description",
-          "title"
         ]
       },
       "ESelfKnowledgeCategoryType": {

--- a/src/__mocks__/fixtures/student/self-knowledge.fixtures.ts
+++ b/src/__mocks__/fixtures/student/self-knowledge.fixtures.ts
@@ -1,4 +1,4 @@
-import { ESelfKnowledgeCategoryType, type PagedResponseSelfKnowledgeElementViewDTO, type SelfKnowledgeCategoryDTO, type SelfKnowledgeElementViewDTO } from '@/api/avenir-esr'
+import { ESelfKnowledgeCategoryType, type PagedResponseSelfKnowledgeElementViewDTO, type SelfKnowledgeCategoryDTO, type SelfKnowledgeElementDetailsDTO, type SelfKnowledgeElementViewDTO } from '@/api/avenir-esr'
 
 export const mockedSelfKnowledgeCategories: SelfKnowledgeCategoryDTO[] = [
   {
@@ -20,6 +20,15 @@ export const mockedSelfKnowledgeCategories: SelfKnowledgeCategoryDTO[] = [
     type: ESelfKnowledgeCategoryType.ASPIRATIONS
   }
 ]
+
+export const mockedSelfKnowledgeElementDetails: SelfKnowledgeElementDetailsDTO = {
+  id: 'element-123',
+  title: 'Créativité',
+  description: 'Je suis capable de trouver des solutions originales et innovantes aux problèmes',
+  rating: 4,
+  createdAt: '2023-10-10T10:00:00Z',
+  updatedAt: '2023-10-15T12:00:00Z'
+}
 
 const strengthsElements = [
   { title: 'Créativité', description: 'Je suis capable de trouver des solutions originales et innovantes aux problèmes' },

--- a/src/__mocks__/msw/handlers/student/self-knowledge.handlers.ts
+++ b/src/__mocks__/msw/handlers/student/self-knowledge.handlers.ts
@@ -1,20 +1,35 @@
 import {
   createMockedPagedResponseSelfKnowledgeElementViewDTO,
   mockedSelfKnowledgeCategories,
-  mockedSelfKnowledgeCategoriesAvailable
+  mockedSelfKnowledgeCategoriesAvailable,
+  mockedSelfKnowledgeElementDetails
 } from '@/__mocks__/fixtures/student/self-knowledge.fixtures'
 import {
   getAddSelfKnowledgeCategoriesUrl,
   getGetSelfKnowledgeCategoriesAvailableUrl,
   getGetSelfKnowledgeCategoriesUrl,
+  getGetSelfKnowledgeElementDetailsUrl,
   getGetSelfKnowledgeElementsUrl,
   getRemoveSelfKnowledgeCategoryUrl,
   type PagedResponseSelfKnowledgeElementViewDTO,
-  type SelfKnowledgeCategoryDTO
+  type SelfKnowledgeCategoryDTO,
+  type SelfKnowledgeElementDetailsDTO
 } from '@/api/avenir-esr'
 import { http, HttpResponse } from 'msw'
 
 export const selfKnowledgeCategoriesErrorHandler = http.get(`*${getGetSelfKnowledgeCategoriesUrl()}`, () => {
+  return HttpResponse.json(
+    { message: 'Internal Server Error' },
+    {
+      status: 500,
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    }
+  )
+})
+
+export const selfKnowledgeElementDetailsErrorHandler = http.get(`*${getGetSelfKnowledgeElementDetailsUrl(':selfKnowledgeElementId')}`, () => {
   return HttpResponse.json(
     { message: 'Internal Server Error' },
     {
@@ -61,6 +76,17 @@ export function createSelfKnowledgeCategoriesAvailableHandler (payload: SelfKnow
   })
 }
 
+export function createSelfKnowledgeElementDetailsHandler (payload: SelfKnowledgeElementDetailsDTO) {
+  return http.get(`*${getGetSelfKnowledgeElementDetailsUrl(':selfKnowledgeElementId')}`, () => {
+    return HttpResponse.json<SelfKnowledgeElementDetailsDTO>(payload, {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json',
+      }
+    })
+  })
+}
+
 export function updateSelectedSelfKnowledgeCategoriesHandler (payload: string[]) {
   return http.post(`*${getAddSelfKnowledgeCategoriesUrl()}`, () => {
     return HttpResponse.json<string[]>(payload, {
@@ -75,6 +101,15 @@ export function updateSelectedSelfKnowledgeCategoriesHandler (payload: string[])
 export const selfKnowledgeHandlers = [
   http.get(`*${getGetSelfKnowledgeCategoriesUrl()}`, () => {
     return HttpResponse.json<SelfKnowledgeCategoryDTO[]>(mockedSelfKnowledgeCategories, {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    })
+  }),
+
+  http.get(`*${getGetSelfKnowledgeElementDetailsUrl(':selfKnowledgeElementId')}`, () => {
+    return HttpResponse.json<SelfKnowledgeElementDetailsDTO>(mockedSelfKnowledgeElementDetails, {
       status: 200,
       headers: {
         'Content-Type': 'application/json'

--- a/src/common/components/PageTitle/PageTitle.stub.ts
+++ b/src/common/components/PageTitle/PageTitle.stub.ts
@@ -1,5 +1,5 @@
 export const PageTitleStub = defineComponent({
   name: 'PageTitle',
-  template: '<div />',
+  template: '<div><slot name="title" /></div>',
   props: ['title', 'breadcrumbLinks', 'back']
 })

--- a/src/common/components/PageTitle/PageTitle.test.ts
+++ b/src/common/components/PageTitle/PageTitle.test.ts
@@ -50,6 +50,26 @@ BddTest().given('a page title', () => {
     })
   })
 
+  BddTest().when('the component is mounted with the title slot', () => {
+    const slotTitle = 'Slot Page Title'
+
+    beforeEach(async () => {
+      wrapper = await mountWithRouter(PageTitle, {
+        props,
+        slots: {
+          title: `<span class="slot-title n2">${slotTitle}</span>`
+        },
+        global: { stubs }
+      })
+    })
+
+    BddTest().then('it should render the slot title instead of the prop title', () => {
+      const pageTitle = wrapper.find('.page-title')
+      const spanTitle = pageTitle.find('.slot-title')
+      expect(spanTitle.text()).toBe(slotTitle)
+    })
+  })
+
   BddTest().when('clicking on the back button without back provided', () => {
     let mockRouter: Partial<Router>
 

--- a/src/common/components/PageTitle/PageTitle.vue
+++ b/src/common/components/PageTitle/PageTitle.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { Slot } from 'vue'
 import type { RouteLocationRaw } from 'vue-router'
 import { ROUTE_NAMES } from '@/common/constants'
 import { AvBreadcrumb, type AvBreadcrumbProps, AvButton, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
@@ -12,6 +13,10 @@ const {
   breadcrumbLinks: AvBreadcrumbProps['links']
   title: string
   back?: RouteLocationRaw
+}>()
+
+defineSlots<{
+  title: Slot
 }>()
 
 const router = useRouter()
@@ -41,7 +46,9 @@ function goBack () {
         :icon="MDI_ICONS.ARROW_LEFT_THIN"
         @click="goBack"
       />
-      <span class="n2">{{ title }}</span>
+      <slot name="title">
+        <span class="n2">{{ title }}</span>
+      </slot>
     </div>
   </div>
 </template>

--- a/src/common/composables/use-navigation/use-navigation.test.ts
+++ b/src/common/composables/use-navigation/use-navigation.test.ts
@@ -90,6 +90,17 @@ BddTest().given('a useNavigation composable', () => {
     })
   })
 
+  BddTest().when('trying to navigate to self-knowledge elements update', () => {
+    BddTest().then('it should navigate to self-knowledge elements update', () => {
+      const { navigateToStudentSelfKnowledgeElementUpdate } = navigation
+      navigateToStudentSelfKnowledgeElementUpdate({ categoryId: 'categoryId', elementId: 'elementId' })
+      expect(pushMock).toHaveBeenCalledWith({
+        name: ROUTE_NAMES.STUDENT.SELFKNOWLEDGE_ELEMENT_UPDATE.name,
+        params: { path: ROUTE_NAMES.STUDENT.SELFKNOWLEDGE_ELEMENT_UPDATE.path, categoryId: 'categoryId', elementId: 'elementId' }
+      })
+    })
+  })
+
   BddTest().when('trying to navigate to student skills', () => {
     BddTest().then('it should navigate to student skills', () => {
       const { navigateToStudentSkills } = navigation

--- a/src/common/composables/use-navigation/use-navigation.ts
+++ b/src/common/composables/use-navigation/use-navigation.ts
@@ -40,6 +40,13 @@ export function useNavigation () {
     return router.push(ROUTE_NAMES.STUDENT.SELFKNOWLEDGE_CATEGORY)
   }
 
+  const navigateToStudentSelfKnowledgeElementUpdate = ({ categoryId, elementId }: { categoryId: string, elementId: string }) => {
+    return router.push({
+      name: ROUTE_NAMES.STUDENT.SELFKNOWLEDGE_ELEMENT_UPDATE.name,
+      params: { path: ROUTE_NAMES.STUDENT.SELFKNOWLEDGE_ELEMENT_UPDATE.path, categoryId, elementId }
+    })
+  }
+
   const navigateToStudentSkills = () => {
     return router.push(ROUTE_NAMES.STUDENT.EDUCATION_SKILLS)
   }
@@ -67,6 +74,7 @@ export function useNavigation () {
     navigateToStudentPages,
     navigateToStudentResumes,
     navigateToStudentSelfKnowledgeCategory,
+    navigateToStudentSelfKnowledgeElementUpdate,
     navigateToStudentSkills,
     navigateToStudentTraces,
     navigateToStudentUpdateAdditionalSkill,

--- a/src/common/constants/route-names.ts
+++ b/src/common/constants/route-names.ts
@@ -10,6 +10,7 @@ export const ROUTE_NAMES = {
     PROJECT_EXPERIENCES: { name: 'student-project-experiences', path: 'projects/experiences' },
     PROJECT_TRAJECTORIES: { name: 'student-project-trajectories', path: 'projects/trajectories' },
     SELFKNOWLEDGE_CATEGORY: { name: 'student-self-knowledge-category', path: 'projects/trajectories/self-knowledge/:id' },
+    SELFKNOWLEDGE_ELEMENT_UPDATE: { name: 'student-self-knowledge-element-update', path: 'projects/trajectories/self-knowledge/:categoryId/:elementId/update' },
     TOOLS_PAGES: { name: 'student-tools-pages', path: 'tools/pages' },
     TOOLS_RESUMES: { name: 'student-tools-resumes', path: 'tools/resumes' },
     ABOUT: { name: 'student-about', path: 'about' },

--- a/src/features/student/global/locales/en.json
+++ b/src/features/student/global/locales/en.json
@@ -204,6 +204,9 @@
       "selfKnowledgeCategoryView": {
         "title": "Details of my {type}"
       },
+      "selfKnowledgeElementUpdateView": {
+        "title": "Update {elementTitle}"
+      },
       "studentAdditionalSkillView": {
         "settings": {
           "ariaLabel": "Declared skill settings",

--- a/src/features/student/global/locales/fr.json
+++ b/src/features/student/global/locales/fr.json
@@ -204,6 +204,9 @@
       "selfKnowledgeCategoryView": {
         "title": "Détail de mes {type}"
       },
+      "selfKnowledgeElementUpdateView": {
+        "title": "Modifier {elementTitle}"
+      },
       "studentAdditionalSkillView": {
         "settings": {
           "ariaLabel": "Paramètres de la compétence déclarée",

--- a/src/features/student/global/routes/index.ts
+++ b/src/features/student/global/routes/index.ts
@@ -2,6 +2,7 @@ import { ROUTE_NAMES } from '@/common/constants'
 import { studentAdditionalSkillRoute, studentUpdateAdditionalSkillRoute } from '@/features/student/additionalSkills/routes'
 import { studentAmsRoute, studentEducationAmsRoute } from '@/features/student/ams/routes'
 import { studentSelfKnowledgeCategoryRoute } from '@/features/student/selfKnowledge'
+import { studentSelfKnowledgeElementUpdateRoute } from '@/features/student/selfKnowledge/routes'
 import { studentEducationSkillsRoute, studentProjectSkillsRoute, studentSkillRoute } from '@/features/student/skills/routes'
 import { studentToolsTracesRoute, studentTraceRoute } from '@/features/student/traces/routes'
 
@@ -52,6 +53,7 @@ export default [
         component: () => import('@/features/student/global/views/StudentProjectTrajectoriesView/StudentProjectTrajectoriesView.vue'),
       },
       studentSelfKnowledgeCategoryRoute,
+      studentSelfKnowledgeElementUpdateRoute,
       studentSkillRoute,
       studentToolsTracesRoute,
       {

--- a/src/features/student/selfKnowledge/components/navigation/SelfKnowledgeElementsSideMenu/SelfKnowledgeElementsSideMenu.stub.ts
+++ b/src/features/student/selfKnowledge/components/navigation/SelfKnowledgeElementsSideMenu/SelfKnowledgeElementsSideMenu.stub.ts
@@ -1,0 +1,19 @@
+export const SelfKnowledgeElementsSideMenuStub = defineComponent({
+  name: 'SelfKnowledgeElementsSideMenu',
+  props: {
+    elements: {
+      type: Array,
+      required: true
+    },
+    categoryType: {
+      type: String,
+      required: true
+    },
+    selectedElementId: {
+      type: String,
+      required: true
+    }
+  },
+  emits: ['selectElement'],
+  template: '<div class="self-knowledge-elements-side-menu-stub" />'
+})

--- a/src/features/student/selfKnowledge/components/navigation/SelfKnowledgeElementsSideMenu/SelfKnowledgeElementsSideMenu.test.ts
+++ b/src/features/student/selfKnowledge/components/navigation/SelfKnowledgeElementsSideMenu/SelfKnowledgeElementsSideMenu.test.ts
@@ -126,6 +126,13 @@ BddTest().given(' a SelfKnowledgeElementsSideMenu component', () => {
         expect(iconText.exists()).toBe(true)
       })
 
+      BddTest().then('it should highlight the selected element', () => {
+        const selectedItem = wrapper.findAllComponents(AvButtonStub).find(item =>
+          item.props('label') === 'Force de communication'
+        )
+        expect(selectedItem?.props('variant')).toBe('OUTLINED')
+      })
+
       BddTest().and('an element is clicked', () => {
         beforeEach(async () => {
           const elementItems = wrapper.findAllComponents(AvButtonStub)

--- a/src/features/student/selfKnowledge/components/navigation/SelfKnowledgeElementsSideMenu/SelfKnowledgeElementsSideMenu.vue
+++ b/src/features/student/selfKnowledge/components/navigation/SelfKnowledgeElementsSideMenu/SelfKnowledgeElementsSideMenu.vue
@@ -68,6 +68,7 @@ const renderedElements = computed(() => {
             v-if="isCollapsed"
             :label="element.title"
             :icon="iconOptions.name"
+            :variant="element.id === selectedElementId ? 'OUTLINED' : 'DEFAULT'"
             icon-only
             @click="$emit('selectElement', element.id)"
           />

--- a/src/features/student/selfKnowledge/queries/self-knowledge.query/self-knowledge.query.test.ts
+++ b/src/features/student/selfKnowledge/queries/self-knowledge.query/self-knowledge.query.test.ts
@@ -1,5 +1,5 @@
-import { mockedSelfKnowledgeCategories } from '@/__mocks__/fixtures/student/self-knowledge.fixtures'
-import { selfKnowledgeCategoriesAvailableErrorHandler, selfKnowledgeCategoriesErrorHandler, selfKnowledgeCategoryElementsErrorHandler } from '@/__mocks__/msw/handlers/student/self-knowledge.handlers'
+import { mockedSelfKnowledgeCategories, mockedSelfKnowledgeElementDetails } from '@/__mocks__/fixtures/student/self-knowledge.fixtures'
+import { selfKnowledgeCategoriesAvailableErrorHandler, selfKnowledgeCategoriesErrorHandler, selfKnowledgeCategoryElementsErrorHandler, selfKnowledgeElementDetailsErrorHandler } from '@/__mocks__/msw/handlers/student/self-knowledge.handlers'
 import { server } from '@/__mocks__/msw/server'
 import { ESelfKnowledgeCategoryType } from '@/api/avenir-esr'
 import { useInvalidateQuery } from '@/common/composables'
@@ -10,7 +10,8 @@ import {
   useRemoveSelfKnowledgeCategoryMutation,
   useSelfKnowledgeCategoriesAvailableQuery,
   useSelfKnowledgeCategoriesQuery,
-  useSelfKnowledgeCategoryElementsViewQuery
+  useSelfKnowledgeCategoryElementsViewQuery,
+  useSelfKnowledgeElementDetailsQuery
 } from '@/features/student/selfKnowledge/queries/self-knowledge.query/self-knowledge.query'
 import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { flushPromises } from '@vue/test-utils'
@@ -101,6 +102,88 @@ BddTest().given('a self knowledge categories query', () => {
       server.use(selfKnowledgeCategoriesErrorHandler)
 
       const result = mountComposable(() => useSelfKnowledgeCategoriesQuery(), {
+        useTanstack: true
+      })
+      const composableResult = result.result
+
+      await vi.waitFor(() => {
+        expect(composableResult.isError.value).toBe(true)
+      })
+
+      expect(composableResult.error.value).toBeDefined()
+    })
+  })
+})
+
+BddTest().given('a self knowledge element details query', () => {
+  let composableResult: ReturnType<typeof useSelfKnowledgeElementDetailsQuery>
+
+  beforeEach(() => {
+    const result = mountComposable(() => useSelfKnowledgeElementDetailsQuery({ selfKnowledgeElementId: 'some-id' }), {
+      useTanstack: true
+    })
+    composableResult = result.result
+  })
+
+  BddTest().when('the query is initialized', () => {
+    BddTest().then('it should return an undefined element initially', () => {
+      expect(composableResult.element.value).toBeUndefined()
+    })
+
+    BddTest().then('it should be in loading state', () => {
+      expect(composableResult.isLoading.value).toBe(true)
+    })
+  })
+
+  BddTest().when('the query fetches data successfully', () => {
+    BddTest().then('it should return a detailed element', async () => {
+      await vi.waitFor(() => {
+        expect(composableResult.isSuccess.value).toBe(true)
+      })
+
+      expect(composableResult.element.value).toBeDefined()
+    })
+
+    BddTest().then('it should return detailed element with correct structure', async () => {
+      await vi.waitFor(() => {
+        expect(composableResult.isSuccess.value).toBe(true)
+      })
+
+      const element = composableResult.element.value
+      expect(element).toEqual(mockedSelfKnowledgeElementDetails)
+    })
+  })
+
+  BddTest().when('the query data is accessed', () => {
+    BddTest().then('it should return the same data as element computed property', async () => {
+      await vi.waitFor(() => {
+        expect(composableResult.isSuccess.value).toBe(true)
+      })
+
+      expect(composableResult.element.value).toEqual(composableResult.data.value ?? [])
+    })
+  })
+
+  BddTest().when('the query fails with server error', () => {
+    BddTest().then('it should set error state', async () => {
+      server.use(selfKnowledgeElementDetailsErrorHandler)
+
+      const result = mountComposable(() => useSelfKnowledgeElementDetailsQuery({ selfKnowledgeElementId: 'some-id' }), {
+        useTanstack: true
+      })
+      const composableResult = result.result
+
+      await vi.waitFor(() => {
+        expect(composableResult.isError.value).toBe(true)
+      })
+
+      expect(composableResult.isSuccess.value).toBe(false)
+      expect(composableResult.element.value).toBeUndefined()
+    })
+
+    BddTest().then('it should have error information', async () => {
+      server.use(selfKnowledgeElementDetailsErrorHandler)
+      const result = mountComposable(() => useSelfKnowledgeElementDetailsQuery({ selfKnowledgeElementId: 'some-id' }), {
         useTanstack: true
       })
       const composableResult = result.result

--- a/src/features/student/selfKnowledge/queries/self-knowledge.query/self-knowledge.query.ts
+++ b/src/features/student/selfKnowledge/queries/self-knowledge.query/self-knowledge.query.ts
@@ -4,11 +4,13 @@ import {
   addSelfKnowledgeCategories,
   getSelfKnowledgeCategories,
   getSelfKnowledgeCategoriesAvailable,
+  getSelfKnowledgeElementDetails,
   getSelfKnowledgeElements,
   type PagedResponseSelfKnowledgeElementViewDTO,
   type PageInfoDTO,
   removeSelfKnowledgeCategory,
   type SelfKnowledgeCategoryDTO,
+  type SelfKnowledgeElementDetailsDTO,
   type SelfKnowledgeElementViewDTO
 } from '@/api/avenir-esr'
 import { useInvalidateQuery } from '@/common/composables'
@@ -19,6 +21,7 @@ import { type MaybeRef, type Ref, toValue } from 'vue'
 const selfKnowledgeCommonQueryKey = [...commonQueryKeys, 'self-knowledge']
 const selfKnowledgeCategoriesQueryKey = [...selfKnowledgeCommonQueryKey, 'categories']
 const selfKnowledgeElementsQueryKey = [...selfKnowledgeCommonQueryKey, 'elements']
+const selfKnowledgeElementDetailsQueryKey = [...selfKnowledgeCommonQueryKey, 'element-details']
 const selfKnowledgeCategoriesAvailableQueryKey = [...selfKnowledgeCommonQueryKey, 'available']
 
 const TWO_MINUTES = 2 * 60 * 1000
@@ -44,6 +47,35 @@ export function useSelfKnowledgeCategoriesQuery (): UseQueryReturnType<SelfKnowl
   return {
     ...query,
     categories
+  }
+}
+
+export interface SelfKnowledgeElementDetailsQueryParams {
+  selfKnowledgeElementId: MaybeRef<string>
+}
+
+export function useSelfKnowledgeElementDetailsQuery ({
+  selfKnowledgeElementId
+}: SelfKnowledgeElementDetailsQueryParams): UseQueryReturnType<SelfKnowledgeElementDetailsDTO | undefined, BaseApiException> & {
+  element: Ref<SelfKnowledgeElementDetailsDTO | undefined>
+} {
+  const queryKey = computed(() => [...selfKnowledgeElementDetailsQueryKey])
+
+  const queryFn = computed(() => async (): Promise<SelfKnowledgeElementDetailsDTO> => {
+    return await getSelfKnowledgeElementDetails(toValue(selfKnowledgeElementId))
+  })
+
+  const query = useQuery<SelfKnowledgeElementDetailsDTO, BaseApiException >({
+    queryKey,
+    queryFn,
+    staleTime: TWO_MINUTES
+  })
+
+  const element = computed(() => query.data.value)
+
+  return {
+    ...query,
+    element
   }
 }
 

--- a/src/features/student/selfKnowledge/routes/index.ts
+++ b/src/features/student/selfKnowledge/routes/index.ts
@@ -9,3 +9,13 @@ export const studentSelfKnowledgeCategoryRoute: AvRoute = {
   component: () =>
     import('@/features/student/selfKnowledge/views/SelfKnowledgeCategoryView/SelfKnowledgeCategoryView.vue'),
 }
+
+export const studentSelfKnowledgeElementUpdateRoute: AvRoute = {
+  ...ROUTE_NAMES.STUDENT.SELFKNOWLEDGE_ELEMENT_UPDATE,
+  props: route => ({
+    categoryId: route.params.categoryId,
+    elementId: route.params.elementId,
+  }),
+  component: () =>
+    import('@/features/student/selfKnowledge/views/SelfKnowledgeElementUpdateView/SelfKnowledgeElementUpdateView.vue'),
+}

--- a/src/features/student/selfKnowledge/views/SelfKnowledgeCategoryView/SelfKnowledgeCategoryView.test.ts
+++ b/src/features/student/selfKnowledge/views/SelfKnowledgeCategoryView/SelfKnowledgeCategoryView.test.ts
@@ -2,32 +2,13 @@ import type { ESelfKnowledgeCategoryType } from '@/api/avenir-esr'
 import type { VueWrapper } from '@vue/test-utils'
 import { PageTitleStub } from '@/common/components/PageTitle/PageTitle.stub'
 import { ROUTE_NAMES } from '@/common/constants'
+import { SelfKnowledgeElementsSideMenuStub } from '@/features/student/selfKnowledge/components/navigation/SelfKnowledgeElementsSideMenu/SelfKnowledgeElementsSideMenu.stub'
 import SelfKnowledgeCategoryView
   from '@/features/student/selfKnowledge/views/SelfKnowledgeCategoryView/SelfKnowledgeCategoryView.vue'
 import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { mountComponent } from 'tests/utils'
 import { beforeEach, expect } from 'vitest'
 import { nextTick } from 'vue'
-
-const SelfKnowledgeElementsSideMenuStub = defineComponent({
-  name: 'SelfKnowledgeElementsSideMenu',
-  props: {
-    elements: {
-      type: Array,
-      required: true
-    },
-    categoryType: {
-      type: String,
-      required: true
-    },
-    selectedElementId: {
-      type: String,
-      required: true
-    }
-  },
-  emits: ['selectElement'],
-  template: '<div class="self-knowledge-elements-side-menu-stub" />'
-})
 
 const stubs = {
   PageTitle: PageTitleStub,

--- a/src/features/student/selfKnowledge/views/SelfKnowledgeElementUpdateView/SelfKnowledgeElementUpdateView.test.ts
+++ b/src/features/student/selfKnowledge/views/SelfKnowledgeElementUpdateView/SelfKnowledgeElementUpdateView.test.ts
@@ -1,0 +1,80 @@
+import type { VueWrapper } from '@vue/test-utils'
+import { mockedSelfKnowledgeElementDetails } from '@/__mocks__/fixtures/student/self-knowledge.fixtures'
+import { createSelfKnowledgeElementDetailsHandler } from '@/__mocks__/msw/handlers/student/self-knowledge.handlers'
+import { server } from '@/__mocks__/msw/server'
+import { PageTitleStub } from '@/common/components/PageTitle/PageTitle.stub'
+import { SelfKnowledgeElementsSideMenuStub } from '@/features/student/selfKnowledge/components/navigation/SelfKnowledgeElementsSideMenu/SelfKnowledgeElementsSideMenu.stub'
+import SelfKnowledgeElementUpdateView from '@/features/student/selfKnowledge/views/SelfKnowledgeElementUpdateView/SelfKnowledgeElementUpdateView.vue'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { mountComponent } from 'tests/utils'
+import { beforeEach, expect, vi } from 'vitest'
+
+const navigateToStudentSelfKnowledgeElementUpdate = vi.fn()
+
+vi.mock('@/common/composables/use-navigation/use-navigation', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/common/composables/use-navigation/use-navigation')>()
+  return {
+    ...actual,
+    useNavigation: () => ({
+      navigateToStudentSelfKnowledgeElementUpdate,
+    }),
+  }
+})
+
+BddTest().given('a self knowledge element update view', () => {
+  let wrapper: VueWrapper<InstanceType<typeof SelfKnowledgeElementUpdateView>>
+
+  const stubs = {
+    PageTitle: PageTitleStub,
+    SelfKnowledgeElementsSideMenu: SelfKnowledgeElementsSideMenuStub,
+  }
+
+  BddTest().when('the view is rendered', () => {
+    beforeEach(() => {
+      const handler = createSelfKnowledgeElementDetailsHandler(mockedSelfKnowledgeElementDetails)
+      server.use(handler)
+
+      wrapper = mountComponent(SelfKnowledgeElementUpdateView, {
+        props: {
+          categoryId: 'strengths',
+          elementId: '1',
+        },
+        global: { stubs },
+      })
+    })
+
+    BddTest().then('it should render the PageTitle component', () => {
+      const pageTitle = wrapper.findComponent(PageTitleStub)
+      expect(pageTitle.exists()).toBe(true)
+    })
+
+    BddTest().then('it should render the SelfKnowledgeElementsSideMenu component', async () => {
+      await vi.waitFor(() => {
+        const sideMenu = wrapper.findComponent(SelfKnowledgeElementsSideMenuStub)
+        expect(sideMenu.exists()).toBe(true)
+      })
+    })
+
+    BddTest().then('it should render the element title', async () => {
+      await vi.waitFor(() => {
+        const elementTitle = wrapper.find('.n4')
+        expect(elementTitle.exists()).toBe(true)
+        expect(elementTitle.text()).toBe(`Modifier ${mockedSelfKnowledgeElementDetails.title}`)
+      })
+    })
+
+    BddTest().and('an element is selected', () => {
+      beforeEach(async () => {
+        await vi.waitFor(() => {
+          const sideMenu = wrapper.findComponent(SelfKnowledgeElementsSideMenuStub)
+          expect(sideMenu.exists()).toBe(true)
+          sideMenu.vm.$emit('selectElement', '2')
+        })
+      })
+
+      BddTest().then('it should navigate to the element update view of the selected element', () => {
+        expect(navigateToStudentSelfKnowledgeElementUpdate).toHaveBeenCalledWith({ categoryId: 'strengths', elementId: '2' })
+      })
+    })
+  })
+})

--- a/src/features/student/selfKnowledge/views/SelfKnowledgeElementUpdateView/SelfKnowledgeElementUpdateView.vue
+++ b/src/features/student/selfKnowledge/views/SelfKnowledgeElementUpdateView/SelfKnowledgeElementUpdateView.vue
@@ -1,0 +1,101 @@
+<script lang="ts" setup>
+import { ESelfKnowledgeCategoryType, type SelfKnowledgeElementViewDTO } from '@/api/avenir-esr'
+import PageTitle from '@/common/components/PageTitle/PageTitle.vue'
+import { useNavigation } from '@/common/composables'
+import { ROUTE_NAMES } from '@/common/constants/route-names'
+import SelfKnowledgeElementsSideMenu from '@/features/student/selfKnowledge/components/navigation/SelfKnowledgeElementsSideMenu/SelfKnowledgeElementsSideMenu.vue'
+import { useSelfKnowledgeElementDetailsQuery } from '@/features/student/selfKnowledge/queries/self-knowledge.query/self-knowledge.query'
+import { useI18n } from 'vue-i18n'
+
+export interface SelfKnowledgeElementUpdateViewProps {
+  categoryId: string
+  elementId: string
+}
+
+const { elementId, categoryId } = defineProps<SelfKnowledgeElementUpdateViewProps>()
+
+const { element } = useSelfKnowledgeElementDetailsQuery({ selfKnowledgeElementId: elementId })
+const { t } = useI18n()
+const { navigateToStudentSelfKnowledgeElementUpdate } = useNavigation()
+
+const breadcrumbLinks = computed(() => [
+  { text: t('student.navigation.tabs.home'), to: ROUTE_NAMES.STUDENT.HOME },
+  { text: t('student.navigation.tabs.project.header') },
+  { text: t('student.navigation.tabs.project.items.trajectories'), to: ROUTE_NAMES.STUDENT.PROJECT_TRAJECTORIES },
+  { text: t('student.navigation.tabs.project.items.selfKnowledge') }
+])
+
+// TODO: replace with real elements from API when ready
+const dummyElements = computed<SelfKnowledgeElementViewDTO[]>(() => [
+  {
+    id: '1',
+    title: 'Intitulé de l\'élément n°1 sur deux lignes maximum',
+    description: 'Petit texte qui explique comment l\'étudiant a développé cet élément, dans quelles formation, exp...',
+    rating: 3
+  },
+  {
+    id: '2',
+    title: 'Force de communication',
+    description: 'J\'ai développé cette compétence lors de mes projets de groupe et mes présentations en classe.',
+    rating: 4
+  },
+  {
+    id: '3',
+    title: 'Créativité',
+    description: 'Ma créativité s\'exprime dans mes projets artistiques et mes solutions innovantes.',
+    rating: 5
+  },
+])
+
+// TODO: replace with real category type from API when ready
+const dummyCategoryType = computed<ESelfKnowledgeCategoryType>(() => ESelfKnowledgeCategoryType.STRENGTHS)
+
+function onSelectElement (selectedElementId: string) {
+  navigateToStudentSelfKnowledgeElementUpdate({ categoryId, elementId: selectedElementId })
+}
+</script>
+
+<template>
+  <PageTitle
+    :title="t('student.views.selfKnowledgeElementUpdateView.title', { elementTitle: element?.title })"
+    :breadcrumb-links="breadcrumbLinks"
+  >
+    <template #title>
+      <span class="page-title__title n4">{{ t('global.buttons.update') }}
+        <span class="page-title__subtitle s1-regular">{{ element?.title }}</span>
+      </span>
+    </template>
+  </PageTitle>
+  <div
+    v-if="element"
+    class="self-knowledge-element-update-view av-flex-row-sm"
+  >
+    <SelfKnowledgeElementsSideMenu
+      :category-type="dummyCategoryType"
+      :selected-element-id="elementId"
+      :elements="dummyElements"
+      @select-element="onSelectElement"
+    />
+    <div class="av-flex-col-md">
+      <span class="self-knowledge-element-update-view__element-title n4">{{ element.title }}</span>
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.page-title {
+  &__title {
+    color: var(--text1);
+  }
+
+  &__subtitle {
+    color: var(--text2);
+  }
+}
+
+.self-knowledge-element-update-view {
+  &__element-title {
+    color: var(--text2);
+  }
+}
+</style>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -23,7 +23,8 @@
       "exit": "Exit",
       "goBack": "Go back",
       "moreActions": "More actions",
-      "save": "Save"
+      "save": "Save",
+      "update": "Update"
     },
     "colon": "{before}:",
     "dates": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -23,7 +23,8 @@
       "exit": "Quitter",
       "goBack": "Retour",
       "moreActions": "Plus d'actions",
-      "save": "Enregistrer"
+      "save": "Enregistrer",
+      "update": "Modifier"
     },
     "colon": "{before} :",
     "dates": {


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> _Describe the changes introduced by this pull request._

:sparkles: add `SelfKnowledgeElementUpdateView` and associated navigation
🔧 add self knowledge element details fixtures and msw handler
:recycle: `PageTitle` - add a `title` slot 
:lipstick: `SelfKnowledgeElementsSideMenu` - add an highlight for selected element in collapsed mode

---

### Reference to an Issue, Feature, Task, User Story or another PR
> _Mention related issue numbers or links (e.g. Closes #123, Implements #456)._

Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/781

---

### Target Branch
> _Which branch is this PR targeting (e.g. `main`, `develop`)?_

develop

---

### Additional Notes
> _Include any relevant context, technical details, or reasons behind certain decisions._


https://github.com/user-attachments/assets/a0142357-f31c-45ef-9179-aac4eea93f16



---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [ ] No unnecessary code (e.g., debug logs, commented code)
- [ ] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and detaiils for the update process

---