### PR TITLE
feat(774): add deleteSelfKnowledgeElements mutation

### DIFF
--- a/api-specs/avenir-esr.swagger.json
+++ b/api-specs/avenir-esr.swagger.json
@@ -245,35 +245,6 @@
             }
           }
         }
-      },
-      "delete": {
-        "tags": [
-          "self-knowledge-controller"
-        ],
-        "operationId": "deleteSelfKnowledgeElement",
-        "parameters": [
-          {
-            "name": "selfKnowledgeElementId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
       }
     },
     "/me/additional-skill-progress/{additionalSkillProgressId}": {
@@ -1405,6 +1376,40 @@
             }
           }
         ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/me/self-knowledge/elements": {
+      "delete": {
+        "tags": [
+          "self-knowledge-controller"
+        ],
+        "operationId": "deleteSelfKnowledgeElements",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              }
+            }
+          },
+          "required": true
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -2901,6 +2906,24 @@
           "title"
         ]
       },
+      "PagedResponseSelfKnowledgeElementViewDTO": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SelfKnowledgeElementViewDTO"
+            }
+          },
+          "page": {
+            "$ref": "#/components/schemas/PageInfoDTO"
+          }
+        },
+        "required": [
+          "data",
+          "page"
+        ]
+      },
       "SelfKnowledgeElementDetailsDTO": {
         "type": "object",
         "properties": {
@@ -2969,24 +2992,6 @@
           "id",
           "title",
           "type"
-        ]
-      },
-      "PagedResponseSelfKnowledgeElementViewDTO": {
-        "type": "object",
-        "properties": {
-          "data": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/SelfKnowledgeElementViewDTO"
-            }
-          },
-          "page": {
-            "$ref": "#/components/schemas/PageInfoDTO"
-          }
-        },
-        "required": [
-          "data",
-          "page"
         ]
       },
       "AccessInfoAPC": {
@@ -3414,6 +3419,7 @@
           "RATING_OUT_OF_BOUNCE",
           "ASSOCIATION_NOT_FOUND",
           "SELF_KNOWLEDGE_ELEMENT_NOT_FOUND",
+          "SELF_KNOWLEDGE_ELEMENTS_ARE_NOT_IN_SAME_CATEGORY",
           "SELF_KNOWLEDGE_CATEGORY_LIST_EMPTY",
           "SELF_KNOWLEDGE_CATEGORY_NOT_FOUND",
           "SELF_KNOWLEDGE_CATEGORY_NOT_AVAILABLE",

--- a/src/__mocks__/msw/handlers/student/self-knowledge.handlers.ts
+++ b/src/__mocks__/msw/handlers/student/self-knowledge.handlers.ts
@@ -6,6 +6,7 @@ import {
 } from '@/__mocks__/fixtures/student/self-knowledge.fixtures'
 import {
   getAddSelfKnowledgeCategoriesUrl,
+  getDeleteSelfKnowledgeElementsUrl,
   getGetSelfKnowledgeCategoriesAvailableUrl,
   getGetSelfKnowledgeCategoriesUrl,
   getGetSelfKnowledgeElementDetailsUrl,
@@ -79,17 +80,6 @@ export function createSelfKnowledgeCategoriesAvailableHandler (payload: SelfKnow
 export function createSelfKnowledgeElementDetailsHandler (payload: SelfKnowledgeElementDetailsDTO) {
   return http.get(`*${getGetSelfKnowledgeElementDetailsUrl(':selfKnowledgeElementId')}`, () => {
     return HttpResponse.json<SelfKnowledgeElementDetailsDTO>(payload, {
-      status: 200,
-      headers: {
-        'Content-Type': 'application/json',
-      }
-    })
-  })
-}
-
-export function updateSelectedSelfKnowledgeCategoriesHandler (payload: string[]) {
-  return http.post(`*${getAddSelfKnowledgeCategoriesUrl()}`, () => {
-    return HttpResponse.json<string[]>(payload, {
       status: 200,
       headers: {
         'Content-Type': 'application/json',
@@ -174,6 +164,26 @@ export const selfKnowledgeHandlers = [
     }
 
     const response = 'Category successfully removed from user'
+    return HttpResponse.json<string>(response, {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json',
+      }
+    })
+  }),
+
+  http.delete(`*${getDeleteSelfKnowledgeElementsUrl()}`, async ({ request }) => {
+    const elementsIds = await request.json() as string[]
+
+    if (elementsIds.length === 0) {
+      return HttpResponse.json({ error: 'No element IDs provided' }, { status: 400 })
+    }
+
+    if (elementsIds.find(id => id === 'INVALID_ELEMENT_ID')) {
+      return HttpResponse.json({ error: 'Invalid element ID' }, { status: 400 })
+    }
+
+    const response = 'Elements successfully removed from user'
     return HttpResponse.json<string>(response, {
       status: 200,
       headers: {

--- a/src/features/student/global/locales/en.json
+++ b/src/features/student/global/locales/en.json
@@ -398,6 +398,8 @@
               "deleteElements": {
                 "ariaLabel": "Select the element {title}",
                 "confirmButton": "Delete selected elements (0) | Delete selected element (1) | Delete selected elements ({count})",
+                "error": "An error occurred while deleting the element. | An error occurred while deleting the elements.",
+                "success": "{count} element deleted successfully | {count} elements deleted successfully",
                 "title": "No element to delete | Which element do you want to delete? | Which elements do you want to delete?"
               }
             }

--- a/src/features/student/global/locales/fr.json
+++ b/src/features/student/global/locales/fr.json
@@ -398,6 +398,8 @@
               "deleteElements": {
                 "ariaLabel": "Sélectionner l'élément {title}",
                 "confirmButton": "Supprimer les éléments sélectionnés (0) | Supprimer l'élément sélectionné (1) | Supprimer les éléments sélectionnés ({count})",
+                "error": "Une erreur est survenue lors de la suppression de l'élément. | Une erreur est survenue lors de la suppression des éléments.",
+                "success": "{count} élément supprimé avec succès | {count} éléments supprimés avec succès",
                 "title": "Aucun élément à supprimer | Quel élément souhaitez-vous supprimer ? | Quels éléments souhaitez-vous supprimer ?"
               }
             }

--- a/src/features/student/selfKnowledge/components/modals/DeleteSelfKnowledgeElementsModal/DeleteSelfKnowledgeElementsModal.test.ts
+++ b/src/features/student/selfKnowledge/components/modals/DeleteSelfKnowledgeElementsModal/DeleteSelfKnowledgeElementsModal.test.ts
@@ -1,8 +1,21 @@
+import type { VueWrapper } from '@vue/test-utils'
 import { ESelfKnowledgeCategoryType } from '@/api/avenir-esr'
 import DeleteSelfKnowledgeElementsModal, { type DeleteSelfKnowledgeElementsModalProps } from '@/features/student/selfKnowledge/components/modals/DeleteSelfKnowledgeElementsModal/DeleteSelfKnowledgeElementsModal.vue'
 import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
-import { mount, type VueWrapper } from '@vue/test-utils'
+import { mockAddErrorMessage, mockAddSuccessMessage } from 'tests/mocks'
+import { mountComponent } from 'tests/utils'
 import { beforeEach, expect } from 'vitest'
+
+vi.mock('@/store', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/store')>()
+  return {
+    ...actual,
+    useToasterStore: () => ({
+      addSuccessMessage: mockAddSuccessMessage,
+      addErrorMessage: mockAddErrorMessage
+    })
+  }
+})
 
 const AvModalStub = defineComponent({
   name: 'AvModal',
@@ -48,7 +61,7 @@ BddTest().given('a delete self knowledge element modal', () => {
 
     BddTest().when('the modal is rendered with no elements', () => {
       beforeEach(() => {
-        wrapper = mount(DeleteSelfKnowledgeElementsModal, { props, global: { stubs } })
+        wrapper = mountComponent(DeleteSelfKnowledgeElementsModal, { props, global: { stubs } })
       })
 
       BddTest().then('it should display the correct title for zero elements', () => {
@@ -69,7 +82,7 @@ BddTest().given('a delete self knowledge element modal', () => {
 
     BddTest().when('the modal is rendered with the provided element', () => {
       beforeEach(() => {
-        wrapper = mount(DeleteSelfKnowledgeElementsModal, { props, global: { stubs } })
+        wrapper = mountComponent(DeleteSelfKnowledgeElementsModal, { props, global: { stubs } })
       })
 
       BddTest().then('it should display the correct title', () => {
@@ -124,18 +137,28 @@ BddTest().given('a delete self knowledge element modal', () => {
           })
 
           BddTest().and('the confirm delete modal emits confirm event', () => {
-            beforeEach(() => {
+            beforeEach(async () => {
               const confirmModal = wrapper.findComponent(ConfirmDeleteSelfKnowledgeElementsModalStub)
               confirmModal.vm.$emit('confirm')
             })
 
-            BddTest().then('the delete self knowledge elements modal should emit confirm event', () => {
-              expect(wrapper.emitted()).toHaveProperty('confirm')
+            BddTest().then('a success message should be added', async () => {
+              await vi.waitFor(() => expect(mockAddSuccessMessage).toHaveBeenCalledWith('1 élément supprimé avec succès'))
             })
 
-            BddTest().then('the confirm delete modal should be hidden', () => {
-              const confirmModal = wrapper.findComponent(ConfirmDeleteSelfKnowledgeElementsModalStub)
-              expect(confirmModal.props('show')).toBe(false)
+            BddTest().then('no error message should be added', () => {
+              expect(mockAddErrorMessage).not.toHaveBeenCalled()
+            })
+
+            BddTest().then('the delete self knowledge elements modal should emit confirm event', async () => {
+              await vi.waitFor(() => expect(wrapper.emitted()).toHaveProperty('confirm'))
+            })
+
+            BddTest().then('the confirm delete modal should be hidden', async () => {
+              await vi.waitFor(() => {
+                const confirmModal = wrapper.findComponent(ConfirmDeleteSelfKnowledgeElementsModalStub)
+                expect(confirmModal.props('show')).toBe(false)
+              })
             })
           })
 
@@ -161,18 +184,149 @@ BddTest().given('a delete self knowledge element modal', () => {
       elements: [
         { id: '1', title: 'Element 1', description: 'Description 1' },
         { id: '2', title: 'Element 2', description: 'Description 2' },
+        { id: '3', title: 'Element 3', description: 'Description 3' },
+        { id: 'INVALID_ELEMENT_ID', title: 'Element 4', description: 'Description 4' },
       ],
       categoryType: ESelfKnowledgeCategoryType.STRENGTHS,
     }
 
     BddTest().when('the modal is rendered with the provided elements', () => {
       beforeEach(() => {
-        wrapper = mount(DeleteSelfKnowledgeElementsModal, { props, global: { stubs } })
+        wrapper = mountComponent(DeleteSelfKnowledgeElementsModal, { props, global: { stubs } })
       })
 
       BddTest().then('it should display the correct title with element count', () => {
         const header = wrapper.find('.header')
         expect(header.text()).toBe('Quels éléments souhaitez-vous supprimer ?')
+      })
+
+      BddTest().and('many elements are selected', () => {
+        beforeEach(() => {
+          const selector = wrapper.findComponent(SelfKnowledgeElementsSelectorStub)
+          selector.vm.$emit('update:modelValue', ['1', '2', '3'])
+        })
+
+        BddTest().then('the selectedElementIds should be updated accordingly', () => {
+          const selector = wrapper.findComponent(SelfKnowledgeElementsSelectorStub)
+          expect(selector.props('modelValue')).toEqual(['1', '2', '3'])
+        })
+
+        BddTest().and('the modal is closed by close event and reopened', () => {
+          beforeEach(async () => {
+            const modal = wrapper.findComponent(AvModalStub)
+            await modal.vm.$emit('close')
+
+            await wrapper.setProps({ show: true })
+          })
+
+          BddTest().then('the selectedElementIds should be reset', () => {
+            const selector = wrapper.findComponent(SelfKnowledgeElementsSelectorStub)
+            expect(selector.props('modelValue')).toEqual([])
+          })
+        })
+
+        BddTest().and('the modal emits confirm event', () => {
+          beforeEach(async () => {
+            const modal = wrapper.findComponent(AvModalStub)
+            modal.vm.$emit('confirm')
+          })
+
+          BddTest().then('the confirm delete modal should be shown', () => {
+            const confirmModal = wrapper.findComponent(ConfirmDeleteSelfKnowledgeElementsModalStub)
+            expect(confirmModal.props('show')).toBe(true)
+          })
+
+          BddTest().and('the confirm delete modal emits confirm event', () => {
+            beforeEach(async () => {
+              const confirmModal = wrapper.findComponent(ConfirmDeleteSelfKnowledgeElementsModalStub)
+              confirmModal.vm.$emit('confirm')
+            })
+
+            BddTest().then('a success message should be added', async () => {
+              await vi.waitFor(() => expect(mockAddSuccessMessage).toHaveBeenCalledWith('3 éléments supprimés avec succès'))
+            })
+
+            BddTest().then('no error message should be added', () => {
+              expect(mockAddErrorMessage).not.toHaveBeenCalled()
+            })
+
+            BddTest().then('the delete self knowledge elements modal should emit confirm event', async () => {
+              await vi.waitFor(() => expect(wrapper.emitted()).toHaveProperty('confirm'))
+            })
+
+            BddTest().then('the confirm delete modal should be hidden', async () => {
+              await vi.waitFor(() => {
+                const confirmModal = wrapper.findComponent(ConfirmDeleteSelfKnowledgeElementsModalStub)
+                expect(confirmModal.props('show')).toBe(false)
+              })
+            })
+          })
+        })
+      })
+
+      BddTest().and('many elements including the invalid one are selected', () => {
+        beforeEach(() => {
+          vi.clearAllMocks()
+          const selector = wrapper.findComponent(SelfKnowledgeElementsSelectorStub)
+          selector.vm.$emit('update:modelValue', ['1', '3', 'INVALID_ELEMENT_ID'])
+        })
+
+        BddTest().then('the selectedElementIds should be updated accordingly', () => {
+          const selector = wrapper.findComponent(SelfKnowledgeElementsSelectorStub)
+          expect(selector.props('modelValue')).toEqual(['1', '3', 'INVALID_ELEMENT_ID'])
+        })
+
+        BddTest().and('the modal is closed by close event and reopened', () => {
+          beforeEach(async () => {
+            const modal = wrapper.findComponent(AvModalStub)
+            await modal.vm.$emit('close')
+
+            await wrapper.setProps({ show: true })
+          })
+
+          BddTest().then('the selectedElementIds should be reset', () => {
+            const selector = wrapper.findComponent(SelfKnowledgeElementsSelectorStub)
+            expect(selector.props('modelValue')).toEqual([])
+          })
+        })
+
+        BddTest().and('the modal emits confirm event', () => {
+          beforeEach(async () => {
+            const modal = wrapper.findComponent(AvModalStub)
+            modal.vm.$emit('confirm')
+          })
+
+          BddTest().then('the confirm delete modal should be shown', () => {
+            const confirmModal = wrapper.findComponent(ConfirmDeleteSelfKnowledgeElementsModalStub)
+            expect(confirmModal.props('show')).toBe(true)
+          })
+
+          BddTest().and('the confirm delete modal emits confirm event', () => {
+            beforeEach(async () => {
+              const confirmModal = wrapper.findComponent(ConfirmDeleteSelfKnowledgeElementsModalStub)
+              confirmModal.vm.$emit('confirm')
+            })
+
+            BddTest().then('no success message should be added', () => {
+              expect(mockAddSuccessMessage).not.toHaveBeenCalled()
+            })
+
+            BddTest().then('an error message should be added', async () => {
+              await vi.waitFor(() => expect(mockAddErrorMessage).toHaveBeenCalled())
+            })
+
+            BddTest().then('the delete self knowledge elements modal should not emit confirm event', async () => {
+              await vi.waitFor(() => expect(wrapper.emitted()).not.toHaveProperty('confirm'))
+            })
+
+            BddTest().then('the confirm delete modal should not be hidden', async () => {
+              await vi.waitFor(() => {
+                const confirmModal = wrapper.findComponent(ConfirmDeleteSelfKnowledgeElementsModalStub)
+                expect(confirmModal.props('show')).toBe(true)
+              })
+            })
+          })
+        })
       })
     })
   })

--- a/src/features/student/selfKnowledge/components/modals/DeleteSelfKnowledgeElementsModal/DeleteSelfKnowledgeElementsModal.vue
+++ b/src/features/student/selfKnowledge/components/modals/DeleteSelfKnowledgeElementsModal/DeleteSelfKnowledgeElementsModal.vue
@@ -3,6 +3,8 @@ import type { ESelfKnowledgeCategoryType, SelfKnowledgeElementViewDTO } from '@/
 import { useModal } from '@/common/composables'
 import ConfirmDeleteSelfKnowledgeElementsModal from '@/features/student/selfKnowledge/components/modals/ConfirmDeleteSelfKnowledgeElementsModal/ConfirmDeleteSelfKnowledgeElementsModal.vue'
 import SelfKnowledgeElementsSelector from '@/features/student/selfKnowledge/components/pickers/SelfKnowledgeElementsSelector/SelfKnowledgeElementsSelector.vue'
+import { useDeleteSelfKnowledgeElementsMutation } from '@/features/student/selfKnowledge/queries/self-knowledge.query/self-knowledge.query'
+import { useToasterStore } from '@/store'
 import { AvModal, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
 import { useI18n } from 'vue-i18n'
 
@@ -25,6 +27,25 @@ const {
   displayModal: displayConfirmModal,
   hideModal: hideConfirmModal
 } = useModal()
+const { addErrorMessage, addSuccessMessage } = useToasterStore()
+
+function onDeleteSuccess (deletedCount: number) {
+  addSuccessMessage(
+    t('student.views.studentProjectTrajectoriesView.selfKnowledge.categoryElementsPaginator.modals.deleteElements.success', { count: deletedCount })
+  )
+  hideConfirmModal()
+  emit('confirm')
+  resetSelectedElements()
+}
+
+const { mutate: deleteSelfKnowledgeElements } = useDeleteSelfKnowledgeElementsMutation({
+  onSuccess: (_data, variables) => onDeleteSuccess(variables.selfKnowledgeElementIds.length),
+  onError: error => addErrorMessage({
+    title: t('student.views.studentProjectTrajectoriesView.selfKnowledge.categoryElementsPaginator.modals.deleteElements.error'),
+    description: error.message
+  })
+
+})
 
 const selectedElementIds = ref<string[]>([])
 
@@ -37,18 +58,8 @@ function onCancel () {
   emit('cancel')
 }
 
-function onConfirm () {
-  displayConfirmModal()
-}
-
-function onCancelDelete () {
-  hideConfirmModal()
-}
-
 function onConfirmDelete () {
-  hideConfirmModal()
-  emit('confirm')
-  resetSelectedElements()
+  deleteSelfKnowledgeElements({ selfKnowledgeElementIds: selectedElementIds.value })
 }
 </script>
 
@@ -61,7 +72,7 @@ function onConfirmDelete () {
     :confirm-button-icon="MDI_ICONS.TRASH_CAN_OUTLINE"
     :confirm-button-disabled="selectedElementIds.length === 0"
     @close="onCancel"
-    @confirm="onConfirm"
+    @confirm="displayConfirmModal"
   >
     <template #header>
       <div class="header av-row av-row--center">
@@ -83,7 +94,7 @@ function onConfirmDelete () {
   <ConfirmDeleteSelfKnowledgeElementsModal
     :show="showConfirmModal"
     :elements="elements.filter(element => selectedElementIds.includes(element.id))"
-    @cancel="onCancelDelete"
+    @cancel="hideConfirmModal"
     @confirm="onConfirmDelete"
   />
 </template>

--- a/src/features/student/selfKnowledge/queries/self-knowledge.query/self-knowledge.query.test.ts
+++ b/src/features/student/selfKnowledge/queries/self-knowledge.query/self-knowledge.query.test.ts
@@ -5,8 +5,10 @@ import { ESelfKnowledgeCategoryType } from '@/api/avenir-esr'
 import { useInvalidateQuery } from '@/common/composables'
 import {
   type AddSelfKnowledgeCategoriesVariables,
+  type DeleteSelfKnowledgeElementsVariables,
   type RemoveSelfKnowledgeCategoryVariables,
   useAddSelfKnowledgeCategoriesMutation,
+  useDeleteSelfKnowledgeElementsMutation,
   useRemoveSelfKnowledgeCategoryMutation,
   useSelfKnowledgeCategoriesAvailableQuery,
   useSelfKnowledgeCategoriesQuery,
@@ -700,7 +702,7 @@ BddTest().given('an add self knowledge categories mutation', () => {
   })
 })
 
-BddTest().given('an delete self knowledge category mutation', () => {
+BddTest().given('a remove self knowledge category mutation', () => {
   let removeSelfKnowledgeCategorySpy: MockInstance<(categoryId: string, options?: (RequestInit | undefined)) => Promise<string>>
   let mutationResult: ReturnType<typeof useRemoveSelfKnowledgeCategoryMutation>
 
@@ -875,6 +877,259 @@ BddTest().given('an delete self knowledge category mutation', () => {
       BddTest().then('it should call the removeSelfKnowledgeCategory API with the invalid parameters', () => {
         expect(removeSelfKnowledgeCategorySpy).toHaveBeenCalledWith(categoryId)
         expect(removeSelfKnowledgeCategorySpy).toHaveBeenCalledTimes(1)
+      })
+
+      BddTest().then('it should contain the error information', () => {
+        expect(mutationResult.error.value).toBeDefined()
+        expect(mutationResult.isError.value).toBe(true)
+      })
+
+      BddTest().then('it should call the custom onError callback', () => {
+        expect(mockOnError).toHaveBeenCalledTimes(1)
+      })
+    })
+  })
+})
+
+BddTest().given('a delete self knowledge elements mutation', () => {
+  let deleteSelfKnowledgeElementsSpy: MockInstance<(selfKnowledgeElementIds: string[], options?: (RequestInit | undefined)) => Promise<string>>
+  let mutationResult: ReturnType<typeof useDeleteSelfKnowledgeElementsMutation>
+
+  const mockUseInvalidateQuery = useInvalidateQuery as MockedFunction<typeof useInvalidateQuery>
+  const mockInvalidateFunction = vi.fn()
+  const mockOnSuccess = vi.fn()
+  const mockOnError = vi.fn()
+  const mutationArgs = {
+    onSuccess: mockOnSuccess,
+    onError: mockOnError
+  }
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    vi.restoreAllMocks()
+
+    deleteSelfKnowledgeElementsSpy = vi.spyOn<typeof import('@/api/avenir-esr'), 'deleteSelfKnowledgeElements'>(
+      await import('@/api/avenir-esr'),
+    'deleteSelfKnowledgeElements'
+    )
+
+    mockUseInvalidateQuery.mockReturnValue(mockInvalidateFunction)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  BddTest().and('valid element IDs and success callback', () => {
+    const elementsIds = ['element-1-id', 'element-2-id', 'element-3-id']
+    const variables: DeleteSelfKnowledgeElementsVariables = { selfKnowledgeElementIds: elementsIds }
+
+    BddTest().when('the mutation is called with mutateAsync', () => {
+      beforeEach(async () => {
+        mutationResult = mountQueryComposable(() => useDeleteSelfKnowledgeElementsMutation(mutationArgs))
+        await mutationResult.mutateAsync(variables)
+        await flushPromises()
+      })
+
+      BddTest().then('it should call the deleteSelfKnowledgeElements API with correct parameters', () => {
+        expect(deleteSelfKnowledgeElementsSpy).toHaveBeenCalledWith(elementsIds)
+        expect(deleteSelfKnowledgeElementsSpy).toHaveBeenCalledTimes(1)
+      })
+
+      BddTest().then('it should return the expected success response', () => {
+        expect(mutationResult.data.value).toBeDefined()
+      })
+
+      BddTest().then('it should mark the mutation as successful', () => {
+        expect(mutationResult.isSuccess.value).toBe(true)
+        expect(mutationResult.isError.value).toBe(false)
+        expect(mutationResult.isPending.value).toBe(false)
+      })
+
+      BddTest().then('it should call the invalidation function', () => {
+        expect(mockUseInvalidateQuery).toHaveBeenCalledTimes(1)
+        expect(mockInvalidateFunction).toHaveBeenCalledTimes(1)
+      })
+
+      BddTest().then('it should call the custom onSuccess callback', () => {
+        expect(mockOnSuccess).toHaveBeenCalledTimes(1)
+        expect(mockOnSuccess).toHaveBeenCalledWith(mutationResult.data.value as string, variables)
+      })
+
+      BddTest().then('it should not call the onError callback', () => {
+        expect(mockOnError).not.toHaveBeenCalled()
+      })
+    })
+
+    BddTest().when('the mutation is called with mutate', () => {
+      beforeEach(async () => {
+        mutationResult = mountQueryComposable(() => useDeleteSelfKnowledgeElementsMutation(mutationArgs))
+        mutationResult.mutate(variables)
+        await flushPromises()
+      })
+
+      BddTest().then('it should call the deleteSelfKnowledgeElements API with correct parameters', () => {
+        expect(deleteSelfKnowledgeElementsSpy).toHaveBeenCalledWith(elementsIds)
+        expect(deleteSelfKnowledgeElementsSpy).toHaveBeenCalledTimes(1)
+      })
+
+      BddTest().then('it should call the custom onSuccess callback', () => {
+        expect(mockOnSuccess).toHaveBeenCalledTimes(1)
+      })
+
+      BddTest().then('it should call the invalidation function', () => {
+        expect(mockInvalidateFunction).toHaveBeenCalledTimes(1)
+      })
+    })
+  })
+
+  BddTest().and('no success or error callbacks', () => {
+    const elementsIds = ['element-1-id', 'element-2-id', 'element-3-id']
+    const variables: DeleteSelfKnowledgeElementsVariables = { selfKnowledgeElementIds: elementsIds }
+    const mutationArgs = {}
+
+    BddTest().when('the mutation is called without callbacks', () => {
+      beforeEach(async () => {
+        mutationResult = mountQueryComposable(() => useDeleteSelfKnowledgeElementsMutation(mutationArgs))
+        await mutationResult.mutateAsync(variables)
+        await flushPromises()
+      })
+
+      BddTest().then('it should call the deleteSelfKnowledgeElements API with correct parameters', () => {
+        expect(deleteSelfKnowledgeElementsSpy).toHaveBeenCalledWith(elementsIds)
+        expect(deleteSelfKnowledgeElementsSpy).toHaveBeenCalledTimes(1)
+      })
+
+      BddTest().then('it should still call the invalidation function', () => {
+        expect(mockInvalidateFunction).toHaveBeenCalledTimes(1)
+      })
+
+      BddTest().then('it should mark the mutation as successful', () => {
+        expect(mutationResult.isSuccess.value).toBe(true)
+        expect(mutationResult.isError.value).toBe(false)
+      })
+
+      BddTest().then('it should return the expected response', () => {
+        expect(mutationResult.data.value).toBeDefined()
+      })
+    })
+  })
+
+  BddTest().and('an invalid elementsId in elementsIds with error callback', () => {
+    const elementsIds: string[] = ['element-id-1', 'INVALID_ELEMENT_ID', 'element-id-3']
+    const variables: DeleteSelfKnowledgeElementsVariables = { selfKnowledgeElementIds: elementsIds }
+
+    BddTest().when('the mutation encounters an error', () => {
+      beforeEach(async () => {
+        mutationResult = mountQueryComposable(() => useDeleteSelfKnowledgeElementsMutation(mutationArgs))
+        await mutationResult.mutateAsync(variables).catch(() => {})
+        await flushPromises()
+      })
+
+      BddTest().then('it should call the deleteSelfKnowledgeElements API with the invalid parameters', () => {
+        expect(deleteSelfKnowledgeElementsSpy).toHaveBeenCalledWith(elementsIds)
+        expect(deleteSelfKnowledgeElementsSpy).toHaveBeenCalledTimes(1)
+      })
+
+      BddTest().then('it should mark the mutation as error', () => {
+        expect(mutationResult.isError.value).toBe(true)
+        expect(mutationResult.isSuccess.value).toBe(false)
+        expect(mutationResult.isPending.value).toBe(false)
+      })
+
+      BddTest().then('it should contain the error information', () => {
+        expect(mutationResult.error.value).toBeDefined()
+      })
+
+      BddTest().then('it should call the custom onError callback', () => {
+        expect(mockOnError).toHaveBeenCalledTimes(1)
+      })
+
+      BddTest().then('it should not call the onSuccess callback', () => {
+        expect(mockOnSuccess).not.toHaveBeenCalled()
+      })
+
+      BddTest().then('it should not call the invalidation function on error', () => {
+        expect(mockInvalidateFunction).not.toHaveBeenCalled()
+      })
+    })
+
+    BddTest().when('the mutation is called using mutate with error', () => {
+      let mutationResult: ReturnType<typeof useDeleteSelfKnowledgeElementsMutation>
+
+      beforeEach(async () => {
+        mutationResult = mountQueryComposable(() => useDeleteSelfKnowledgeElementsMutation(mutationArgs))
+        mutationResult.mutate(variables)
+        await flushPromises()
+      })
+
+      BddTest().then('it should call the deleteSelfKnowledgeElements API with the invalid parameters', () => {
+        expect(deleteSelfKnowledgeElementsSpy).toHaveBeenCalledWith(elementsIds)
+        expect(deleteSelfKnowledgeElementsSpy).toHaveBeenCalledTimes(1)
+      })
+
+      BddTest().then('it should contain the error information', () => {
+        expect(mutationResult.error.value).toBeDefined()
+        expect(mutationResult.isError.value).toBe(true)
+      })
+
+      BddTest().then('it should call the custom onError callback', () => {
+        expect(mockOnError).toHaveBeenCalledTimes(1)
+      })
+    })
+  })
+
+  BddTest().and('an empty elementsIds with error callback', () => {
+    const elementsIds: string[] = []
+    const variables: DeleteSelfKnowledgeElementsVariables = { selfKnowledgeElementIds: elementsIds }
+
+    BddTest().when('the mutation encounters an error', () => {
+      beforeEach(async () => {
+        mutationResult = mountQueryComposable(() => useDeleteSelfKnowledgeElementsMutation(mutationArgs))
+        await mutationResult.mutateAsync(variables).catch(() => {})
+        await flushPromises()
+      })
+
+      BddTest().then('it should call the deleteSelfKnowledgeElements API with the invalid parameters', () => {
+        expect(deleteSelfKnowledgeElementsSpy).toHaveBeenCalledWith(elementsIds)
+        expect(deleteSelfKnowledgeElementsSpy).toHaveBeenCalledTimes(1)
+      })
+
+      BddTest().then('it should mark the mutation as error', () => {
+        expect(mutationResult.isError.value).toBe(true)
+        expect(mutationResult.isSuccess.value).toBe(false)
+        expect(mutationResult.isPending.value).toBe(false)
+      })
+
+      BddTest().then('it should contain the error information', () => {
+        expect(mutationResult.error.value).toBeDefined()
+      })
+
+      BddTest().then('it should call the custom onError callback', () => {
+        expect(mockOnError).toHaveBeenCalledTimes(1)
+      })
+
+      BddTest().then('it should not call the onSuccess callback', () => {
+        expect(mockOnSuccess).not.toHaveBeenCalled()
+      })
+
+      BddTest().then('it should not call the invalidation function on error', () => {
+        expect(mockInvalidateFunction).not.toHaveBeenCalled()
+      })
+    })
+
+    BddTest().when('the mutation is called using mutate with error', () => {
+      let mutationResult: ReturnType<typeof useDeleteSelfKnowledgeElementsMutation>
+
+      beforeEach(async () => {
+        mutationResult = mountQueryComposable(() => useDeleteSelfKnowledgeElementsMutation(mutationArgs))
+        mutationResult.mutate(variables)
+        await flushPromises()
+      })
+
+      BddTest().then('it should call the deleteSelfKnowledgeElements API with the invalid parameters', () => {
+        expect(deleteSelfKnowledgeElementsSpy).toHaveBeenCalledWith(elementsIds)
+        expect(deleteSelfKnowledgeElementsSpy).toHaveBeenCalledTimes(1)
       })
 
       BddTest().then('it should contain the error information', () => {

--- a/src/features/student/selfKnowledge/queries/self-knowledge.query/self-knowledge.query.ts
+++ b/src/features/student/selfKnowledge/queries/self-knowledge.query/self-knowledge.query.ts
@@ -2,6 +2,7 @@ import type { BaseApiException } from '@/common/exceptions'
 import type { MutationArgs } from '@/types'
 import {
   addSelfKnowledgeCategories,
+  deleteSelfKnowledgeElements,
   getSelfKnowledgeCategories,
   getSelfKnowledgeCategoriesAvailable,
   getSelfKnowledgeElementDetails,
@@ -180,6 +181,24 @@ export function useRemoveSelfKnowledgeCategoryMutation ({ onError, onSuccess }: 
     },
     onSuccess: async (data, variables) => {
       await invalidateSelfKnowledgeCommonQuery()
+      onSuccess?.(data, variables)
+    },
+    onError
+  })
+}
+
+export interface DeleteSelfKnowledgeElementsVariables {
+  selfKnowledgeElementIds: string[]
+}
+
+export function useDeleteSelfKnowledgeElementsMutation ({ onError, onSuccess }: MutationArgs<string, DeleteSelfKnowledgeElementsVariables> = {}) {
+  const invalidateSelfKnowledgeElementsQuery = useInvalidateQuery([...selfKnowledgeElementsQueryKey])
+  return useMutation<string, BaseApiException, DeleteSelfKnowledgeElementsVariables>({
+    mutationFn: async ({ selfKnowledgeElementIds }: DeleteSelfKnowledgeElementsVariables): Promise<string> => {
+      return await deleteSelfKnowledgeElements(selfKnowledgeElementIds)
+    },
+    onSuccess: async (data, variables) => {
+      await invalidateSelfKnowledgeElementsQuery()
       onSuccess?.(data, variables)
     },
     onError


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> _Describe the changes introduced by this pull request._

:sparkles: add deleteSelfKnowledgeElements mutation

---

### Reference to an Issue, Feature, Task, User Story or another PR
> _Mention related issue numbers or links (e.g. Closes #123, Implements #456)._

Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/774

---

### Target Branch
> _Which branch is this PR targeting (e.g. `main`, `develop`)?_

develop

---

### Additional Notes
> _Include any relevant context, technical details, or reasons behind certain decisions._

blocked by https://github.com/avenirs-esr/avenirs-portfolio-api/pull/168

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [ ] No unnecessary code (e.g., debug logs, commented code)
- [ ] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and detaiils for the update process

---