### PR TITLE
feat(796): use shared i18n for textarea

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "avenirs-cofolio-client",
       "version": "0.0.0",
       "dependencies": {
-        "@avenirs-esr/avenirs-dsav": "^0.1.90",
+        "@avenirs-esr/avenirs-dsav": "^0.1.91",
         "@tanstack/vue-form": "^1.15.0",
         "@tanstack/vue-query": "^5.74.9",
         "@vueuse/core": "^13.7.0",
@@ -309,9 +309,9 @@
       }
     },
     "node_modules/@avenirs-esr/avenirs-dsav": {
-      "version": "0.1.90",
-      "resolved": "https://registry.npmjs.org/@avenirs-esr/avenirs-dsav/-/avenirs-dsav-0.1.90.tgz",
-      "integrity": "sha512-NJ6r8aP5E8iybzSRzRQyhfvGkuC2BJlAImEgIDE/rFeWSuRGq4QYWqPpWqTs6ZiXUJry9GsLezIf4187uiaWCQ==",
+      "version": "0.1.91",
+      "resolved": "https://registry.npmjs.org/@avenirs-esr/avenirs-dsav/-/avenirs-dsav-0.1.91.tgz",
+      "integrity": "sha512-ebPw3FRF/Ldfy7FY9s2xG4Hj7ExFcmQsmGL4J6pwVYgmZR9sZ7vBHzRG2+XB5PFNFyOASTQRh8Uw1RQUlUo1Lw==",
       "dependencies": {
         "@vueuse/core": "^13.9.0",
         "date-fns": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
-    "@avenirs-esr/avenirs-dsav": "^0.1.90",
+    "@avenirs-esr/avenirs-dsav": "^0.1.91",
     "@tanstack/vue-form": "^1.15.0",
     "@tanstack/vue-query": "^5.74.9",
     "@vueuse/core": "^13.7.0",

--- a/src/features/student/additionalSkills/components/interactions/formFields/AdditionalSkillCommentFormField/AdditionalSkillCommentFormField.vue
+++ b/src/features/student/additionalSkills/components/interactions/formFields/AdditionalSkillCommentFormField/AdditionalSkillCommentFormField.vue
@@ -31,7 +31,7 @@ const { t } = useI18n()
       >
         <template #customCaptions>
           <span class="caption-regular">
-            {{ t('global.inputs.limit', { count: (field.state.value?.length ?? 0), maxlength: 400 }) }}
+            {{ t('global.inputs.textarea.limit', { count: (field.state.value?.length ?? 0), maxlength: 400 }) }}
           </span>
         </template>
       </AvInput>

--- a/src/features/student/additionalSkills/views/StudentAdditionalSkillView/components/AdditionalSkillDetails/AdditionalSkillDetails.vue
+++ b/src/features/student/additionalSkills/views/StudentAdditionalSkillView/components/AdditionalSkillDetails/AdditionalSkillDetails.vue
@@ -65,7 +65,7 @@ const createdAtPrefix = computed(() => capitalize(t('student.skills.skill')))
       >
         <template #customCaptions>
           <span class="caption-regular">
-            {{ t('global.inputs.limit', { count: description?.length ?? 0, maxlength: 400 }) }}
+            {{ t('global.inputs.textarea.limit', { count: description?.length ?? 0, maxlength: 400 }) }}
           </span>
         </template>
       </AvInput>

--- a/src/features/student/global/locales/fr.json
+++ b/src/features/student/global/locales/fr.json
@@ -172,7 +172,6 @@
         "description": "Je soumets une production de groupe"
       },
       "traceIaJustificationTextarea": {
-        "hint": "{count} / {maxlength} caractères (espaces compris)",
         "label": "Justification de l'usage de l'IA",
         "placeholder": "Décrivez comment et pourquoi vous avez utilisé l'IA..."
       },
@@ -181,7 +180,6 @@
         "placeholder": "Nom-de-ma-trace-01"
       },
       "tracePersonalNoteTextarea": {
-        "hint": "{count} / {maxlength} caractères (espaces compris)",
         "label": "Note personnelle",
         "placeholder": "Ajoutez votre note personnelle ici..."
       },
@@ -206,7 +204,6 @@
         "titleWithCategory": "Ajouter un élément - {category}"
       },
       "categoryElementDescriptionTextarea": {
-        "hint": "{count} / {maxlength} caractères (espaces compris)",
         "label": "Description de votre élément",
         "placeholder": "Décrivez votre élément..."
       },

--- a/src/features/student/selfKnowledge/components/interactions/inputs/CategoryElementDescriptionTextarea/CategoryElementDescriptionTextarea.vue
+++ b/src/features/student/selfKnowledge/components/interactions/inputs/CategoryElementDescriptionTextarea/CategoryElementDescriptionTextarea.vue
@@ -44,7 +44,7 @@ const avInputProps = computed(() => ({
         #customCaptions="{ currentValue }"
       >
         <span class="caption-light">
-          {{ t('student.selfKnowledge.categoryElementDescriptionTextarea.hint', {
+          {{ t('global.inputs.textarea.limit', {
             count: currentValue?.toString().length || 0,
             maxlength,
           }) }}

--- a/src/features/student/traces/components/interactions/inputs/TraceIaJustificationTextarea/TraceIaJustificationTextarea.vue
+++ b/src/features/student/traces/components/interactions/inputs/TraceIaJustificationTextarea/TraceIaJustificationTextarea.vue
@@ -51,7 +51,7 @@ const avInputProps = computed(() => ({
         #customCaptions="{ currentValue }"
       >
         <span class="caption-light">
-          {{ t('student.traces.traceIaJustificationTextarea.hint', {
+          {{ t('global.inputs.textarea.limit', {
             count: currentValue?.toString().length || 0,
             maxlength,
           }) }}

--- a/src/features/student/traces/components/interactions/inputs/TracePersonalNoteTextarea/TracePersonalNoteTextarea.vue
+++ b/src/features/student/traces/components/interactions/inputs/TracePersonalNoteTextarea/TracePersonalNoteTextarea.vue
@@ -48,7 +48,7 @@ const avInputProps = computed(() => ({
         #customCaptions="{ currentValue }"
       >
         <span class="caption-light">
-          {{ t('student.traces.tracePersonalNoteTextarea.hint', {
+          {{ t('global.inputs.textarea.limit', {
             count: currentValue?.toString().length || 0,
             maxlength,
           }) }}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -83,7 +83,9 @@
       }
     },
     "inputs": {
-      "limit": "{count} / {maxlength} characters (including spaces)"
+      "textarea": {
+        "limit": "{count} / {maxlength} characters (including spaces)"
+      }
     },
     "modals": {
       "confirmation": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -83,7 +83,9 @@
       }
     },
     "inputs": {
-      "limit": "{count} / {maxlength} caractères (espaces compris)"
+      "textarea": {
+        "limit": "{count} / {maxlength} caractères (espaces compris)"
+      }
     },
     "modals": {
       "confirmation": {


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> This PR centralizes textarea-related i18n keys by moving them from feature-specific locales to global shared translations. All textarea components across the application now use consistent translation keys from `global.input.textarea`.

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/796

---

### Documentation
> No documentation changes required. This is a refactoring PR that improves i18n key organization without changing functionality.

---

### Target Branch
> `develop`

---

### Additional Notes
> - Moved textarea i18n keys (`label`, `placeholder`, `error`) from `src/features/student/global/locales/fr.json` to global locales (`src/locales/fr.json` and `src/locales/en.json`)
> - Updated all textarea components to reference `global.input.textarea.*` keys
> - Affected components:
>   - `AdditionalSkillCommentFormField`
>   - `AdditionalSkillDetails`
>   - `CategoryElementDescriptionTextarea`
>   - `TraceIaJustificationTextarea`
>   - `TracePersonalNoteTextarea`
> - Updated `@avenirs-esr/avenirs-dsav` package version

---

### Known Limitations or Side Effects
> None. This is a pure refactoring PR with no functional changes.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [x] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and detaiils for the update process