### PR TITLE
refactor(742): standardize mutation args with generic MutationArgs type

### DIFF
--- a/src/features/student/additionalSkills/queries/use-additional-skills.query/use-additional-skills.query.ts
+++ b/src/features/student/additionalSkills/queries/use-additional-skills.query/use-additional-skills.query.ts
@@ -111,21 +111,16 @@ export function useSearchAdditionalSkillsQuery (
   }
 }
 
-export interface UseCreateAdditionalSkillMutationArgs {
-  onSuccess?: () => void
-  onError?: (error: BaseApiException) => void
-}
-
-export function useCreateAdditionalSkillMutation ({ onError, onSuccess }: UseCreateAdditionalSkillMutationArgs = {}) {
+export function useCreateAdditionalSkillMutation ({ onError, onSuccess }: MutationArgs = {}) {
   const invalidateAdditionalSkillsViewQuery = useInvalidateQuery([...additionalSkillCommonQueryKey])
 
   return useMutation<void, BaseApiException, AddAdditionalSkillDTO>({
     mutationFn: async (addAdditionalSkillDTO: AddAdditionalSkillDTO): Promise<void> => {
       await createAdditionalSkillProgress(addAdditionalSkillDTO)
     },
-    onSuccess: async () => {
+    onSuccess: async (data, variables) => {
       await invalidateAdditionalSkillsViewQuery()
-      onSuccess?.()
+      onSuccess?.(data, variables)
     },
     onError
   })
@@ -153,12 +148,7 @@ export function useAdditionalSkillDetailedQuery (skillId: MaybeRef<string>) {
   }
 }
 
-export interface UseUpdateAdditionalSkillMutationArgs {
-  onSuccess?: () => void
-  onError?: (error: BaseApiException) => void
-}
-
-export function useUpdateAdditionalSkillMutation ({ onError, onSuccess }: UseUpdateAdditionalSkillMutationArgs = {}) {
+export function useUpdateAdditionalSkillMutation ({ onError, onSuccess }: MutationArgs = {}) {
   const invalidateQueryKey = useInvalidateQuery()
 
   return useMutation<void, BaseApiException, AdditionalSkillProgressDetailsDTO>({
@@ -169,9 +159,9 @@ export function useUpdateAdditionalSkillMutation ({ onError, onSuccess }: UseUpd
       }
       await updateAdditionalSkillProgress(additionalSkillProgressDetailsDTO.id, additionalSkillProgressRequest)
     },
-    onSuccess: async (_, { id }) => {
-      await invalidateQueryKey([...additionalSkillDetailsQueryKey, id])
-      onSuccess?.()
+    onSuccess: async (data, variables) => {
+      await invalidateQueryKey([...additionalSkillDetailsQueryKey, variables.id])
+      onSuccess?.(data, variables)
     },
     onError
   })

--- a/src/features/student/traces/queries/use-traces.query/use-traces.query.test.ts
+++ b/src/features/student/traces/queries/use-traces.query/use-traces.query.test.ts
@@ -1,6 +1,8 @@
 import type { BaseApiException } from '@/common/exceptions'
+import type { MutationArgs } from '@/types'
 import type { UseQueryReturnType } from '@tanstack/vue-query'
 import { invalidTraceId, mockedTraceDetailed, mockedTracesSummary } from '@/__mocks__/fixtures/student'
+
 import {
   ELanguage,
   type PagedResponseTraceViewDTO,
@@ -11,20 +13,17 @@ import {
   type TracesSummaryDTO,
   type TracesViewParams,
 } from '@/api/avenir-esr'
-
 import { useInvalidateQuery } from '@/common/composables'
 import {
   type DeleteTraceVariables,
   type UpdateTraceVariables,
   useDeleteTraceMutation,
-  type UseDeleteTraceMutationArgs,
   useStudentTracesSummaryQuery,
   useTraceDetailedQuery,
   useTracesConfigurationQuery,
   useTracesSummaryQuery,
   useTracesViewQuery,
-  useUpdateTraceMutation,
-  type UseUpdateTraceMutationArgs
+  useUpdateTraceMutation
 } from '@/features/student/traces/queries/use-traces.query/use-traces.query'
 import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { flushPromises } from '@vue/test-utils'
@@ -223,7 +222,7 @@ BddTest().given('a useDeleteTraceMutation composable', async () => {
   const mockInvalidateFunction = vi.fn()
   const mockOnSuccess = vi.fn()
   const mockOnError = vi.fn()
-  const mutationArgs: UseDeleteTraceMutationArgs = {
+  const mutationArgs: MutationArgs = {
     onSuccess: mockOnSuccess,
     onError: mockOnError
   }
@@ -277,7 +276,10 @@ BddTest().given('a useDeleteTraceMutation composable', async () => {
 
       BddTest().then('it should call the custom onSuccess callback', () => {
         expect(mockOnSuccess).toHaveBeenCalledTimes(1)
-        expect(mockOnSuccess).toHaveBeenCalledWith()
+        expect(mockOnSuccess).toHaveBeenCalledWith(
+          expect.any(String),
+          variables
+        )
       })
 
       BddTest().then('it should not call the onError callback', () => {
@@ -310,7 +312,7 @@ BddTest().given('a useDeleteTraceMutation composable', async () => {
   BddTest().and('no success or error callbacks', () => {
     const traceId = '123e4567-e89b-12d3-a456-426614174000'
     const variables: DeleteTraceVariables = { traceId }
-    const mutationArgs: UseDeleteTraceMutationArgs = {}
+    const mutationArgs: MutationArgs = {}
 
     BddTest().when('the mutation is called without callbacks', () => {
       beforeEach(async () => {
@@ -644,7 +646,7 @@ BddTest().given('a useUpdateTraceMutation composable', async () => {
 
   BddTest().and('a valid trace update with success callback', () => {
     const traceId = 'trace1'
-    const mutationArgs: UseUpdateTraceMutationArgs = {
+    const mutationArgs: MutationArgs = {
       onSuccess: mockOnSuccess,
       onError: mockOnError
     }
@@ -696,7 +698,13 @@ BddTest().given('a useUpdateTraceMutation composable', async () => {
 
       BddTest().then('it should call the custom onSuccess callback', () => {
         expect(mockOnSuccess).toHaveBeenCalledTimes(1)
-        expect(mockOnSuccess).toHaveBeenCalledWith()
+        expect(mockOnSuccess).toHaveBeenCalledWith(
+          expect.objectContaining({
+            id: traceId,
+            title: 'Updated Title'
+          }),
+          variables
+        )
       })
 
       BddTest().then('it should not call the onError callback', () => {
@@ -734,7 +742,7 @@ BddTest().given('a useUpdateTraceMutation composable', async () => {
 
   BddTest().and('no success or error callbacks', () => {
     const traceId = 'trace1'
-    const mutationArgs: UseUpdateTraceMutationArgs = {}
+    const mutationArgs: MutationArgs = {}
     const variables: UpdateTraceVariables = {
       traceId,
       updateTraceDTO: {
@@ -780,7 +788,7 @@ BddTest().given('a useUpdateTraceMutation composable', async () => {
 
   BddTest().and('an invalid trace ID with error callback', () => {
     const traceId = invalidTraceId
-    const mutationArgs: UseUpdateTraceMutationArgs = {
+    const mutationArgs: MutationArgs = {
       onSuccess: mockOnSuccess,
       onError: mockOnError
     }

--- a/src/features/student/traces/queries/use-traces.query/use-traces.query.ts
+++ b/src/features/student/traces/queries/use-traces.query/use-traces.query.ts
@@ -1,5 +1,6 @@
 import type { BaseApiException } from '@/common/exceptions'
 
+import type { MutationArgs } from '@/types'
 import {
   associate,
   type AssociateTraceDTO,
@@ -94,20 +95,15 @@ export interface DeleteTraceVariables {
   traceId: string
 }
 
-export interface UseDeleteTraceMutationArgs {
-  onSuccess?: () => void
-  onError?: (error: BaseApiException) => void
-}
-
-export function useDeleteTraceMutation ({ onError, onSuccess }: UseDeleteTraceMutationArgs = {}) {
+export function useDeleteTraceMutation ({ onError, onSuccess }: MutationArgs = {}) {
   const invalidateTracesViewQuery = useInvalidateQuery(tracesViewQueryKey)
   return useMutation<string, BaseApiException, DeleteTraceVariables>({
     mutationFn: async ({ traceId }: DeleteTraceVariables): Promise<string> => {
       return await deleteTrace(traceId)
     },
-    onSuccess: async () => {
+    onSuccess: async (data, variables) => {
       await invalidateTracesViewQuery()
-      onSuccess?.()
+      onSuccess?.(data, variables)
     },
     onError
   })
@@ -124,21 +120,16 @@ export function useTracesConfigurationQuery (): UseQueryReturnType<TraceConfigur
   })
 }
 
-export interface UseCreateTraceMutationArgs {
-  onSuccess?: (data: TracesCreationResponse) => void
-  onError?: (error: BaseApiException) => void
-}
-
-export function useCreateTraceMutation ({ onError, onSuccess }: UseCreateTraceMutationArgs = {}) {
+export function useCreateTraceMutation ({ onError, onSuccess }: MutationArgs = {}) {
   const invalidateTracesViewQuery = useInvalidateQuery(tracesViewQueryKey)
 
   return useMutation<TracesCreationResponse, BaseApiException, CreateTraceDTO>({
     mutationFn: async (createTraceDTO: CreateTraceDTO): Promise<TracesCreationResponse> => {
       return await createTrace(createTraceDTO)
     },
-    onSuccess: async (data) => {
+    onSuccess: async (data, variables) => {
       await invalidateTracesViewQuery()
-      onSuccess?.(data)
+      onSuccess?.(data, variables)
     },
     onError
   })
@@ -149,21 +140,16 @@ export interface UploadAttachmentVariables {
   file: File
 }
 
-export interface UseUploadAttachmentMutationArgs {
-  onSuccess?: () => void
-  onError?: (error: BaseApiException) => void
-}
-
-export function useUploadAttachmentMutation ({ onError, onSuccess }: UseUploadAttachmentMutationArgs) {
+export function useUploadAttachmentMutation ({ onError, onSuccess }: MutationArgs) {
   const invalidateTraceDetailQuery = useInvalidateTraceDetailQuery()
   return useMutation<void, BaseApiException, UploadAttachmentVariables>({
     mutationFn: async ({ traceId, file }: UploadAttachmentVariables): Promise<void> => {
       const uploadAttachmentBody: UploadAttachmentBody = { file }
       await uploadAttachment(traceId, uploadAttachmentBody)
     },
-    onSuccess: async (_, { traceId }) => {
-      await invalidateTraceDetailQuery(traceId)
-      onSuccess?.()
+    onSuccess: async (data, variables) => {
+      await invalidateTraceDetailQuery(variables.traceId)
+      onSuccess?.(data, variables)
     },
     onError
   })
@@ -253,26 +239,21 @@ export function useTracesAssociationQuery (
   }
 }
 
-export interface UseCreateAssociateTraceMutationArgs {
-  onSuccess?: () => void
-  onError?: (error: BaseApiException) => void
-}
-
 export interface UseCreateAssociateTraceMutationVariables {
   traceId: string
   associateTraceDTO: AssociateTraceDTO
 }
 
-export function useCreateAssociateTraceMutation ({ onError, onSuccess }: UseCreateAssociateTraceMutationArgs) {
+export function useCreateAssociateTraceMutation ({ onError, onSuccess }: MutationArgs) {
   const invalidateTraceDetailQuery = useInvalidateTraceDetailQuery()
 
   return useMutation<void, BaseApiException, UseCreateAssociateTraceMutationVariables>({
     mutationFn: async ({ traceId, associateTraceDTO }): Promise<void> => {
       await associate(traceId, associateTraceDTO)
     },
-    onSuccess: async (_, { traceId }) => {
-      await invalidateTraceDetailQuery(traceId)
-      onSuccess?.()
+    onSuccess: async (data, variables) => {
+      await invalidateTraceDetailQuery(variables.traceId)
+      onSuccess?.(data, variables)
     },
     onError
   })
@@ -283,12 +264,7 @@ export interface UpdateTraceVariables {
   updateTraceDTO: UpdateTraceDTO
 }
 
-export interface UseUpdateTraceMutationArgs {
-  onSuccess?: () => void
-  onError?: (error: BaseApiException) => void
-}
-
-export function useUpdateTraceMutation ({ onError, onSuccess }: UseUpdateTraceMutationArgs) {
+export function useUpdateTraceMutation ({ onError, onSuccess }: MutationArgs<TraceDetailDTO>) {
   const invalidateTraceDetailQuery = useInvalidateTraceDetailQuery()
   const invalidateTracesViewQuery = useInvalidateQuery(tracesViewQueryKey)
 
@@ -296,10 +272,10 @@ export function useUpdateTraceMutation ({ onError, onSuccess }: UseUpdateTraceMu
     mutationFn: async ({ traceId, updateTraceDTO }: UpdateTraceVariables): Promise<TraceDetailDTO> => {
       return await updateTrace(traceId, updateTraceDTO)
     },
-    onSuccess: async (_, { traceId }) => {
-      await invalidateTraceDetailQuery(traceId)
+    onSuccess: async (data, variables) => {
+      await invalidateTraceDetailQuery(variables.traceId)
       await invalidateTracesViewQuery()
-      onSuccess?.()
+      onSuccess?.(data, variables)
     },
     onError
   })

--- a/src/features/student/traces/views/StudentTraceView/components/TraceDeletionConfirmationModal/TraceDeletionConfirmationModal.test.ts
+++ b/src/features/student/traces/views/StudentTraceView/components/TraceDeletionConfirmationModal/TraceDeletionConfirmationModal.test.ts
@@ -80,12 +80,9 @@ BddTest().given('a trace deletion confirmation modal', () => {
       addErrorMessage: mockAddErrorMessage
     } as unknown as ReturnType<typeof useToasterStore>)
 
-    mockedUseDeleteTraceMutation.mockImplementation(({ onError, onSuccess } = {}) => {
+    mockedUseDeleteTraceMutation.mockImplementation(({ onError } = {}) => {
       if (onError) {
         onErrorCallback = onError
-      }
-      if (onSuccess) {
-        onConfirmDeleteMock = onSuccess
       }
       return {
         mutate: mockMutate,

--- a/src/features/student/user/components/composites/UpdateProfileDrawer/use-update-profile.ts
+++ b/src/features/student/user/components/composites/UpdateProfileDrawer/use-update-profile.ts
@@ -1,10 +1,14 @@
 import type { BaseApiException } from '@/common/exceptions'
 import { EUserCategory, type ProfileUpdateRequest, type UpdateProfilePhotoBody } from '@/api/avenir-esr'
-import { useUpdateProfileCoverMutation, useUpdateProfileMutation, useUpdateProfilePhotoMutation } from '@/features/student/user/queries/use-student-profile/use-student-profile.query'
+import {
+  useUpdateProfileCoverMutation,
+  useUpdateProfileMutation,
+  useUpdateProfilePhotoMutation
+} from '@/features/student/user/queries/use-student-profile/use-student-profile.query'
 import { useToasterStore } from '@/store'
 import { useI18n } from 'vue-i18n'
 
-export function useUpdateProfile (onSuccess: () => void) {
+export function useUpdateProfile (onProfileUpdated: () => void) {
   const { t } = useI18n()
   const { addErrorMessage } = useToasterStore()
 
@@ -15,13 +19,9 @@ export function useUpdateProfile (onSuccess: () => void) {
     })
   }
 
-  function onUpdateProfileSuccess () {
-    onSuccess()
-  }
-
   const updateProfileMutation = useUpdateProfileMutation({
     onError: onUpdateProfileError,
-    onSuccess: onUpdateProfileSuccess
+    onSuccess: onProfileUpdated
   })
 
   function onUpdateProfile (profileUpdateRequest: ProfileUpdateRequest) {
@@ -64,7 +64,7 @@ export function useUpdateProfileCover (onSuccess: (data: string) => void) {
   }
 }
 
-export function useUpdateProfilePhoto (onSuccess: (data: string) => void) {
+export function useUpdateProfilePhoto (onProfilePhotoUpdated: (data: string) => void) {
   const { t } = useI18n()
   const { addErrorMessage } = useToasterStore()
 
@@ -75,13 +75,9 @@ export function useUpdateProfilePhoto (onSuccess: (data: string) => void) {
     })
   }
 
-  function onUpdateProfilePhotoSuccess (data: string) {
-    onSuccess(data)
-  }
-
   const updateProfilePhotoMutation = useUpdateProfilePhotoMutation({
     onError: onUpdateProfilePhotoError,
-    onSuccess: onUpdateProfilePhotoSuccess
+    onSuccess: onProfilePhotoUpdated
   })
 
   async function onUpdateProfilePhotoAsync (updateProfilePhotoBody: UpdateProfilePhotoBody) {

--- a/src/features/student/user/queries/use-student-profile/use-student-profile.query.ts
+++ b/src/features/student/user/queries/use-student-profile/use-student-profile.query.ts
@@ -1,5 +1,5 @@
 import type { BaseApiException } from '@/common/exceptions'
-import type { CommonMutationArgs, StudentHeaderSummaryDTO } from '@/types'
+import type { MutationArgs, StudentHeaderSummaryDTO } from '@/types'
 import { mockedHeaderOverview } from '@/__mocks__/fixtures/student'
 import {
   deleteUserPhoto,
@@ -45,17 +45,17 @@ export interface UpdateProfileVariables {
   profileUpdateRequest: ProfileUpdateRequest
 }
 
-export function useUpdateProfileMutation ({ onError, onSuccess }: CommonMutationArgs = {}) {
+export function useUpdateProfileMutation ({ onError, onSuccess }: MutationArgs<string> = {}) {
   const invalidateStudentSummaryQuery = useInvalidateQuery(studentSummaryQueryKeys)
   const invalidateHeaderSummaryQuery = useInvalidateQuery(headerSummaryQueryKeys)
   return useMutation<string, BaseApiException, UpdateProfileVariables>({
     mutationFn: async ({ profile, profileUpdateRequest }: UpdateProfileVariables): Promise<string> => {
       return await updateProfile(profile, profileUpdateRequest)
     },
-    onSuccess: async (data) => {
+    onSuccess: async (data, variables) => {
       await invalidateStudentSummaryQuery()
       await invalidateHeaderSummaryQuery()
-      onSuccess?.(data)
+      onSuccess?.(data, variables)
     },
     onError
   })
@@ -66,7 +66,7 @@ export interface UpdateProfileCoverVariables {
   updateProfileCoverBody: UpdateProfilePhotoBody
 }
 
-export function useUpdateProfileCoverMutation ({ onError, onSuccess }: CommonMutationArgs = {}) {
+export function useUpdateProfileCoverMutation ({ onError, onSuccess }: MutationArgs<string>) {
   return useMutation<string, BaseApiException, UpdateProfileCoverVariables>({
     mutationFn: async ({ profile, updateProfileCoverBody }: UpdateProfileCoverVariables): Promise<string> => {
       const uploadedPhoto = await updateProfilePhoto(profile, EUserPhotoType.COVER, updateProfileCoverBody)
@@ -82,7 +82,7 @@ export interface UpdateProfilePhotoVariables {
   updateProfilePhotoBody: UpdateProfilePhotoBody
 }
 
-export function useUpdateProfilePhotoMutation ({ onError, onSuccess }: CommonMutationArgs = {}) {
+export function useUpdateProfilePhotoMutation ({ onError, onSuccess }: MutationArgs<string, UpdateProfilePhotoVariables>) {
   return useMutation<string, BaseApiException, UpdateProfilePhotoVariables>({
     mutationFn: async ({ profile, updateProfilePhotoBody }: UpdateProfilePhotoVariables): Promise<string> => {
       const uploadedPhoto = await updateProfilePhoto(profile, EUserPhotoType.PROFILE, updateProfilePhotoBody)
@@ -97,20 +97,15 @@ interface DeleteUserPhotoVariables {
   fileId: string
 }
 
-export interface UseDeletePhotoMutationArgs {
-  onSuccess?: () => void
-  onError?: (error: BaseApiException) => void
-}
-
-export function useDeletePhotoMutation ({ onError, onSuccess }: UseDeletePhotoMutationArgs = {}) {
+export function useDeletePhotoMutation ({ onError, onSuccess }: MutationArgs = {}) {
   const invalidateStudentSummaryQuery = useInvalidateQuery(studentSummaryQueryKeys)
   return useMutation<string, BaseApiException, DeleteUserPhotoVariables>({
     mutationFn: async ({ fileId }: DeleteUserPhotoVariables): Promise<string> => {
       return await deleteUserPhoto(fileId)
     },
-    onSuccess: async () => {
+    onSuccess: async (data, variables) => {
       await invalidateStudentSummaryQuery()
-      onSuccess?.()
+      onSuccess?.(data, variables)
     },
     onError
   })

--- a/src/types/queries.types.ts
+++ b/src/types/queries.types.ts
@@ -1,10 +1,5 @@
 import type { BaseApiException } from '@/common/exceptions'
 
-export interface CommonMutationArgs {
-  onSuccess?: (data: string) => void
-  onError?: (error: BaseApiException) => void
-}
-
 export interface MutationArgs<TData = unknown, TVariables = unknown, TError = BaseApiException> {
   onSuccess?: (data: TData, variables: TVariables) => void | Promise<void>
   onError?: (error: TError) => void | Promise<void>

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,5 +1,5 @@
 import type { AvRoute } from '@/common/types'
-import type { CommonMutationArgs } from '@/types'
+import type { MutationArgs } from '@/types'
 import { useInvalidateQuery } from '@/common/composables/use-invalidate-query/use-invalidate-query'
 import { BaseApiErrorCode, type BaseApiException } from '@/common/exceptions'
 import { i18n } from '@/plugins/vue-i18n/vue-i18n'
@@ -184,7 +184,7 @@ export function testUseMutation<
 
     const mockUseInvalidateQuery = useInvalidateQuery as MockedFunction<typeof useInvalidateQuery>
     const mockInvalidateFunction = vi.fn()
-    const mutationArgs: CommonMutationArgs = {
+    const mutationArgs: MutationArgs = {
       onSuccess: mockOnSuccess,
       onError: mockOnError
     }


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
This PR refactors the mutation argument pattern across the codebase to use a single, generic `MutationArgs<TData, TVariables, TError>` type instead of multiple feature-specific interfaces. All mutation callbacks now receive both `data` and `variables` parameters for better type safety and consistency.

**Key changes:**
- Removed `CommonMutationArgs` interface and all feature-specific mutation arg interfaces
- Introduced generic `MutationArgs<TData, TVariables, TError>` type with proper type parameters
- Updated all mutation hooks to pass both `data` and `variables` to success callbacks
- Applied changes across traces, additionalSkills, and user profile features
- Improved type safety by explicitly specifying generic type parameters where needed

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/742

---

### Documentation
No documentation updates required. This is an internal refactoring that does not change public APIs or user-facing behavior.

---

### Target Branch
`develop`

---

### Additional Notes
This refactoring improves code consistency and type safety across all TanStack Query mutations. The generic `MutationArgs` type provides:
- Better TypeScript inference for callback parameters
- Consistent callback signatures (both `data` and `variables` are always available)
- Reduced code duplication by eliminating feature-specific interfaces
- Easier maintenance and future extensibility

All tests have been updated to reflect the new callback signature where `onSuccess` now receives both `data` and `variables` parameters.

---

### Known Limitations or Side Effects
None. This is a purely internal refactoring with no breaking changes to component behavior or user experience.

---

## ✅ Checklist

- [x] a11y tested (if the PR includes frontend changes) - N/A, no UI changes
- [x] Tests provided (including unit and integration tests for both frontend and backend) - Existing tests updated
- [x] i18n handled (texts are translated) - N/A, no new text content
- [x] Performance tests - N/A, no performance impact
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [x] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process - N/A, internal refactoring only