### PR TITLE
feat(919): declared experiences tabs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "avenirs-cofolio-client",
       "version": "0.0.0",
       "dependencies": {
-        "@avenirs-esr/avenirs-dsav": "^0.1.117",
+        "@avenirs-esr/avenirs-dsav": "^0.1.121",
         "@tanstack/vue-form": "^1.15.0",
         "@tanstack/vue-query": "^5.74.9",
         "@vue-flow/core": "^1.48.0",
@@ -309,9 +309,9 @@
       }
     },
     "node_modules/@avenirs-esr/avenirs-dsav": {
-      "version": "0.1.117",
-      "resolved": "https://registry.npmjs.org/@avenirs-esr/avenirs-dsav/-/avenirs-dsav-0.1.117.tgz",
-      "integrity": "sha512-oKIs+aqRq1SiWl1NqAESJjgXW0FZP+6x5wWJ9r4c38SYJb2IcLdeDAp6coaKSo1D21N40XAcAwFAifMbhzTE+A==",
+      "version": "0.1.121",
+      "resolved": "https://registry.npmjs.org/@avenirs-esr/avenirs-dsav/-/avenirs-dsav-0.1.121.tgz",
+      "integrity": "sha512-RNulxSrFPTJh+tDMfKzgTWIp7s//e4XCCO1TOr2F4KbtOqrnyKawSNyHPt6pZoSHFRcSAEBsKHwbtvuEHtDNHA==",
       "dependencies": {
         "@vueuse/core": "^13.9.0",
         "date-fns": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
-    "@avenirs-esr/avenirs-dsav": "^0.1.117",
+    "@avenirs-esr/avenirs-dsav": "^0.1.121",
     "@tanstack/vue-form": "^1.15.0",
     "@tanstack/vue-query": "^5.74.9",
     "@vue-flow/core": "^1.48.0",

--- a/src/features/student/personalCareer/locales/en.json
+++ b/src/features/student/personalCareer/locales/en.json
@@ -73,7 +73,16 @@
             "title": "My activities"
           },
           "ExperiencesSection": {
-            "title": "My experiences"
+            "AmsTab": {
+              "title": "My AMS"
+            },
+            "DeclaredExperiencesTab": {
+              "title": "My declared experiences"
+            },
+            "title": "My experiences",
+            "VerifiedExperiencesTab": {
+              "title": "My verified experiences"
+            }
           },
           "MyCareerSection": {
             "title": "My career"

--- a/src/features/student/personalCareer/locales/fr.json
+++ b/src/features/student/personalCareer/locales/fr.json
@@ -73,7 +73,16 @@
             "title": "Mes activités"
           },
           "ExperiencesSection": {
-            "title": "Mes expériences"
+            "AmsTab": {
+              "title": "Mes AMS"
+            },
+            "DeclaredExperiencesTab": {
+              "title": "Mes expériences déclarées"
+            },
+            "title": "Mes expériences",
+            "VerifiedExperiencesTab": {
+              "title": "Mes expériences vérifiées"
+            }
           },
           "MyCareerSection": {
             "title": "Mon parcours"

--- a/src/features/student/personalCareer/views/PersonalCareerView/sections/ExperiencesSection/ExperiencesSection.test.ts
+++ b/src/features/student/personalCareer/views/PersonalCareerView/sections/ExperiencesSection/ExperiencesSection.test.ts
@@ -1,25 +1,141 @@
 import ExperiencesSection from '@/features/student/personalCareer/views/PersonalCareerView/sections/ExperiencesSection/ExperiencesSection.vue'
+import { MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
 import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { mount, type VueWrapper } from '@vue/test-utils'
-import { beforeEach, expect } from 'vitest'
+import { beforeEach, expect, vi } from 'vitest'
 
 BddTest().given('an experiences section component', () => {
   let wrapper: VueWrapper<InstanceType<typeof ExperiencesSection>>
 
+  const stubs = {
+    DeclaredExperiencesTab: defineComponent({
+      name: 'DeclaredExperiencesTab',
+      template: '<div data-testid="declared-experiences-tab-stub"></div>'
+    }),
+    VerifiedExperiencesTab: defineComponent({
+      name: 'VerifiedExperiencesTab',
+      template: '<div data-testid="verified-experiences-tab-stub"></div>'
+    }),
+    AmsTab: defineComponent({
+      name: 'AmsTab',
+      template: '<div data-testid="amss-tab-stub"></div>'
+    })
+  }
+
   beforeEach(() => {
-    wrapper = mount(ExperiencesSection)
+    vi.clearAllMocks()
+    wrapper = mount(ExperiencesSection, {
+      global: { stubs }
+    })
   })
 
   BddTest().when('the experiences section is mounted', () => {
-    BddTest().then('it should render the experiences title', () => {
-      const titleElement = wrapper.find('.b1-bold')
-      expect(titleElement.exists()).toBe(true)
-      expect(titleElement.text()).toBe('Mes expériences')
+    BddTest().then('it should render', () => {
+      expect(wrapper.exists()).toBe(true)
     })
 
-    BddTest().then('it should have the correct CSS class', () => {
-      const titleElement = wrapper.find('.b1-bold')
-      expect(titleElement.classes()).toContain('b1-bold')
+    BddTest().then('it should render the tabs component', () => {
+      const tabs = wrapper.findComponent({ name: 'AvTabs' })
+      expect(tabs.exists()).toBe(true)
+    })
+
+    BddTest().then('it should render three tab buttons', () => {
+      const tabButtons = wrapper.findAll('[role="tab"]')
+      expect(tabButtons).toHaveLength(3)
+    })
+
+    BddTest().then('it should pass FLARE icon to the declared experiences tab', () => {
+      const tabs = wrapper.findComponent({ name: 'AvTabs' })
+      const tabSlots = tabs.vm.$slots.default?.()
+      expect(tabSlots[0].props?.icon).toBe(MDI_ICONS.FLARE)
+    })
+
+    BddTest().then('it should pass CHECK_DECAGRAM_OUTLINE icon to the verified experiences tab', () => {
+      const tabs = wrapper.findComponent({ name: 'AvTabs' })
+      const tabSlots = tabs.vm.$slots.default?.()
+      expect(tabSlots[1].props?.icon).toBe(MDI_ICONS.CHECK_DECAGRAM_OUTLINE)
+    })
+
+    BddTest().then('it should pass BOOK_OUTLINE icon to the amss tab', () => {
+      const tabs = wrapper.findComponent({ name: 'AvTabs' })
+      const tabSlots = tabs.vm.$slots.default?.()
+      expect(tabSlots[2].props?.icon).toBe(MDI_ICONS.BOOK_OUTLINE)
+    })
+
+    BddTest().and('the declared experiences tab is active by default', () => {
+      BddTest().then('it should have the correct title', () => {
+        const tabButtons = wrapper.findAll('[role="tab"]')
+        expect(tabButtons[0].text()).toContain('Mes expériences déclarées')
+      })
+
+      BddTest().then('it should render the declared experiences tab content', () => {
+        const content = wrapper.findComponent({ name: 'DeclaredExperiencesTab' })
+        expect(content.exists()).toBe(true)
+      })
+
+      BddTest().then('it should not render the verified experiences tab content', () => {
+        const content = wrapper.findComponent({ name: 'VerifiedExperiencesTab' })
+        expect(content.exists()).toBe(false)
+      })
+
+      BddTest().then('it should not render the amss tab content', () => {
+        const content = wrapper.findComponent({ name: 'AmssTab' })
+        expect(content.exists()).toBe(false)
+      })
+    })
+  })
+
+  BddTest().when('the verified experiences tab is clicked', () => {
+    beforeEach(async () => {
+      const tabButtons = wrapper.findAll('[role="tab"]')
+      await tabButtons[1].trigger('click')
+    })
+
+    BddTest().then('it should have the correct title', () => {
+      const tabButtons = wrapper.findAll('[role="tab"]')
+      expect(tabButtons[1].text()).toContain('Mes expériences vérifiées')
+    })
+
+    BddTest().then('it should render the verified experiences tab content', () => {
+      const content = wrapper.findComponent({ name: 'VerifiedExperiencesTab' })
+      expect(content.exists()).toBe(true)
+    })
+
+    BddTest().then('it should not render the declared experiences tab content', () => {
+      const content = wrapper.findComponent({ name: 'DeclaredExperiencesTab' })
+      expect(content.exists()).toBe(false)
+    })
+
+    BddTest().then('it should not render the amss tab content', () => {
+      const content = wrapper.findComponent({ name: 'AmssTab' })
+      expect(content.exists()).toBe(false)
+    })
+  })
+
+  BddTest().when('the amss tab is clicked', () => {
+    beforeEach(async () => {
+      const tabButtons = wrapper.findAll('[role="tab"]')
+      await tabButtons[2].trigger('click')
+    })
+
+    BddTest().then('it should have the correct title', () => {
+      const tabButtons = wrapper.findAll('[role="tab"]')
+      expect(tabButtons[2].text()).toContain('Mes AMS')
+    })
+
+    BddTest().then('it should render the amss tab content', () => {
+      const content = wrapper.findComponent({ name: 'AmsTab' })
+      expect(content.exists()).toBe(true)
+    })
+
+    BddTest().then('it should not render the declared experiences tab content', () => {
+      const content = wrapper.findComponent({ name: 'DeclaredExperiencesTab' })
+      expect(content.exists()).toBe(false)
+    })
+
+    BddTest().then('it should not render the verified experiences tab content', () => {
+      const content = wrapper.findComponent({ name: 'VerifiedExperiencesTab' })
+      expect(content.exists()).toBe(false)
     })
   })
 })

--- a/src/features/student/personalCareer/views/PersonalCareerView/sections/ExperiencesSection/ExperiencesSection.vue
+++ b/src/features/student/personalCareer/views/PersonalCareerView/sections/ExperiencesSection/ExperiencesSection.vue
@@ -1,11 +1,35 @@
 <script setup lang="ts">
+import AmsTab
+  from '@/features/student/personalCareer/views/PersonalCareerView/sections/ExperiencesSection/components/AmsTab/AmsTab.vue'
+import DeclaredExperiencesTab
+  from '@/features/student/personalCareer/views/PersonalCareerView/sections/ExperiencesSection/components/DeclaredExperiencesTab/DeclaredExperiencesTab.vue'
+import VerifiedExperiencesTab
+  from '@/features/student/personalCareer/views/PersonalCareerView/sections/ExperiencesSection/components/VerifiedExperiencesTab/VerifiedExperiencesTab.vue'
+import { AvTab, AvTabs, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
 import { useI18n } from 'vue-i18n'
 
 const { t } = useI18n()
 </script>
 
 <template>
-  <div class="b1-bold">
-    {{ t('student.personalCareer.views.PersonalCareerView.ExperiencesSection.title') }}
-  </div>
+  <AvTabs>
+    <AvTab
+      :icon="MDI_ICONS.FLARE"
+      :title="t('student.personalCareer.views.PersonalCareerView.ExperiencesSection.DeclaredExperiencesTab.title')"
+    >
+      <DeclaredExperiencesTab />
+    </AvTab>
+    <AvTab
+      :icon="MDI_ICONS.CHECK_DECAGRAM_OUTLINE"
+      :title="t('student.personalCareer.views.PersonalCareerView.ExperiencesSection.VerifiedExperiencesTab.title')"
+    >
+      <VerifiedExperiencesTab />
+    </AvTab>
+    <AvTab
+      :icon="MDI_ICONS.BOOK_OUTLINE"
+      :title="t('student.personalCareer.views.PersonalCareerView.ExperiencesSection.AmsTab.title')"
+    >
+      <AmsTab />
+    </AvTab>
+  </AvTabs>
 </template>

--- a/src/features/student/personalCareer/views/PersonalCareerView/sections/ExperiencesSection/components/AmsTab/AmsTab.test.ts
+++ b/src/features/student/personalCareer/views/PersonalCareerView/sections/ExperiencesSection/components/AmsTab/AmsTab.test.ts
@@ -1,0 +1,27 @@
+import AmsTab from '@/features/student/personalCareer/views/PersonalCareerView/sections/ExperiencesSection/components/AmsTab/AmsTab.vue'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { beforeEach, expect, vi } from 'vitest'
+
+BddTest().given('an amss tab', () => {
+  let wrapper: VueWrapper<InstanceType<typeof AmsTab>>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    wrapper = mount(AmsTab)
+  })
+
+  BddTest().when('the component is mounted', () => {
+    BddTest().then('it should render', () => {
+      expect(wrapper.exists()).toBe(true)
+    })
+
+    BddTest().then('it should render the content placeholder', () => {
+      expect(wrapper.text()).toBe('Mes AMS placeholder')
+    })
+
+    BddTest().then('it should have a root div element with correct class', () => {
+      expect(wrapper.find('.amss-tab').exists()).toBe(true)
+    })
+  })
+})

--- a/src/features/student/personalCareer/views/PersonalCareerView/sections/ExperiencesSection/components/AmsTab/AmsTab.vue
+++ b/src/features/student/personalCareer/views/PersonalCareerView/sections/ExperiencesSection/components/AmsTab/AmsTab.vue
@@ -1,0 +1,5 @@
+<template>
+  <div class="amss-tab">
+    Mes AMS placeholder
+  </div>
+</template>

--- a/src/features/student/personalCareer/views/PersonalCareerView/sections/ExperiencesSection/components/DeclaredExperiencesTab/DeclaredExperiencesTab.test.ts
+++ b/src/features/student/personalCareer/views/PersonalCareerView/sections/ExperiencesSection/components/DeclaredExperiencesTab/DeclaredExperiencesTab.test.ts
@@ -1,0 +1,27 @@
+import DeclaredExperiencesTab from '@/features/student/personalCareer/views/PersonalCareerView/sections/ExperiencesSection/components/DeclaredExperiencesTab/DeclaredExperiencesTab.vue'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { beforeEach, expect, vi } from 'vitest'
+
+BddTest().given('a declared experiences tab', () => {
+  let wrapper: VueWrapper<InstanceType<typeof DeclaredExperiencesTab>>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    wrapper = mount(DeclaredExperiencesTab)
+  })
+
+  BddTest().when('the component is mounted', () => {
+    BddTest().then('it should render', () => {
+      expect(wrapper.exists()).toBe(true)
+    })
+
+    BddTest().then('it should render the content placeholder', () => {
+      expect(wrapper.text()).toBe('Mes expériences déclarées placeholder')
+    })
+
+    BddTest().then('it should have a root div element with correct class', () => {
+      expect(wrapper.find('.declared-experiences-tab').exists()).toBe(true)
+    })
+  })
+})

--- a/src/features/student/personalCareer/views/PersonalCareerView/sections/ExperiencesSection/components/DeclaredExperiencesTab/DeclaredExperiencesTab.vue
+++ b/src/features/student/personalCareer/views/PersonalCareerView/sections/ExperiencesSection/components/DeclaredExperiencesTab/DeclaredExperiencesTab.vue
@@ -1,0 +1,5 @@
+<template>
+  <div class="declared-experiences-tab">
+    Mes expériences déclarées placeholder
+  </div>
+</template>

--- a/src/features/student/personalCareer/views/PersonalCareerView/sections/ExperiencesSection/components/VerifiedExperiencesTab/VerifiedExperiencesTab.test.ts
+++ b/src/features/student/personalCareer/views/PersonalCareerView/sections/ExperiencesSection/components/VerifiedExperiencesTab/VerifiedExperiencesTab.test.ts
@@ -1,0 +1,27 @@
+import VerifiedExperiencesTab from '@/features/student/personalCareer/views/PersonalCareerView/sections/ExperiencesSection/components/VerifiedExperiencesTab/VerifiedExperiencesTab.vue'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { beforeEach, expect, vi } from 'vitest'
+
+BddTest().given('a verified experiences tab', () => {
+  let wrapper: VueWrapper<InstanceType<typeof VerifiedExperiencesTab>>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    wrapper = mount(VerifiedExperiencesTab)
+  })
+
+  BddTest().when('the component is mounted', () => {
+    BddTest().then('it should render', () => {
+      expect(wrapper.exists()).toBe(true)
+    })
+
+    BddTest().then('it should render the content placeholder', () => {
+      expect(wrapper.text()).toBe('Mes expériences vérifiées placeholder')
+    })
+
+    BddTest().then('it should have a root div element with correct class', () => {
+      expect(wrapper.find('.verified-experiences-tab').exists()).toBe(true)
+    })
+  })
+})

--- a/src/features/student/personalCareer/views/PersonalCareerView/sections/ExperiencesSection/components/VerifiedExperiencesTab/VerifiedExperiencesTab.vue
+++ b/src/features/student/personalCareer/views/PersonalCareerView/sections/ExperiencesSection/components/VerifiedExperiencesTab/VerifiedExperiencesTab.vue
@@ -1,0 +1,5 @@
+<template>
+  <div class="verified-experiences-tab">
+    Mes expériences vérifiées placeholder
+  </div>
+</template>


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> This PR implements the ExperiencesSection tabs with AvTabs component containing 3 tabs:
> - **Mes expériences déclarées** (DeclaredExperiencesTab) - with FLARE icon
> - **Mes expériences vérifiées** (VerifiedExperiencesTab) - with CHECK_DECAGRAM_OUTLINE icon
> - **Mes AMS** (AmsTab) - with BOOK_OUTLINE icon
>
> Each tab currently displays placeholder content that will be implemented in future PRs.

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/919

---

### Documentation
> - Tab components follow existing ProgramsSection pattern
> - i18n keys added for tab titles in both French and English locales
> - Unit tests provided for all new components (27 tests total)

---

### Target Branch
> `develop`

---

### Additional Notes
> - Components created under `ExperiencesSection/components/` directory
> - Each tab component has placeholder text that will be replaced with actual content
> - Test coverage includes tab rendering, icon verification, and tab switching behavior

---

### Known Limitations or Side Effects
> - Tab content is placeholder only - actual functionality will be implemented in subsequent PRs

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [x] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [x] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [x] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process