### PR TITLE
feat(920): declared experiences list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "avenirs-cofolio-client",
       "version": "0.0.0",
       "dependencies": {
-        "@avenirs-esr/avenirs-dsav": "^0.1.123",
+        "@avenirs-esr/avenirs-dsav": "^0.1.124",
         "@tanstack/vue-form": "^1.15.0",
         "@tanstack/vue-query": "^5.74.9",
         "@vue-flow/core": "^1.48.0",
@@ -309,9 +309,9 @@
       }
     },
     "node_modules/@avenirs-esr/avenirs-dsav": {
-      "version": "0.1.123",
-      "resolved": "https://registry.npmjs.org/@avenirs-esr/avenirs-dsav/-/avenirs-dsav-0.1.123.tgz",
-      "integrity": "sha512-vLv+LR9IJclTfLADx4MOWN5wi2pRluVOIF6dSKNmQ/BQP4Rqd9nBOLBUxmFWsZrBjHQ+QyCLvYYm03dYbtL/VQ==",
+      "version": "0.1.124",
+      "resolved": "https://registry.npmjs.org/@avenirs-esr/avenirs-dsav/-/avenirs-dsav-0.1.124.tgz",
+      "integrity": "sha512-FE6+vTsZIJWOzl6JTRQ/q26t7MLYalf5v6wojo0+QB+Yr6ZXuptxL+meEi+GldrONbJrWdpWK4IwOIfH8z9NKQ==",
       "dependencies": {
         "@vueuse/core": "^13.9.0",
         "date-fns": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
-    "@avenirs-esr/avenirs-dsav": "^0.1.123",
+    "@avenirs-esr/avenirs-dsav": "^0.1.124",
     "@tanstack/vue-form": "^1.15.0",
     "@tanstack/vue-query": "^5.74.9",
     "@vue-flow/core": "^1.48.0",

--- a/src/__mocks__/fixtures/student/declaredExperiences.fixtures.ts
+++ b/src/__mocks__/fixtures/student/declaredExperiences.fixtures.ts
@@ -1,0 +1,102 @@
+import {
+  type DeclaredExperienceViewDTO,
+  EExperienceType,
+  type PagedResponseDeclaredExperienceViewDTO
+} from '@/api/avenir-esr'
+
+export const declaredExperienceViewDTOFixture: DeclaredExperienceViewDTO = {
+  id: 'declared-experience-123-456-789',
+  title: 'Développeur Web Full Stack',
+  experienceType: EExperienceType.PROFESSIONAL,
+  organization: 'Tech Startup Paris',
+  activitySector: 'Technologie de l\'information',
+  location: 'Paris, France',
+  description: 'Développement d\'applications web avec Vue.js et Node.js',
+  sourceOfInformation: 'LinkedIn',
+  summary: 'Expérience enrichissante en startup',
+  externalLink: 'https://www.techstartup.fr',
+  startDate: '2023-01',
+  endDate: '2024-06',
+  createdAt: '2024-01-15T10:30:00Z',
+  updatedAt: '2024-01-15T10:30:00Z'
+}
+
+export const mockedDeclaredExperiences: DeclaredExperienceViewDTO[] = [
+  {
+    id: 'declared-experience-1',
+    title: 'Développeur Web Full Stack',
+    experienceType: EExperienceType.PROFESSIONAL,
+    organization: 'Tech Startup Paris',
+    activitySector: 'Technologie',
+    location: 'La Poste',
+    startDate: '2023-01',
+    endDate: '2024-06',
+    createdAt: '2024-01-15T10:30:00Z',
+    updatedAt: '2024-01-15T10:30:00Z'
+  },
+  {
+    id: 'declared-experience-2',
+    title: 'Stage en Marketing Digital',
+    experienceType: EExperienceType.PROFESSIONAL,
+    organization: 'Agence Marketing Lyon',
+    activitySector: 'Marketing',
+    location: 'Les Subsistances, Lyon',
+    startDate: '2022-06',
+    endDate: '2022-12',
+    createdAt: '2024-01-15T10:30:00Z',
+    updatedAt: '2024-01-15T10:30:00Z'
+  },
+  {
+    id: 'declared-experience-3',
+    title: 'Bénévolat Association Sportive',
+    experienceType: EExperienceType.PERSONAL,
+    organization: 'Club de Football Local',
+    location: 'La Poste',
+    startDate: '2021-09',
+    createdAt: '2024-01-15T10:30:00Z',
+    updatedAt: '2024-01-15T10:30:00Z'
+  },
+  {
+    id: 'declared-experience-4',
+    title: 'Projet Personnel Open Source',
+    experienceType: EExperienceType.PERSONAL,
+    organization: 'GitHub',
+    location: 'Les Subsistances, Lyon',
+    description: 'Contribution à des projets open source',
+    startDate: '2020-01',
+    createdAt: '2024-01-15T10:30:00Z',
+    updatedAt: '2024-01-15T10:30:00Z'
+  },
+  {
+    id: 'declared-experience-5',
+    title: 'Assistant Commercial',
+    experienceType: EExperienceType.PROFESSIONAL,
+    organization: 'Grande Distribution SA',
+    activitySector: 'Commerce',
+    location: 'Marseille, France',
+    startDate: '2019-07',
+    endDate: '2020-08',
+    createdAt: '2024-01-15T10:30:00Z',
+    updatedAt: '2024-01-15T10:30:00Z'
+  }
+]
+
+export function createMockedDeclaredExperiencesPagedResponse (
+  pageSize: number,
+  totalElements: number,
+  page: number
+): PagedResponseDeclaredExperienceViewDTO {
+  const start = page * pageSize
+  const end = Math.min(start + pageSize, totalElements)
+  const paginatedData = mockedDeclaredExperiences.slice(start, end)
+
+  return {
+    data: paginatedData,
+    page: {
+      page,
+      pageSize,
+      totalElements,
+      totalPages: Math.ceil(totalElements / pageSize)
+    }
+  }
+}

--- a/src/__mocks__/fixtures/student/index.ts
+++ b/src/__mocks__/fixtures/student/index.ts
@@ -1,4 +1,5 @@
 export * from '@/__mocks__/fixtures/student/ams.fixtures'
+export * from '@/__mocks__/fixtures/student/declaredExperiences.fixtures'
 export * from '@/__mocks__/fixtures/student/declaredPrograms.fixtures'
 export * from '@/__mocks__/fixtures/student/overviews.fixtures'
 export * from '@/__mocks__/fixtures/student/program-progress.fixtures'

--- a/src/__mocks__/msw/handlers/index.ts
+++ b/src/__mocks__/msw/handlers/index.ts
@@ -1,5 +1,6 @@
 import { amsHandlers } from '@/__mocks__/msw/handlers/student/ams.handlers'
 import { backOfficeHandlers } from '@/__mocks__/msw/handlers/student/back-office.handlers'
+import { declaredExperiencesHandlers } from '@/__mocks__/msw/handlers/student/declaredExperiences.handlers'
 import { declaredProgramsHandlers } from '@/__mocks__/msw/handlers/student/declaredPrograms.handlers'
 import { overviewsHandlers } from '@/__mocks__/msw/handlers/student/overviews.handlers'
 import { programProgressHandlers } from '@/__mocks__/msw/handlers/student/program-progress.handlers'
@@ -10,6 +11,7 @@ import { tracesHandlers } from '@/__mocks__/msw/handlers/student/traces.handlers
 export const handlers = [
   ...amsHandlers,
   ...backOfficeHandlers,
+  ...declaredExperiencesHandlers,
   ...declaredProgramsHandlers,
   ...overviewsHandlers,
   ...programProgressHandlers,

--- a/src/__mocks__/msw/handlers/student/declaredExperiences.handlers.ts
+++ b/src/__mocks__/msw/handlers/student/declaredExperiences.handlers.ts
@@ -1,0 +1,56 @@
+import {
+  createMockedDeclaredExperiencesPagedResponse,
+  declaredExperienceViewDTOFixture
+} from '@/__mocks__/fixtures/student/declaredExperiences.fixtures'
+import {
+  getCreateDeclaredExperienceUrl,
+  getGetDeclaredExperienceViewUrl,
+  type PagedResponseDeclaredExperienceViewDTO
+} from '@/api/avenir-esr'
+import { delay, http, HttpResponse } from 'msw'
+
+export const declaredExperiencesQueryErrorHandler = http.get(`*${getGetDeclaredExperienceViewUrl()}`, () => {
+  return HttpResponse.json(
+    { message: 'Internal Server Error' },
+    {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' }
+    }
+  )
+})
+
+export const declaredExperiencesQueryEmptyHandler = http.get(`*${getGetDeclaredExperienceViewUrl()}`, async ({ request }) => {
+  const url = new URL(request.url)
+  const page = Number.parseInt(url.searchParams.get('page') ?? '0')
+  const pageSize = Number.parseInt(url.searchParams.get('pageSize') ?? '10')
+
+  await delay('real')
+  const mockData = createMockedDeclaredExperiencesPagedResponse(pageSize, 0, page)
+
+  return HttpResponse.json<PagedResponseDeclaredExperienceViewDTO>(mockData, {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' }
+  })
+})
+
+export const declaredExperiencesHandlers = [
+  http.get(`*${getGetDeclaredExperienceViewUrl()}`, async ({ request }) => {
+    const url = new URL(request.url)
+    const page = Number.parseInt(url.searchParams.get('page') ?? '0')
+    const pageSize = Number.parseInt(url.searchParams.get('pageSize') ?? '10')
+
+    await delay('real')
+    const mockData = createMockedDeclaredExperiencesPagedResponse(pageSize, 5, page)
+
+    return HttpResponse.json<PagedResponseDeclaredExperienceViewDTO>(mockData, {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' }
+    })
+  }),
+  http.post(
+    `*${getCreateDeclaredExperienceUrl()}`,
+    () => {
+      return HttpResponse.json(declaredExperienceViewDTOFixture, { status: 200 })
+    }
+  )
+]

--- a/src/features/student/ams/queries/use-ams-view.query/use-ams-view.query.ts
+++ b/src/features/student/ams/queries/use-ams-view.query/use-ams-view.query.ts
@@ -7,8 +7,6 @@ import { type Ref, toValue } from 'vue'
 
 const amsCommonQueryKeys = [...commonQueryKeys, 'ams']
 
-const TWO_MINUTES = 2 * 60 * 1000
-
 export function useAmsViewQuery (
   programProgramId: Ref<string | undefined>,
   page: Ref<number>,
@@ -37,7 +35,6 @@ export function useAmsViewQuery (
     queryKey,
     queryFn,
     enabled: computed(() => !isNil(programProgramId.value)),
-    staleTime: TWO_MINUTES,
     placeholderData: keepPreviousData
   })
 

--- a/src/features/student/declaredSkills/queries/use-declared-skills.query/use-declared-skills.query.ts
+++ b/src/features/student/declaredSkills/queries/use-declared-skills.query/use-declared-skills.query.ts
@@ -25,8 +25,6 @@ import { type MaybeRef, type Ref, toValue, type UnwrapRef } from 'vue'
 const declaredSkillCommonQueryKey = ['user', 'student', 'declared-skills']
 const declaredSkillDetailsQueryKey = [...declaredSkillCommonQueryKey, 'details']
 
-const TWO_MINUTES = 2 * 60 * 1000
-
 export function useDeclaredSkillsViewQuery (
   page: Ref<number>,
   pageSize: Ref<number>
@@ -54,7 +52,6 @@ export function useDeclaredSkillsViewQuery (
   >({
     queryKey,
     queryFn,
-    staleTime: TWO_MINUTES,
     placeholderData: keepPreviousData
   })
 
@@ -96,7 +93,6 @@ export function useSearchExternalSkillsQuery (
     queryKey,
     queryFn,
     enabled: computed(() => keyword.value.trim().length >= 3),
-    staleTime: TWO_MINUTES,
     initialPageParam: 0,
     getNextPageParam: (lastPage: PagedResponseExternalSkillDTO) => {
       const { page, totalPages } = lastPage.page
@@ -157,7 +153,6 @@ export function useDeclaredSkillDetailedQuery (skillId: MaybeRef<string>) {
   const query = useQuery<DeclaredSkillProgressDetailsDTO, BaseApiException, DeclaredSkillProgressDetailsDTO, readonly unknown[]>({
     queryKey,
     queryFn,
-    staleTime: TWO_MINUTES,
     enabled: computed(() => toValue(skillId).trim().length > 0),
   })
 

--- a/src/features/student/global/queries/use-back-office.query/use-back-office.query.ts
+++ b/src/features/student/global/queries/use-back-office.query/use-back-office.query.ts
@@ -3,7 +3,6 @@ import { type BuildLifeProjectConfigDTO, getBuildLifeProjectConfig } from '@/api
 import { useQuery, type UseQueryReturnType } from '@tanstack/vue-query'
 
 const commonQueryKeys = ['back-office', 'config']
-const TWO_MINUTES = 2 * 60 * 1000
 
 export function useBackOfficeBuildLifeProjectConfigQuery (): UseQueryReturnType<BuildLifeProjectConfigDTO, BaseApiException> {
   const queryKey = [...commonQueryKeys, 'website-content', 'build-life-project']
@@ -11,6 +10,5 @@ export function useBackOfficeBuildLifeProjectConfigQuery (): UseQueryReturnType<
   return useQuery<BuildLifeProjectConfigDTO, BaseApiException>({
     queryKey,
     queryFn: getBuildLifeProjectConfig,
-    staleTime: TWO_MINUTES
   })
 }

--- a/src/features/student/personalCareer/locales/en.json
+++ b/src/features/student/personalCareer/locales/en.json
@@ -88,6 +88,7 @@
               "title": "My AMS"
             },
             "DeclaredExperiencesTab": {
+              "emptyState": "No declared experiences yet. Click on the \"Add\" button in the More Actions menu to declare your first experience!",
               "title": "My declared experiences"
             },
             "title": "My experiences",

--- a/src/features/student/personalCareer/locales/fr.json
+++ b/src/features/student/personalCareer/locales/fr.json
@@ -88,6 +88,7 @@
               "title": "Mes AMS"
             },
             "DeclaredExperiencesTab": {
+              "emptyState": "Aucune expérience déclarée pour le moment. Cliquez sur le bouton \"Ajouter\" dans le menu Plus d'actions pour déclarer votre première expérience !",
               "title": "Mes expériences déclarées"
             },
             "title": "Mes expériences",

--- a/src/features/student/personalCareer/queries/use-declared-experiences.query.test.ts
+++ b/src/features/student/personalCareer/queries/use-declared-experiences.query.test.ts
@@ -1,0 +1,152 @@
+import type { Ref } from 'vue'
+import {
+  declaredExperiencesQueryEmptyHandler,
+  declaredExperiencesQueryErrorHandler
+} from '@/__mocks__/msw/handlers/student/declaredExperiences.handlers'
+import { server } from '@/__mocks__/msw/server'
+import {
+  type DeclaredExperiencesViewQueryReturnType,
+  useDeclaredExperiencesViewQuery
+} from '@/features/student/personalCareer/queries/use-declared-experiences.query'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { flushPromises } from '@vue/test-utils'
+import { mountQueryComposable } from 'tests/utils'
+import { beforeEach, expect, vi } from 'vitest'
+
+BddTest().given('a declared experiences view query', () => {
+  let queryResult: DeclaredExperiencesViewQueryReturnType
+  let page: Ref<number>
+  let pageSize: Ref<number>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    page = ref(0)
+    pageSize = ref(10)
+  })
+
+  BddTest().when('the query is executed with initial parameters', () => {
+    beforeEach(async () => {
+      queryResult = mountQueryComposable(() => useDeclaredExperiencesViewQuery({ page, pageSize }))
+      await vi.waitFor(() => {
+        expect(queryResult.isSuccess.value).toBe(true)
+      })
+    })
+
+    BddTest().then('it should return paginated data', () => {
+      expect(queryResult.data.value).toBeDefined()
+      expect(queryResult.data.value?.data).toBeDefined()
+      expect(queryResult.data.value?.page).toBeDefined()
+    })
+
+    BddTest().then('it should have success state', () => {
+      expect(queryResult.isSuccess.value).toBe(true)
+      expect(queryResult.isError.value).toBe(false)
+    })
+
+    BddTest().then('it should compute declaredExperiences array', () => {
+      expect(queryResult.declaredExperiences.value).toBeDefined()
+      expect(Array.isArray(queryResult.declaredExperiences.value)).toBe(true)
+    })
+
+    BddTest().then('it should compute pageInfo object', () => {
+      expect(queryResult.pageInfo.value).toBeDefined()
+      expect(queryResult.pageInfo.value.page).toBe(0)
+      expect(queryResult.pageInfo.value.pageSize).toBeDefined()
+      expect(queryResult.pageInfo.value.totalElements).toBeDefined()
+      expect(queryResult.pageInfo.value.totalPages).toBeDefined()
+    })
+
+    BddTest().then('it should return declared experiences with expected structure', () => {
+      const firstExperience = queryResult.declaredExperiences.value[0]
+      if (firstExperience) {
+        expect(firstExperience).toMatchObject({
+          id: expect.any(String),
+          title: expect.any(String),
+          organization: expect.any(String),
+          startDate: expect.any(String)
+        })
+      }
+    })
+
+    BddTest().and('the page parameter changes', () => {
+      beforeEach(async () => {
+        page.value = 1
+        await vi.waitFor(() => {
+          expect(queryResult.pageInfo.value.page).toBe(1)
+        })
+      })
+
+      BddTest().then('it should fetch new page data', () => {
+        expect(queryResult.pageInfo.value.page).toBe(1)
+      })
+
+      BddTest().then('it should maintain success state', () => {
+        expect(queryResult.isSuccess.value).toBe(true)
+      })
+    })
+
+    BddTest().and('the pageSize parameter changes', () => {
+      beforeEach(async () => {
+        pageSize.value = 20
+        await vi.waitFor(() => {
+          expect(queryResult.pageInfo.value.pageSize).toBe(20)
+        })
+      })
+
+      BddTest().then('it should fetch data with new page size', () => {
+        expect(queryResult.pageInfo.value.pageSize).toBe(20)
+      })
+    })
+  })
+
+  BddTest().when('the query fails with server error', () => {
+    beforeEach(async () => {
+      server.use(declaredExperiencesQueryErrorHandler)
+      queryResult = mountQueryComposable(() => useDeclaredExperiencesViewQuery({ page, pageSize }))
+      await flushPromises()
+    })
+
+    BddTest().then('it should set error state', async () => {
+      await vi.waitFor(() => {
+        expect(queryResult.isError.value).toBe(true)
+      })
+
+      expect(queryResult.isSuccess.value).toBe(false)
+      expect(queryResult.error.value).toBeDefined()
+    })
+
+    BddTest().then('it should return empty declaredExperiences array', () => {
+      expect(queryResult.declaredExperiences.value).toEqual([])
+    })
+
+    BddTest().then('it should return default pageInfo', () => {
+      expect(queryResult.pageInfo.value).toEqual({
+        page: 0,
+        pageSize: 0,
+        totalElements: 0,
+        totalPages: 0
+      })
+    })
+  })
+
+  BddTest().when('the query data is empty', () => {
+    beforeEach(async () => {
+      server.use(declaredExperiencesQueryEmptyHandler)
+      queryResult = mountQueryComposable(() => useDeclaredExperiencesViewQuery({ page, pageSize }))
+      await flushPromises()
+    })
+
+    BddTest().then('it should return empty array for declaredExperiences', () => {
+      expect(queryResult.declaredExperiences.value).toEqual([])
+    })
+
+    BddTest().then('it should return default pageInfo with zeros', () => {
+      expect(queryResult.pageInfo.value).toEqual({
+        page: 0,
+        pageSize: 0,
+        totalElements: 0,
+        totalPages: 0
+      })
+    })
+  })
+})

--- a/src/features/student/personalCareer/queries/use-declared-experiences.query.ts
+++ b/src/features/student/personalCareer/queries/use-declared-experiences.query.ts
@@ -12,8 +12,6 @@ import { type MaybeRef, type Ref, toValue } from 'vue'
 const declaredExperiencesCommonQueryKey = [...commonQueryKeys, 'declared-experiences']
 const declaredExperiencesViewQueryKey = [...declaredExperiencesCommonQueryKey, 'view']
 
-const TWO_MINUTES = 2 * 60 * 1000
-
 export interface DeclaredExperiencesViewQueryParams {
   page: MaybeRef<number>
   pageSize: MaybeRef<number>
@@ -43,7 +41,6 @@ export function useDeclaredExperiencesViewQuery ({
   const query = useQuery<PagedResponseDeclaredExperienceViewDTO, BaseApiException>({
     queryKey,
     queryFn,
-    staleTime: TWO_MINUTES,
     placeholderData: keepPreviousData
   })
 

--- a/src/features/student/personalCareer/queries/use-declared-experiences.query.ts
+++ b/src/features/student/personalCareer/queries/use-declared-experiences.query.ts
@@ -1,0 +1,58 @@
+import type { BaseApiException } from '@/common/exceptions'
+import {
+  type DeclaredExperienceViewDTO,
+  getDeclaredExperienceView,
+  type PagedResponseDeclaredExperienceViewDTO,
+  type PageInfoDTO
+} from '@/api/avenir-esr'
+import { commonQueryKeys } from '@/features/student/global'
+import { keepPreviousData, useQuery, type UseQueryReturnType } from '@tanstack/vue-query'
+import { type MaybeRef, type Ref, toValue } from 'vue'
+
+const declaredExperiencesCommonQueryKey = [...commonQueryKeys, 'declared-experiences']
+const declaredExperiencesViewQueryKey = [...declaredExperiencesCommonQueryKey, 'view']
+
+const TWO_MINUTES = 2 * 60 * 1000
+
+export interface DeclaredExperiencesViewQueryParams {
+  page: MaybeRef<number>
+  pageSize: MaybeRef<number>
+}
+
+export type DeclaredExperiencesViewQueryReturnType = UseQueryReturnType<PagedResponseDeclaredExperienceViewDTO, BaseApiException> & {
+  declaredExperiences: Ref<DeclaredExperienceViewDTO[]>
+  pageInfo: Ref<PageInfoDTO>
+}
+
+export function useDeclaredExperiencesViewQuery ({
+  page,
+  pageSize
+}: DeclaredExperiencesViewQueryParams): DeclaredExperiencesViewQueryReturnType {
+  const queryKey = computed(() => [...declaredExperiencesViewQueryKey, {
+    page: toValue(page),
+    pageSize: toValue(pageSize)
+  }])
+
+  const queryFn = computed(() => async (): Promise<PagedResponseDeclaredExperienceViewDTO> => {
+    return await getDeclaredExperienceView({
+      page: toValue(page),
+      pageSize: toValue(pageSize)
+    })
+  })
+
+  const query = useQuery<PagedResponseDeclaredExperienceViewDTO, BaseApiException>({
+    queryKey,
+    queryFn,
+    staleTime: TWO_MINUTES,
+    placeholderData: keepPreviousData
+  })
+
+  const declaredExperiences = computed(() => query.data.value?.data ?? [])
+  const pageInfo = computed(() => query.data.value?.page ?? { page: 0, pageSize: 0, totalElements: 0, totalPages: 0 })
+
+  return {
+    ...query,
+    declaredExperiences,
+    pageInfo
+  }
+}

--- a/src/features/student/personalCareer/queries/use-declared-programs.query.ts
+++ b/src/features/student/personalCareer/queries/use-declared-programs.query.ts
@@ -16,8 +16,6 @@ import { type MaybeRef, type Ref, toValue } from 'vue'
 const declaredProgramsCommonQueryKey = [...commonQueryKeys, 'declared-programs']
 const declaredProgramsViewQueryKey = [...declaredProgramsCommonQueryKey, 'view']
 
-const TWO_MINUTES = 2 * 60 * 1000
-
 export interface DeclaredProgramsViewQueryParams {
   page: MaybeRef<number>
   pageSize: MaybeRef<number>
@@ -47,7 +45,6 @@ export function useDeclaredProgramsViewQuery ({
   const query = useQuery<PagedResponseDeclaredProgramViewDTO, BaseApiException>({
     queryKey,
     queryFn,
-    staleTime: TWO_MINUTES,
     placeholderData: keepPreviousData
   })
 

--- a/src/features/student/personalCareer/stores/personalCareer.store.test.ts
+++ b/src/features/student/personalCareer/stores/personalCareer.store.test.ts
@@ -1,9 +1,10 @@
 import { usePersonalCareerStore } from '@/features/student/personalCareer/stores/personalCareer.store'
+import { PageSizes } from '@avenirs-esr/avenirs-dsav'
 import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, expect } from 'vitest'
 
-BddTest().given('a declared programs store', () => {
+BddTest().given('a personal career store', () => {
   let store: ReturnType<typeof usePersonalCareerStore>
 
   beforeEach(() => {
@@ -20,6 +21,26 @@ BddTest().given('a declared programs store', () => {
 
     BddTest().then('it should have drawer initially hidden', () => {
       expect(store.showAddDeclaredProgramDrawer).toBe(false)
+    })
+
+    BddTest().then('it should provide declared programs pagination state', () => {
+      expect(store.declaredProgramsCurrentPage).toBeDefined()
+      expect(store.declaredProgramsPageSizeSelected).toBeDefined()
+    })
+
+    BddTest().then('it should have default declared programs pagination values', () => {
+      expect(store.declaredProgramsCurrentPage).toBe(0)
+      expect(store.declaredProgramsPageSizeSelected).toBe(PageSizes.FOUR)
+    })
+
+    BddTest().then('it should provide declared experiences pagination state', () => {
+      expect(store.declaredExperiencesCurrentPage).toBeDefined()
+      expect(store.declaredExperiencesPageSizeSelected).toBeDefined()
+    })
+
+    BddTest().then('it should have default declared experiences pagination values', () => {
+      expect(store.declaredExperiencesCurrentPage).toBe(0)
+      expect(store.declaredExperiencesPageSizeSelected).toBe(PageSizes.FOUR)
     })
 
     BddTest().and('displaying the add declared program drawer', () => {
@@ -55,6 +76,30 @@ BddTest().given('a declared programs store', () => {
 
         store.displayAddDeclaredProgramDrawer()
         expect(store.showAddDeclaredProgramDrawer).toBe(true)
+      })
+    })
+
+    BddTest().and('updating declared programs pagination', () => {
+      BddTest().then('it should allow updating current page', () => {
+        store.declaredProgramsCurrentPage = 2
+        expect(store.declaredProgramsCurrentPage).toBe(2)
+      })
+
+      BddTest().then('it should allow updating page size', () => {
+        store.declaredProgramsPageSizeSelected = PageSizes.EIGHT
+        expect(store.declaredProgramsPageSizeSelected).toBe(PageSizes.EIGHT)
+      })
+    })
+
+    BddTest().and('updating declared experiences pagination', () => {
+      BddTest().then('it should allow updating current page', () => {
+        store.declaredExperiencesCurrentPage = 3
+        expect(store.declaredExperiencesCurrentPage).toBe(3)
+      })
+
+      BddTest().then('it should allow updating page size', () => {
+        store.declaredExperiencesPageSizeSelected = PageSizes.TWELVE
+        expect(store.declaredExperiencesPageSizeSelected).toBe(PageSizes.TWELVE)
       })
     })
   })

--- a/src/features/student/personalCareer/stores/personalCareer.store.ts
+++ b/src/features/student/personalCareer/stores/personalCareer.store.ts
@@ -14,18 +14,25 @@ export const usePersonalCareerStore = defineStore('personalCareer', () => {
   const declaredProgramsPageSizeSelected = ref<PageSizes>(DEFAULT_PAGE_SIZE)
   const declaredProgramsCurrentPage = ref(0)
 
+  const declaredExperiencesPageSizeSelected = ref<PageSizes>(DEFAULT_PAGE_SIZE)
+  const declaredExperiencesCurrentPage = ref(0)
+
   return {
     showAddDeclaredProgramDrawer,
     displayAddDeclaredProgramDrawer,
     hideAddDeclaredProgramDrawer,
     declaredProgramsCurrentPage,
-    declaredProgramsPageSizeSelected
+    declaredProgramsPageSizeSelected,
+    declaredExperiencesCurrentPage,
+    declaredExperiencesPageSizeSelected
   }
 }, {
   persist: {
     pick: [
       'declaredProgramsCurrentPage',
-      'declaredProgramsPageSizeSelected'
+      'declaredProgramsPageSizeSelected',
+      'declaredExperiencesCurrentPage',
+      'declaredExperiencesPageSizeSelected'
     ]
   }
 })

--- a/src/features/student/personalCareer/views/PersonalCareerView/sections/ExperiencesSection/ExperiencesSection.test.ts
+++ b/src/features/student/personalCareer/views/PersonalCareerView/sections/ExperiencesSection/ExperiencesSection.test.ts
@@ -1,5 +1,4 @@
 import ExperiencesSection from '@/features/student/personalCareer/views/PersonalCareerView/sections/ExperiencesSection/ExperiencesSection.vue'
-import { MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
 import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { mount, type VueWrapper } from '@vue/test-utils'
 import { beforeEach, expect, vi } from 'vitest'
@@ -11,14 +10,6 @@ BddTest().given('an experiences section component', () => {
     DeclaredExperiencesTab: defineComponent({
       name: 'DeclaredExperiencesTab',
       template: '<div data-testid="declared-experiences-tab-stub"></div>'
-    }),
-    VerifiedExperiencesTab: defineComponent({
-      name: 'VerifiedExperiencesTab',
-      template: '<div data-testid="verified-experiences-tab-stub"></div>'
-    }),
-    AmsTab: defineComponent({
-      name: 'AmsTab',
-      template: '<div data-testid="amss-tab-stub"></div>'
     })
   }
 
@@ -34,108 +25,9 @@ BddTest().given('an experiences section component', () => {
       expect(wrapper.exists()).toBe(true)
     })
 
-    BddTest().then('it should render the tabs component', () => {
-      const tabs = wrapper.findComponent({ name: 'AvTabs' })
-      expect(tabs.exists()).toBe(true)
-    })
-
-    BddTest().then('it should render three tab buttons', () => {
-      const tabButtons = wrapper.findAll('[role="tab"]')
-      expect(tabButtons).toHaveLength(3)
-    })
-
-    BddTest().then('it should pass FLARE icon to the declared experiences tab', () => {
-      const tabs = wrapper.findComponent({ name: 'AvTabs' })
-      const tabSlots = tabs.vm.$slots.default?.()
-      expect(tabSlots[0].props?.icon).toBe(MDI_ICONS.FLARE)
-    })
-
-    BddTest().then('it should pass CHECK_DECAGRAM_OUTLINE icon to the verified experiences tab', () => {
-      const tabs = wrapper.findComponent({ name: 'AvTabs' })
-      const tabSlots = tabs.vm.$slots.default?.()
-      expect(tabSlots[1].props?.icon).toBe(MDI_ICONS.CHECK_DECAGRAM_OUTLINE)
-    })
-
-    BddTest().then('it should pass BOOK_OUTLINE icon to the amss tab', () => {
-      const tabs = wrapper.findComponent({ name: 'AvTabs' })
-      const tabSlots = tabs.vm.$slots.default?.()
-      expect(tabSlots[2].props?.icon).toBe(MDI_ICONS.BOOK_OUTLINE)
-    })
-
-    BddTest().and('the declared experiences tab is active by default', () => {
-      BddTest().then('it should have the correct title', () => {
-        const tabButtons = wrapper.findAll('[role="tab"]')
-        expect(tabButtons[0].text()).toContain('Mes expériences déclarées')
-      })
-
-      BddTest().then('it should render the declared experiences tab content', () => {
-        const content = wrapper.findComponent({ name: 'DeclaredExperiencesTab' })
-        expect(content.exists()).toBe(true)
-      })
-
-      BddTest().then('it should not render the verified experiences tab content', () => {
-        const content = wrapper.findComponent({ name: 'VerifiedExperiencesTab' })
-        expect(content.exists()).toBe(false)
-      })
-
-      BddTest().then('it should not render the amss tab content', () => {
-        const content = wrapper.findComponent({ name: 'AmssTab' })
-        expect(content.exists()).toBe(false)
-      })
-    })
-  })
-
-  BddTest().when('the verified experiences tab is clicked', () => {
-    beforeEach(async () => {
-      const tabButtons = wrapper.findAll('[role="tab"]')
-      await tabButtons[1].trigger('click')
-    })
-
-    BddTest().then('it should have the correct title', () => {
-      const tabButtons = wrapper.findAll('[role="tab"]')
-      expect(tabButtons[1].text()).toContain('Mes expériences vérifiées')
-    })
-
-    BddTest().then('it should render the verified experiences tab content', () => {
-      const content = wrapper.findComponent({ name: 'VerifiedExperiencesTab' })
-      expect(content.exists()).toBe(true)
-    })
-
-    BddTest().then('it should not render the declared experiences tab content', () => {
-      const content = wrapper.findComponent({ name: 'DeclaredExperiencesTab' })
-      expect(content.exists()).toBe(false)
-    })
-
-    BddTest().then('it should not render the amss tab content', () => {
-      const content = wrapper.findComponent({ name: 'AmssTab' })
-      expect(content.exists()).toBe(false)
-    })
-  })
-
-  BddTest().when('the amss tab is clicked', () => {
-    beforeEach(async () => {
-      const tabButtons = wrapper.findAll('[role="tab"]')
-      await tabButtons[2].trigger('click')
-    })
-
-    BddTest().then('it should have the correct title', () => {
-      const tabButtons = wrapper.findAll('[role="tab"]')
-      expect(tabButtons[2].text()).toContain('Mes AMS')
-    })
-
-    BddTest().then('it should render the amss tab content', () => {
-      const content = wrapper.findComponent({ name: 'AmsTab' })
-      expect(content.exists()).toBe(true)
-    })
-
-    BddTest().then('it should not render the declared experiences tab content', () => {
-      const content = wrapper.findComponent({ name: 'DeclaredExperiencesTab' })
-      expect(content.exists()).toBe(false)
-    })
-
-    BddTest().then('it should not render the verified experiences tab content', () => {
-      const content = wrapper.findComponent({ name: 'VerifiedExperiencesTab' })
-      expect(content.exists()).toBe(false)
+    BddTest().then('it should render the declared experiences tab', () => {
+      const declaredExperiencesTab = wrapper.findComponent({ name: 'DeclaredExperiencesTab' })
+      expect(declaredExperiencesTab.exists()).toBe(true)
     })
   })
 })

--- a/src/features/student/personalCareer/views/PersonalCareerView/sections/ExperiencesSection/ExperiencesSection.vue
+++ b/src/features/student/personalCareer/views/PersonalCareerView/sections/ExperiencesSection/ExperiencesSection.vue
@@ -1,35 +1,8 @@
 <script setup lang="ts">
-import AmsTab
-  from '@/features/student/personalCareer/views/PersonalCareerView/sections/ExperiencesSection/components/AmsTab/AmsTab.vue'
 import DeclaredExperiencesTab
   from '@/features/student/personalCareer/views/PersonalCareerView/sections/ExperiencesSection/components/DeclaredExperiencesTab/DeclaredExperiencesTab.vue'
-import VerifiedExperiencesTab
-  from '@/features/student/personalCareer/views/PersonalCareerView/sections/ExperiencesSection/components/VerifiedExperiencesTab/VerifiedExperiencesTab.vue'
-import { AvTab, AvTabs, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
-import { useI18n } from 'vue-i18n'
-
-const { t } = useI18n()
 </script>
 
 <template>
-  <AvTabs>
-    <AvTab
-      :icon="MDI_ICONS.FLARE"
-      :title="t('student.personalCareer.views.PersonalCareerView.ExperiencesSection.DeclaredExperiencesTab.title')"
-    >
-      <DeclaredExperiencesTab />
-    </AvTab>
-    <AvTab
-      :icon="MDI_ICONS.CHECK_DECAGRAM_OUTLINE"
-      :title="t('student.personalCareer.views.PersonalCareerView.ExperiencesSection.VerifiedExperiencesTab.title')"
-    >
-      <VerifiedExperiencesTab />
-    </AvTab>
-    <AvTab
-      :icon="MDI_ICONS.BOOK_OUTLINE"
-      :title="t('student.personalCareer.views.PersonalCareerView.ExperiencesSection.AmsTab.title')"
-    >
-      <AmsTab />
-    </AvTab>
-  </AvTabs>
+  <DeclaredExperiencesTab />
 </template>

--- a/src/features/student/personalCareer/views/PersonalCareerView/sections/ExperiencesSection/components/DeclaredExperiencesTab/DeclaredExperiencesTab.test.ts
+++ b/src/features/student/personalCareer/views/PersonalCareerView/sections/ExperiencesSection/components/DeclaredExperiencesTab/DeclaredExperiencesTab.test.ts
@@ -1,27 +1,165 @@
+import type { VueWrapper } from '@vue/test-utils'
+import { declaredExperiencesQueryEmptyHandler, declaredExperiencesQueryErrorHandler } from '@/__mocks__/msw/handlers/student/declaredExperiences.handlers'
+import { server } from '@/__mocks__/msw/server'
+import { LoaderStub } from '@/common/components/Loader/Loader.stub'
+import { PaginationStub } from '@/common/components/Pagination/Pagination.stub'
+import { DeclaredExperienceCardStub } from '@/features/student/personalCareer/components/cards/DeclaredExperienceCard/DeclaredExperienceCard.stub'
 import DeclaredExperiencesTab from '@/features/student/personalCareer/views/PersonalCareerView/sections/ExperiencesSection/components/DeclaredExperiencesTab/DeclaredExperiencesTab.vue'
-import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
-import { mount, type VueWrapper } from '@vue/test-utils'
+import { PageSizes } from '@avenirs-esr/avenirs-dsav'
+import { AvIconTextStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { mountComponent } from 'tests/utils'
 import { beforeEach, expect, vi } from 'vitest'
+
+const mockOnUpdateCurrentPage = vi.fn()
+const mockOnUpdatePageSize = vi.fn()
+
+vi.mock('@/common/composables/use-pagination/use-pagination', () => ({
+  usePagination: vi.fn(() => ({
+    currentPage: ref(0),
+    pageSizeSelected: ref(PageSizes.FOUR),
+    onUpdateCurrentPage: mockOnUpdateCurrentPage,
+    onUpdatePageSize: mockOnUpdatePageSize
+  }))
+}))
+
+vi.mock('@/common/composables/use-base-api-exception-toast/use-base-api-exception-toast', () => ({
+  useBaseApiExceptionToast: vi.fn()
+}))
+
+vi.mock('@/features/student/personalCareer/stores/personalCareer.store', () => ({
+  usePersonalCareerStore: vi.fn(() => ({
+    declaredExperiencesCurrentPage: ref(0),
+    declaredExperiencesPageSizeSelected: ref(PageSizes.FOUR)
+  }))
+}))
 
 BddTest().given('a declared experiences tab', () => {
   let wrapper: VueWrapper<InstanceType<typeof DeclaredExperiencesTab>>
 
-  beforeEach(() => {
+  const stubs = {
+    DeclaredExperienceCard: DeclaredExperienceCardStub,
+    Pagination: PaginationStub,
+    Loader: LoaderStub,
+    AvIconText: AvIconTextStub
+  }
+
+  beforeEach(async () => {
     vi.clearAllMocks()
-    wrapper = mount(DeclaredExperiencesTab)
+    wrapper = mountComponent(DeclaredExperiencesTab, {
+      global: { stubs }
+    })
+    await vi.waitFor(() => {
+      expect(wrapper.findComponent({ name: 'Pagination' }).exists()).toBe(true)
+    })
   })
 
   BddTest().when('the component is mounted', () => {
-    BddTest().then('it should render', () => {
+    BddTest().then('it should render the component', () => {
       expect(wrapper.exists()).toBe(true)
     })
 
-    BddTest().then('it should render the content placeholder', () => {
-      expect(wrapper.text()).toBe('Mes expériences déclarées placeholder')
+    BddTest().then('it should have the correct layout classes', () => {
+      const container = wrapper.find('.av-col.av-gap-md')
+      expect(container.exists()).toBe(true)
     })
 
-    BddTest().then('it should have a root div element with correct class', () => {
-      expect(wrapper.find('.declared-experiences-tab').exists()).toBe(true)
+    BddTest().then('it should render the AvIconText component', () => {
+      const iconText = wrapper.findComponent({ name: 'AvIconText' })
+      expect(iconText.exists()).toBe(true)
+    })
+
+    BddTest().then('it should render the pagination component', () => {
+      const pagination = wrapper.findComponent({ name: 'Pagination' })
+      expect(pagination.exists()).toBe(true)
+    })
+  })
+
+  BddTest().when('declared experiences data is loaded', () => {
+    beforeEach(async () => {
+      await vi.waitFor(() => {
+        const cards = wrapper.findAllComponents({ name: 'DeclaredExperienceCard' })
+        expect(cards.length).toBeGreaterThan(0)
+      })
+    })
+
+    BddTest().then('it should render declared experience cards', () => {
+      const cards = wrapper.findAllComponents({ name: 'DeclaredExperienceCard' })
+      expect(cards.length).toBeGreaterThan(0)
+    })
+
+    BddTest().then('it should render cards with layout and spacing classes', () => {
+      const cards = wrapper.findAllComponents({ name: 'DeclaredExperienceCard' })
+      const firstCard = cards[0]
+      expect(firstCard.classes()).toContain('av-col')
+      expect(firstCard.classes()).toContain('av-gap-lg')
+      expect(firstCard.classes()).toContain('av-py-md')
+    })
+
+    BddTest().then('it should not display the loader', () => {
+      const loaderSpinner = wrapper.find('[data-testid="loader-stub"]')
+      expect(loaderSpinner.exists()).toBe(false)
+    })
+  })
+
+  BddTest().when('there are no declared experiences', () => {
+    beforeEach(async () => {
+      server.use(declaredExperiencesQueryEmptyHandler)
+      wrapper = mountComponent(DeclaredExperiencesTab, {
+        global: { stubs }
+      })
+      await vi.waitFor(() => {
+        const emptyState = wrapper.find('.av-row.av-justify-center.av-my-md')
+        expect(emptyState.exists()).toBe(true)
+      })
+    })
+
+    BddTest().then('it should display the empty state message', () => {
+      const emptyState = wrapper.find('.av-row.av-justify-center.av-my-md')
+      expect(emptyState.exists()).toBe(true)
+      expect(emptyState.find('.s2-regular').exists()).toBe(true)
+    })
+
+    BddTest().then('it should not render declared experience cards', () => {
+      const cards = wrapper.findAllComponents({ name: 'DeclaredExperienceCard' })
+      expect(cards).toHaveLength(0)
+    })
+
+    BddTest().then('it should not display the loader', () => {
+      const loaderSpinner = wrapper.find('[data-testid="loader-stub"]')
+      expect(loaderSpinner.exists()).toBe(false)
+    })
+
+    BddTest().then('it should render the pagination component', () => {
+      const pagination = wrapper.findComponent({ name: 'Pagination' })
+      expect(pagination.exists()).toBe(true)
+    })
+  })
+
+  BddTest().when('the query fails with an error', () => {
+    beforeEach(async () => {
+      server.use(declaredExperiencesQueryErrorHandler)
+      wrapper = mountComponent(DeclaredExperiencesTab, {
+        global: { stubs }
+      })
+      await vi.waitFor(() => {
+        const loaderSpinner = wrapper.find('[data-testid="loader-stub"]')
+        expect(loaderSpinner.exists()).toBe(false)
+      })
+    })
+
+    BddTest().then('it should not render declared experience cards', () => {
+      const cards = wrapper.findAllComponents({ name: 'DeclaredExperienceCard' })
+      expect(cards).toHaveLength(0)
+    })
+
+    BddTest().then('it should not display the loader after error', () => {
+      const loaderSpinner = wrapper.find('[data-testid="loader-stub"]')
+      expect(loaderSpinner.exists()).toBe(false)
+    })
+
+    BddTest().then('it should not display the empty state', () => {
+      const emptyState = wrapper.find('.av-row.av-justify-center.av-my-md')
+      expect(emptyState.exists()).toBe(false)
     })
   })
 })

--- a/src/features/student/personalCareer/views/PersonalCareerView/sections/ExperiencesSection/components/DeclaredExperiencesTab/DeclaredExperiencesTab.vue
+++ b/src/features/student/personalCareer/views/PersonalCareerView/sections/ExperiencesSection/components/DeclaredExperiencesTab/DeclaredExperiencesTab.vue
@@ -1,5 +1,72 @@
+<script setup lang="ts">
+import { Loader, Pagination } from '@/common/components'
+import { useBaseApiExceptionToast, usePagination } from '@/common/composables'
+import DeclaredExperienceCard from '@/features/student/personalCareer/components/cards/DeclaredExperienceCard/DeclaredExperienceCard.vue'
+import { useDeclaredExperiencesViewQuery } from '@/features/student/personalCareer/queries/use-declared-experiences.query'
+import { usePersonalCareerStore } from '@/features/student/personalCareer/stores/personalCareer.store'
+import { AvIconText, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
+const personalCareerStore = usePersonalCareerStore()
+
+const {
+  currentPage,
+  pageSizeSelected,
+  onUpdateCurrentPage,
+  onUpdatePageSize
+} = usePagination(
+  toRef(personalCareerStore, 'declaredExperiencesCurrentPage'),
+  toRef(personalCareerStore, 'declaredExperiencesPageSizeSelected')
+)
+
+const { declaredExperiences, pageInfo, error, isFetching, isError } = useDeclaredExperiencesViewQuery({
+  page: currentPage,
+  pageSize: pageSizeSelected
+})
+
+const titleWithCount = computed(() => t('student.personalCareer.views.PersonalCareerView.ExperiencesSection.DeclaredExperiencesTab.title').concat(` (${pageInfo.value.totalElements})`))
+
+const shouldShowEmptyState = computed(() => !isFetching.value && declaredExperiences.value.length === 0 && !isError.value)
+
+useBaseApiExceptionToast(error)
+</script>
+
 <template>
-  <div class="declared-experiences-tab">
-    Mes expériences déclarées placeholder
+  <div class="av-col av-gap-md">
+    <AvIconText
+      icon-color="var(--text2)"
+      typography-class="n6"
+      :icon="MDI_ICONS.FLARE"
+      :text="titleWithCount"
+    />
+    <div
+      v-if="shouldShowEmptyState"
+      class="av-row av-justify-center av-my-md"
+    >
+      <span class="s2-regular">
+        {{ t('student.personalCareer.views.PersonalCareerView.ExperiencesSection.DeclaredExperiencesTab.emptyState') }}
+      </span>
+    </div>
+    <Pagination
+      :page-info="pageInfo"
+      :page-size-selected="pageSizeSelected"
+      :on-update-current-page="onUpdateCurrentPage"
+      :on-update-page-size="onUpdatePageSize"
+    >
+      <div>
+        <Loader
+          :is-loading="isFetching && !isError"
+          size="2xl"
+        >
+          <DeclaredExperienceCard
+            v-for="experience in declaredExperiences"
+            :key="experience.id"
+            class="av-col av-gap-lg av-py-md"
+            :declared-experience="experience"
+          />
+        </Loader>
+      </div>
+    </Pagination>
   </div>
 </template>

--- a/src/features/student/personalCareer/views/PersonalCareerView/sections/ExperiencesSection/components/DeclaredExperiencesTab/DeclaredExperiencesTab.vue
+++ b/src/features/student/personalCareer/views/PersonalCareerView/sections/ExperiencesSection/components/DeclaredExperiencesTab/DeclaredExperiencesTab.vue
@@ -54,19 +54,17 @@ useBaseApiExceptionToast(error)
       :on-update-current-page="onUpdateCurrentPage"
       :on-update-page-size="onUpdatePageSize"
     >
-      <div>
-        <Loader
-          :is-loading="isFetching && !isError"
-          size="2xl"
-        >
-          <DeclaredExperienceCard
-            v-for="experience in declaredExperiences"
-            :key="experience.id"
-            class="av-col av-gap-lg av-py-md"
-            :declared-experience="experience"
-          />
-        </Loader>
-      </div>
+      <Loader
+        :is-loading="isFetching && !isError"
+        size="2xl"
+      >
+        <DeclaredExperienceCard
+          v-for="experience in declaredExperiences"
+          :key="experience.id"
+          class="av-col av-gap-lg av-py-md"
+          :declared-experience="experience"
+        />
+      </Loader>
     </Pagination>
   </div>
 </template>

--- a/src/features/student/personalCareer/views/PersonalCareerView/sections/ProgramsSection/components/DeclaredProgramsTab/DeclaredProgramsTab.test.ts
+++ b/src/features/student/personalCareer/views/PersonalCareerView/sections/ProgramsSection/components/DeclaredProgramsTab/DeclaredProgramsTab.test.ts
@@ -143,7 +143,7 @@ BddTest().given('a declared programs tab', () => {
     BddTest().then('it should display the empty state message', () => {
       const emptyState = wrapper.find('.av-row.av-justify-center.av-my-md')
       expect(emptyState.exists()).toBe(true)
-      expect(emptyState.find('.s1-regular').exists()).toBe(true)
+      expect(emptyState.find('.s2-regular').exists()).toBe(true)
     })
 
     BddTest().then('it should not render declared program cards', () => {

--- a/src/features/student/personalCareer/views/PersonalCareerView/sections/ProgramsSection/components/DeclaredProgramsTab/DeclaredProgramsTab.vue
+++ b/src/features/student/personalCareer/views/PersonalCareerView/sections/ProgramsSection/components/DeclaredProgramsTab/DeclaredProgramsTab.vue
@@ -53,7 +53,7 @@ useBaseApiExceptionToast(error)
       v-if="shouldShowEmptyState"
       class="av-row av-justify-center av-my-md"
     >
-      <span class="s1-regular">
+      <span class="s2-regular">
         {{ t('student.personalCareer.views.PersonalCareerView.ProgramsSection.DeclaredProgramsTab.emptyState') }}
       </span>
     </div>

--- a/src/features/student/selfKnowledge/queries/self-knowledge.query/self-knowledge.query.ts
+++ b/src/features/student/selfKnowledge/queries/self-knowledge.query/self-knowledge.query.ts
@@ -29,7 +29,6 @@ const selfKnowledgeElementsViewQueryKey = [...selfKnowledgeElementsQueryKey, 'vi
 const selfKnowledgeElementDetailsQueryKey = [...selfKnowledgeCommonQueryKey, 'element-details']
 const selfKnowledgeCategoriesAvailableQueryKey = [...selfKnowledgeCommonQueryKey, 'available']
 
-const TWO_MINUTES = 2 * 60 * 1000
 const CATEGORY_ELEMENTS_PAGE_SIZE = 3
 
 export function useSelfKnowledgeCategoriesQuery (): UseQueryReturnType<SelfKnowledgeCategoryDTO[], BaseApiException> & {
@@ -44,7 +43,6 @@ export function useSelfKnowledgeCategoriesQuery (): UseQueryReturnType<SelfKnowl
   const query = useQuery<SelfKnowledgeCategoryDTO[], BaseApiException >({
     queryKey,
     queryFn,
-    staleTime: TWO_MINUTES
   })
 
   const categories = computed(() => query.data.value ?? [])
@@ -73,7 +71,6 @@ export function useSelfKnowledgeElementDetailsQuery ({
   const query = useQuery<SelfKnowledgeElementDetailsDTO, BaseApiException >({
     queryKey,
     queryFn,
-    staleTime: TWO_MINUTES
   })
 
   const element = computed(() => query.data.value)
@@ -116,7 +113,6 @@ export function useSelfKnowledgeCategoryElementsViewQuery ({
   const query = useQuery<PagedResponseSelfKnowledgeElementViewDTO, BaseApiException>({
     queryKey,
     queryFn,
-    staleTime: TWO_MINUTES,
     placeholderData: keepPreviousData,
     enabled: computed(() => {
       const id = toValue(selfKnowledgeCategoryId)
@@ -151,7 +147,6 @@ export function useSelfKnowledgeCategoriesAvailableQuery (): UseQueryReturnType<
   const query = useQuery<SelfKnowledgeCategoryDTO[], BaseApiException >({
     queryKey,
     queryFn,
-    staleTime: TWO_MINUTES
   })
 
   const categoriesAvailable = computed(() => query.data.value ?? [])

--- a/src/features/student/skills/queries/use-skills-view.query/use-skills-view.query.ts
+++ b/src/features/student/skills/queries/use-skills-view.query/use-skills-view.query.ts
@@ -17,8 +17,6 @@ import { type Ref, toValue } from 'vue'
 
 const skillsCommonQueryKeys = [...commonQueryKeys, 'skills']
 
-const TWO_MINUTES = 2 * 60 * 1000
-
 export function useSkillsViewQuery (
   sort: Ref<string | undefined>,
   page: Ref<number>,
@@ -44,7 +42,6 @@ export function useSkillsViewQuery (
   const query = useQuery<PagedResponseSkillDTO, BaseApiException, PagedResponseSkillDTO, readonly unknown[]>({
     queryKey,
     queryFn,
-    staleTime: TWO_MINUTES,
     placeholderData: keepPreviousData
   })
 
@@ -68,7 +65,6 @@ export function useSkillDetailedQuery (skillId: Ref<string>) {
   const query = useQuery<SkillDetailedDTO, BaseApiException, SkillDetailedDTO, readonly unknown[]>({
     queryKey,
     queryFn,
-    staleTime: TWO_MINUTES,
     enabled: computed(() => skillId.value.trim().length > 0),
   })
 
@@ -90,7 +86,6 @@ export function useAllSkillsQuery () {
   const query = useQuery<SkillListItemDTO[], BaseApiException, SkillListItemDTO[], readonly unknown[]>({
     queryKey,
     queryFn,
-    staleTime: TWO_MINUTES,
   })
 
   const allSkills = computed(() => query.data.value)

--- a/src/features/student/traces/queries/use-traces.query/use-traces.query.ts
+++ b/src/features/student/traces/queries/use-traces.query/use-traces.query.ts
@@ -39,7 +39,6 @@ import { type MaybeRef, type Ref, toValue, type UnwrapRef } from 'vue'
 const tracesCommonQueryKeys = [...commonQueryKeys, 'traces']
 const traceDetailQueryKey = [...tracesCommonQueryKeys, 'trace-detailed']
 const tracesViewQueryKey = [...tracesCommonQueryKeys, 'view']
-const TWO_MINUTES = 2 * 60 * 1000
 
 export interface UseTracesViewQueryParams {
   params: Ref<TracesViewParams>
@@ -65,7 +64,6 @@ export function useTracesViewQuery ({ params, traceFilter }: UseTracesViewQueryP
       const cleanParams = computed(() => removeEmpty(params.value))
       return await tracesView(cleanFilter.value, cleanParams.value)
     },
-    staleTime: TWO_MINUTES,
     placeholderData: keepPreviousData
   })
 
@@ -87,7 +85,6 @@ export function useTracesSummaryQuery (): UseQueryReturnType<TracesSummaryDTO, B
     queryFn: async (): Promise<TracesSummaryDTO> => {
       return await getTracesSummary()
     },
-    staleTime: TWO_MINUTES,
   })
 }
 
@@ -116,7 +113,6 @@ export function useTracesConfigurationQuery (): UseQueryReturnType<TraceConfigur
     queryFn: async (): Promise<TraceConfigurationDTO> => {
       return await getTraceConfig()
     },
-    staleTime: TWO_MINUTES,
   })
 }
 
@@ -165,7 +161,6 @@ export function useTraceDetailedQuery (traceId: MaybeRef<string>) {
   const query = useQuery<TraceDetailDTO, BaseApiException, TraceDetailDTO, readonly unknown[]>({
     queryKey,
     queryFn,
-    staleTime: TWO_MINUTES,
     enabled: computed(() => toValue(traceId).trim().length > 0),
   })
 
@@ -222,7 +217,6 @@ export function useTracesAssociationQuery (
     queryKey,
     queryFn,
     enabled: computed(() => keyword.value.trim().length >= 3),
-    staleTime: TWO_MINUTES,
     initialPageParam: 0,
     getNextPageParam: (lastPage) => {
       const { page, totalPages } = lastPage.page

--- a/src/plugins/tanstack-query/tanstack-query.test.ts
+++ b/src/plugins/tanstack-query/tanstack-query.test.ts
@@ -17,6 +17,7 @@ BddTest().given('a tanstack query plugin', () => {
           defaultOptions: {
             queries: {
               retry: 3,
+              staleTime: 120000
             },
             mutations: {
               retry: 1,

--- a/src/plugins/tanstack-query/tanstack-query.ts
+++ b/src/plugins/tanstack-query/tanstack-query.ts
@@ -1,6 +1,8 @@
 import type { App } from 'vue'
 import { VueQueryPlugin, type VueQueryPluginOptions } from '@tanstack/vue-query'
 
+const DEFAULT_STALE_TIME = 2 * 60 * 1000
+
 export default {
   install (app: App) {
     const queryOptions: VueQueryPluginOptions = {
@@ -8,6 +10,7 @@ export default {
         defaultOptions: {
           queries: {
             retry: 3,
+            staleTime: DEFAULT_STALE_TIME,
           },
           mutations: {
             retry: 1,


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> Implements the declared experiences list feature for the personal career view. This includes:
> - New TanStack Query hook `useDeclaredExperiencesViewQuery` for fetching paginated declared experiences
> - Updated `DeclaredExperiencesTab` component with full pagination, loading states, and empty state handling
> - Added pagination state management in `personalCareer.store` for declared experiences
> - Created fixtures and MSW handlers for testing declared experiences API
> - Comprehensive unit tests for the query, store, and component

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/920

---

### Documentation
> No documentation changes required.

---

### Target Branch
> `develop`

---

### Additional Notes
> - Follows the same pattern as `DeclaredProgramsTab` for consistency
> - Uses `DeclaredExperienceCard` component to display each experience
> - Pagination state is persisted using pinia-plugin-persistedstate
> - Empty state message guides users to add their first declared experience

---

### Known Limitations or Side Effects
> None identified.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [x] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [x] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process