### PR TITLE
feat(957): add declared experience drawer

### DIFF
--- a/src/__mocks__/msw/handlers/student/declaredExperiences.handlers.ts
+++ b/src/__mocks__/msw/handlers/student/declaredExperiences.handlers.ts
@@ -36,6 +36,16 @@ export const declaredExperiencesQueryErrorHandler = http.get(`*${getGetDeclaredE
   )
 })
 
+export const createDeclaredExperienceErrorHandler = http.post(`*${getCreateDeclaredExperienceUrl()}`, () => {
+  return HttpResponse.json(
+    { message: 'Internal Server Error' },
+    {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' }
+    }
+  )
+})
+
 export const declaredExperiencesQueryEmptyHandler = http.get(`*${getGetDeclaredExperienceViewUrl()}`, async ({ request }) => {
   const url = new URL(request.url)
   const page = Number.parseInt(url.searchParams.get('page') ?? '0')

--- a/src/common/components/FormCancelConfirmButtons/FormCancelConfirmButtons.stub.ts
+++ b/src/common/components/FormCancelConfirmButtons/FormCancelConfirmButtons.stub.ts
@@ -1,0 +1,6 @@
+export const FormCancelConfirmButtonsStub = defineComponent({
+  name: 'FormCancelConfirmButtons',
+  props: ['isSubmitting', 'isFormValid', 'cancelLabel', 'confirmLabel'],
+  emits: ['handleCancel', 'handleSubmit'],
+  template: '<div data-testid="form-cancel-confirm-buttons-stub"></div>'
+})

--- a/src/common/components/FormCancelConfirmButtons/FormCancelConfirmButtons.vue
+++ b/src/common/components/FormCancelConfirmButtons/FormCancelConfirmButtons.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+import { AvCancelConfirmButtons, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
+import { useI18n } from 'vue-i18n'
+
+export interface FormCancelConfirmButtonsProps {
+  isSubmitting: boolean
+  isFormValid: boolean
+  cancelLabel?: string
+  confirmLabel?: string
+}
+
+const {
+  isSubmitting,
+  isFormValid,
+} = defineProps<FormCancelConfirmButtonsProps>()
+
+const emit = defineEmits<{
+  (e: 'handleCancel'): void
+  (e: 'handleSubmit'): void
+}>()
+
+const { t } = useI18n()
+</script>
+
+<template>
+  <AvCancelConfirmButtons
+    :cancel-label="cancelLabel ?? t('global.buttons.cancel')"
+    :confirm-label="confirmLabel ?? t('global.buttons.save')"
+    :cancel-icon="MDI_ICONS.CLOSE_CIRCLE_OUTLINE"
+    :confirm-icon="MDI_ICONS.CONTENT_SAVE_OUTLINE"
+    :cancel-disabled="isSubmitting"
+    :confirm-disabled="!isFormValid || isSubmitting"
+    :confirm-is-loading="isSubmitting"
+    @cancel="emit('handleCancel')"
+    @confirm="emit('handleSubmit')"
+  />
+</template>

--- a/src/common/components/index.ts
+++ b/src/common/components/index.ts
@@ -3,6 +3,7 @@ export { default as ConfirmationModal, type ConfirmationModalProps } from './Con
 export { CreationUpdateDateDetailsStub } from './CreationUpdateDateDetails/CreationUpdateDateDetails.stub'
 export { default as CreationUpdateDateDetails, type DeclaredSkillDateDetailsProps } from './CreationUpdateDateDetails/CreationUpdateDateDetails.vue'
 export { default as Footer } from './Footer/Footer.vue'
+export { default as FormCancelConfirmButtons, type FormCancelConfirmButtonsProps } from './FormCancelConfirmButtons/FormCancelConfirmButtons.vue'
 export { default as ImageUpload } from './ImageUpload/ImageUpload.vue'
 export { default as Loader, type LoaderColor, type LoaderProps, type LoaderSize } from './Loader/Loader.vue'
 export { default as PageTitle } from './PageTitle/PageTitle.vue'

--- a/src/common/composables/use-form-validators/use-form-validators.test.ts
+++ b/src/common/composables/use-form-validators/use-form-validators.test.ts
@@ -17,6 +17,7 @@ BddTest().given('a form validators composable', () => {
     BddTest().then('it should return validation functions', () => {
       expect(composableResult.validateRequired).toBeDefined()
       expect(composableResult.validateMaxLength).toBeDefined()
+      expect(composableResult.validateDateInterval).toBeDefined()
     })
   })
 
@@ -89,6 +90,65 @@ BddTest().given('a form validators composable', () => {
     BddTest().and('the value is under max length', () => {
       BddTest().then('it should return undefined', () => {
         const error = composableResult.validateMaxLength('Short', 10)
+        expect(error).toBeUndefined()
+      })
+    })
+  })
+
+  BddTest().when('validating ongoing interval', () => {
+    BddTest().and('startDate is missing', () => {
+      BddTest().then('it should return required error for startDate', () => {
+        const error = composableResult.validateDateInterval({
+          startDate: undefined,
+          endDate: '2025-06',
+          format: 'yyyy-MM'
+        })
+        expect(error).toBe('Ce champ est requis.')
+      })
+    })
+
+    BddTest().and('endDate is missing and not required', () => {
+      BddTest().then('it should return undefined (ongoing interval is valid)', () => {
+        const error = composableResult.validateDateInterval({
+          startDate: '2025-01',
+          endDate: null,
+          format: 'yyyy-MM',
+          isOnGoing: true
+        })
+        expect(error).toBeUndefined()
+      })
+    })
+
+    BddTest().and('endDate is missing and required', () => {
+      BddTest().then('it should return required error for endDate', () => {
+        const error = composableResult.validateDateInterval({
+          startDate: '2025-01',
+          endDate: null,
+          format: 'yyyy-MM',
+          isOnGoing: false
+        })
+        expect(error).toBe('Ce champ est requis.')
+      })
+    })
+
+    BddTest().and('endDate is before startDate', () => {
+      BddTest().then('it should return chronological error', () => {
+        const error = composableResult.validateDateInterval({
+          startDate: '2025-06',
+          endDate: '2025-05',
+          format: 'yyyy-MM'
+        })
+        expect(error).toBe('La date de fin doit être postérieure à la date de début')
+      })
+    })
+
+    BddTest().and('endDate is after startDate', () => {
+      BddTest().then('it should return undefined', () => {
+        const error = composableResult.validateDateInterval({
+          startDate: '2025-05',
+          endDate: '2025-06',
+          format: 'yyyy-MM'
+        })
         expect(error).toBeUndefined()
       })
     })

--- a/src/common/composables/use-form-validators/use-form-validators.ts
+++ b/src/common/composables/use-form-validators/use-form-validators.ts
@@ -1,5 +1,13 @@
+import { isBefore, parse } from 'date-fns'
 import isEmpty from 'lodash-es/isEmpty'
 import { useI18n } from 'vue-i18n'
+
+export interface validateDateIntervalArgs {
+  startDate: string | undefined | null
+  endDate: string | undefined | null
+  format: string
+  isOnGoing?: boolean
+}
 
 /**
  * useFormValidators returned result.
@@ -9,6 +17,12 @@ export interface UseFormValidatorsReturn {
   validateRequired: (value: string | undefined | null) => string | undefined
   /** Validates that a value does not exceed the maximum length */
   validateMaxLength: (value: string | undefined | null, maxLength: number) => string | undefined
+  /** Validates an interval where endDate can be null (ongoing). If endDate provided, it must be after startDate. */
+  validateDateInterval: (args: validateDateIntervalArgs) => string | undefined
+}
+
+export interface ValidationOptions {
+  isRequired?: boolean
 }
 
 /**
@@ -21,6 +35,7 @@ export interface UseFormValidatorsReturn {
  * @returns {UseFormValidatorsReturn} Object containing :
  *  - `validateRequired` (function) : returns an error message if the value is empty, undefined otherwise,
  *  - `validateMaxLength` (function) : returns an error message if the value exceeds the max length, undefined otherwise.
+ *  - `validateDateInterval` (function) : returns an error message if the end date is before the start date in an ongoing interval, undefined otherwise.
  */
 export function useFormValidators (): UseFormValidatorsReturn {
   const { t } = useI18n()
@@ -37,8 +52,34 @@ export function useFormValidators (): UseFormValidatorsReturn {
     }
   }
 
+  function validateDateInterval ({ startDate, endDate, format, isOnGoing = false }: validateDateIntervalArgs): string | undefined {
+    const startRequiredError = validateRequired(startDate)
+    if (startRequiredError) {
+      return startRequiredError
+    }
+
+    if (!isOnGoing) {
+      const endRequiredError = validateRequired(endDate)
+      if (endRequiredError) {
+        return endRequiredError
+      }
+    }
+
+    if (!endDate) {
+      return undefined
+    }
+
+    const parsedStartDate = parse(startDate as string, format, new Date())
+    const parsedEndDate = parse(endDate as string, format, new Date())
+
+    if (isBefore(parsedEndDate, parsedStartDate)) {
+      return t('global.dates.endDateBeforeStartDate')
+    }
+  }
+
   return {
     validateMaxLength,
-    validateRequired
+    validateRequired,
+    validateDateInterval
   }
 }

--- a/src/features/student/declaredSkills/components/overlays/AddDeclaredSkillDrawer/AddDeclaredSkillDrawer.vue
+++ b/src/features/student/declaredSkills/components/overlays/AddDeclaredSkillDrawer/AddDeclaredSkillDrawer.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ConfirmationModal } from '@/common/components'
+import { ConfirmationModal, FormCancelConfirmButtons } from '@/common/components'
 import { useModal } from '@/common/composables'
 import DeclaredSkillLevelRadioButtonSetFormField from '@/features/student/declaredSkills/components/interactions/formFields/DeclaredSkillLevelRadioButtonSetFormField/DeclaredSkillLevelRadioButtonSetFormField.vue'
 import AddDeclaredSkillAutocompleteField from '@/features/student/declaredSkills/components/overlays/AddDeclaredSkillDrawer/components/AddDeclaredSkillAutocompleteField/AddDeclaredSkillAutocompleteField.vue'
@@ -8,7 +8,7 @@ import {
 } from '@/features/student/declaredSkills/components/overlays/AddDeclaredSkillDrawer/use-declared-skill-form/use-declared-skill-form'
 import { useDeclaredSkillsStore } from '@/features/student/declaredSkills/stores/declaredSkills.store'
 import { useToasterStore } from '@/store'
-import { AvCancelConfirmButtons, AvDrawer, AvIconText, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
+import { AvDrawer, AvIconText, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
 import { useI18n } from 'vue-i18n'
 
 const { t } = useI18n()
@@ -89,16 +89,11 @@ function confirmCancel () {
         class="av-row av-justify-end av-p-md"
         data-testid="add-declared-skill-drawer__footer"
       >
-        <AvCancelConfirmButtons
-          :cancel-label="t('global.buttons.cancel')"
-          :confirm-label="t('global.buttons.save')"
-          :cancel-icon="MDI_ICONS.CLOSE_CIRCLE_OUTLINE"
-          :confirm-icon="MDI_ICONS.CONTENT_SAVE_OUTLINE"
-          :cancel-disabled="isSubmitting"
-          :confirm-disabled="!isFormValid || !isDirty || isSubmitting"
-          :confirm-is-loading="isSubmitting"
-          @cancel="handleCancel"
-          @confirm="form.handleSubmit"
+        <FormCancelConfirmButtons
+          :is-submitting="isSubmitting"
+          :is-form-valid="isFormValid && isDirty"
+          @handle-cancel="handleCancel"
+          @handle-submit="form.handleSubmit"
         />
       </div>
     </template>

--- a/src/features/student/declaredSkills/views/StudentUpdateDeclaredSkillView/components/UpdateDeclaredSkillForm/UpdateDeclaredSkillForm.vue
+++ b/src/features/student/declaredSkills/views/StudentUpdateDeclaredSkillView/components/UpdateDeclaredSkillForm/UpdateDeclaredSkillForm.vue
@@ -1,11 +1,11 @@
 <script lang="ts" setup>
 import type { DeclaredSkillProgressDetailsDTO } from '@/api/avenir-esr'
-import { CreationUpdateDateDetails } from '@/common/components'
+import { CreationUpdateDateDetails, FormCancelConfirmButtons } from '@/common/components'
 import DeclaredSkillRefCard from '@/features/student/declaredSkills/components/cards/DeclaredSkillRefCard/DeclaredSkillRefCard.vue'
 import DeclaredSkillCommentFormField from '@/features/student/declaredSkills/components/interactions/formFields/DeclaredSkillCommentFormField/DeclaredSkillCommentFormField.vue'
 import DeclaredSkillLevelRadioButtonSetFormField from '@/features/student/declaredSkills/components/interactions/formFields/DeclaredSkillLevelRadioButtonSetFormField/DeclaredSkillLevelRadioButtonSetFormField.vue'
 import { useUpdateDeclaredSkillForm } from '@/features/student/declaredSkills/views/StudentUpdateDeclaredSkillView/components/use-update-declared-skill-form/use-update-declared-skill-form'
-import { AvCancelConfirmButtons, AvCard, AvInput, MDI_ICONS, RI_ICONS } from '@avenirs-esr/avenirs-dsav'
+import { AvCard, AvInput, RI_ICONS } from '@avenirs-esr/avenirs-dsav'
 import capitalize from 'lodash-es/capitalize'
 import { useI18n } from 'vue-i18n'
 
@@ -100,16 +100,11 @@ const createdAtPrefix = computed(() => capitalize(t('student.skills.skill')))
         class="av-row av-justify-end"
         data-testid="update-declared-skill-form__actions"
       >
-        <AvCancelConfirmButtons
-          :cancel-label="t('global.buttons.cancel')"
-          :confirm-label="t('global.buttons.save')"
-          :cancel-icon="MDI_ICONS.CLOSE_CIRCLE_OUTLINE"
-          :confirm-icon="MDI_ICONS.CONTENT_SAVE_OUTLINE"
-          :cancel-disabled="isSubmitting"
-          :confirm-disabled="!isFormValid || isSubmitting"
-          :confirm-is-loading="isSubmitting"
-          @cancel="handleCancel"
-          @confirm="handleSubmit"
+        <FormCancelConfirmButtons
+          :is-submitting="isSubmitting"
+          :is-form-valid="isFormValid"
+          @handle-cancel="handleCancel"
+          @handle-submit="handleSubmit"
         />
       </div>
     </template>

--- a/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceActivitySectorFormField/DeclaredExperienceActivitySectorFormField.stub.ts
+++ b/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceActivitySectorFormField/DeclaredExperienceActivitySectorFormField.stub.ts
@@ -1,0 +1,7 @@
+import type { Component } from 'vue'
+
+export const DeclaredExperienceActivitySectorFormFieldStub: Component = {
+  name: 'DeclaredExperienceActivitySectorFormField',
+  props: ['form'],
+  template: '<div data-testid="experience-activity-sector-form-field" />'
+}

--- a/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceActivitySectorFormField/DeclaredExperienceActivitySectorFormField.stub.ts
+++ b/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceActivitySectorFormField/DeclaredExperienceActivitySectorFormField.stub.ts
@@ -1,7 +1,5 @@
-import type { Component } from 'vue'
-
-export const DeclaredExperienceActivitySectorFormFieldStub: Component = {
+export const DeclaredExperienceActivitySectorFormFieldStub = defineComponent({
   name: 'DeclaredExperienceActivitySectorFormField',
   props: ['form'],
   template: '<div data-testid="experience-activity-sector-form-field" />'
-}
+})

--- a/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceActivitySectorFormField/DeclaredExperienceActivitySectorFormField.test.ts
+++ b/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceActivitySectorFormField/DeclaredExperienceActivitySectorFormField.test.ts
@@ -1,0 +1,128 @@
+import type { AddDeclaredExperienceForm, DeclaredExperienceFormData } from '@/features/student/personalCareer/types/forms.types'
+import DeclaredExperienceActivitySectorFormField
+  from '@/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceActivitySectorFormField/DeclaredExperienceActivitySectorFormField.vue'
+import { DeclaredExperienceActivitySectorInputStub } from '@/features/student/personalCareer/components/interactions/inputs/DeclaredExperienceActivitySectorInput/DeclaredExperienceActivitySectorInput.stub'
+import { DECLARED_EXPERIENCE_ACTIVITY_SECTOR_MAX_LENGTH } from '@/features/student/personalCareer/config'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { useForm } from '@tanstack/vue-form'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { beforeEach, expect, vi } from 'vitest'
+
+const TestWrapper = defineComponent({
+  components: {
+    DeclaredExperienceActivitySectorFormField
+  },
+  setup () {
+    const form = useForm({
+      defaultValues: {
+        activitySector: ''
+      } as DeclaredExperienceFormData,
+      validators: {
+        onSubmit () {
+          return { fields: { activitySector: undefined } }
+        }
+      }
+    }) as unknown as AddDeclaredExperienceForm
+
+    return { form }
+  },
+  template: `
+    <form @submit.prevent="form.handleSubmit">
+      <DeclaredExperienceActivitySectorFormField :form="form" />
+    </form>
+  `
+})
+
+BddTest().given('a declared experience activity sector form field', () => {
+  let wrapper: VueWrapper<InstanceType<typeof TestWrapper>>
+
+  const stubs = {
+    DeclaredExperienceActivitySectorInput: DeclaredExperienceActivitySectorInputStub
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    wrapper = mount(TestWrapper, {
+      global: { stubs }
+    })
+  })
+
+  BddTest().when('the component is mounted', () => {
+    BddTest().then('it should render the activity sector input component', () => {
+      const input = wrapper.findComponent({ name: 'DeclaredExperienceActivitySectorInput' })
+      expect(input.exists()).toBe(true)
+    })
+
+    BddTest().then('it should have empty initial value', () => {
+      const input = wrapper.findComponent({ name: 'DeclaredExperienceActivitySectorInput' })
+      expect(input.props('modelValue')).toBe('')
+    })
+
+    BddTest().and('the user enters an activity sector', () => {
+      BddTest().then('it should update the form field value', async () => {
+        const input = wrapper.findComponent({ name: 'DeclaredExperienceActivitySectorInput' })
+        const textInput = input.find('input')
+        await textInput.setValue('Technology')
+        await wrapper.vm.$nextTick()
+
+        await vi.waitFor(() => {
+          const updated = wrapper.findComponent({ name: 'DeclaredExperienceActivitySectorInput' })
+          expect(updated.props('modelValue')).toBe('Technology')
+        })
+      })
+    })
+
+    BddTest().and('the user enters an activity sector exceeding max length', () => {
+      BddTest().then('it should truncate the value to max length', async () => {
+        const input = wrapper.findComponent({ name: 'DeclaredExperienceActivitySectorInput' })
+        const textInput = input.find('input')
+        const longSector = 'a'.repeat(DECLARED_EXPERIENCE_ACTIVITY_SECTOR_MAX_LENGTH + 10)
+        await textInput.setValue(longSector)
+        await wrapper.vm.$nextTick()
+
+        await vi.waitFor(() => {
+          const updated = wrapper.findComponent({ name: 'DeclaredExperienceActivitySectorInput' })
+          expect(updated.props('modelValue')).toHaveLength(DECLARED_EXPERIENCE_ACTIVITY_SECTOR_MAX_LENGTH)
+        })
+      })
+    })
+
+    BddTest().and('the input emits blur', () => {
+      BddTest().then('it should trigger blur handler', async () => {
+        const input = wrapper.findComponent({ name: 'DeclaredExperienceActivitySectorInput' })
+        await input.vm.$emit('blur')
+        await wrapper.vm.$nextTick()
+
+        expect(input.emitted('blur')).toBeTruthy()
+      })
+    })
+
+    BddTest().and('the form is submitted with empty activity sector', () => {
+      BddTest().then('it should not show validation error because it is optional', async () => {
+        await wrapper.find('form').trigger('submit')
+        await wrapper.vm.$nextTick()
+
+        await vi.waitFor(() => {
+          const input = wrapper.findComponent({ name: 'DeclaredExperienceActivitySectorInput' })
+          expect(input.props('errorMessage')).toBeFalsy()
+        })
+      })
+    })
+
+    BddTest().and('the form is submitted with valid activity sector', () => {
+      BddTest().then('it should not show validation error', async () => {
+        const input = wrapper.findComponent({ name: 'DeclaredExperienceActivitySectorInput' })
+        const textInput = input.find('input')
+        await textInput.setValue('Healthcare')
+        await wrapper.vm.$nextTick()
+        await wrapper.find('form').trigger('submit')
+        await wrapper.vm.$nextTick()
+
+        await vi.waitFor(() => {
+          const updated = wrapper.findComponent({ name: 'DeclaredExperienceActivitySectorInput' })
+          expect(updated.props('errorMessage')).toBeFalsy()
+        })
+      })
+    })
+  })
+})

--- a/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceActivitySectorFormField/DeclaredExperienceActivitySectorFormField.test.ts
+++ b/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceActivitySectorFormField/DeclaredExperienceActivitySectorFormField.test.ts
@@ -2,35 +2,20 @@ import type { AddDeclaredExperienceForm, DeclaredExperienceFormData } from '@/fe
 import DeclaredExperienceActivitySectorFormField
   from '@/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceActivitySectorFormField/DeclaredExperienceActivitySectorFormField.vue'
 import { DeclaredExperienceActivitySectorInputStub } from '@/features/student/personalCareer/components/interactions/inputs/DeclaredExperienceActivitySectorInput/DeclaredExperienceActivitySectorInput.stub'
+import {
+  useDeclaredExperienceFormValidators
+} from '@/features/student/personalCareer/composables/use-declared-experience-form-validators/use-declared-experience-form-validators'
 import { DECLARED_EXPERIENCE_ACTIVITY_SECTOR_MAX_LENGTH } from '@/features/student/personalCareer/config'
 import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
-import { useForm } from '@tanstack/vue-form'
 import { mount, type VueWrapper } from '@vue/test-utils'
+import { createFormFieldTestWrapper } from 'tests/utils'
 import { beforeEach, expect, vi } from 'vitest'
 
-const TestWrapper = defineComponent({
-  components: {
-    DeclaredExperienceActivitySectorFormField
-  },
-  setup () {
-    const form = useForm({
-      defaultValues: {
-        activitySector: ''
-      } as DeclaredExperienceFormData,
-      validators: {
-        onSubmit () {
-          return { fields: { activitySector: undefined } }
-        }
-      }
-    }) as unknown as AddDeclaredExperienceForm
-
-    return { form }
-  },
-  template: `
-    <form @submit.prevent="form.handleSubmit">
-      <DeclaredExperienceActivitySectorFormField :form="form" />
-    </form>
-  `
+const TestWrapper = createFormFieldTestWrapper<AddDeclaredExperienceForm, DeclaredExperienceFormData, 'activitySector'>({
+  formFieldComponent: DeclaredExperienceActivitySectorFormField,
+  fieldName: 'activitySector',
+  defaultValue: '',
+  useValidator: () => useDeclaredExperienceFormValidators().validateActivitySector
 })
 
 BddTest().given('a declared experience activity sector form field', () => {

--- a/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceActivitySectorFormField/DeclaredExperienceActivitySectorFormField.vue
+++ b/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceActivitySectorFormField/DeclaredExperienceActivitySectorFormField.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import type { AddDeclaredExperienceForm } from '@/features/student/personalCareer/types/forms.types'
+import DeclaredExperienceActivitySectorInput from '@/features/student/personalCareer/components/interactions/inputs/DeclaredExperienceActivitySectorInput/DeclaredExperienceActivitySectorInput.vue'
+import { DECLARED_EXPERIENCE_ACTIVITY_SECTOR_MAX_LENGTH } from '@/features/student/personalCareer/config'
+import { markRaw } from 'vue'
+
+interface DeclaredExperienceActivitySectorFormFieldProps {
+  form: AddDeclaredExperienceForm
+}
+
+defineOptions({
+  inheritAttrs: false
+})
+
+const { form } = defineProps<DeclaredExperienceActivitySectorFormFieldProps>()
+const FormField = markRaw(form.Field)
+const activitySectorField = form.useField({ name: 'activitySector' })
+
+function onUpdateActivitySector (value: string | undefined) {
+  activitySectorField.api.handleChange(String(value ?? '').slice(0, DECLARED_EXPERIENCE_ACTIVITY_SECTOR_MAX_LENGTH))
+}
+</script>
+
+<template>
+  <FormField name="activitySector">
+    <template #default="{ field }">
+      <DeclaredExperienceActivitySectorInput
+        v-bind="$attrs"
+        :model-value="(field.state.value ?? '').slice(0, DECLARED_EXPERIENCE_ACTIVITY_SECTOR_MAX_LENGTH)"
+        :error-message="field.state.meta.errors?.join(', ')"
+        @blur="field.handleBlur"
+        @update:model-value="onUpdateActivitySector"
+      />
+    </template>
+  </FormField>
+</template>

--- a/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceDescriptionFormField/DeclaredExperienceDescriptionFormField.stub.ts
+++ b/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceDescriptionFormField/DeclaredExperienceDescriptionFormField.stub.ts
@@ -1,0 +1,7 @@
+import type { Component } from 'vue'
+
+export const DeclaredExperienceDescriptionFormFieldStub: Component = {
+  name: 'DeclaredExperienceDescriptionFormField',
+  props: ['form'],
+  template: '<div data-testid="experience-description-form-field" />'
+}

--- a/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceDescriptionFormField/DeclaredExperienceDescriptionFormField.stub.ts
+++ b/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceDescriptionFormField/DeclaredExperienceDescriptionFormField.stub.ts
@@ -1,7 +1,5 @@
-import type { Component } from 'vue'
-
-export const DeclaredExperienceDescriptionFormFieldStub: Component = {
+export const DeclaredExperienceDescriptionFormFieldStub = defineComponent({
   name: 'DeclaredExperienceDescriptionFormField',
   props: ['form'],
   template: '<div data-testid="experience-description-form-field" />'
-}
+})

--- a/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceDescriptionFormField/DeclaredExperienceDescriptionFormField.test.ts
+++ b/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceDescriptionFormField/DeclaredExperienceDescriptionFormField.test.ts
@@ -1,0 +1,128 @@
+import type { AddDeclaredExperienceForm, DeclaredExperienceFormData } from '@/features/student/personalCareer/types/forms.types'
+import DeclaredExperienceDescriptionFormField
+  from '@/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceDescriptionFormField/DeclaredExperienceDescriptionFormField.vue'
+import { DeclaredExperienceDescriptionTextareaStub } from '@/features/student/personalCareer/components/interactions/inputs/DeclaredExperienceDescriptionTextarea/DeclaredExperienceDescriptionTextarea.stub'
+import { DECLARED_EXPERIENCE_DESCRIPTION_MAX_LENGTH } from '@/features/student/personalCareer/config'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { useForm } from '@tanstack/vue-form'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { beforeEach, expect, vi } from 'vitest'
+
+const TestWrapper = defineComponent({
+  components: {
+    DeclaredExperienceDescriptionFormField
+  },
+  setup () {
+    const form = useForm({
+      defaultValues: {
+        description: ''
+      } as DeclaredExperienceFormData,
+      validators: {
+        onSubmit () {
+          return { fields: { description: undefined } }
+        }
+      }
+    }) as unknown as AddDeclaredExperienceForm
+
+    return { form }
+  },
+  template: `
+    <form @submit.prevent="form.handleSubmit">
+      <DeclaredExperienceDescriptionFormField :form="form" />
+    </form>
+  `
+})
+
+BddTest().given('a declared experience description form field', () => {
+  let wrapper: VueWrapper<InstanceType<typeof TestWrapper>>
+
+  const stubs = {
+    DeclaredExperienceDescriptionTextarea: DeclaredExperienceDescriptionTextareaStub
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    wrapper = mount(TestWrapper, {
+      global: { stubs }
+    })
+  })
+
+  BddTest().when('the component is mounted', () => {
+    BddTest().then('it should render the description textarea component', () => {
+      const textarea = wrapper.findComponent({ name: 'DeclaredExperienceDescriptionTextarea' })
+      expect(textarea.exists()).toBe(true)
+    })
+
+    BddTest().then('it should have empty initial value', () => {
+      const textarea = wrapper.findComponent({ name: 'DeclaredExperienceDescriptionTextarea' })
+      expect(textarea.props('modelValue')).toBe('')
+    })
+
+    BddTest().and('the user enters a description', () => {
+      BddTest().then('it should update the form field value', async () => {
+        const textarea = wrapper.findComponent({ name: 'DeclaredExperienceDescriptionTextarea' })
+        const textInput = textarea.find('textarea')
+        await textInput.setValue('A detailed description of my experience')
+        await wrapper.vm.$nextTick()
+
+        await vi.waitFor(() => {
+          const updated = wrapper.findComponent({ name: 'DeclaredExperienceDescriptionTextarea' })
+          expect(updated.props('modelValue')).toBe('A detailed description of my experience')
+        })
+      })
+    })
+
+    BddTest().and('the user enters a description exceeding max length', () => {
+      BddTest().then('it should truncate the value to max length', async () => {
+        const textarea = wrapper.findComponent({ name: 'DeclaredExperienceDescriptionTextarea' })
+        const textInput = textarea.find('textarea')
+        const longDescription = 'a'.repeat(DECLARED_EXPERIENCE_DESCRIPTION_MAX_LENGTH + 10)
+        await textInput.setValue(longDescription)
+        await wrapper.vm.$nextTick()
+
+        await vi.waitFor(() => {
+          const updated = wrapper.findComponent({ name: 'DeclaredExperienceDescriptionTextarea' })
+          expect(updated.props('modelValue')).toHaveLength(DECLARED_EXPERIENCE_DESCRIPTION_MAX_LENGTH)
+        })
+      })
+    })
+
+    BddTest().and('the textarea emits blur', () => {
+      BddTest().then('it should trigger blur handler', async () => {
+        const textarea = wrapper.findComponent({ name: 'DeclaredExperienceDescriptionTextarea' })
+        await textarea.vm.$emit('blur')
+        await wrapper.vm.$nextTick()
+
+        expect(textarea.emitted('blur')).toBeTruthy()
+      })
+    })
+
+    BddTest().and('the form is submitted with empty description', () => {
+      BddTest().then('it should not show validation error because it is optional', async () => {
+        await wrapper.find('form').trigger('submit')
+        await wrapper.vm.$nextTick()
+
+        await vi.waitFor(() => {
+          const textarea = wrapper.findComponent({ name: 'DeclaredExperienceDescriptionTextarea' })
+          expect(textarea.props('errorMessage')).toBeFalsy()
+        })
+      })
+    })
+
+    BddTest().and('the form is submitted with valid description', () => {
+      BddTest().then('it should not show validation error', async () => {
+        const textarea = wrapper.findComponent({ name: 'DeclaredExperienceDescriptionTextarea' })
+        const textInput = textarea.find('textarea')
+        await textInput.setValue('Valid description of experience')
+        await wrapper.vm.$nextTick()
+        await wrapper.find('form').trigger('submit')
+        await wrapper.vm.$nextTick()
+
+        await vi.waitFor(() => {
+          const updated = wrapper.findComponent({ name: 'DeclaredExperienceDescriptionTextarea' })
+          expect(updated.props('errorMessage')).toBeFalsy()
+        })
+      })
+    })
+  })
+})

--- a/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceDescriptionFormField/DeclaredExperienceDescriptionFormField.test.ts
+++ b/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceDescriptionFormField/DeclaredExperienceDescriptionFormField.test.ts
@@ -2,35 +2,20 @@ import type { AddDeclaredExperienceForm, DeclaredExperienceFormData } from '@/fe
 import DeclaredExperienceDescriptionFormField
   from '@/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceDescriptionFormField/DeclaredExperienceDescriptionFormField.vue'
 import { DeclaredExperienceDescriptionTextareaStub } from '@/features/student/personalCareer/components/interactions/inputs/DeclaredExperienceDescriptionTextarea/DeclaredExperienceDescriptionTextarea.stub'
+import {
+  useDeclaredExperienceFormValidators
+} from '@/features/student/personalCareer/composables/use-declared-experience-form-validators/use-declared-experience-form-validators'
 import { DECLARED_EXPERIENCE_DESCRIPTION_MAX_LENGTH } from '@/features/student/personalCareer/config'
 import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
-import { useForm } from '@tanstack/vue-form'
 import { mount, type VueWrapper } from '@vue/test-utils'
+import { createFormFieldTestWrapper } from 'tests/utils'
 import { beforeEach, expect, vi } from 'vitest'
 
-const TestWrapper = defineComponent({
-  components: {
-    DeclaredExperienceDescriptionFormField
-  },
-  setup () {
-    const form = useForm({
-      defaultValues: {
-        description: ''
-      } as DeclaredExperienceFormData,
-      validators: {
-        onSubmit () {
-          return { fields: { description: undefined } }
-        }
-      }
-    }) as unknown as AddDeclaredExperienceForm
-
-    return { form }
-  },
-  template: `
-    <form @submit.prevent="form.handleSubmit">
-      <DeclaredExperienceDescriptionFormField :form="form" />
-    </form>
-  `
+const TestWrapper = createFormFieldTestWrapper<AddDeclaredExperienceForm, DeclaredExperienceFormData, 'description'>({
+  formFieldComponent: DeclaredExperienceDescriptionFormField,
+  fieldName: 'description',
+  defaultValue: '',
+  useValidator: () => useDeclaredExperienceFormValidators().validateDescription
 })
 
 BddTest().given('a declared experience description form field', () => {

--- a/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceDescriptionFormField/DeclaredExperienceDescriptionFormField.vue
+++ b/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceDescriptionFormField/DeclaredExperienceDescriptionFormField.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import type { AddDeclaredExperienceForm } from '@/features/student/personalCareer/types/forms.types'
+import DeclaredExperienceDescriptionTextarea from '@/features/student/personalCareer/components/interactions/inputs/DeclaredExperienceDescriptionTextarea/DeclaredExperienceDescriptionTextarea.vue'
+import { DECLARED_EXPERIENCE_DESCRIPTION_MAX_LENGTH } from '@/features/student/personalCareer/config'
+import { markRaw } from 'vue'
+
+interface DeclaredExperienceDescriptionFormFieldProps {
+  form: AddDeclaredExperienceForm
+}
+
+defineOptions({
+  inheritAttrs: false
+})
+
+const { form } = defineProps<DeclaredExperienceDescriptionFormFieldProps>()
+const FormField = markRaw(form.Field)
+const descriptionField = form.useField({ name: 'description' })
+
+function onUpdateDescription (value: string | undefined) {
+  descriptionField.api.handleChange(String(value ?? '').slice(0, DECLARED_EXPERIENCE_DESCRIPTION_MAX_LENGTH))
+}
+</script>
+
+<template>
+  <FormField name="description">
+    <template #default="{ field }">
+      <DeclaredExperienceDescriptionTextarea
+        v-bind="$attrs"
+        :model-value="(field.state.value ?? '').slice(0, DECLARED_EXPERIENCE_DESCRIPTION_MAX_LENGTH)"
+        :error-message="field.state.meta.errors?.join(', ')"
+        @blur="field.handleBlur"
+        @update:model-value="onUpdateDescription"
+      />
+    </template>
+  </FormField>
+</template>

--- a/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceLinkFormField/DeclaredExperienceLinkFormField.stub.ts
+++ b/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceLinkFormField/DeclaredExperienceLinkFormField.stub.ts
@@ -1,7 +1,5 @@
-import type { Component } from 'vue'
-
-export const DeclaredExperienceLinkFormFieldStub: Component = {
+export const DeclaredExperienceLinkFormFieldStub = defineComponent({
   name: 'DeclaredExperienceLinkFormField',
   props: ['form'],
   template: '<div data-testid="experience-link-form-field" />'
-}
+})

--- a/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceLinkFormField/DeclaredExperienceLinkFormField.stub.ts
+++ b/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceLinkFormField/DeclaredExperienceLinkFormField.stub.ts
@@ -1,0 +1,7 @@
+import type { Component } from 'vue'
+
+export const DeclaredExperienceLinkFormFieldStub: Component = {
+  name: 'DeclaredExperienceLinkFormField',
+  props: ['form'],
+  template: '<div data-testid="experience-link-form-field" />'
+}

--- a/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceLinkFormField/DeclaredExperienceLinkFormField.test.ts
+++ b/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceLinkFormField/DeclaredExperienceLinkFormField.test.ts
@@ -1,0 +1,128 @@
+import type { AddDeclaredExperienceForm, DeclaredExperienceFormData } from '@/features/student/personalCareer/types/forms.types'
+import DeclaredExperienceLinkFormField
+  from '@/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceLinkFormField/DeclaredExperienceLinkFormField.vue'
+import { DeclaredExperienceLinkInputStub } from '@/features/student/personalCareer/components/interactions/inputs/DeclaredExperienceLinkInput/DeclaredExperienceLinkInput.stub'
+import { DECLARED_EXPERIENCE_LINK_MAX_LENGTH } from '@/features/student/personalCareer/config'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { useForm } from '@tanstack/vue-form'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { beforeEach, expect, vi } from 'vitest'
+
+const TestWrapper = defineComponent({
+  components: {
+    DeclaredExperienceLinkFormField
+  },
+  setup () {
+    const form = useForm({
+      defaultValues: {
+        link: ''
+      } as DeclaredExperienceFormData,
+      validators: {
+        onSubmit () {
+          return { fields: { link: undefined } }
+        }
+      }
+    }) as unknown as AddDeclaredExperienceForm
+
+    return { form }
+  },
+  template: `
+    <form @submit.prevent="form.handleSubmit">
+      <DeclaredExperienceLinkFormField :form="form" />
+    </form>
+  `
+})
+
+BddTest().given('a declared experience link form field', () => {
+  let wrapper: VueWrapper<InstanceType<typeof TestWrapper>>
+
+  const stubs = {
+    DeclaredExperienceLinkInput: DeclaredExperienceLinkInputStub
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    wrapper = mount(TestWrapper, {
+      global: { stubs }
+    })
+  })
+
+  BddTest().when('the component is mounted', () => {
+    BddTest().then('it should render the link input component', () => {
+      const input = wrapper.findComponent({ name: 'DeclaredExperienceLinkInput' })
+      expect(input.exists()).toBe(true)
+    })
+
+    BddTest().then('it should have empty initial value', () => {
+      const input = wrapper.findComponent({ name: 'DeclaredExperienceLinkInput' })
+      expect(input.props('modelValue')).toBe('')
+    })
+
+    BddTest().and('the user enters a link', () => {
+      BddTest().then('it should update the form field value', async () => {
+        const input = wrapper.findComponent({ name: 'DeclaredExperienceLinkInput' })
+        const textInput = input.find('input')
+        await textInput.setValue('https://example.com/experience')
+        await wrapper.vm.$nextTick()
+
+        await vi.waitFor(() => {
+          const updated = wrapper.findComponent({ name: 'DeclaredExperienceLinkInput' })
+          expect(updated.props('modelValue')).toBe('https://example.com/experience')
+        })
+      })
+    })
+
+    BddTest().and('the user enters a link exceeding max length', () => {
+      BddTest().then('it should truncate the value to max length', async () => {
+        const input = wrapper.findComponent({ name: 'DeclaredExperienceLinkInput' })
+        const textInput = input.find('input')
+        const longLink = `https://example.com/${'a'.repeat(DECLARED_EXPERIENCE_LINK_MAX_LENGTH)}`
+        await textInput.setValue(longLink)
+        await wrapper.vm.$nextTick()
+
+        await vi.waitFor(() => {
+          const updated = wrapper.findComponent({ name: 'DeclaredExperienceLinkInput' })
+          expect(updated.props('modelValue')).toHaveLength(DECLARED_EXPERIENCE_LINK_MAX_LENGTH)
+        })
+      })
+    })
+
+    BddTest().and('the input emits blur', () => {
+      BddTest().then('it should trigger blur handler', async () => {
+        const input = wrapper.findComponent({ name: 'DeclaredExperienceLinkInput' })
+        await input.vm.$emit('blur')
+        await wrapper.vm.$nextTick()
+
+        expect(input.emitted('blur')).toBeTruthy()
+      })
+    })
+
+    BddTest().and('the form is submitted with empty link', () => {
+      BddTest().then('it should not show validation error because it is optional', async () => {
+        await wrapper.find('form').trigger('submit')
+        await wrapper.vm.$nextTick()
+
+        await vi.waitFor(() => {
+          const input = wrapper.findComponent({ name: 'DeclaredExperienceLinkInput' })
+          expect(input.props('errorMessage')).toBeFalsy()
+        })
+      })
+    })
+
+    BddTest().and('the form is submitted with valid link', () => {
+      BddTest().then('it should not show validation error', async () => {
+        const input = wrapper.findComponent({ name: 'DeclaredExperienceLinkInput' })
+        const textInput = input.find('input')
+        await textInput.setValue('https://example.com')
+        await wrapper.vm.$nextTick()
+        await wrapper.find('form').trigger('submit')
+        await wrapper.vm.$nextTick()
+
+        await vi.waitFor(() => {
+          const updated = wrapper.findComponent({ name: 'DeclaredExperienceLinkInput' })
+          expect(updated.props('errorMessage')).toBeFalsy()
+        })
+      })
+    })
+  })
+})

--- a/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceLinkFormField/DeclaredExperienceLinkFormField.test.ts
+++ b/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceLinkFormField/DeclaredExperienceLinkFormField.test.ts
@@ -4,33 +4,15 @@ import DeclaredExperienceLinkFormField
 import { DeclaredExperienceLinkInputStub } from '@/features/student/personalCareer/components/interactions/inputs/DeclaredExperienceLinkInput/DeclaredExperienceLinkInput.stub'
 import { DECLARED_EXPERIENCE_LINK_MAX_LENGTH } from '@/features/student/personalCareer/config'
 import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
-import { useForm } from '@tanstack/vue-form'
 import { mount, type VueWrapper } from '@vue/test-utils'
+import { createFormFieldTestWrapper } from 'tests/utils'
 import { beforeEach, expect, vi } from 'vitest'
 
-const TestWrapper = defineComponent({
-  components: {
-    DeclaredExperienceLinkFormField
-  },
-  setup () {
-    const form = useForm({
-      defaultValues: {
-        link: ''
-      } as DeclaredExperienceFormData,
-      validators: {
-        onSubmit () {
-          return { fields: { link: undefined } }
-        }
-      }
-    }) as unknown as AddDeclaredExperienceForm
-
-    return { form }
-  },
-  template: `
-    <form @submit.prevent="form.handleSubmit">
-      <DeclaredExperienceLinkFormField :form="form" />
-    </form>
-  `
+const TestWrapper = createFormFieldTestWrapper<AddDeclaredExperienceForm, DeclaredExperienceFormData, 'link'>({
+  formFieldComponent: DeclaredExperienceLinkFormField,
+  fieldName: 'link',
+  defaultValue: '',
+  useValidator: () => () => undefined
 })
 
 BddTest().given('a declared experience link form field', () => {

--- a/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceLinkFormField/DeclaredExperienceLinkFormField.vue
+++ b/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceLinkFormField/DeclaredExperienceLinkFormField.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import type { AddDeclaredExperienceForm } from '@/features/student/personalCareer/types/forms.types'
+import DeclaredExperienceLinkInput from '@/features/student/personalCareer/components/interactions/inputs/DeclaredExperienceLinkInput/DeclaredExperienceLinkInput.vue'
+import { DECLARED_EXPERIENCE_LINK_MAX_LENGTH } from '@/features/student/personalCareer/config'
+import { markRaw } from 'vue'
+
+interface DeclaredExperienceLinkFormFieldProps {
+  form: AddDeclaredExperienceForm
+}
+
+defineOptions({
+  inheritAttrs: false
+})
+
+const { form } = defineProps<DeclaredExperienceLinkFormFieldProps>()
+const FormField = markRaw(form.Field)
+const linkField = form.useField({ name: 'link' })
+
+function onUpdateLink (value: string | undefined) {
+  linkField.api.handleChange(String(value ?? '').slice(0, DECLARED_EXPERIENCE_LINK_MAX_LENGTH))
+}
+</script>
+
+<template>
+  <FormField name="link">
+    <template #default="{ field }">
+      <DeclaredExperienceLinkInput
+        v-bind="$attrs"
+        :model-value="(field.state.value ?? '').slice(0, DECLARED_EXPERIENCE_LINK_MAX_LENGTH)"
+        :error-message="field.state.meta.errors?.join(', ')"
+        @blur="field.handleBlur"
+        @update:model-value="onUpdateLink"
+      />
+    </template>
+  </FormField>
+</template>

--- a/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceLocationFormField/DeclaredExperienceLocationFormField.stub.ts
+++ b/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceLocationFormField/DeclaredExperienceLocationFormField.stub.ts
@@ -1,7 +1,5 @@
-import type { Component } from 'vue'
-
-export const DeclaredExperienceLocationFormFieldStub: Component = {
+export const DeclaredExperienceLocationFormFieldStub = defineComponent({
   name: 'DeclaredExperienceLocationFormField',
   props: ['form'],
   template: '<div data-testid="experience-location-form-field" />'
-}
+})

--- a/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceLocationFormField/DeclaredExperienceLocationFormField.stub.ts
+++ b/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceLocationFormField/DeclaredExperienceLocationFormField.stub.ts
@@ -1,0 +1,7 @@
+import type { Component } from 'vue'
+
+export const DeclaredExperienceLocationFormFieldStub: Component = {
+  name: 'DeclaredExperienceLocationFormField',
+  props: ['form'],
+  template: '<div data-testid="experience-location-form-field" />'
+}

--- a/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceLocationFormField/DeclaredExperienceLocationFormField.test.ts
+++ b/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceLocationFormField/DeclaredExperienceLocationFormField.test.ts
@@ -1,0 +1,132 @@
+import type { AddDeclaredExperienceForm, DeclaredExperienceFormData } from '@/features/student/personalCareer/types/forms.types'
+import DeclaredExperienceLocationFormField
+  from '@/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceLocationFormField/DeclaredExperienceLocationFormField.vue'
+import { DeclaredExperienceLocationInputStub } from '@/features/student/personalCareer/components/interactions/inputs/DeclaredExperienceLocationInput/DeclaredExperienceLocationInput.stub'
+import {
+  useDeclaredExperienceFormValidators
+} from '@/features/student/personalCareer/composables/use-declared-experience-form-validators/use-declared-experience-form-validators'
+import { DECLARED_EXPERIENCE_LOCATION_MAX_LENGTH } from '@/features/student/personalCareer/config'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { useForm } from '@tanstack/vue-form'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { beforeEach, expect, vi } from 'vitest'
+
+const TestWrapper = defineComponent({
+  components: {
+    DeclaredExperienceLocationFormField
+  },
+  setup () {
+    const { validateLocation } = useDeclaredExperienceFormValidators()
+    const form = useForm({
+      defaultValues: {
+        location: ''
+      } as DeclaredExperienceFormData,
+      validators: {
+        onSubmit ({ value }: { value: DeclaredExperienceFormData }) {
+          return { fields: { location: validateLocation(value.location) } }
+        }
+      }
+    }) as unknown as AddDeclaredExperienceForm
+
+    return { form }
+  },
+  template: `
+    <form @submit.prevent="form.handleSubmit">
+      <DeclaredExperienceLocationFormField :form="form" />
+    </form>
+  `
+})
+
+BddTest().given('a declared experience location form field', () => {
+  let wrapper: VueWrapper<InstanceType<typeof TestWrapper>>
+
+  const stubs = {
+    DeclaredExperienceLocationInput: DeclaredExperienceLocationInputStub
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    wrapper = mount(TestWrapper, {
+      global: { stubs }
+    })
+  })
+
+  BddTest().when('the component is mounted', () => {
+    BddTest().then('it should render the location input component', () => {
+      const input = wrapper.findComponent({ name: 'DeclaredExperienceLocationInput' })
+      expect(input.exists()).toBe(true)
+    })
+
+    BddTest().then('it should have empty initial value', () => {
+      const input = wrapper.findComponent({ name: 'DeclaredExperienceLocationInput' })
+      expect(input.props('modelValue')).toBe('')
+    })
+
+    BddTest().and('the user enters a location', () => {
+      BddTest().then('it should update the form field value', async () => {
+        const input = wrapper.findComponent({ name: 'DeclaredExperienceLocationInput' })
+        const textInput = input.find('input')
+        await textInput.setValue('Paris, France')
+        await wrapper.vm.$nextTick()
+
+        await vi.waitFor(() => {
+          const updated = wrapper.findComponent({ name: 'DeclaredExperienceLocationInput' })
+          expect(updated.props('modelValue')).toBe('Paris, France')
+        })
+      })
+    })
+
+    BddTest().and('the user enters a location exceeding max length', () => {
+      BddTest().then('it should truncate the value to max length', async () => {
+        const input = wrapper.findComponent({ name: 'DeclaredExperienceLocationInput' })
+        const textInput = input.find('input')
+        const longLocation = 'a'.repeat(DECLARED_EXPERIENCE_LOCATION_MAX_LENGTH + 10)
+        await textInput.setValue(longLocation)
+        await wrapper.vm.$nextTick()
+
+        await vi.waitFor(() => {
+          const updated = wrapper.findComponent({ name: 'DeclaredExperienceLocationInput' })
+          expect(updated.props('modelValue')).toHaveLength(DECLARED_EXPERIENCE_LOCATION_MAX_LENGTH)
+        })
+      })
+    })
+
+    BddTest().and('the input emits blur', () => {
+      BddTest().then('it should trigger blur handler', async () => {
+        const input = wrapper.findComponent({ name: 'DeclaredExperienceLocationInput' })
+        await input.vm.$emit('blur')
+        await wrapper.vm.$nextTick()
+
+        expect(input.emitted('blur')).toBeTruthy()
+      })
+    })
+
+    BddTest().and('the form is submitted with empty location', () => {
+      BddTest().then('it should not show validation error because it is optional', async () => {
+        await wrapper.find('form').trigger('submit')
+        await wrapper.vm.$nextTick()
+
+        await vi.waitFor(() => {
+          const input = wrapper.findComponent({ name: 'DeclaredExperienceLocationInput' })
+          expect(input.props('errorMessage')).toBeFalsy()
+        })
+      })
+    })
+
+    BddTest().and('the form is submitted with valid location', () => {
+      BddTest().then('it should not show validation error', async () => {
+        const input = wrapper.findComponent({ name: 'DeclaredExperienceLocationInput' })
+        const textInput = input.find('input')
+        await textInput.setValue('Lyon, France')
+        await wrapper.vm.$nextTick()
+        await wrapper.find('form').trigger('submit')
+        await wrapper.vm.$nextTick()
+
+        await vi.waitFor(() => {
+          const updated = wrapper.findComponent({ name: 'DeclaredExperienceLocationInput' })
+          expect(updated.props('errorMessage')).toBeFalsy()
+        })
+      })
+    })
+  })
+})

--- a/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceLocationFormField/DeclaredExperienceLocationFormField.test.ts
+++ b/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceLocationFormField/DeclaredExperienceLocationFormField.test.ts
@@ -7,34 +7,15 @@ import {
 } from '@/features/student/personalCareer/composables/use-declared-experience-form-validators/use-declared-experience-form-validators'
 import { DECLARED_EXPERIENCE_LOCATION_MAX_LENGTH } from '@/features/student/personalCareer/config'
 import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
-import { useForm } from '@tanstack/vue-form'
 import { mount, type VueWrapper } from '@vue/test-utils'
+import { createFormFieldTestWrapper } from 'tests/utils'
 import { beforeEach, expect, vi } from 'vitest'
 
-const TestWrapper = defineComponent({
-  components: {
-    DeclaredExperienceLocationFormField
-  },
-  setup () {
-    const { validateLocation } = useDeclaredExperienceFormValidators()
-    const form = useForm({
-      defaultValues: {
-        location: ''
-      } as DeclaredExperienceFormData,
-      validators: {
-        onSubmit ({ value }: { value: DeclaredExperienceFormData }) {
-          return { fields: { location: validateLocation(value.location) } }
-        }
-      }
-    }) as unknown as AddDeclaredExperienceForm
-
-    return { form }
-  },
-  template: `
-    <form @submit.prevent="form.handleSubmit">
-      <DeclaredExperienceLocationFormField :form="form" />
-    </form>
-  `
+const TestWrapper = createFormFieldTestWrapper<AddDeclaredExperienceForm, DeclaredExperienceFormData, 'location'>({
+  formFieldComponent: DeclaredExperienceLocationFormField,
+  fieldName: 'location',
+  defaultValue: '',
+  useValidator: () => useDeclaredExperienceFormValidators().validateLocation
 })
 
 BddTest().given('a declared experience location form field', () => {

--- a/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceLocationFormField/DeclaredExperienceLocationFormField.vue
+++ b/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceLocationFormField/DeclaredExperienceLocationFormField.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import type { AddDeclaredExperienceForm } from '@/features/student/personalCareer/types/forms.types'
+import DeclaredExperienceLocationInput from '@/features/student/personalCareer/components/interactions/inputs/DeclaredExperienceLocationInput/DeclaredExperienceLocationInput.vue'
+import { DECLARED_EXPERIENCE_LOCATION_MAX_LENGTH } from '@/features/student/personalCareer/config'
+import { markRaw } from 'vue'
+
+interface DeclaredExperienceLocationFormFieldProps {
+  form: AddDeclaredExperienceForm
+}
+
+defineOptions({
+  inheritAttrs: false
+})
+
+const { form } = defineProps<DeclaredExperienceLocationFormFieldProps>()
+const FormField = markRaw(form.Field)
+const locationField = form.useField({ name: 'location' })
+
+function onUpdateLocation (value: string | undefined) {
+  locationField.api.handleChange(String(value ?? '').slice(0, DECLARED_EXPERIENCE_LOCATION_MAX_LENGTH))
+}
+</script>
+
+<template>
+  <FormField name="location">
+    <template #default="{ field }">
+      <DeclaredExperienceLocationInput
+        v-bind="$attrs"
+        :model-value="(field.state.value ?? '').slice(0, DECLARED_EXPERIENCE_LOCATION_MAX_LENGTH)"
+        :error-message="field.state.meta.errors?.join(', ')"
+        @blur="field.handleBlur"
+        @update:model-value="onUpdateLocation"
+      />
+    </template>
+  </FormField>
+</template>

--- a/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceOrganizationFormField/DeclaredExperienceOrganizationFormField.stub.ts
+++ b/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceOrganizationFormField/DeclaredExperienceOrganizationFormField.stub.ts
@@ -1,7 +1,5 @@
-import type { Component } from 'vue'
-
-export const DeclaredExperienceOrganizationFormFieldStub: Component = {
+export const DeclaredExperienceOrganizationFormFieldStub = defineComponent({
   name: 'DeclaredExperienceOrganizationFormField',
   props: ['form'],
   template: '<div data-testid="experience-organization-form-field" />'
-}
+})

--- a/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceOrganizationFormField/DeclaredExperienceOrganizationFormField.stub.ts
+++ b/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceOrganizationFormField/DeclaredExperienceOrganizationFormField.stub.ts
@@ -1,0 +1,7 @@
+import type { Component } from 'vue'
+
+export const DeclaredExperienceOrganizationFormFieldStub: Component = {
+  name: 'DeclaredExperienceOrganizationFormField',
+  props: ['form'],
+  template: '<div data-testid="experience-organization-form-field" />'
+}

--- a/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceOrganizationFormField/DeclaredExperienceOrganizationFormField.test.ts
+++ b/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceOrganizationFormField/DeclaredExperienceOrganizationFormField.test.ts
@@ -1,0 +1,135 @@
+import type { AddDeclaredExperienceForm, DeclaredExperienceFormData } from '@/features/student/personalCareer/types/forms.types'
+import DeclaredExperienceOrganizationFormField
+  from '@/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceOrganizationFormField/DeclaredExperienceOrganizationFormField.vue'
+import { DeclaredExperienceOrganizationInputStub } from '@/features/student/personalCareer/components/interactions/inputs/DeclaredExperienceOrganizationInput/DeclaredExperienceOrganizationInput.stub'
+import { DECLARED_EXPERIENCE_ORGANIZATION_MAX_LENGTH } from '@/features/student/personalCareer/config'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { useForm } from '@tanstack/vue-form'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { beforeEach, expect, vi } from 'vitest'
+
+const TestWrapper = defineComponent({
+  components: {
+    DeclaredExperienceOrganizationFormField
+  },
+  setup () {
+    const form = useForm({
+      defaultValues: {
+        organization: ''
+      } as DeclaredExperienceFormData,
+      validators: {
+        onSubmit ({ value }) {
+          if (!value.organization || value.organization.trim() === '') {
+            return {
+              fields: {
+                organization: 'L\'organisation est requise'
+              }
+            }
+          }
+          return { fields: { organization: undefined } }
+        }
+      }
+    }) as unknown as AddDeclaredExperienceForm
+
+    return { form }
+  },
+  template: `
+    <form @submit.prevent="form.handleSubmit">
+      <DeclaredExperienceOrganizationFormField :form="form" />
+    </form>
+  `
+})
+
+BddTest().given('a declared experience organization form field', () => {
+  let wrapper: VueWrapper<InstanceType<typeof TestWrapper>>
+
+  const stubs = {
+    DeclaredExperienceOrganizationInput: DeclaredExperienceOrganizationInputStub
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    wrapper = mount(TestWrapper, {
+      global: { stubs }
+    })
+  })
+
+  BddTest().when('the component is mounted', () => {
+    BddTest().then('it should render the organization input component', () => {
+      const input = wrapper.findComponent({ name: 'DeclaredExperienceOrganizationInput' })
+      expect(input.exists()).toBe(true)
+    })
+
+    BddTest().then('it should have empty initial value', () => {
+      const input = wrapper.findComponent({ name: 'DeclaredExperienceOrganizationInput' })
+      expect(input.props('modelValue')).toBe('')
+    })
+
+    BddTest().and('the user enters an organization', () => {
+      BddTest().then('it should update the form field value', async () => {
+        const input = wrapper.findComponent({ name: 'DeclaredExperienceOrganizationInput' })
+        const textInput = input.find('input')
+        await textInput.setValue('My Organization')
+        await wrapper.vm.$nextTick()
+
+        await vi.waitFor(() => {
+          const updated = wrapper.findComponent({ name: 'DeclaredExperienceOrganizationInput' })
+          expect(updated.props('modelValue')).toBe('My Organization')
+        })
+      })
+    })
+
+    BddTest().and('the user enters an organization exceeding max length', () => {
+      BddTest().then('it should truncate the value to max length', async () => {
+        const input = wrapper.findComponent({ name: 'DeclaredExperienceOrganizationInput' })
+        const textInput = input.find('input')
+        const longOrganization = 'a'.repeat(DECLARED_EXPERIENCE_ORGANIZATION_MAX_LENGTH + 10)
+        await textInput.setValue(longOrganization)
+        await wrapper.vm.$nextTick()
+
+        await vi.waitFor(() => {
+          const updated = wrapper.findComponent({ name: 'DeclaredExperienceOrganizationInput' })
+          expect(updated.props('modelValue')).toHaveLength(DECLARED_EXPERIENCE_ORGANIZATION_MAX_LENGTH)
+        })
+      })
+    })
+
+    BddTest().and('the input emits blur', () => {
+      BddTest().then('it should trigger blur handler', async () => {
+        const input = wrapper.findComponent({ name: 'DeclaredExperienceOrganizationInput' })
+        await input.vm.$emit('blur')
+        await wrapper.vm.$nextTick()
+
+        expect(input.emitted('blur')).toBeTruthy()
+      })
+    })
+
+    BddTest().and('the form is submitted with empty organization', () => {
+      BddTest().then('it should show validation error', async () => {
+        await wrapper.find('form').trigger('submit')
+        await wrapper.vm.$nextTick()
+
+        await vi.waitFor(() => {
+          const input = wrapper.findComponent({ name: 'DeclaredExperienceOrganizationInput' })
+          expect(input.props('errorMessage')).toBe('L\'organisation est requise')
+        })
+      })
+    })
+
+    BddTest().and('the form is submitted with valid organization', () => {
+      BddTest().then('it should not show validation error', async () => {
+        const input = wrapper.findComponent({ name: 'DeclaredExperienceOrganizationInput' })
+        const textInput = input.find('input')
+        await textInput.setValue('Valid Organization')
+        await wrapper.vm.$nextTick()
+        await wrapper.find('form').trigger('submit')
+        await wrapper.vm.$nextTick()
+
+        await vi.waitFor(() => {
+          const updated = wrapper.findComponent({ name: 'DeclaredExperienceOrganizationInput' })
+          expect(updated.props('errorMessage')).toBeFalsy()
+        })
+      })
+    })
+  })
+})

--- a/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceOrganizationFormField/DeclaredExperienceOrganizationFormField.test.ts
+++ b/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceOrganizationFormField/DeclaredExperienceOrganizationFormField.test.ts
@@ -2,42 +2,20 @@ import type { AddDeclaredExperienceForm, DeclaredExperienceFormData } from '@/fe
 import DeclaredExperienceOrganizationFormField
   from '@/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceOrganizationFormField/DeclaredExperienceOrganizationFormField.vue'
 import { DeclaredExperienceOrganizationInputStub } from '@/features/student/personalCareer/components/interactions/inputs/DeclaredExperienceOrganizationInput/DeclaredExperienceOrganizationInput.stub'
+import {
+  useDeclaredExperienceFormValidators
+} from '@/features/student/personalCareer/composables/use-declared-experience-form-validators/use-declared-experience-form-validators'
 import { DECLARED_EXPERIENCE_ORGANIZATION_MAX_LENGTH } from '@/features/student/personalCareer/config'
 import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
-import { useForm } from '@tanstack/vue-form'
 import { mount, type VueWrapper } from '@vue/test-utils'
+import { createFormFieldTestWrapper } from 'tests/utils'
 import { beforeEach, expect, vi } from 'vitest'
 
-const TestWrapper = defineComponent({
-  components: {
-    DeclaredExperienceOrganizationFormField
-  },
-  setup () {
-    const form = useForm({
-      defaultValues: {
-        organization: ''
-      } as DeclaredExperienceFormData,
-      validators: {
-        onSubmit ({ value }) {
-          if (!value.organization || value.organization.trim() === '') {
-            return {
-              fields: {
-                organization: 'L\'organisation est requise'
-              }
-            }
-          }
-          return { fields: { organization: undefined } }
-        }
-      }
-    }) as unknown as AddDeclaredExperienceForm
-
-    return { form }
-  },
-  template: `
-    <form @submit.prevent="form.handleSubmit">
-      <DeclaredExperienceOrganizationFormField :form="form" />
-    </form>
-  `
+const TestWrapper = createFormFieldTestWrapper<AddDeclaredExperienceForm, DeclaredExperienceFormData, 'organization'>({
+  formFieldComponent: DeclaredExperienceOrganizationFormField,
+  fieldName: 'organization',
+  defaultValue: '',
+  useValidator: () => useDeclaredExperienceFormValidators().validateOrganization
 })
 
 BddTest().given('a declared experience organization form field', () => {
@@ -111,7 +89,7 @@ BddTest().given('a declared experience organization form field', () => {
 
         await vi.waitFor(() => {
           const input = wrapper.findComponent({ name: 'DeclaredExperienceOrganizationInput' })
-          expect(input.props('errorMessage')).toBe('L\'organisation est requise')
+          expect(input.props('errorMessage')).toBe('Ce champ est requis.')
         })
       })
     })

--- a/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceOrganizationFormField/DeclaredExperienceOrganizationFormField.vue
+++ b/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceOrganizationFormField/DeclaredExperienceOrganizationFormField.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import type { AddDeclaredExperienceForm } from '@/features/student/personalCareer/types/forms.types'
+import DeclaredExperienceOrganizationInput from '@/features/student/personalCareer/components/interactions/inputs/DeclaredExperienceOrganizationInput/DeclaredExperienceOrganizationInput.vue'
+import { DECLARED_EXPERIENCE_ORGANIZATION_MAX_LENGTH } from '@/features/student/personalCareer/config'
+import { markRaw } from 'vue'
+
+interface DeclaredExperienceOrganizationFormFieldProps {
+  form: AddDeclaredExperienceForm
+}
+
+defineOptions({
+  inheritAttrs: false
+})
+
+const { form } = defineProps<DeclaredExperienceOrganizationFormFieldProps>()
+const FormField = markRaw(form.Field)
+const organizationField = form.useField({ name: 'organization' })
+
+function onUpdateOrganization (value: string | undefined) {
+  organizationField.api.handleChange(String(value ?? '').slice(0, DECLARED_EXPERIENCE_ORGANIZATION_MAX_LENGTH))
+}
+</script>
+
+<template>
+  <FormField name="organization">
+    <template #default="{ field }">
+      <DeclaredExperienceOrganizationInput
+        v-bind="$attrs"
+        :model-value="(field.state.value ?? '').slice(0, DECLARED_EXPERIENCE_ORGANIZATION_MAX_LENGTH)"
+        :error-message="field.state.meta.errors?.join(', ')"
+        @blur="field.handleBlur"
+        @update:model-value="onUpdateOrganization"
+      />
+    </template>
+  </FormField>
+</template>

--- a/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperiencePeriodFormField/DeclaredExperiencePeriodFormField.stub.ts
+++ b/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperiencePeriodFormField/DeclaredExperiencePeriodFormField.stub.ts
@@ -1,0 +1,7 @@
+import type { Component } from 'vue'
+
+export const DeclaredExperiencePeriodFormFieldStub: Component = {
+  name: 'DeclaredExperiencePeriodFormField',
+  props: ['form'],
+  template: '<div data-testid="experience-period-form-field" />'
+}

--- a/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperiencePeriodFormField/DeclaredExperiencePeriodFormField.stub.ts
+++ b/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperiencePeriodFormField/DeclaredExperiencePeriodFormField.stub.ts
@@ -1,7 +1,5 @@
-import type { Component } from 'vue'
-
-export const DeclaredExperiencePeriodFormFieldStub: Component = {
+export const DeclaredExperiencePeriodFormFieldStub = defineComponent({
   name: 'DeclaredExperiencePeriodFormField',
   props: ['form'],
   template: '<div data-testid="experience-period-form-field" />'
-}
+})

--- a/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperiencePeriodFormField/DeclaredExperiencePeriodFormField.test.ts
+++ b/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperiencePeriodFormField/DeclaredExperiencePeriodFormField.test.ts
@@ -1,0 +1,207 @@
+import type { AddDeclaredExperienceForm, DeclaredExperienceFormData } from '@/features/student/personalCareer/types/forms.types'
+import DeclaredExperiencePeriodFormField
+  from '@/features/student/personalCareer/components/interactions/formFields/DeclaredExperiencePeriodFormField/DeclaredExperiencePeriodFormField.vue'
+import { DeclaredExperiencePeriodInputStub } from '@/features/student/personalCareer/components/interactions/inputs/DeclaredExperiencePeriodInput/DeclaredExperiencePeriodInput.stub'
+import { AvCheckboxStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { useForm } from '@tanstack/vue-form'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { beforeEach, expect, vi } from 'vitest'
+
+const TestWrapper = defineComponent({
+  components: {
+    DeclaredExperiencePeriodFormField
+  },
+  setup () {
+    const form = useForm({
+      defaultValues: {
+        startDate: '',
+        endDate: '',
+        isOngoing: false
+      } as DeclaredExperienceFormData,
+      validators: {
+        onSubmit ({ value }) {
+          const errors: Record<string, string | undefined> = {
+            startDate: undefined,
+            endDate: undefined,
+            isOngoing: undefined
+          }
+
+          if (!value.startDate || value.startDate.trim() === '') {
+            errors.startDate = 'La date de début est requise'
+          }
+
+          if (!value.isOngoing && (!value.endDate || value.endDate.trim() === '')) {
+            errors.endDate = 'La date de fin est requise'
+          }
+
+          return { fields: errors }
+        }
+      }
+    }) as unknown as AddDeclaredExperienceForm
+
+    return { form }
+  },
+  template: `
+    <form @submit.prevent="form.handleSubmit">
+      <DeclaredExperiencePeriodFormField :form="form" />
+    </form>
+  `
+})
+
+BddTest().given('a declared experience period form field', () => {
+  let wrapper: VueWrapper<InstanceType<typeof TestWrapper>>
+
+  const stubs = {
+    AvCheckbox: AvCheckboxStub,
+    DeclaredExperiencePeriodInput: DeclaredExperiencePeriodInputStub
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    wrapper = mount(TestWrapper, {
+      global: { stubs }
+    })
+  })
+
+  BddTest().when('the component is mounted', () => {
+    BddTest().then('it should render the checkbox and period input', () => {
+      const checkbox = wrapper.findAllComponents({ name: 'AvCheckbox' })
+      const periodInput = wrapper.findComponent({ name: 'DeclaredExperiencePeriodInput' })
+      expect(checkbox.length).toBe(1)
+      expect(periodInput.exists()).toBe(true)
+    })
+
+    BddTest().then('it should have empty initial values', () => {
+      const periodInput = wrapper.findComponent({ name: 'DeclaredExperiencePeriodInput' })
+      expect(periodInput.props('startModelValue')).toBe('')
+      expect(periodInput.props('endModelValue')).toBe('')
+    })
+
+    BddTest().then('it should have isOngoing unchecked', () => {
+      const checkbox = wrapper.findComponent({ name: 'AvCheckbox' })
+      expect(checkbox.props('modelValue')).toEqual([])
+    })
+
+    BddTest().then('it should enable end date input', () => {
+      const periodInput = wrapper.findComponent({ name: 'DeclaredExperiencePeriodInput' })
+      expect(periodInput.props('endDateDisabled')).toBe(false)
+    })
+
+    BddTest().and('the user enters a start date', () => {
+      BddTest().then('it should update the start date value', async () => {
+        const periodInput = wrapper.findComponent({ name: 'DeclaredExperiencePeriodInput' })
+        await periodInput.vm.$emit('update:startModelValue', '2024-01')
+        await wrapper.vm.$nextTick()
+
+        await vi.waitFor(() => {
+          const updated = wrapper.findComponent({ name: 'DeclaredExperiencePeriodInput' })
+          expect(updated.props('startModelValue')).toBe('2024-01')
+        })
+      })
+    })
+
+    BddTest().and('the user enters an end date', () => {
+      BddTest().then('it should update the end date value', async () => {
+        const periodInput = wrapper.findComponent({ name: 'DeclaredExperiencePeriodInput' })
+        await periodInput.vm.$emit('update:endModelValue', '2024-12')
+        await wrapper.vm.$nextTick()
+
+        await vi.waitFor(() => {
+          const updated = wrapper.findComponent({ name: 'DeclaredExperiencePeriodInput' })
+          expect(updated.props('endModelValue')).toBe('2024-12')
+        })
+      })
+    })
+
+    BddTest().and('the user checks isOngoing checkbox', () => {
+      BddTest().then('it should check the checkbox and disable end date input', async () => {
+        const checkbox = wrapper.findComponent({ name: 'AvCheckbox' })
+        await checkbox.vm.$emit('update:modelValue', ['isOngoing'])
+        await wrapper.vm.$nextTick()
+
+        await vi.waitFor(() => {
+          const updatedCheckbox = wrapper.findComponent({ name: 'AvCheckbox' })
+          expect(updatedCheckbox.props('modelValue')).toEqual(['isOngoing'])
+        })
+
+        await vi.waitFor(() => {
+          const periodInput = wrapper.findComponent({ name: 'DeclaredExperiencePeriodInput' })
+          expect(periodInput.props('endDateDisabled')).toBe(true)
+        })
+
+        await vi.waitFor(() => {
+          const periodInput = wrapper.findComponent({ name: 'DeclaredExperiencePeriodInput' })
+          expect(periodInput.props('endModelValue')).toBe('')
+        })
+      })
+    })
+
+    BddTest().and('the user unchecks isOngoing checkbox', () => {
+      BddTest().then('it should uncheck the checkbox and enable end date input', async () => {
+        const checkbox = wrapper.findComponent({ name: 'AvCheckbox' })
+        await checkbox.vm.$emit('update:modelValue', ['isOngoing'])
+        await wrapper.vm.$nextTick()
+        await checkbox.vm.$emit('update:modelValue', [])
+        await wrapper.vm.$nextTick()
+
+        await vi.waitFor(() => {
+          const updatedCheckbox = wrapper.findComponent({ name: 'AvCheckbox' })
+          expect(updatedCheckbox.props('modelValue')).toEqual([])
+        })
+
+        await vi.waitFor(() => {
+          const periodInput = wrapper.findComponent({ name: 'DeclaredExperiencePeriodInput' })
+          expect(periodInput.props('endDateDisabled')).toBe(false)
+        })
+      })
+    })
+
+    BddTest().and('the form is submitted with empty dates', () => {
+      BddTest().then('it should show validation errors for start and end dates', async () => {
+        await wrapper.find('form').trigger('submit')
+        await wrapper.vm.$nextTick()
+
+        await vi.waitFor(() => {
+          const periodInput = wrapper.findComponent({ name: 'DeclaredExperiencePeriodInput' })
+          expect(periodInput.props('startErrorMessage')).toBe('La date de début est requise')
+          expect(periodInput.props('endErrorMessage')).toBe('La date de fin est requise')
+        })
+      })
+    })
+
+    BddTest().and('the form is submitted with valid dates', () => {
+      BddTest().then('it should not show validation errors', async () => {
+        const periodInput = wrapper.findComponent({ name: 'DeclaredExperiencePeriodInput' })
+        await periodInput.vm.$emit('update:startModelValue', '2024-01')
+        await periodInput.vm.$emit('update:endModelValue', '2024-12')
+        await wrapper.vm.$nextTick()
+        await wrapper.find('form').trigger('submit')
+        await wrapper.vm.$nextTick()
+
+        await vi.waitFor(() => {
+          const updated = wrapper.findComponent({ name: 'DeclaredExperiencePeriodInput' })
+          expect(updated.props('startErrorMessage')).toBeFalsy()
+          expect(updated.props('endErrorMessage')).toBeFalsy()
+        })
+      })
+    })
+
+    BddTest().and('the form is submitted with isOngoing checked and start date', () => {
+      BddTest().then('it should not show validation errors', async () => {
+        const periodInput = wrapper.findComponent({ name: 'DeclaredExperiencePeriodInput' })
+        const checkbox = wrapper.findComponent({ name: 'AvCheckbox' })
+        await periodInput.vm.$emit('update:startModelValue', '2024-01')
+        await checkbox.vm.$emit('update:modelValue', ['isOngoing'])
+        await wrapper.vm.$nextTick()
+        await wrapper.find('form').trigger('submit')
+        await wrapper.vm.$nextTick()
+
+        await vi.waitFor(() => {
+          const updated = wrapper.findComponent({ name: 'DeclaredExperiencePeriodInput' })
+          expect(updated.props('startErrorMessage')).toBeFalsy()
+          expect(updated.props('endErrorMessage')).toBeFalsy()
+        })
+      })
+    })
+  })
+})

--- a/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperiencePeriodFormField/DeclaredExperiencePeriodFormField.test.ts
+++ b/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperiencePeriodFormField/DeclaredExperiencePeriodFormField.test.ts
@@ -2,6 +2,9 @@ import type { AddDeclaredExperienceForm, DeclaredExperienceFormData } from '@/fe
 import DeclaredExperiencePeriodFormField
   from '@/features/student/personalCareer/components/interactions/formFields/DeclaredExperiencePeriodFormField/DeclaredExperiencePeriodFormField.vue'
 import { DeclaredExperiencePeriodInputStub } from '@/features/student/personalCareer/components/interactions/inputs/DeclaredExperiencePeriodInput/DeclaredExperiencePeriodInput.stub'
+import {
+  useDeclaredExperienceFormValidators
+} from '@/features/student/personalCareer/composables/use-declared-experience-form-validators/use-declared-experience-form-validators'
 import { AvCheckboxStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { useForm } from '@tanstack/vue-form'
 import { mount, type VueWrapper } from '@vue/test-utils'
@@ -12,6 +15,8 @@ const TestWrapper = defineComponent({
     DeclaredExperiencePeriodFormField
   },
   setup () {
+    const { validateStartDate, validateEndDate } = useDeclaredExperienceFormValidators()
+
     const form = useForm({
       defaultValues: {
         startDate: '',
@@ -20,21 +25,12 @@ const TestWrapper = defineComponent({
       } as DeclaredExperienceFormData,
       validators: {
         onSubmit ({ value }) {
-          const errors: Record<string, string | undefined> = {
-            startDate: undefined,
-            endDate: undefined,
-            isOngoing: undefined
+          return {
+            fields: {
+              startDate: validateStartDate(value.startDate),
+              endDate: validateEndDate(value.endDate, value.startDate, { isRequired: !value.isOngoing })
+            }
           }
-
-          if (!value.startDate || value.startDate.trim() === '') {
-            errors.startDate = 'La date de début est requise'
-          }
-
-          if (!value.isOngoing && (!value.endDate || value.endDate.trim() === '')) {
-            errors.endDate = 'La date de fin est requise'
-          }
-
-          return { fields: errors }
         }
       }
     }) as unknown as AddDeclaredExperienceForm
@@ -163,8 +159,8 @@ BddTest().given('a declared experience period form field', () => {
 
         await vi.waitFor(() => {
           const periodInput = wrapper.findComponent({ name: 'DeclaredExperiencePeriodInput' })
-          expect(periodInput.props('startErrorMessage')).toBe('La date de début est requise')
-          expect(periodInput.props('endErrorMessage')).toBe('La date de fin est requise')
+          expect(periodInput.props('startErrorMessage')).toBe('Ce champ est requis.')
+          expect(periodInput.props('endErrorMessage')).toBe('Ce champ est requis.')
         })
       })
     })

--- a/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperiencePeriodFormField/DeclaredExperiencePeriodFormField.vue
+++ b/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperiencePeriodFormField/DeclaredExperiencePeriodFormField.vue
@@ -1,0 +1,87 @@
+<script setup lang="ts">
+import type { AddDeclaredExperienceForm } from '@/features/student/personalCareer/types/forms.types'
+import DeclaredExperiencePeriodInput from '@/features/student/personalCareer/components/interactions/inputs/DeclaredExperiencePeriodInput/DeclaredExperiencePeriodInput.vue'
+import { AvCheckbox } from '@avenirs-esr/avenirs-dsav'
+import { markRaw } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+interface DeclaredExperiencePeriodFormFieldProps {
+  form: AddDeclaredExperienceForm
+}
+
+defineOptions({
+  inheritAttrs: false
+})
+
+const { form } = defineProps<DeclaredExperiencePeriodFormFieldProps>()
+const { t } = useI18n()
+
+const IS_ONGOING = 'isOngoing'
+
+const FormField = markRaw(form.Field)
+const startDateField = form.useField({ name: 'startDate' })
+const endDateField = form.useField({ name: 'endDate' })
+const isOngoingField = form.useField({ name: IS_ONGOING })
+
+const isOngoing = computed(() => isOngoingField.state.value.value)
+
+function onUpdateStartDate (value: string | number | null) {
+  startDateField.api.handleChange(String(value ?? ''))
+}
+
+function onUpdateEndDate (value: string | number | null) {
+  endDateField.api.handleChange(String(value ?? ''))
+}
+
+function onUpdateIsOngoing (values: (string | number | boolean | undefined)[]) {
+  const [value] = values
+  isOngoingField.api.handleChange(value === IS_ONGOING)
+  if (value) {
+    endDateField.api.handleChange('')
+  }
+}
+
+const startErrorMessage = computed(() => startDateField.state.value.meta.errors?.join(', '))
+const endErrorMessage = computed(() => endDateField.state.value.meta.errors?.join(', '))
+</script>
+
+<template>
+  <div class="declared-experience-period-form-field">
+    <div class="av-col av-gap-xs">
+      <span class="av-label b2-light">
+        {{ t('student.personalCareer.interactions.inputs.DeclaredExperiencePeriodInput.label') }}
+      </span>
+      <FormField :name="IS_ONGOING">
+        <template #default="{ field }">
+          <AvCheckbox
+            id="on-going-declared-experience"
+            :name="IS_ONGOING"
+            :model-value="field.state.value ? [IS_ONGOING] : []"
+            :value="IS_ONGOING"
+            :label="t('student.personalCareer.interactions.formFields.DeclaredExperiencePeriodFormField.ongoing')"
+            @update:model-value="onUpdateIsOngoing"
+          />
+        </template>
+      </FormField>
+
+      <DeclaredExperiencePeriodInput
+        :label-visible="false"
+        :start-model-value="startDateField.state.value.value"
+        :end-model-value="endDateField.state.value.value"
+        :start-error-message="startErrorMessage"
+        :end-error-message="endErrorMessage"
+        :end-date-disabled="isOngoing"
+        @update:start-model-value="onUpdateStartDate"
+        @update:end-model-value="onUpdateEndDate"
+      />
+    </div>
+  </div>
+</template>
+
+<style scoped lang="scss">
+.declared-experience-period-form-field {
+  :deep(.av-fieldset__element) {
+    padding-left: 0 !important;
+  }
+}
+</style>

--- a/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceReviewFormField/DeclaredExperienceReviewFormField.stub.ts
+++ b/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceReviewFormField/DeclaredExperienceReviewFormField.stub.ts
@@ -1,7 +1,5 @@
-import type { Component } from 'vue'
-
-export const DeclaredExperienceReviewFormFieldStub: Component = {
+export const DeclaredExperienceReviewFormFieldStub = defineComponent({
   name: 'DeclaredExperienceReviewFormField',
   props: ['form'],
   template: '<div data-testid="experience-review-form-field" />'
-}
+})

--- a/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceReviewFormField/DeclaredExperienceReviewFormField.stub.ts
+++ b/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceReviewFormField/DeclaredExperienceReviewFormField.stub.ts
@@ -1,0 +1,7 @@
+import type { Component } from 'vue'
+
+export const DeclaredExperienceReviewFormFieldStub: Component = {
+  name: 'DeclaredExperienceReviewFormField',
+  props: ['form'],
+  template: '<div data-testid="experience-review-form-field" />'
+}

--- a/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceReviewFormField/DeclaredExperienceReviewFormField.test.ts
+++ b/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceReviewFormField/DeclaredExperienceReviewFormField.test.ts
@@ -1,0 +1,128 @@
+import type { AddDeclaredExperienceForm, DeclaredExperienceFormData } from '@/features/student/personalCareer/types/forms.types'
+import DeclaredExperienceReviewFormField
+  from '@/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceReviewFormField/DeclaredExperienceReviewFormField.vue'
+import { DeclaredExperienceReviewTextareaStub } from '@/features/student/personalCareer/components/interactions/inputs/DeclaredExperienceReviewTextarea/DeclaredExperienceReviewTextarea.stub'
+import { DECLARED_EXPERIENCE_REVIEW_MAX_LENGTH } from '@/features/student/personalCareer/config'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { useForm } from '@tanstack/vue-form'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { beforeEach, expect, vi } from 'vitest'
+
+const TestWrapper = defineComponent({
+  components: {
+    DeclaredExperienceReviewFormField
+  },
+  setup () {
+    const form = useForm({
+      defaultValues: {
+        review: ''
+      } as DeclaredExperienceFormData,
+      validators: {
+        onSubmit () {
+          return { fields: { review: undefined } }
+        }
+      }
+    }) as unknown as AddDeclaredExperienceForm
+
+    return { form }
+  },
+  template: `
+    <form @submit.prevent="form.handleSubmit">
+      <DeclaredExperienceReviewFormField :form="form" />
+    </form>
+  `
+})
+
+BddTest().given('a declared experience review form field', () => {
+  let wrapper: VueWrapper<InstanceType<typeof TestWrapper>>
+
+  const stubs = {
+    DeclaredExperienceReviewTextarea: DeclaredExperienceReviewTextareaStub
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    wrapper = mount(TestWrapper, {
+      global: { stubs }
+    })
+  })
+
+  BddTest().when('the component is mounted', () => {
+    BddTest().then('it should render the review textarea component', () => {
+      const textarea = wrapper.findComponent({ name: 'DeclaredExperienceReviewTextarea' })
+      expect(textarea.exists()).toBe(true)
+    })
+
+    BddTest().then('it should have empty initial value', () => {
+      const textarea = wrapper.findComponent({ name: 'DeclaredExperienceReviewTextarea' })
+      expect(textarea.props('modelValue')).toBe('')
+    })
+
+    BddTest().and('the user enters a review', () => {
+      BddTest().then('it should update the form field value', async () => {
+        const textarea = wrapper.findComponent({ name: 'DeclaredExperienceReviewTextarea' })
+        const textInput = textarea.find('textarea')
+        await textInput.setValue('A positive review of my experience')
+        await wrapper.vm.$nextTick()
+
+        await vi.waitFor(() => {
+          const updated = wrapper.findComponent({ name: 'DeclaredExperienceReviewTextarea' })
+          expect(updated.props('modelValue')).toBe('A positive review of my experience')
+        })
+      })
+    })
+
+    BddTest().and('the user enters a review exceeding max length', () => {
+      BddTest().then('it should truncate the value to max length', async () => {
+        const textarea = wrapper.findComponent({ name: 'DeclaredExperienceReviewTextarea' })
+        const textInput = textarea.find('textarea')
+        const longReview = 'a'.repeat(DECLARED_EXPERIENCE_REVIEW_MAX_LENGTH + 10)
+        await textInput.setValue(longReview)
+        await wrapper.vm.$nextTick()
+
+        await vi.waitFor(() => {
+          const updated = wrapper.findComponent({ name: 'DeclaredExperienceReviewTextarea' })
+          expect(updated.props('modelValue')).toHaveLength(DECLARED_EXPERIENCE_REVIEW_MAX_LENGTH)
+        })
+      })
+    })
+
+    BddTest().and('the textarea emits blur', () => {
+      BddTest().then('it should trigger blur handler', async () => {
+        const textarea = wrapper.findComponent({ name: 'DeclaredExperienceReviewTextarea' })
+        await textarea.vm.$emit('blur')
+        await wrapper.vm.$nextTick()
+
+        expect(textarea.emitted('blur')).toBeTruthy()
+      })
+    })
+
+    BddTest().and('the form is submitted with empty review', () => {
+      BddTest().then('it should not show validation error because it is optional', async () => {
+        await wrapper.find('form').trigger('submit')
+        await wrapper.vm.$nextTick()
+
+        await vi.waitFor(() => {
+          const textarea = wrapper.findComponent({ name: 'DeclaredExperienceReviewTextarea' })
+          expect(textarea.props('errorMessage')).toBeFalsy()
+        })
+      })
+    })
+
+    BddTest().and('the form is submitted with valid review', () => {
+      BddTest().then('it should not show validation error', async () => {
+        const textarea = wrapper.findComponent({ name: 'DeclaredExperienceReviewTextarea' })
+        const textInput = textarea.find('textarea')
+        await textInput.setValue('Valid review of the experience')
+        await wrapper.vm.$nextTick()
+        await wrapper.find('form').trigger('submit')
+        await wrapper.vm.$nextTick()
+
+        await vi.waitFor(() => {
+          const updated = wrapper.findComponent({ name: 'DeclaredExperienceReviewTextarea' })
+          expect(updated.props('errorMessage')).toBeFalsy()
+        })
+      })
+    })
+  })
+})

--- a/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceReviewFormField/DeclaredExperienceReviewFormField.test.ts
+++ b/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceReviewFormField/DeclaredExperienceReviewFormField.test.ts
@@ -2,35 +2,20 @@ import type { AddDeclaredExperienceForm, DeclaredExperienceFormData } from '@/fe
 import DeclaredExperienceReviewFormField
   from '@/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceReviewFormField/DeclaredExperienceReviewFormField.vue'
 import { DeclaredExperienceReviewTextareaStub } from '@/features/student/personalCareer/components/interactions/inputs/DeclaredExperienceReviewTextarea/DeclaredExperienceReviewTextarea.stub'
+import {
+  useDeclaredExperienceFormValidators
+} from '@/features/student/personalCareer/composables/use-declared-experience-form-validators/use-declared-experience-form-validators'
 import { DECLARED_EXPERIENCE_REVIEW_MAX_LENGTH } from '@/features/student/personalCareer/config'
 import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
-import { useForm } from '@tanstack/vue-form'
 import { mount, type VueWrapper } from '@vue/test-utils'
+import { createFormFieldTestWrapper } from 'tests/utils'
 import { beforeEach, expect, vi } from 'vitest'
 
-const TestWrapper = defineComponent({
-  components: {
-    DeclaredExperienceReviewFormField
-  },
-  setup () {
-    const form = useForm({
-      defaultValues: {
-        review: ''
-      } as DeclaredExperienceFormData,
-      validators: {
-        onSubmit () {
-          return { fields: { review: undefined } }
-        }
-      }
-    }) as unknown as AddDeclaredExperienceForm
-
-    return { form }
-  },
-  template: `
-    <form @submit.prevent="form.handleSubmit">
-      <DeclaredExperienceReviewFormField :form="form" />
-    </form>
-  `
+const TestWrapper = createFormFieldTestWrapper<AddDeclaredExperienceForm, DeclaredExperienceFormData, 'review'>({
+  formFieldComponent: DeclaredExperienceReviewFormField,
+  fieldName: 'review',
+  defaultValue: '',
+  useValidator: () => useDeclaredExperienceFormValidators().validateReview
 })
 
 BddTest().given('a declared experience review form field', () => {

--- a/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceReviewFormField/DeclaredExperienceReviewFormField.vue
+++ b/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceReviewFormField/DeclaredExperienceReviewFormField.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import type { AddDeclaredExperienceForm } from '@/features/student/personalCareer/types/forms.types'
+import DeclaredExperienceReviewTextarea from '@/features/student/personalCareer/components/interactions/inputs/DeclaredExperienceReviewTextarea/DeclaredExperienceReviewTextarea.vue'
+import { DECLARED_EXPERIENCE_REVIEW_MAX_LENGTH } from '@/features/student/personalCareer/config'
+import { markRaw } from 'vue'
+
+interface DeclaredExperienceReviewFormFieldProps {
+  form: AddDeclaredExperienceForm
+}
+
+defineOptions({
+  inheritAttrs: false
+})
+
+const { form } = defineProps<DeclaredExperienceReviewFormFieldProps>()
+const FormField = markRaw(form.Field)
+const reviewField = form.useField({ name: 'review' })
+
+function onUpdateReview (value: string | undefined) {
+  reviewField.api.handleChange(String(value ?? '').slice(0, DECLARED_EXPERIENCE_REVIEW_MAX_LENGTH))
+}
+</script>
+
+<template>
+  <FormField name="review">
+    <template #default="{ field }">
+      <DeclaredExperienceReviewTextarea
+        v-bind="$attrs"
+        :model-value="(field.state.value ?? '').slice(0, DECLARED_EXPERIENCE_REVIEW_MAX_LENGTH)"
+        :error-message="field.state.meta.errors?.join(', ')"
+        @blur="field.handleBlur"
+        @update:model-value="onUpdateReview"
+      />
+    </template>
+  </FormField>
+</template>

--- a/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceSourceOfInformationFormField/DeclaredExperienceSourceOfInformationFormField.stub.ts
+++ b/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceSourceOfInformationFormField/DeclaredExperienceSourceOfInformationFormField.stub.ts
@@ -1,7 +1,5 @@
-import type { Component } from 'vue'
-
-export const DeclaredExperienceSourceOfInformationFormFieldStub: Component = {
+export const DeclaredExperienceSourceOfInformationFormFieldStub = defineComponent({
   name: 'DeclaredExperienceSourceOfInformationFormField',
   props: ['form'],
   template: '<div data-testid="experience-source-form-field" />'
-}
+})

--- a/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceSourceOfInformationFormField/DeclaredExperienceSourceOfInformationFormField.stub.ts
+++ b/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceSourceOfInformationFormField/DeclaredExperienceSourceOfInformationFormField.stub.ts
@@ -1,0 +1,7 @@
+import type { Component } from 'vue'
+
+export const DeclaredExperienceSourceOfInformationFormFieldStub: Component = {
+  name: 'DeclaredExperienceSourceOfInformationFormField',
+  props: ['form'],
+  template: '<div data-testid="experience-source-form-field" />'
+}

--- a/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceSourceOfInformationFormField/DeclaredExperienceSourceOfInformationFormField.test.ts
+++ b/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceSourceOfInformationFormField/DeclaredExperienceSourceOfInformationFormField.test.ts
@@ -1,0 +1,128 @@
+import type { AddDeclaredExperienceForm, DeclaredExperienceFormData } from '@/features/student/personalCareer/types/forms.types'
+import DeclaredExperienceSourceOfInformationFormField
+  from '@/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceSourceOfInformationFormField/DeclaredExperienceSourceOfInformationFormField.vue'
+import { DeclaredExperienceSourceOfInformationInputStub } from '@/features/student/personalCareer/components/interactions/inputs/DeclaredExperienceSourceOfInformationInput/DeclaredExperienceSourceOfInformationInput.stub'
+import { DECLARED_EXPERIENCE_SOURCE_OF_INFORMATION_MAX_LENGTH } from '@/features/student/personalCareer/config'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { useForm } from '@tanstack/vue-form'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { beforeEach, expect, vi } from 'vitest'
+
+const TestWrapper = defineComponent({
+  components: {
+    DeclaredExperienceSourceOfInformationFormField
+  },
+  setup () {
+    const form = useForm({
+      defaultValues: {
+        sourceOfInformation: ''
+      } as DeclaredExperienceFormData,
+      validators: {
+        onSubmit () {
+          return { fields: { sourceOfInformation: undefined } }
+        }
+      }
+    }) as unknown as AddDeclaredExperienceForm
+
+    return { form }
+  },
+  template: `
+    <form @submit.prevent="form.handleSubmit">
+      <DeclaredExperienceSourceOfInformationFormField :form="form" />
+    </form>
+  `
+})
+
+BddTest().given('a declared experience source of information form field', () => {
+  let wrapper: VueWrapper<InstanceType<typeof TestWrapper>>
+
+  const stubs = {
+    DeclaredExperienceSourceOfInformationInput: DeclaredExperienceSourceOfInformationInputStub
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    wrapper = mount(TestWrapper, {
+      global: { stubs }
+    })
+  })
+
+  BddTest().when('the component is mounted', () => {
+    BddTest().then('it should render the source of information input component', () => {
+      const input = wrapper.findComponent({ name: 'DeclaredExperienceSourceOfInformationInput' })
+      expect(input.exists()).toBe(true)
+    })
+
+    BddTest().then('it should have empty initial value', () => {
+      const input = wrapper.findComponent({ name: 'DeclaredExperienceSourceOfInformationInput' })
+      expect(input.props('modelValue')).toBe('')
+    })
+
+    BddTest().and('the user enters a source of information', () => {
+      BddTest().then('it should update the form field value', async () => {
+        const input = wrapper.findComponent({ name: 'DeclaredExperienceSourceOfInformationInput' })
+        const textInput = input.find('input')
+        await textInput.setValue('LinkedIn profile')
+        await wrapper.vm.$nextTick()
+
+        await vi.waitFor(() => {
+          const updated = wrapper.findComponent({ name: 'DeclaredExperienceSourceOfInformationInput' })
+          expect(updated.props('modelValue')).toBe('LinkedIn profile')
+        })
+      })
+    })
+
+    BddTest().and('the user enters a source exceeding max length', () => {
+      BddTest().then('it should truncate the value to max length', async () => {
+        const input = wrapper.findComponent({ name: 'DeclaredExperienceSourceOfInformationInput' })
+        const textInput = input.find('input')
+        const longSource = 'a'.repeat(DECLARED_EXPERIENCE_SOURCE_OF_INFORMATION_MAX_LENGTH + 10)
+        await textInput.setValue(longSource)
+        await wrapper.vm.$nextTick()
+
+        await vi.waitFor(() => {
+          const updated = wrapper.findComponent({ name: 'DeclaredExperienceSourceOfInformationInput' })
+          expect(updated.props('modelValue')).toHaveLength(DECLARED_EXPERIENCE_SOURCE_OF_INFORMATION_MAX_LENGTH)
+        })
+      })
+    })
+
+    BddTest().and('the input emits blur', () => {
+      BddTest().then('it should trigger blur handler', async () => {
+        const input = wrapper.findComponent({ name: 'DeclaredExperienceSourceOfInformationInput' })
+        await input.vm.$emit('blur')
+        await wrapper.vm.$nextTick()
+
+        expect(input.emitted('blur')).toBeTruthy()
+      })
+    })
+
+    BddTest().and('the form is submitted with empty source', () => {
+      BddTest().then('it should not show validation error because it is optional', async () => {
+        await wrapper.find('form').trigger('submit')
+        await wrapper.vm.$nextTick()
+
+        await vi.waitFor(() => {
+          const input = wrapper.findComponent({ name: 'DeclaredExperienceSourceOfInformationInput' })
+          expect(input.props('errorMessage')).toBeFalsy()
+        })
+      })
+    })
+
+    BddTest().and('the form is submitted with valid source', () => {
+      BddTest().then('it should not show validation error', async () => {
+        const input = wrapper.findComponent({ name: 'DeclaredExperienceSourceOfInformationInput' })
+        const textInput = input.find('input')
+        await textInput.setValue('Company website')
+        await wrapper.vm.$nextTick()
+        await wrapper.find('form').trigger('submit')
+        await wrapper.vm.$nextTick()
+
+        await vi.waitFor(() => {
+          const updated = wrapper.findComponent({ name: 'DeclaredExperienceSourceOfInformationInput' })
+          expect(updated.props('errorMessage')).toBeFalsy()
+        })
+      })
+    })
+  })
+})

--- a/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceSourceOfInformationFormField/DeclaredExperienceSourceOfInformationFormField.test.ts
+++ b/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceSourceOfInformationFormField/DeclaredExperienceSourceOfInformationFormField.test.ts
@@ -2,35 +2,20 @@ import type { AddDeclaredExperienceForm, DeclaredExperienceFormData } from '@/fe
 import DeclaredExperienceSourceOfInformationFormField
   from '@/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceSourceOfInformationFormField/DeclaredExperienceSourceOfInformationFormField.vue'
 import { DeclaredExperienceSourceOfInformationInputStub } from '@/features/student/personalCareer/components/interactions/inputs/DeclaredExperienceSourceOfInformationInput/DeclaredExperienceSourceOfInformationInput.stub'
+import {
+  useDeclaredExperienceFormValidators
+} from '@/features/student/personalCareer/composables/use-declared-experience-form-validators/use-declared-experience-form-validators'
 import { DECLARED_EXPERIENCE_SOURCE_OF_INFORMATION_MAX_LENGTH } from '@/features/student/personalCareer/config'
 import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
-import { useForm } from '@tanstack/vue-form'
 import { mount, type VueWrapper } from '@vue/test-utils'
+import { createFormFieldTestWrapper } from 'tests/utils'
 import { beforeEach, expect, vi } from 'vitest'
 
-const TestWrapper = defineComponent({
-  components: {
-    DeclaredExperienceSourceOfInformationFormField
-  },
-  setup () {
-    const form = useForm({
-      defaultValues: {
-        sourceOfInformation: ''
-      } as DeclaredExperienceFormData,
-      validators: {
-        onSubmit () {
-          return { fields: { sourceOfInformation: undefined } }
-        }
-      }
-    }) as unknown as AddDeclaredExperienceForm
-
-    return { form }
-  },
-  template: `
-    <form @submit.prevent="form.handleSubmit">
-      <DeclaredExperienceSourceOfInformationFormField :form="form" />
-    </form>
-  `
+const TestWrapper = createFormFieldTestWrapper<AddDeclaredExperienceForm, DeclaredExperienceFormData, 'sourceOfInformation'>({
+  formFieldComponent: DeclaredExperienceSourceOfInformationFormField,
+  fieldName: 'sourceOfInformation',
+  defaultValue: '',
+  useValidator: () => useDeclaredExperienceFormValidators().validateSourceOfInformation
 })
 
 BddTest().given('a declared experience source of information form field', () => {

--- a/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceSourceOfInformationFormField/DeclaredExperienceSourceOfInformationFormField.vue
+++ b/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceSourceOfInformationFormField/DeclaredExperienceSourceOfInformationFormField.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import type { AddDeclaredExperienceForm } from '@/features/student/personalCareer/types/forms.types'
+import DeclaredExperienceSourceOfInformationInput from '@/features/student/personalCareer/components/interactions/inputs/DeclaredExperienceSourceOfInformationInput/DeclaredExperienceSourceOfInformationInput.vue'
+import { DECLARED_EXPERIENCE_SOURCE_OF_INFORMATION_MAX_LENGTH } from '@/features/student/personalCareer/config'
+import { markRaw } from 'vue'
+
+interface DeclaredExperienceSourceOfInformationFormFieldProps {
+  form: AddDeclaredExperienceForm
+}
+
+defineOptions({
+  inheritAttrs: false
+})
+
+const { form } = defineProps<DeclaredExperienceSourceOfInformationFormFieldProps>()
+const FormField = markRaw(form.Field)
+const sourceOfInformationField = form.useField({ name: 'sourceOfInformation' })
+
+function onUpdateSourceOfInformation (value: string | undefined) {
+  sourceOfInformationField.api.handleChange(String(value ?? '').slice(0, DECLARED_EXPERIENCE_SOURCE_OF_INFORMATION_MAX_LENGTH))
+}
+</script>
+
+<template>
+  <FormField name="sourceOfInformation">
+    <template #default="{ field }">
+      <DeclaredExperienceSourceOfInformationInput
+        v-bind="$attrs"
+        :model-value="(field.state.value ?? '').slice(0, DECLARED_EXPERIENCE_SOURCE_OF_INFORMATION_MAX_LENGTH)"
+        :error-message="field.state.meta.errors?.join(', ')"
+        @blur="field.handleBlur"
+        @update:model-value="onUpdateSourceOfInformation"
+      />
+    </template>
+  </FormField>
+</template>

--- a/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceTitleFormField/DeclaredExperienceTitleFormField.stub.ts
+++ b/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceTitleFormField/DeclaredExperienceTitleFormField.stub.ts
@@ -1,7 +1,5 @@
-import type { Component } from 'vue'
-
-export const DeclaredExperienceTitleFormFieldStub: Component = {
+export const DeclaredExperienceTitleFormFieldStub = defineComponent({
   name: 'DeclaredExperienceTitleFormField',
   props: ['form'],
   template: '<div data-testid="experience-title-form-field" />'
-}
+})

--- a/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceTitleFormField/DeclaredExperienceTitleFormField.stub.ts
+++ b/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceTitleFormField/DeclaredExperienceTitleFormField.stub.ts
@@ -1,0 +1,7 @@
+import type { Component } from 'vue'
+
+export const DeclaredExperienceTitleFormFieldStub: Component = {
+  name: 'DeclaredExperienceTitleFormField',
+  props: ['form'],
+  template: '<div data-testid="experience-title-form-field" />'
+}

--- a/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceTitleFormField/DeclaredExperienceTitleFormField.test.ts
+++ b/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceTitleFormField/DeclaredExperienceTitleFormField.test.ts
@@ -1,0 +1,135 @@
+import type { AddDeclaredExperienceForm, DeclaredExperienceFormData } from '@/features/student/personalCareer/types/forms.types'
+import DeclaredExperienceTitleFormField
+  from '@/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceTitleFormField/DeclaredExperienceTitleFormField.vue'
+import { DeclaredExperienceTitleInputStub } from '@/features/student/personalCareer/components/interactions/inputs/DeclaredExperienceTitleInput/DeclaredExperienceTitleInput.stub'
+import { DECLARED_EXPERIENCE_TITLE_MAX_LENGTH } from '@/features/student/personalCareer/config'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { useForm } from '@tanstack/vue-form'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { beforeEach, expect, vi } from 'vitest'
+
+const TestWrapper = defineComponent({
+  components: {
+    DeclaredExperienceTitleFormField
+  },
+  setup () {
+    const form = useForm({
+      defaultValues: {
+        title: ''
+      } as DeclaredExperienceFormData,
+      validators: {
+        onSubmit ({ value }) {
+          if (!value.title || value.title.trim() === '') {
+            return {
+              fields: {
+                title: 'Le titre est requis'
+              }
+            }
+          }
+          return { fields: { title: undefined } }
+        }
+      }
+    }) as unknown as AddDeclaredExperienceForm
+
+    return { form }
+  },
+  template: `
+    <form @submit.prevent="form.handleSubmit">
+      <DeclaredExperienceTitleFormField :form="form" />
+    </form>
+  `
+})
+
+BddTest().given('a declared experience title form field', () => {
+  let wrapper: VueWrapper<InstanceType<typeof TestWrapper>>
+
+  const stubs = {
+    DeclaredExperienceTitleInput: DeclaredExperienceTitleInputStub
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    wrapper = mount(TestWrapper, {
+      global: { stubs }
+    })
+  })
+
+  BddTest().when('the component is mounted', () => {
+    BddTest().then('it should render the title input component', () => {
+      const input = wrapper.findComponent({ name: 'DeclaredExperienceTitleInput' })
+      expect(input.exists()).toBe(true)
+    })
+
+    BddTest().then('it should have empty initial value', () => {
+      const input = wrapper.findComponent({ name: 'DeclaredExperienceTitleInput' })
+      expect(input.props('modelValue')).toBe('')
+    })
+
+    BddTest().and('the user enters a title', () => {
+      BddTest().then('it should update the form field value', async () => {
+        const input = wrapper.findComponent({ name: 'DeclaredExperienceTitleInput' })
+        const textInput = input.find('input')
+        await textInput.setValue('My Experience Title')
+        await wrapper.vm.$nextTick()
+
+        await vi.waitFor(() => {
+          const updated = wrapper.findComponent({ name: 'DeclaredExperienceTitleInput' })
+          expect(updated.props('modelValue')).toBe('My Experience Title')
+        })
+      })
+    })
+
+    BddTest().and('the user enters a title exceeding max length', () => {
+      BddTest().then('it should truncate the value to max length', async () => {
+        const input = wrapper.findComponent({ name: 'DeclaredExperienceTitleInput' })
+        const textInput = input.find('input')
+        const longTitle = 'a'.repeat(DECLARED_EXPERIENCE_TITLE_MAX_LENGTH + 10)
+        await textInput.setValue(longTitle)
+        await wrapper.vm.$nextTick()
+
+        await vi.waitFor(() => {
+          const updated = wrapper.findComponent({ name: 'DeclaredExperienceTitleInput' })
+          expect(updated.props('modelValue')).toHaveLength(DECLARED_EXPERIENCE_TITLE_MAX_LENGTH)
+        })
+      })
+    })
+
+    BddTest().and('the input emits blur', () => {
+      BddTest().then('it should trigger blur handler', async () => {
+        const input = wrapper.findComponent({ name: 'DeclaredExperienceTitleInput' })
+        await input.vm.$emit('blur')
+        await wrapper.vm.$nextTick()
+
+        expect(input.emitted('blur')).toBeTruthy()
+      })
+    })
+
+    BddTest().and('the form is submitted with empty title', () => {
+      BddTest().then('it should show validation error', async () => {
+        await wrapper.find('form').trigger('submit')
+        await wrapper.vm.$nextTick()
+
+        await vi.waitFor(() => {
+          const input = wrapper.findComponent({ name: 'DeclaredExperienceTitleInput' })
+          expect(input.props('errorMessage')).toBe('Le titre est requis')
+        })
+      })
+    })
+
+    BddTest().and('the form is submitted with valid title', () => {
+      BddTest().then('it should not show validation error', async () => {
+        const input = wrapper.findComponent({ name: 'DeclaredExperienceTitleInput' })
+        const textInput = input.find('input')
+        await textInput.setValue('Valid Experience Title')
+        await wrapper.vm.$nextTick()
+        await wrapper.find('form').trigger('submit')
+        await wrapper.vm.$nextTick()
+
+        await vi.waitFor(() => {
+          const updated = wrapper.findComponent({ name: 'DeclaredExperienceTitleInput' })
+          expect(updated.props('errorMessage')).toBeFalsy()
+        })
+      })
+    })
+  })
+})

--- a/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceTitleFormField/DeclaredExperienceTitleFormField.test.ts
+++ b/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceTitleFormField/DeclaredExperienceTitleFormField.test.ts
@@ -2,42 +2,20 @@ import type { AddDeclaredExperienceForm, DeclaredExperienceFormData } from '@/fe
 import DeclaredExperienceTitleFormField
   from '@/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceTitleFormField/DeclaredExperienceTitleFormField.vue'
 import { DeclaredExperienceTitleInputStub } from '@/features/student/personalCareer/components/interactions/inputs/DeclaredExperienceTitleInput/DeclaredExperienceTitleInput.stub'
+import {
+  useDeclaredExperienceFormValidators
+} from '@/features/student/personalCareer/composables/use-declared-experience-form-validators/use-declared-experience-form-validators'
 import { DECLARED_EXPERIENCE_TITLE_MAX_LENGTH } from '@/features/student/personalCareer/config'
 import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
-import { useForm } from '@tanstack/vue-form'
 import { mount, type VueWrapper } from '@vue/test-utils'
+import { createFormFieldTestWrapper } from 'tests/utils'
 import { beforeEach, expect, vi } from 'vitest'
 
-const TestWrapper = defineComponent({
-  components: {
-    DeclaredExperienceTitleFormField
-  },
-  setup () {
-    const form = useForm({
-      defaultValues: {
-        title: ''
-      } as DeclaredExperienceFormData,
-      validators: {
-        onSubmit ({ value }) {
-          if (!value.title || value.title.trim() === '') {
-            return {
-              fields: {
-                title: 'Le titre est requis'
-              }
-            }
-          }
-          return { fields: { title: undefined } }
-        }
-      }
-    }) as unknown as AddDeclaredExperienceForm
-
-    return { form }
-  },
-  template: `
-    <form @submit.prevent="form.handleSubmit">
-      <DeclaredExperienceTitleFormField :form="form" />
-    </form>
-  `
+const TestWrapper = createFormFieldTestWrapper<AddDeclaredExperienceForm, DeclaredExperienceFormData, 'title'>({
+  formFieldComponent: DeclaredExperienceTitleFormField,
+  fieldName: 'title',
+  defaultValue: '',
+  useValidator: () => useDeclaredExperienceFormValidators().validateTitle
 })
 
 BddTest().given('a declared experience title form field', () => {
@@ -111,7 +89,7 @@ BddTest().given('a declared experience title form field', () => {
 
         await vi.waitFor(() => {
           const input = wrapper.findComponent({ name: 'DeclaredExperienceTitleInput' })
-          expect(input.props('errorMessage')).toBe('Le titre est requis')
+          expect(input.props('errorMessage')).toBe('Ce champ est requis.')
         })
       })
     })

--- a/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceTitleFormField/DeclaredExperienceTitleFormField.vue
+++ b/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceTitleFormField/DeclaredExperienceTitleFormField.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import type { AddDeclaredExperienceForm } from '@/features/student/personalCareer/types/forms.types'
+import DeclaredExperienceTitleInput from '@/features/student/personalCareer/components/interactions/inputs/DeclaredExperienceTitleInput/DeclaredExperienceTitleInput.vue'
+import { DECLARED_EXPERIENCE_TITLE_MAX_LENGTH } from '@/features/student/personalCareer/config'
+import { markRaw } from 'vue'
+
+interface DeclaredExperienceTitleFormFieldProps {
+  form: AddDeclaredExperienceForm
+}
+
+defineOptions({
+  inheritAttrs: false
+})
+
+const { form } = defineProps<DeclaredExperienceTitleFormFieldProps>()
+const FormField = markRaw(form.Field)
+const titleField = form.useField({ name: 'title' })
+
+function onUpdateTitle (value: string | undefined) {
+  titleField.api.handleChange(String(value ?? '').slice(0, DECLARED_EXPERIENCE_TITLE_MAX_LENGTH))
+}
+</script>
+
+<template>
+  <FormField name="title">
+    <template #default="{ field }">
+      <DeclaredExperienceTitleInput
+        v-bind="$attrs"
+        :model-value="(field.state.value ?? '').slice(0, DECLARED_EXPERIENCE_TITLE_MAX_LENGTH)"
+        :error-message="field.state.meta.errors?.join(', ')"
+        @blur="field.handleBlur"
+        @update:model-value="onUpdateTitle"
+      />
+    </template>
+  </FormField>
+</template>

--- a/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceTypeFormField/DeclaredExperienceTypeFormField.stub.ts
+++ b/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceTypeFormField/DeclaredExperienceTypeFormField.stub.ts
@@ -1,7 +1,5 @@
-import type { Component } from 'vue'
-
-export const DeclaredExperienceTypeFormFieldStub: Component = {
+export const DeclaredExperienceTypeFormFieldStub = defineComponent({
   name: 'DeclaredExperienceTypeFormField',
   props: ['form'],
   template: '<div data-testid="experience-type-form-field" />'
-}
+})

--- a/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceTypeFormField/DeclaredExperienceTypeFormField.stub.ts
+++ b/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceTypeFormField/DeclaredExperienceTypeFormField.stub.ts
@@ -1,0 +1,7 @@
+import type { Component } from 'vue'
+
+export const DeclaredExperienceTypeFormFieldStub: Component = {
+  name: 'DeclaredExperienceTypeFormField',
+  props: ['form'],
+  template: '<div data-testid="experience-type-form-field" />'
+}

--- a/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceTypeFormField/DeclaredExperienceTypeFormField.test.ts
+++ b/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceTypeFormField/DeclaredExperienceTypeFormField.test.ts
@@ -3,41 +3,19 @@ import type { AddDeclaredExperienceForm, DeclaredExperienceFormData } from '@/fe
 import DeclaredExperienceTypeFormField
   from '@/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceTypeFormField/DeclaredExperienceTypeFormField.vue'
 import { DeclaredExperienceTypeSelectStub } from '@/features/student/personalCareer/components/interactions/inputs/DeclaredExperienceTypeSelect/DeclaredExperienceTypeSelect.stub'
+import {
+  useDeclaredExperienceFormValidators
+} from '@/features/student/personalCareer/composables/use-declared-experience-form-validators/use-declared-experience-form-validators'
 import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
-import { useForm } from '@tanstack/vue-form'
 import { mount, type VueWrapper } from '@vue/test-utils'
+import { createFormFieldTestWrapper } from 'tests/utils'
 import { beforeEach, expect, vi } from 'vitest'
 
-const TestWrapper = defineComponent({
-  components: {
-    DeclaredExperienceTypeFormField
-  },
-  setup () {
-    const form = useForm({
-      defaultValues: {
-        type: ''
-      } as DeclaredExperienceFormData,
-      validators: {
-        onSubmit ({ value }) {
-          if (!value.type || value.type.trim() === '') {
-            return {
-              fields: {
-                type: 'Le type est requis'
-              }
-            }
-          }
-          return { fields: { type: undefined } }
-        }
-      }
-    }) as unknown as AddDeclaredExperienceForm
-
-    return { form }
-  },
-  template: `
-    <form @submit.prevent="form.handleSubmit">
-      <DeclaredExperienceTypeFormField :form="form" />
-    </form>
-  `
+const TestWrapper = createFormFieldTestWrapper<AddDeclaredExperienceForm, DeclaredExperienceFormData, 'type'>({
+  formFieldComponent: DeclaredExperienceTypeFormField,
+  fieldName: 'type',
+  defaultValue: '',
+  useValidator: () => useDeclaredExperienceFormValidators().validateType
 })
 
 BddTest().given('a declared experience type form field', () => {
@@ -95,7 +73,7 @@ BddTest().given('a declared experience type form field', () => {
 
         await vi.waitFor(() => {
           const select = wrapper.findComponent({ name: 'DeclaredExperienceTypeSelect' })
-          expect(select.props('errorMessage')).toBe('Le type est requis')
+          expect(select.props('errorMessage')).toBe('Ce champ est requis.')
         })
       })
     })

--- a/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceTypeFormField/DeclaredExperienceTypeFormField.test.ts
+++ b/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceTypeFormField/DeclaredExperienceTypeFormField.test.ts
@@ -1,0 +1,118 @@
+import type { EExperienceType } from '@/api/avenir-esr'
+import type { AddDeclaredExperienceForm, DeclaredExperienceFormData } from '@/features/student/personalCareer/types/forms.types'
+import DeclaredExperienceTypeFormField
+  from '@/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceTypeFormField/DeclaredExperienceTypeFormField.vue'
+import { DeclaredExperienceTypeSelectStub } from '@/features/student/personalCareer/components/interactions/inputs/DeclaredExperienceTypeSelect/DeclaredExperienceTypeSelect.stub'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { useForm } from '@tanstack/vue-form'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { beforeEach, expect, vi } from 'vitest'
+
+const TestWrapper = defineComponent({
+  components: {
+    DeclaredExperienceTypeFormField
+  },
+  setup () {
+    const form = useForm({
+      defaultValues: {
+        type: ''
+      } as DeclaredExperienceFormData,
+      validators: {
+        onSubmit ({ value }) {
+          if (!value.type || value.type.trim() === '') {
+            return {
+              fields: {
+                type: 'Le type est requis'
+              }
+            }
+          }
+          return { fields: { type: undefined } }
+        }
+      }
+    }) as unknown as AddDeclaredExperienceForm
+
+    return { form }
+  },
+  template: `
+    <form @submit.prevent="form.handleSubmit">
+      <DeclaredExperienceTypeFormField :form="form" />
+    </form>
+  `
+})
+
+BddTest().given('a declared experience type form field', () => {
+  let wrapper: VueWrapper<InstanceType<typeof TestWrapper>>
+
+  const stubs = {
+    DeclaredExperienceTypeSelect: DeclaredExperienceTypeSelectStub
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    wrapper = mount(TestWrapper, {
+      global: { stubs }
+    })
+  })
+
+  BddTest().when('the component is mounted', () => {
+    BddTest().then('it should render the type select component', () => {
+      const select = wrapper.findComponent({ name: 'DeclaredExperienceTypeSelect' })
+      expect(select.exists()).toBe(true)
+    })
+
+    BddTest().then('it should have empty initial value', () => {
+      const select = wrapper.findComponent({ name: 'DeclaredExperienceTypeSelect' })
+      expect(select.props('modelValue')).toBe('')
+    })
+
+    BddTest().and('the user selects a type', () => {
+      BddTest().then('it should update the form field value', async () => {
+        const select = wrapper.findComponent({ name: 'DeclaredExperienceTypeSelect' })
+        await select.vm.$emit('update:modelValue', 'PROFESSIONAL' as EExperienceType)
+        await wrapper.vm.$nextTick()
+
+        await vi.waitFor(() => {
+          const updated = wrapper.findComponent({ name: 'DeclaredExperienceTypeSelect' })
+          expect(updated.props('modelValue')).toBe('PROFESSIONAL')
+        })
+      })
+    })
+
+    BddTest().and('the input emits blur', () => {
+      BddTest().then('it should trigger blur handler', async () => {
+        const select = wrapper.findComponent({ name: 'DeclaredExperienceTypeSelect' })
+        await select.vm.$emit('blur')
+        await wrapper.vm.$nextTick()
+
+        expect(select.emitted('blur')).toBeTruthy()
+      })
+    })
+
+    BddTest().and('the form is submitted with empty type', () => {
+      BddTest().then('it should show validation error', async () => {
+        await wrapper.find('form').trigger('submit')
+        await wrapper.vm.$nextTick()
+
+        await vi.waitFor(() => {
+          const select = wrapper.findComponent({ name: 'DeclaredExperienceTypeSelect' })
+          expect(select.props('errorMessage')).toBe('Le type est requis')
+        })
+      })
+    })
+
+    BddTest().and('the form is submitted with valid type', () => {
+      BddTest().then('it should not show validation error', async () => {
+        const select = wrapper.findComponent({ name: 'DeclaredExperienceTypeSelect' })
+        await select.vm.$emit('update:modelValue', 'ASSOCIATIVE' as EExperienceType)
+        await wrapper.vm.$nextTick()
+        await wrapper.find('form').trigger('submit')
+        await wrapper.vm.$nextTick()
+
+        await vi.waitFor(() => {
+          const updated = wrapper.findComponent({ name: 'DeclaredExperienceTypeSelect' })
+          expect(updated.props('errorMessage')).toBeFalsy()
+        })
+      })
+    })
+  })
+})

--- a/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceTypeFormField/DeclaredExperienceTypeFormField.vue
+++ b/src/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceTypeFormField/DeclaredExperienceTypeFormField.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import type { EExperienceType } from '@/api/avenir-esr'
+import type { AddDeclaredExperienceForm } from '@/features/student/personalCareer/types/forms.types'
+import DeclaredExperienceTypeSelect from '@/features/student/personalCareer/components/interactions/inputs/DeclaredExperienceTypeSelect/DeclaredExperienceTypeSelect.vue'
+import { markRaw } from 'vue'
+
+interface DeclaredExperienceTypeFormFieldProps {
+  form: AddDeclaredExperienceForm
+}
+
+defineOptions({
+  inheritAttrs: false
+})
+
+const { form } = defineProps<DeclaredExperienceTypeFormFieldProps>()
+const FormField = markRaw(form.Field)
+const typeField = form.useField({ name: 'type' })
+
+function onUpdateType (value: EExperienceType | undefined) {
+  typeField.api.handleChange(value ?? '')
+}
+</script>
+
+<template>
+  <FormField name="type">
+    <template #default="{ field }">
+      <DeclaredExperienceTypeSelect
+        v-bind="$attrs"
+        :model-value="field.state.value as EExperienceType"
+        :error-message="field.state.meta.errors?.join(', ')"
+        @blur="field.handleBlur"
+        @update:model-value="onUpdateType"
+      />
+    </template>
+  </FormField>
+</template>

--- a/src/features/student/personalCareer/components/interactions/inputs/DeclaredExperienceActivitySectorInput/DeclaredExperienceActivitySectorInput.stub.ts
+++ b/src/features/student/personalCareer/components/interactions/inputs/DeclaredExperienceActivitySectorInput/DeclaredExperienceActivitySectorInput.stub.ts
@@ -1,6 +1,4 @@
-import type { Component } from 'vue'
-
-export const DeclaredExperienceActivitySectorInputStub: Component = {
+export const DeclaredExperienceActivitySectorInputStub = defineComponent({
   name: 'DeclaredExperienceActivitySectorInput',
   props: ['modelValue', 'errorMessage'],
   emits: ['update:modelValue', 'blur'],
@@ -13,4 +11,4 @@ export const DeclaredExperienceActivitySectorInputStub: Component = {
       />
     </div>
   `
-}
+})

--- a/src/features/student/personalCareer/components/interactions/inputs/DeclaredExperienceActivitySectorInput/DeclaredExperienceActivitySectorInput.stub.ts
+++ b/src/features/student/personalCareer/components/interactions/inputs/DeclaredExperienceActivitySectorInput/DeclaredExperienceActivitySectorInput.stub.ts
@@ -1,0 +1,16 @@
+import type { Component } from 'vue'
+
+export const DeclaredExperienceActivitySectorInputStub: Component = {
+  name: 'DeclaredExperienceActivitySectorInput',
+  props: ['modelValue', 'errorMessage'],
+  emits: ['update:modelValue', 'blur'],
+  template: `
+    <div data-testid="declared-experience-activity-sector-input-stub">
+      <input
+        :value="modelValue"
+        @input="$emit('update:modelValue', $event.target.value)"
+        @blur="$emit('blur')"
+      />
+    </div>
+  `
+}

--- a/src/features/student/personalCareer/components/interactions/inputs/DeclaredExperienceDescriptionTextarea/DeclaredExperienceDescriptionTextarea.stub.ts
+++ b/src/features/student/personalCareer/components/interactions/inputs/DeclaredExperienceDescriptionTextarea/DeclaredExperienceDescriptionTextarea.stub.ts
@@ -1,0 +1,16 @@
+import type { Component } from 'vue'
+
+export const DeclaredExperienceDescriptionTextareaStub: Component = {
+  name: 'DeclaredExperienceDescriptionTextarea',
+  props: ['modelValue', 'errorMessage'],
+  emits: ['update:modelValue', 'blur'],
+  template: `
+    <div data-testid="declared-experience-description-textarea-stub">
+      <textarea
+        :value="modelValue"
+        @input="$emit('update:modelValue', $event.target.value)"
+        @blur="$emit('blur')"
+      />
+    </div>
+  `
+}

--- a/src/features/student/personalCareer/components/interactions/inputs/DeclaredExperienceDescriptionTextarea/DeclaredExperienceDescriptionTextarea.stub.ts
+++ b/src/features/student/personalCareer/components/interactions/inputs/DeclaredExperienceDescriptionTextarea/DeclaredExperienceDescriptionTextarea.stub.ts
@@ -1,6 +1,4 @@
-import type { Component } from 'vue'
-
-export const DeclaredExperienceDescriptionTextareaStub: Component = {
+export const DeclaredExperienceDescriptionTextareaStub = defineComponent({
   name: 'DeclaredExperienceDescriptionTextarea',
   props: ['modelValue', 'errorMessage'],
   emits: ['update:modelValue', 'blur'],
@@ -13,4 +11,4 @@ export const DeclaredExperienceDescriptionTextareaStub: Component = {
       />
     </div>
   `
-}
+})

--- a/src/features/student/personalCareer/components/interactions/inputs/DeclaredExperienceLinkInput/DeclaredExperienceLinkInput.stub.ts
+++ b/src/features/student/personalCareer/components/interactions/inputs/DeclaredExperienceLinkInput/DeclaredExperienceLinkInput.stub.ts
@@ -1,6 +1,4 @@
-import type { Component } from 'vue'
-
-export const DeclaredExperienceLinkInputStub: Component = {
+export const DeclaredExperienceLinkInputStub = defineComponent({
   name: 'DeclaredExperienceLinkInput',
   props: ['modelValue', 'errorMessage'],
   emits: ['update:modelValue', 'blur'],
@@ -13,4 +11,4 @@ export const DeclaredExperienceLinkInputStub: Component = {
       />
     </div>
   `
-}
+})

--- a/src/features/student/personalCareer/components/interactions/inputs/DeclaredExperienceLinkInput/DeclaredExperienceLinkInput.stub.ts
+++ b/src/features/student/personalCareer/components/interactions/inputs/DeclaredExperienceLinkInput/DeclaredExperienceLinkInput.stub.ts
@@ -1,0 +1,16 @@
+import type { Component } from 'vue'
+
+export const DeclaredExperienceLinkInputStub: Component = {
+  name: 'DeclaredExperienceLinkInput',
+  props: ['modelValue', 'errorMessage'],
+  emits: ['update:modelValue', 'blur'],
+  template: `
+    <div data-testid="declared-experience-link-input-stub">
+      <input
+        :value="modelValue"
+        @input="$emit('update:modelValue', $event.target.value)"
+        @blur="$emit('blur')"
+      />
+    </div>
+  `
+}

--- a/src/features/student/personalCareer/components/interactions/inputs/DeclaredExperienceLocationInput/DeclaredExperienceLocationInput.stub.ts
+++ b/src/features/student/personalCareer/components/interactions/inputs/DeclaredExperienceLocationInput/DeclaredExperienceLocationInput.stub.ts
@@ -1,6 +1,4 @@
-import type { Component } from 'vue'
-
-export const DeclaredExperienceLocationInputStub: Component = {
+export const DeclaredExperienceLocationInputStub = defineComponent({
   name: 'DeclaredExperienceLocationInput',
   props: ['modelValue', 'errorMessage'],
   emits: ['update:modelValue', 'blur'],
@@ -13,4 +11,4 @@ export const DeclaredExperienceLocationInputStub: Component = {
       />
     </div>
   `
-}
+})

--- a/src/features/student/personalCareer/components/interactions/inputs/DeclaredExperienceLocationInput/DeclaredExperienceLocationInput.stub.ts
+++ b/src/features/student/personalCareer/components/interactions/inputs/DeclaredExperienceLocationInput/DeclaredExperienceLocationInput.stub.ts
@@ -1,0 +1,16 @@
+import type { Component } from 'vue'
+
+export const DeclaredExperienceLocationInputStub: Component = {
+  name: 'DeclaredExperienceLocationInput',
+  props: ['modelValue', 'errorMessage'],
+  emits: ['update:modelValue', 'blur'],
+  template: `
+    <div data-testid="declared-experience-location-input-stub">
+      <input
+        :value="modelValue"
+        @input="$emit('update:modelValue', $event.target.value)"
+        @blur="$emit('blur')"
+      />
+    </div>
+  `
+}

--- a/src/features/student/personalCareer/components/interactions/inputs/DeclaredExperienceOrganizationInput/DeclaredExperienceOrganizationInput.stub.ts
+++ b/src/features/student/personalCareer/components/interactions/inputs/DeclaredExperienceOrganizationInput/DeclaredExperienceOrganizationInput.stub.ts
@@ -1,6 +1,4 @@
-import type { Component } from 'vue'
-
-export const DeclaredExperienceOrganizationInputStub: Component = {
+export const DeclaredExperienceOrganizationInputStub = defineComponent({
   name: 'DeclaredExperienceOrganizationInput',
   props: ['modelValue', 'errorMessage'],
   emits: ['update:modelValue', 'blur'],
@@ -13,4 +11,4 @@ export const DeclaredExperienceOrganizationInputStub: Component = {
       />
     </div>
   `
-}
+})

--- a/src/features/student/personalCareer/components/interactions/inputs/DeclaredExperienceOrganizationInput/DeclaredExperienceOrganizationInput.stub.ts
+++ b/src/features/student/personalCareer/components/interactions/inputs/DeclaredExperienceOrganizationInput/DeclaredExperienceOrganizationInput.stub.ts
@@ -1,0 +1,16 @@
+import type { Component } from 'vue'
+
+export const DeclaredExperienceOrganizationInputStub: Component = {
+  name: 'DeclaredExperienceOrganizationInput',
+  props: ['modelValue', 'errorMessage'],
+  emits: ['update:modelValue', 'blur'],
+  template: `
+    <div data-testid="declared-experience-organization-input-stub">
+      <input
+        :value="modelValue"
+        @input="$emit('update:modelValue', $event.target.value)"
+        @blur="$emit('blur')"
+      />
+    </div>
+  `
+}

--- a/src/features/student/personalCareer/components/interactions/inputs/DeclaredExperiencePeriodInput/DeclaredExperiencePeriodInput.stub.ts
+++ b/src/features/student/personalCareer/components/interactions/inputs/DeclaredExperiencePeriodInput/DeclaredExperiencePeriodInput.stub.ts
@@ -1,0 +1,22 @@
+import type { Component } from 'vue'
+
+export const DeclaredExperiencePeriodInputStub: Component = {
+  name: 'DeclaredExperiencePeriodInput',
+  props: ['labelVisible', 'startModelValue', 'endModelValue', 'startErrorMessage', 'endErrorMessage', 'endDateDisabled'],
+  emits: ['update:startModelValue', 'update:endModelValue'],
+  template: `
+    <div data-testid="declared-experience-period-input-stub">
+      <input
+        data-testid="start-date-input"
+        :value="startModelValue"
+        @input="$emit('update:startModelValue', $event.target.value)"
+      />
+      <input
+        data-testid="end-date-input"
+        :value="endModelValue"
+        :disabled="endDateDisabled"
+        @input="$emit('update:endModelValue', $event.target.value)"
+      />
+    </div>
+  `
+}

--- a/src/features/student/personalCareer/components/interactions/inputs/DeclaredExperiencePeriodInput/DeclaredExperiencePeriodInput.stub.ts
+++ b/src/features/student/personalCareer/components/interactions/inputs/DeclaredExperiencePeriodInput/DeclaredExperiencePeriodInput.stub.ts
@@ -1,6 +1,4 @@
-import type { Component } from 'vue'
-
-export const DeclaredExperiencePeriodInputStub: Component = {
+export const DeclaredExperiencePeriodInputStub = defineComponent({
   name: 'DeclaredExperiencePeriodInput',
   props: ['labelVisible', 'startModelValue', 'endModelValue', 'startErrorMessage', 'endErrorMessage', 'endDateDisabled'],
   emits: ['update:startModelValue', 'update:endModelValue'],
@@ -19,4 +17,4 @@ export const DeclaredExperiencePeriodInputStub: Component = {
       />
     </div>
   `
-}
+})

--- a/src/features/student/personalCareer/components/interactions/inputs/DeclaredExperiencePeriodInput/DeclaredExperiencePeriodInput.test.ts
+++ b/src/features/student/personalCareer/components/interactions/inputs/DeclaredExperiencePeriodInput/DeclaredExperiencePeriodInput.test.ts
@@ -1,0 +1,186 @@
+import DeclaredExperiencePeriodInput from '@/features/student/personalCareer/components/interactions/inputs/DeclaredExperiencePeriodInput/DeclaredExperiencePeriodInput.vue'
+import { AvPeriodInputStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { beforeEach, expect, vi } from 'vitest'
+
+vi.mock('@avenirs-esr/avenirs-dsav', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@avenirs-esr/avenirs-dsav')>()
+  return {
+    ...original,
+    useAvBreakpoints: () => ({
+      isMobile: ref(false)
+    })
+  }
+})
+
+BddTest().given('a declared experience period input component', () => {
+  let wrapper: VueWrapper<InstanceType<typeof DeclaredExperiencePeriodInput>>
+
+  const stubs = {
+    AvPeriodInput: AvPeriodInputStub
+  }
+
+  BddTest().when('the component is mounted', () => {
+    beforeEach(() => {
+      vi.clearAllMocks()
+      wrapper = mount(DeclaredExperiencePeriodInput, {
+        global: { stubs }
+      })
+    })
+
+    BddTest().then('it should render correctly', () => {
+      expect(wrapper.exists()).toBe(true)
+    })
+
+    BddTest().then('it should render the AvPeriodInput component', () => {
+      const input = wrapper.findComponent({ name: 'AvPeriodInput' })
+      expect(input.exists()).toBe(true)
+    })
+
+    BddTest().then('it should have type set to month', () => {
+      const input = wrapper.findComponent({ name: 'AvPeriodInput' })
+      expect(input.props('type')).toBe('month')
+    })
+
+    BddTest().then('it should display the correct French label', () => {
+      const input = wrapper.findComponent({ name: 'AvPeriodInput' })
+      expect(input.props('label')).toBe('Période')
+    })
+
+    BddTest().then('it should display the correct French start label', () => {
+      const input = wrapper.findComponent({ name: 'AvPeriodInput' })
+      expect(input.props('startLabel')).toBe('Date de début')
+    })
+
+    BddTest().then('it should display the correct French end label', () => {
+      const input = wrapper.findComponent({ name: 'AvPeriodInput' })
+      expect(input.props('endLabel')).toBe('Date de fin')
+    })
+
+    BddTest().then('it should have separator spacing', () => {
+      const input = wrapper.findComponent({ name: 'AvPeriodInput' })
+      expect(input.props('separatorSpacing')).toBe('var(--spacing-sm)')
+    })
+
+    BddTest().then('it should not be stacked on desktop', () => {
+      const input = wrapper.findComponent({ name: 'AvPeriodInput' })
+      expect(input.props('stacked')).toBe(false)
+    })
+  })
+
+  BddTest().when('the component is mounted with custom props', () => {
+    beforeEach(() => {
+      vi.clearAllMocks()
+      wrapper = mount(DeclaredExperiencePeriodInput, {
+        props: {
+          startModelValue: '2024-01',
+          endModelValue: '2024-12',
+          endDateDisabled: true
+        },
+        global: { stubs }
+      })
+    })
+
+    BddTest().then('it should pass start model value to AvPeriodInput', () => {
+      const input = wrapper.findComponent({ name: 'AvPeriodInput' })
+      expect(input.props('startModelValue')).toBe('2024-01')
+    })
+
+    BddTest().then('it should pass end model value to AvPeriodInput', () => {
+      const input = wrapper.findComponent({ name: 'AvPeriodInput' })
+      expect(input.props('endModelValue')).toBe('2024-12')
+    })
+
+    BddTest().then('it should pass endDateDisabled to AvPeriodInput', () => {
+      const input = wrapper.findComponent({ name: 'AvPeriodInput' })
+      expect(input.props('endDateDisabled')).toBe(true)
+    })
+  })
+
+  BddTest().when('the component is mounted with label visibility disabled', () => {
+    beforeEach(() => {
+      vi.clearAllMocks()
+      wrapper = mount(DeclaredExperiencePeriodInput, {
+        props: {
+          labelVisible: false
+        },
+        global: { stubs }
+      })
+    })
+
+    BddTest().then('it should pass labelVisible false to AvPeriodInput', () => {
+      const input = wrapper.findComponent({ name: 'AvPeriodInput' })
+      expect(input.props('labelVisible')).toBe(false)
+    })
+  })
+
+  BddTest().when('the user enters a start date', () => {
+    beforeEach(async () => {
+      vi.clearAllMocks()
+      wrapper = mount(DeclaredExperiencePeriodInput, {
+        global: { stubs }
+      })
+      const input = wrapper.findComponent({ name: 'AvPeriodInput' })
+      await input.vm.$emit('update:startModelValue', '2024-01')
+      await wrapper.vm.$nextTick()
+    })
+
+    BddTest().then('it should emit update:startModelValue event', () => {
+      const input = wrapper.findComponent({ name: 'AvPeriodInput' })
+      expect(input.emitted('update:startModelValue')).toBeTruthy()
+      expect(input.emitted('update:startModelValue')?.[0]).toEqual(['2024-01'])
+    })
+  })
+
+  BddTest().when('the user enters an end date', () => {
+    beforeEach(async () => {
+      vi.clearAllMocks()
+      wrapper = mount(DeclaredExperiencePeriodInput, {
+        global: { stubs }
+      })
+      const input = wrapper.findComponent({ name: 'AvPeriodInput' })
+      await input.vm.$emit('update:endModelValue', '2024-12')
+      await wrapper.vm.$nextTick()
+    })
+
+    BddTest().then('it should emit update:endModelValue event', () => {
+      const input = wrapper.findComponent({ name: 'AvPeriodInput' })
+      expect(input.emitted('update:endModelValue')).toBeTruthy()
+      expect(input.emitted('update:endModelValue')?.[0]).toEqual(['2024-12'])
+    })
+  })
+
+  BddTest().when('the component is mounted with attributes', () => {
+    beforeEach(() => {
+      vi.clearAllMocks()
+      wrapper = mount(DeclaredExperiencePeriodInput, {
+        attrs: {
+          'data-testid': 'custom-period-input'
+        },
+        global: { stubs }
+      })
+    })
+
+    BddTest().then('it should pass attrs to AvPeriodInput', () => {
+      const input = wrapper.findComponent({ name: 'AvPeriodInput' })
+      expect(input.attributes('data-testid')).toBe('custom-period-input')
+    })
+  })
+
+  BddTest().when('the component is mounted with custom label class', () => {
+    beforeEach(() => {
+      vi.clearAllMocks()
+      wrapper = mount(DeclaredExperiencePeriodInput, {
+        props: {
+          labelClass: 'custom-class'
+        },
+        global: { stubs }
+      })
+    })
+
+    BddTest().then('it should pass label class to AvPeriodInput', () => {
+      const input = wrapper.findComponent({ name: 'AvPeriodInput' })
+      expect(input.props('labelClass')).toBe('custom-class')
+    })
+  })
+})

--- a/src/features/student/personalCareer/components/interactions/inputs/DeclaredExperiencePeriodInput/DeclaredExperiencePeriodInput.vue
+++ b/src/features/student/personalCareer/components/interactions/inputs/DeclaredExperiencePeriodInput/DeclaredExperiencePeriodInput.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import { AvPeriodInput, type AvPeriodInputProps, useAvBreakpoints } from '@avenirs-esr/avenirs-dsav'
+import { useAttrs } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+type DeclaredExperiencePeriodInputProps = Omit<AvPeriodInputProps, 'label' | 'startLabel' | 'endLabel' | 'separatorSpacing' | 'stacked' | 'type'>
+
+const {
+  labelClass,
+  ...restProps
+} = defineProps<DeclaredExperiencePeriodInputProps>()
+
+const { t } = useI18n()
+const { isMobile } = useAvBreakpoints()
+const attrs = useAttrs()
+
+const avPeriodInputProps = computed<AvPeriodInputProps>(() => ({
+  ...attrs,
+  ...restProps,
+  type: 'month',
+  label: t('student.personalCareer.interactions.inputs.DeclaredExperiencePeriodInput.label'),
+  labelClass,
+  startLabel: t('student.personalCareer.interactions.inputs.DeclaredExperiencePeriodInput.startLabel'),
+  endLabel: t('student.personalCareer.interactions.inputs.DeclaredExperiencePeriodInput.endLabel'),
+  stacked: isMobile.value,
+  separatorSpacing: 'var(--spacing-sm)'
+}))
+</script>
+
+<template>
+  <AvPeriodInput
+    v-bind="avPeriodInputProps"
+  />
+</template>

--- a/src/features/student/personalCareer/components/interactions/inputs/DeclaredExperiencePeriodInput/DeclaredExperiencePeriodInput.vue
+++ b/src/features/student/personalCareer/components/interactions/inputs/DeclaredExperiencePeriodInput/DeclaredExperiencePeriodInput.vue
@@ -28,7 +28,5 @@ const avPeriodInputProps = computed<AvPeriodInputProps>(() => ({
 </script>
 
 <template>
-  <AvPeriodInput
-    v-bind="avPeriodInputProps"
-  />
+  <AvPeriodInput v-bind="avPeriodInputProps" />
 </template>

--- a/src/features/student/personalCareer/components/interactions/inputs/DeclaredExperienceReviewTextarea/DeclaredExperienceReviewTextarea.stub.ts
+++ b/src/features/student/personalCareer/components/interactions/inputs/DeclaredExperienceReviewTextarea/DeclaredExperienceReviewTextarea.stub.ts
@@ -1,6 +1,4 @@
-import type { Component } from 'vue'
-
-export const DeclaredExperienceReviewTextareaStub: Component = {
+export const DeclaredExperienceReviewTextareaStub = defineComponent({
   name: 'DeclaredExperienceReviewTextarea',
   props: ['modelValue', 'errorMessage'],
   emits: ['update:modelValue', 'blur'],
@@ -13,4 +11,4 @@ export const DeclaredExperienceReviewTextareaStub: Component = {
       />
     </div>
   `
-}
+})

--- a/src/features/student/personalCareer/components/interactions/inputs/DeclaredExperienceReviewTextarea/DeclaredExperienceReviewTextarea.stub.ts
+++ b/src/features/student/personalCareer/components/interactions/inputs/DeclaredExperienceReviewTextarea/DeclaredExperienceReviewTextarea.stub.ts
@@ -1,0 +1,16 @@
+import type { Component } from 'vue'
+
+export const DeclaredExperienceReviewTextareaStub: Component = {
+  name: 'DeclaredExperienceReviewTextarea',
+  props: ['modelValue', 'errorMessage'],
+  emits: ['update:modelValue', 'blur'],
+  template: `
+    <div data-testid="declared-experience-review-textarea-stub">
+      <textarea
+        :value="modelValue"
+        @input="$emit('update:modelValue', $event.target.value)"
+        @blur="$emit('blur')"
+      />
+    </div>
+  `
+}

--- a/src/features/student/personalCareer/components/interactions/inputs/DeclaredExperienceSourceOfInformationInput/DeclaredExperienceSourceOfInformationInput.stub.ts
+++ b/src/features/student/personalCareer/components/interactions/inputs/DeclaredExperienceSourceOfInformationInput/DeclaredExperienceSourceOfInformationInput.stub.ts
@@ -1,6 +1,4 @@
-import type { Component } from 'vue'
-
-export const DeclaredExperienceSourceOfInformationInputStub: Component = {
+export const DeclaredExperienceSourceOfInformationInputStub = defineComponent({
   name: 'DeclaredExperienceSourceOfInformationInput',
   props: ['modelValue', 'errorMessage'],
   emits: ['update:modelValue', 'blur'],
@@ -13,4 +11,4 @@ export const DeclaredExperienceSourceOfInformationInputStub: Component = {
       />
     </div>
   `
-}
+})

--- a/src/features/student/personalCareer/components/interactions/inputs/DeclaredExperienceSourceOfInformationInput/DeclaredExperienceSourceOfInformationInput.stub.ts
+++ b/src/features/student/personalCareer/components/interactions/inputs/DeclaredExperienceSourceOfInformationInput/DeclaredExperienceSourceOfInformationInput.stub.ts
@@ -1,0 +1,16 @@
+import type { Component } from 'vue'
+
+export const DeclaredExperienceSourceOfInformationInputStub: Component = {
+  name: 'DeclaredExperienceSourceOfInformationInput',
+  props: ['modelValue', 'errorMessage'],
+  emits: ['update:modelValue', 'blur'],
+  template: `
+    <div data-testid="declared-experience-source-input-stub">
+      <input
+        :value="modelValue"
+        @input="$emit('update:modelValue', $event.target.value)"
+        @blur="$emit('blur')"
+      />
+    </div>
+  `
+}

--- a/src/features/student/personalCareer/components/interactions/inputs/DeclaredExperienceTitleInput/DeclaredExperienceTitleInput.stub.ts
+++ b/src/features/student/personalCareer/components/interactions/inputs/DeclaredExperienceTitleInput/DeclaredExperienceTitleInput.stub.ts
@@ -1,0 +1,16 @@
+import type { Component } from 'vue'
+
+export const DeclaredExperienceTitleInputStub: Component = {
+  name: 'DeclaredExperienceTitleInput',
+  props: ['modelValue', 'errorMessage'],
+  emits: ['update:modelValue', 'blur'],
+  template: `
+    <div data-testid="declared-experience-title-input-stub">
+      <input
+        :value="modelValue"
+        @input="$emit('update:modelValue', $event.target.value)"
+        @blur="$emit('blur')"
+      />
+    </div>
+  `
+}

--- a/src/features/student/personalCareer/components/interactions/inputs/DeclaredExperienceTitleInput/DeclaredExperienceTitleInput.stub.ts
+++ b/src/features/student/personalCareer/components/interactions/inputs/DeclaredExperienceTitleInput/DeclaredExperienceTitleInput.stub.ts
@@ -1,6 +1,4 @@
-import type { Component } from 'vue'
-
-export const DeclaredExperienceTitleInputStub: Component = {
+export const DeclaredExperienceTitleInputStub = defineComponent({
   name: 'DeclaredExperienceTitleInput',
   props: ['modelValue', 'errorMessage'],
   emits: ['update:modelValue', 'blur'],
@@ -13,4 +11,4 @@ export const DeclaredExperienceTitleInputStub: Component = {
       />
     </div>
   `
-}
+})

--- a/src/features/student/personalCareer/components/interactions/inputs/DeclaredExperienceTypeSelect/DeclaredExperienceTypeSelect.stub.ts
+++ b/src/features/student/personalCareer/components/interactions/inputs/DeclaredExperienceTypeSelect/DeclaredExperienceTypeSelect.stub.ts
@@ -1,6 +1,4 @@
-import type { Component } from 'vue'
-
-export const DeclaredExperienceTypeSelectStub: Component = {
+export const DeclaredExperienceTypeSelectStub = defineComponent({
   name: 'DeclaredExperienceTypeSelect',
   props: ['modelValue', 'errorMessage'],
   emits: ['update:modelValue', 'blur'],
@@ -17,4 +15,4 @@ export const DeclaredExperienceTypeSelectStub: Component = {
       </select>
     </div>
   `
-}
+})

--- a/src/features/student/personalCareer/components/interactions/inputs/DeclaredExperienceTypeSelect/DeclaredExperienceTypeSelect.stub.ts
+++ b/src/features/student/personalCareer/components/interactions/inputs/DeclaredExperienceTypeSelect/DeclaredExperienceTypeSelect.stub.ts
@@ -1,0 +1,20 @@
+import type { Component } from 'vue'
+
+export const DeclaredExperienceTypeSelectStub: Component = {
+  name: 'DeclaredExperienceTypeSelect',
+  props: ['modelValue', 'errorMessage'],
+  emits: ['update:modelValue', 'blur'],
+  template: `
+    <div data-testid="declared-experience-type-select-stub">
+      <select
+        :value="modelValue"
+        @change="$emit('update:modelValue', $event.target.value)"
+        @blur="$emit('blur')"
+      >
+        <option value="">Select</option>
+        <option value="PROFESSIONAL">Professional</option>
+        <option value="ASSOCIATIVE">Associative</option>
+      </select>
+    </div>
+  `
+}

--- a/src/features/student/personalCareer/components/overlays/AddDeclaredExperienceDrawer/AddDeclaredExperienceDrawer.test.ts
+++ b/src/features/student/personalCareer/components/overlays/AddDeclaredExperienceDrawer/AddDeclaredExperienceDrawer.test.ts
@@ -61,14 +61,9 @@ BddTest().given('an add declared experience drawer avIconText', () => {
 
     wrapper = mountComponent<typeof AddDeclaredExperienceDrawer>(
       AddDeclaredExperienceDrawer,
-      {
-        global: {
-          stubs
-        }
+      { global: { stubs }
       },
-      {
-        usePinia: false
-      }
+      { usePinia: false }
     )
 
     await wrapper.vm.$nextTick()
@@ -95,7 +90,7 @@ BddTest().given('an add declared experience drawer avIconText', () => {
       const accordions = wrapper.findAllComponents({ name: 'AvAccordion' })
 
       expect(accordionsGroup.exists()).toBe(true)
-      expect(accordions).toHaveLength(3)
+      expect(accordions).toHaveLength(1)
     })
 
     BddTest().then('it should render all form field components in first accordion', () => {
@@ -136,20 +131,6 @@ BddTest().given('an add declared experience drawer avIconText', () => {
 
       expect(addExperienceAccordion.props('title')).toBe('Ajouter mon expérience')
       expect(addExperienceAccordion.props('icon')).toBeDefined()
-    })
-
-    BddTest().then('it should render specify experience accordion with correct title', () => {
-      const accordions = wrapper.findAllComponents({ name: 'AvAccordion' })
-      const specifyAccordion = accordions[1]
-
-      expect(specifyAccordion.props('title')).toBe('Préciser mon expérience')
-    })
-
-    BddTest().then('it should render associate experience accordion with correct title', () => {
-      const accordions = wrapper.findAllComponents({ name: 'AvAccordion' })
-      const associateAccordion = accordions[2]
-
-      expect(associateAccordion.props('title')).toBe('Associer mon expérience')
     })
 
     BddTest().then('it should have confirmation modal rendered', () => {

--- a/src/features/student/personalCareer/components/overlays/AddDeclaredExperienceDrawer/AddDeclaredExperienceDrawer.test.ts
+++ b/src/features/student/personalCareer/components/overlays/AddDeclaredExperienceDrawer/AddDeclaredExperienceDrawer.test.ts
@@ -1,0 +1,197 @@
+import { ConfirmationModalStub } from '@/common/components/ConfirmationModal/ConfirmationModal.stub'
+import { DeclaredExperienceActivitySectorFormFieldStub } from '@/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceActivitySectorFormField/DeclaredExperienceActivitySectorFormField.stub'
+import { DeclaredExperienceDescriptionFormFieldStub } from '@/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceDescriptionFormField/DeclaredExperienceDescriptionFormField.stub'
+import { DeclaredExperienceLinkFormFieldStub } from '@/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceLinkFormField/DeclaredExperienceLinkFormField.stub'
+import { DeclaredExperienceLocationFormFieldStub } from '@/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceLocationFormField/DeclaredExperienceLocationFormField.stub'
+import { DeclaredExperienceOrganizationFormFieldStub } from '@/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceOrganizationFormField/DeclaredExperienceOrganizationFormField.stub'
+import { DeclaredExperiencePeriodFormFieldStub } from '@/features/student/personalCareer/components/interactions/formFields/DeclaredExperiencePeriodFormField/DeclaredExperiencePeriodFormField.stub'
+import { DeclaredExperienceReviewFormFieldStub } from '@/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceReviewFormField/DeclaredExperienceReviewFormField.stub'
+import { DeclaredExperienceSourceOfInformationFormFieldStub } from '@/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceSourceOfInformationFormField/DeclaredExperienceSourceOfInformationFormField.stub'
+import { DeclaredExperienceTitleFormFieldStub } from '@/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceTitleFormField/DeclaredExperienceTitleFormField.stub'
+import { DeclaredExperienceTypeFormFieldStub } from '@/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceTypeFormField/DeclaredExperienceTypeFormField.stub'
+import AddDeclaredExperienceDrawer from '@/features/student/personalCareer/components/overlays/AddDeclaredExperienceDrawer/AddDeclaredExperienceDrawer.vue'
+import { usePersonalCareerStore } from '@/features/student/personalCareer/stores/personalCareer.store'
+import { MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
+import { AvAccordionStub, AvCancelConfirmButtonsStub, AvDrawerStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { mountComponent } from 'tests/utils'
+
+const mockAddSuccessMessage = vi.fn()
+const mockAddErrorMessage = vi.fn()
+
+vi.mock('@/store', async () => {
+  const actual = await vi.importActual<typeof import('@/store')>('@/store')
+  return {
+    ...actual,
+    useToasterStore: vi.fn(() => ({
+      addSuccessMessage: mockAddSuccessMessage,
+      addErrorMessage: mockAddErrorMessage
+    }))
+  }
+})
+
+BddTest().given('an add declared experience drawer avIconText', () => {
+  let wrapper: ReturnType<typeof mountComponent<typeof AddDeclaredExperienceDrawer>>
+
+  const stubs = {
+    AvDrawer: AvDrawerStub,
+    AvAccordion: AvAccordionStub,
+    AvCancelConfirmButtons: AvCancelConfirmButtonsStub,
+    ConfirmationModal: ConfirmationModalStub,
+    DeclaredExperienceTitleFormField: DeclaredExperienceTitleFormFieldStub,
+    DeclaredExperienceTypeFormField: DeclaredExperienceTypeFormFieldStub,
+    DeclaredExperienceOrganizationFormField: DeclaredExperienceOrganizationFormFieldStub,
+    DeclaredExperienceActivitySectorFormField: DeclaredExperienceActivitySectorFormFieldStub,
+    DeclaredExperienceLocationFormField: DeclaredExperienceLocationFormFieldStub,
+    DeclaredExperiencePeriodFormField: DeclaredExperiencePeriodFormFieldStub,
+    DeclaredExperienceSourceOfInformationFormField: DeclaredExperienceSourceOfInformationFormFieldStub,
+    DeclaredExperienceDescriptionFormField: DeclaredExperienceDescriptionFormFieldStub,
+    DeclaredExperienceReviewFormField: DeclaredExperienceReviewFormFieldStub,
+    DeclaredExperienceLinkFormField: DeclaredExperienceLinkFormFieldStub
+  }
+
+  const getCancelConfirmButtons = () => wrapper.findComponent(AvCancelConfirmButtonsStub)
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    setActivePinia(createPinia())
+
+    const store = usePersonalCareerStore()
+    store.displayAddDeclaredExperienceDrawer()
+
+    wrapper = mountComponent<typeof AddDeclaredExperienceDrawer>(
+      AddDeclaredExperienceDrawer,
+      {
+        global: {
+          stubs
+        }
+      },
+      {
+        usePinia: false
+      }
+    )
+
+    await wrapper.vm.$nextTick()
+  })
+
+  BddTest().when('the avIconText is mounted', () => {
+    BddTest().then('it should render the drawer with correct props', () => {
+      const drawer = wrapper.findComponent({ name: 'AvDrawer' })
+
+      expect(drawer.exists()).toBe(true)
+      expect(drawer.props('position')).toBe('right')
+      expect(drawer.props('width')).toBe('40rem')
+    })
+
+    BddTest().then('it should render the title', () => {
+      const avIconText = wrapper.findComponent({ name: 'AvIconText' })
+
+      expect(avIconText.props('text')).toBe('Ajouter une expérience déclarée')
+      expect(avIconText.props('icon')).toBe(MDI_ICONS.PLUS_CIRCLE_OUTLINE)
+    })
+
+    BddTest().then('it should render accordion group with three accordions', () => {
+      const accordionsGroup = wrapper.findComponent({ name: 'AvAccordionsGroup' })
+      const accordions = wrapper.findAllComponents({ name: 'AvAccordion' })
+
+      expect(accordionsGroup.exists()).toBe(true)
+      expect(accordions).toHaveLength(3)
+    })
+
+    BddTest().then('it should render all form field components in first accordion', () => {
+      expect(wrapper.find('[data-testid="experience-title-form-field"]').exists()).toBe(true)
+      expect(wrapper.find('[data-testid="experience-type-form-field"]').exists()).toBe(true)
+      expect(wrapper.find('[data-testid="experience-organization-form-field"]').exists()).toBe(true)
+      expect(wrapper.find('[data-testid="experience-activity-sector-form-field"]').exists()).toBe(true)
+      expect(wrapper.find('[data-testid="experience-location-form-field"]').exists()).toBe(true)
+      expect(wrapper.find('[data-testid="experience-period-form-field"]').exists()).toBe(true)
+      expect(wrapper.find('[data-testid="experience-source-form-field"]').exists()).toBe(true)
+      expect(wrapper.find('[data-testid="experience-description-form-field"]').exists()).toBe(true)
+      expect(wrapper.find('[data-testid="experience-review-form-field"]').exists()).toBe(true)
+      expect(wrapper.find('[data-testid="experience-link-form-field"]').exists()).toBe(true)
+    })
+
+    BddTest().then('it should render footer buttons', () => {
+      const cancelConfirmButtons = getCancelConfirmButtons()
+
+      expect(cancelConfirmButtons.exists()).toBe(true)
+      expect(cancelConfirmButtons.props('cancelLabel')).toBe('Annuler')
+      expect(cancelConfirmButtons.props('confirmLabel')).toBe('Enregistrer')
+    })
+
+    BddTest().then('it should render form element', () => {
+      const form = wrapper.find('form')
+      expect(form.exists()).toBe(true)
+    })
+
+    BddTest().then('it should be disabled initially when form is invalid', async () => {
+      const cancelConfirmButtons = getCancelConfirmButtons()
+
+      expect(cancelConfirmButtons.props('confirmDisabled')).toBe(true)
+    })
+
+    BddTest().then('it should render add experience accordion with correct title', () => {
+      const accordions = wrapper.findAllComponents({ name: 'AvAccordion' })
+      const addExperienceAccordion = accordions[0]
+
+      expect(addExperienceAccordion.props('title')).toBe('Ajouter mon expérience')
+      expect(addExperienceAccordion.props('icon')).toBeDefined()
+    })
+
+    BddTest().then('it should render specify experience accordion with correct title', () => {
+      const accordions = wrapper.findAllComponents({ name: 'AvAccordion' })
+      const specifyAccordion = accordions[1]
+
+      expect(specifyAccordion.props('title')).toBe('Préciser mon expérience')
+    })
+
+    BddTest().then('it should render associate experience accordion with correct title', () => {
+      const accordions = wrapper.findAllComponents({ name: 'AvAccordion' })
+      const associateAccordion = accordions[2]
+
+      expect(associateAccordion.props('title')).toBe('Associer mon expérience')
+    })
+
+    BddTest().then('it should have confirmation modal rendered', () => {
+      const confirmationModal = wrapper.findComponent({ name: 'ConfirmationModal' })
+      expect(confirmationModal.exists()).toBe(true)
+    })
+
+    BddTest().and('store showAddDeclaredExperienceDrawer is false', () => {
+      beforeEach(async () => {
+        const store = usePersonalCareerStore()
+        store.hideAddDeclaredExperienceDrawer()
+        await wrapper.vm.$nextTick()
+      })
+
+      BddTest().then('it should pass false to drawer show prop', async () => {
+        const drawer = wrapper.findComponent({ name: 'AvDrawer' })
+        expect(drawer.props('show')).toBe(false)
+      })
+    })
+
+    BddTest().and('escape is pressed on drawer', () => {
+      BddTest().then('it should hide drawer when form is not dirty', async () => {
+        const store = usePersonalCareerStore()
+        const hideDrawerSpy = vi.spyOn(store, 'hideAddDeclaredExperienceDrawer')
+        const drawer = wrapper.findComponent({ name: 'AvDrawer' })
+
+        await drawer.vm.$emit('escape-pressed')
+
+        expect(hideDrawerSpy).toHaveBeenCalled()
+      })
+    })
+
+    BddTest().and('cancel button is clicked', () => {
+      BddTest().then('it should hide drawer when form is not dirty', async () => {
+        const store = usePersonalCareerStore()
+        const hideDrawerSpy = vi.spyOn(store, 'hideAddDeclaredExperienceDrawer')
+
+        const cancelConfirmButtons = getCancelConfirmButtons()
+        await cancelConfirmButtons.vm.$emit('cancel')
+
+        expect(hideDrawerSpy).toHaveBeenCalled()
+      })
+    })
+  })
+})

--- a/src/features/student/personalCareer/components/overlays/AddDeclaredExperienceDrawer/AddDeclaredExperienceDrawer.vue
+++ b/src/features/student/personalCareer/components/overlays/AddDeclaredExperienceDrawer/AddDeclaredExperienceDrawer.vue
@@ -1,0 +1,149 @@
+<script setup lang="ts">
+import { ConfirmationModal } from '@/common/components'
+import { useModal } from '@/common/composables'
+import DeclaredExperienceActivitySectorFormField from '@/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceActivitySectorFormField/DeclaredExperienceActivitySectorFormField.vue'
+import DeclaredExperienceDescriptionFormField from '@/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceDescriptionFormField/DeclaredExperienceDescriptionFormField.vue'
+import DeclaredExperienceLinkFormField from '@/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceLinkFormField/DeclaredExperienceLinkFormField.vue'
+import DeclaredExperienceLocationFormField from '@/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceLocationFormField/DeclaredExperienceLocationFormField.vue'
+import DeclaredExperienceOrganizationFormField from '@/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceOrganizationFormField/DeclaredExperienceOrganizationFormField.vue'
+import DeclaredExperiencePeriodFormField from '@/features/student/personalCareer/components/interactions/formFields/DeclaredExperiencePeriodFormField/DeclaredExperiencePeriodFormField.vue'
+import DeclaredExperienceReviewFormField from '@/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceReviewFormField/DeclaredExperienceReviewFormField.vue'
+import DeclaredExperienceSourceOfInformationFormField from '@/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceSourceOfInformationFormField/DeclaredExperienceSourceOfInformationFormField.vue'
+import DeclaredExperienceTitleFormField from '@/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceTitleFormField/DeclaredExperienceTitleFormField.vue'
+import DeclaredExperienceTypeFormField from '@/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceTypeFormField/DeclaredExperienceTypeFormField.vue'
+import { useAddDeclaredExperienceForm } from '@/features/student/personalCareer/components/overlays/AddDeclaredExperienceDrawer/use-add-declared-experience-form/use-add-declared-experience-form'
+import { usePersonalCareerStore } from '@/features/student/personalCareer/stores/personalCareer.store'
+import { useToasterStore } from '@/store'
+import { AvAccordion, AvAccordionsGroup, AvCancelConfirmButtons, AvDrawer, AvIconText, MDI_ICONS, RI_ICONS } from '@avenirs-esr/avenirs-dsav'
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
+const personalCareerStore = usePersonalCareerStore()
+const { addSuccessMessage } = useToasterStore()
+const showDrawer = toRef(personalCareerStore, 'showAddDeclaredExperienceDrawer')
+
+const { form, isFormValid, isSubmitting } = useAddDeclaredExperienceForm(() => {
+  addSuccessMessage({
+    timeout: 2000,
+    description: t('student.personalCareer.overlays.AddDeclaredExperienceDrawer.success')
+  })
+  form.reset()
+  personalCareerStore.hideAddDeclaredExperienceDrawer()
+})
+
+const { showModal: showConfirmationModal, displayModal: displayConfirmationModal, hideModal: hideConfirmationModal } = useModal()
+
+const isDirty = computed(() => {
+  const state = form.useStore(state => state)
+  return state.value.isDirty
+})
+
+function handleCancel () {
+  if (isDirty.value) {
+    displayConfirmationModal()
+  }
+  else {
+    confirmCancel()
+  }
+}
+
+function confirmCancel () {
+  form.reset()
+  personalCareerStore.hideAddDeclaredExperienceDrawer()
+  hideConfirmationModal()
+}
+
+const activeAccordion = ref(0)
+</script>
+
+<template>
+  <AvDrawer
+    :show="showDrawer"
+    position="right"
+    width="40rem"
+    @escape-pressed="handleCancel"
+  >
+    <div class="av-col av-gap-lg h-full">
+      <AvIconText
+        :icon="MDI_ICONS.PLUS_CIRCLE_OUTLINE"
+        :text="t('student.personalCareer.overlays.AddDeclaredExperienceDrawer.title')"
+        typography-class="n5"
+        icon-color="var(--text2)"
+      />
+
+      <div class="add-declared-experience-drawer__content">
+        <form
+          novalidate
+          @submit.prevent.stop="form.handleSubmit"
+        >
+          <AvAccordionsGroup v-model:active-accordion="activeAccordion">
+            <AvAccordion
+              :title="t('student.personalCareer.overlays.AddDeclaredExperienceDrawer.sections.addExperience')"
+              :icon="MDI_ICONS.SCHOOL_OUTLINE"
+            >
+              <div class="av-col av-gap-md">
+                <DeclaredExperienceTitleFormField :form="form" />
+                <DeclaredExperienceTypeFormField :form="form" />
+                <DeclaredExperienceOrganizationFormField :form="form" />
+                <div class="av-row av-gap-md">
+                  <div class="av-flex-fill">
+                    <DeclaredExperienceActivitySectorFormField :form="form" />
+                  </div>
+
+                  <div class="av-flex-fill">
+                    <DeclaredExperienceLocationFormField :form="form" />
+                  </div>
+                </div>
+                <DeclaredExperiencePeriodFormField :form="form" />
+                <DeclaredExperienceSourceOfInformationFormField :form="form" />
+                <DeclaredExperienceDescriptionFormField :form="form" />
+                <DeclaredExperienceReviewFormField :form="form" />
+                <DeclaredExperienceLinkFormField :form="form" />
+              </div>
+            </AvAccordion>
+
+            <AvAccordion
+              :title="t('student.personalCareer.overlays.AddDeclaredExperienceDrawer.sections.specifyExperience')"
+              :icon="RI_ICONS.HONOUR_LINE"
+            >
+              <div class="av-col av-gap-md" />
+            </AvAccordion>
+
+            <AvAccordion
+              :title="t('student.personalCareer.overlays.AddDeclaredExperienceDrawer.sections.associateExperience')"
+              :icon="MDI_ICONS.LINK"
+            >
+              <div class="av-col av-gap-md" />
+            </AvAccordion>
+          </AvAccordionsGroup>
+        </form>
+      </div>
+    </div>
+
+    <template #footer>
+      <div
+        v-memo="[isFormValid, isSubmitting]"
+        class="av-row av-justify-end av-p-md"
+      >
+        <AvCancelConfirmButtons
+          :cancel-label="t('global.buttons.cancel')"
+          :confirm-label="t('global.buttons.save')"
+          :cancel-icon="MDI_ICONS.CLOSE_CIRCLE_OUTLINE"
+          :confirm-icon="MDI_ICONS.CONTENT_SAVE_OUTLINE"
+          :cancel-disabled="isSubmitting"
+          :confirm-disabled="!isFormValid || isSubmitting"
+          :confirm-is-loading="isSubmitting"
+          @cancel="handleCancel"
+          @confirm="form.handleSubmit"
+        />
+      </div>
+    </template>
+  </AvDrawer>
+
+  <ConfirmationModal
+    :show="showConfirmationModal"
+    :description="t('student.personalCareer.overlays.AddDeclaredExperienceDrawer.confirmationModal.description')"
+    @close="hideConfirmationModal"
+    @confirm="confirmCancel"
+  />
+</template>

--- a/src/features/student/personalCareer/components/overlays/AddDeclaredExperienceDrawer/AddDeclaredExperienceDrawer.vue
+++ b/src/features/student/personalCareer/components/overlays/AddDeclaredExperienceDrawer/AddDeclaredExperienceDrawer.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ConfirmationModal } from '@/common/components'
+import { ConfirmationModal, FormCancelConfirmButtons } from '@/common/components'
 import { useModal } from '@/common/composables'
 import DeclaredExperienceActivitySectorFormField from '@/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceActivitySectorFormField/DeclaredExperienceActivitySectorFormField.vue'
 import DeclaredExperienceDescriptionFormField from '@/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceDescriptionFormField/DeclaredExperienceDescriptionFormField.vue'
@@ -14,7 +14,7 @@ import DeclaredExperienceTypeFormField from '@/features/student/personalCareer/c
 import { useAddDeclaredExperienceForm } from '@/features/student/personalCareer/components/overlays/AddDeclaredExperienceDrawer/use-add-declared-experience-form/use-add-declared-experience-form'
 import { usePersonalCareerStore } from '@/features/student/personalCareer/stores/personalCareer.store'
 import { useToasterStore } from '@/store'
-import { AvAccordion, AvAccordionsGroup, AvCancelConfirmButtons, AvDrawer, AvIconText, MDI_ICONS, RI_ICONS } from '@avenirs-esr/avenirs-dsav'
+import { AvAccordion, AvAccordionsGroup, AvDrawer, AvIconText, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
 import { useI18n } from 'vue-i18n'
 
 const { t } = useI18n()
@@ -101,16 +101,6 @@ const activeAccordion = ref(0)
                 <DeclaredExperienceLinkFormField :form="form" />
               </div>
             </AvAccordion>
-
-            <AvAccordion
-              :title="t('student.personalCareer.overlays.AddDeclaredExperienceDrawer.sections.specifyExperience')"
-              :icon="RI_ICONS.HONOUR_LINE"
-            />
-
-            <AvAccordion
-              :title="t('student.personalCareer.overlays.AddDeclaredExperienceDrawer.sections.associateExperience')"
-              :icon="MDI_ICONS.LINK"
-            />
           </AvAccordionsGroup>
         </form>
       </div>
@@ -121,16 +111,11 @@ const activeAccordion = ref(0)
         v-memo="[isFormValid, isSubmitting]"
         class="av-row av-justify-end av-p-md"
       >
-        <AvCancelConfirmButtons
-          :cancel-label="t('global.buttons.cancel')"
-          :confirm-label="t('global.buttons.save')"
-          :cancel-icon="MDI_ICONS.CLOSE_CIRCLE_OUTLINE"
-          :confirm-icon="MDI_ICONS.CONTENT_SAVE_OUTLINE"
-          :cancel-disabled="isSubmitting"
-          :confirm-disabled="!isFormValid || isSubmitting"
-          :confirm-is-loading="isSubmitting"
-          @cancel="handleCancel"
-          @confirm="form.handleSubmit"
+        <FormCancelConfirmButtons
+          :is-submitting="isSubmitting"
+          :is-form-valid="isFormValid"
+          @handle-cancel="handleCancel"
+          @handle-submit="form.handleSubmit"
         />
       </div>
     </template>

--- a/src/features/student/personalCareer/components/overlays/AddDeclaredExperienceDrawer/AddDeclaredExperienceDrawer.vue
+++ b/src/features/student/personalCareer/components/overlays/AddDeclaredExperienceDrawer/AddDeclaredExperienceDrawer.vue
@@ -105,16 +105,12 @@ const activeAccordion = ref(0)
             <AvAccordion
               :title="t('student.personalCareer.overlays.AddDeclaredExperienceDrawer.sections.specifyExperience')"
               :icon="RI_ICONS.HONOUR_LINE"
-            >
-              <div class="av-col av-gap-md" />
-            </AvAccordion>
+            />
 
             <AvAccordion
               :title="t('student.personalCareer.overlays.AddDeclaredExperienceDrawer.sections.associateExperience')"
               :icon="MDI_ICONS.LINK"
-            >
-              <div class="av-col av-gap-md" />
-            </AvAccordion>
+            />
           </AvAccordionsGroup>
         </form>
       </div>

--- a/src/features/student/personalCareer/components/overlays/AddDeclaredExperienceDrawer/use-add-declared-experience-form/use-add-declared-experience-form.test.ts
+++ b/src/features/student/personalCareer/components/overlays/AddDeclaredExperienceDrawer/use-add-declared-experience-form/use-add-declared-experience-form.test.ts
@@ -1,10 +1,10 @@
-import type {
-  useAddDeclaredExperienceForm
-} from '@/features/student/personalCareer/components/overlays/AddDeclaredExperienceDrawer/use-add-declared-experience-form/use-add-declared-experience-form'
 import type { DeclaredExperienceFormData } from '@/features/student/personalCareer/types/forms.types'
 import { createDeclaredExperienceErrorHandler } from '@/__mocks__/msw/handlers/student/declaredExperiences.handlers'
 import { server } from '@/__mocks__/msw/server'
 import { EExperienceType } from '@/api/avenir-esr'
+import {
+  useAddDeclaredExperienceForm
+} from '@/features/student/personalCareer/components/overlays/AddDeclaredExperienceDrawer/use-add-declared-experience-form/use-add-declared-experience-form'
 import {
   DECLARED_EXPERIENCE_ACTIVITY_SECTOR_MAX_LENGTH,
   DECLARED_EXPERIENCE_DESCRIPTION_MAX_LENGTH,
@@ -46,21 +46,6 @@ BddTest().given('an add declared experience form', () => {
     description: 'Description of the experience',
     review: 'A positive review',
     link: 'https://example.com'
-  }
-
-  const invalidData: DeclaredExperienceFormData = {
-    title: '',
-    type: '',
-    organization: '',
-    activitySector: '',
-    location: '',
-    startDate: '',
-    endDate: '',
-    isOngoing: false,
-    sourceOfInformation: '',
-    description: '',
-    review: '',
-    link: ''
   }
 
   const mountForm = (onExperienceAdded?: () => void) => {
@@ -143,6 +128,21 @@ BddTest().given('an add declared experience form', () => {
   BddTest().when('validating form fields', () => {
     BddTest().and('all required fields are empty', () => {
       BddTest().then('it should return validation errors for required fields', () => {
+        const invalidData: DeclaredExperienceFormData = {
+          title: '',
+          type: '',
+          organization: '',
+          activitySector: '',
+          location: '',
+          startDate: '',
+          endDate: '',
+          isOngoing: false,
+          sourceOfInformation: '',
+          description: '',
+          review: '',
+          link: ''
+        }
+
         const requiredFields = ['title', 'type', 'organization', 'startDate', 'endDate'] as const
         const validator = getOnSubmitValidator()
         const result = validator({ value: invalidData })

--- a/src/features/student/personalCareer/components/overlays/AddDeclaredExperienceDrawer/use-add-declared-experience-form/use-add-declared-experience-form.test.ts
+++ b/src/features/student/personalCareer/components/overlays/AddDeclaredExperienceDrawer/use-add-declared-experience-form/use-add-declared-experience-form.test.ts
@@ -1,0 +1,307 @@
+import type {
+  useAddDeclaredExperienceForm
+} from '@/features/student/personalCareer/components/overlays/AddDeclaredExperienceDrawer/use-add-declared-experience-form/use-add-declared-experience-form'
+import type { DeclaredExperienceFormData } from '@/features/student/personalCareer/types/forms.types'
+import { createDeclaredExperienceErrorHandler } from '@/__mocks__/msw/handlers/student/declaredExperiences.handlers'
+import { server } from '@/__mocks__/msw/server'
+import { EExperienceType } from '@/api/avenir-esr'
+import {
+  DECLARED_EXPERIENCE_ACTIVITY_SECTOR_MAX_LENGTH,
+  DECLARED_EXPERIENCE_DESCRIPTION_MAX_LENGTH,
+  DECLARED_EXPERIENCE_LOCATION_MAX_LENGTH,
+  DECLARED_EXPERIENCE_ORGANIZATION_MAX_LENGTH,
+  DECLARED_EXPERIENCE_REVIEW_MAX_LENGTH,
+  DECLARED_EXPERIENCE_SOURCE_OF_INFORMATION_MAX_LENGTH,
+  DECLARED_EXPERIENCE_TITLE_MAX_LENGTH
+} from '@/features/student/personalCareer/config'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { mountComposable } from 'tests/utils'
+import { beforeEach, expect, vi } from 'vitest'
+
+vi.mock('@/store', async () => {
+  const actual = await vi.importActual<typeof import('@/store')>('@/store')
+  return {
+    ...actual,
+    useToasterStore: vi.fn(() => ({
+      addErrorMessage: vi.fn(),
+      addSuccessMessage: vi.fn()
+    }))
+  }
+})
+
+BddTest().given('an add declared experience form', () => {
+  let composableResult: ReturnType<typeof useAddDeclaredExperienceForm>
+  let mockOnExperienceAdded: ReturnType<typeof vi.fn>
+
+  const validData: DeclaredExperienceFormData = {
+    title: 'Software Engineer',
+    type: EExperienceType.PROFESSIONAL,
+    organization: 'Tech Company',
+    activitySector: 'Technology',
+    location: 'Paris, France',
+    startDate: '2024-01',
+    endDate: '2025-12',
+    isOngoing: false,
+    sourceOfInformation: 'LinkedIn',
+    description: 'Description of the experience',
+    review: 'A positive review',
+    link: 'https://example.com'
+  }
+
+  const invalidData: DeclaredExperienceFormData = {
+    title: '',
+    type: '',
+    organization: '',
+    activitySector: '',
+    location: '',
+    startDate: '',
+    endDate: '',
+    isOngoing: false,
+    sourceOfInformation: '',
+    description: '',
+    review: '',
+    link: ''
+  }
+
+  const mountForm = (onExperienceAdded?: () => void) => {
+    const result = mountComposable(() => useAddDeclaredExperienceForm(onExperienceAdded), {
+      useI18n: true,
+      useTanstack: true,
+      usePinia: true
+    })
+    composableResult = result.result
+  }
+
+  const getOnSubmitValidator = () => {
+    const validator = composableResult.form.options.validators?.onSubmit
+    expect(validator).toBeDefined()
+    return validator!
+  }
+
+  const setFormValues = (data: Partial<DeclaredExperienceFormData>) => {
+    Object.entries(data).forEach(([key, value]) => {
+      if (value !== undefined) {
+        composableResult.form.setFieldValue(key as keyof DeclaredExperienceFormData, value)
+      }
+    })
+  }
+
+  beforeEach(() => {
+    mountForm()
+  })
+
+  BddTest().when('the form is initialized', () => {
+    BddTest().then('it should return the expected structure', () => {
+      expect(composableResult).toBeDefined()
+      expect(composableResult.form).toBeDefined()
+      expect(composableResult.isFormValid).toBeDefined()
+      expect(composableResult.isSubmitting).toBeDefined()
+    })
+
+    BddTest().then('it should have default values', () => {
+      const expectedDefaults: DeclaredExperienceFormData = {
+        title: '',
+        type: '',
+        organization: '',
+        activitySector: '',
+        location: '',
+        startDate: '',
+        endDate: '',
+        isOngoing: false,
+        sourceOfInformation: '',
+        description: '',
+        review: '',
+        link: ''
+      }
+
+      Object.entries(expectedDefaults).forEach(([key, expectedValue]) => {
+        expect(composableResult.form.state.values[key as keyof DeclaredExperienceFormData]).toBe(expectedValue)
+      })
+    })
+
+    BddTest().then('it should not be submitting initially', () => {
+      expect(composableResult.isSubmitting.value).toBe(false)
+    })
+
+    BddTest().then('it should not be valid initially', () => {
+      expect(composableResult.isFormValid.value).toBe(false)
+    })
+
+    BddTest().and('callback is provided', () => {
+      beforeEach(() => {
+        mockOnExperienceAdded = vi.fn()
+        mountForm(mockOnExperienceAdded)
+      })
+
+      BddTest().then('it should accept onExperienceAdded callback', () => {
+        expect(composableResult).toBeDefined()
+        expect(mockOnExperienceAdded).toBeDefined()
+      })
+    })
+  })
+
+  BddTest().when('validating form fields', () => {
+    BddTest().and('all required fields are empty', () => {
+      BddTest().then('it should return validation errors for required fields', () => {
+        const requiredFields = ['title', 'type', 'organization', 'startDate', 'endDate'] as const
+        const validator = getOnSubmitValidator()
+        const result = validator({ value: invalidData })
+
+        requiredFields.forEach((field) => {
+          expect(result?.fields?.[field]).toBe('Ce champ est requis.')
+        })
+      })
+    })
+
+    BddTest().and('fields exceed max length', () => {
+      BddTest().then('it should return max length errors', () => {
+        const maxLengthFields = {
+          title: DECLARED_EXPERIENCE_TITLE_MAX_LENGTH,
+          organization: DECLARED_EXPERIENCE_ORGANIZATION_MAX_LENGTH,
+          activitySector: DECLARED_EXPERIENCE_ACTIVITY_SECTOR_MAX_LENGTH,
+          location: DECLARED_EXPERIENCE_LOCATION_MAX_LENGTH,
+          sourceOfInformation: DECLARED_EXPERIENCE_SOURCE_OF_INFORMATION_MAX_LENGTH,
+          description: DECLARED_EXPERIENCE_DESCRIPTION_MAX_LENGTH,
+          review: DECLARED_EXPERIENCE_REVIEW_MAX_LENGTH
+        } as const
+
+        const dataExceedingMaxLength = Object.entries(maxLengthFields).reduce(
+          (acc, [field, maxLength]) => ({ ...acc, [field]: 'a'.repeat(maxLength + 1) }),
+          { ...validData }
+        )
+
+        const validator = getOnSubmitValidator()
+        const result = validator({ value: dataExceedingMaxLength })
+
+        Object.entries(maxLengthFields).forEach(([field, maxLength]) => {
+          expect(result?.fields?.[field as keyof typeof maxLengthFields]).toBe(
+            `Veuillez limiter votre saisie à ${maxLength} caractères`
+          )
+        })
+      })
+    })
+
+    BddTest().and('endDate is missing when not ongoing', () => {
+      BddTest().then('it should return endDate required error', () => {
+        const invalidData: DeclaredExperienceFormData = {
+          ...validData,
+          startDate: '2024-01',
+          endDate: '',
+          isOngoing: false
+        }
+
+        const validator = getOnSubmitValidator()
+        const result = validator({ value: invalidData })
+
+        expect(result?.fields?.endDate).toBe('Ce champ est requis.')
+      })
+    })
+
+    BddTest().and('all required fields are filled and isOngoing is true', () => {
+      BddTest().then('it should not require endDate', () => {
+        const ongoingExperience: DeclaredExperienceFormData = {
+          ...validData,
+          endDate: '',
+          isOngoing: true
+        }
+
+        const validator = getOnSubmitValidator()
+        const result = validator({ value: ongoingExperience })
+
+        expect(result?.fields?.title).toBeUndefined()
+        expect(result?.fields?.type).toBeUndefined()
+        expect(result?.fields?.organization).toBeUndefined()
+        expect(result?.fields?.startDate).toBeUndefined()
+        expect(result?.fields?.endDate).toBeUndefined()
+      })
+    })
+
+    BddTest().and('data is valid', () => {
+      BddTest().then('it should not return validation errors', () => {
+        const validator = getOnSubmitValidator()
+        const result = validator({ value: validData })
+
+        expect(result?.fields?.title).toBeUndefined()
+        expect(result?.fields?.type).toBeUndefined()
+        expect(result?.fields?.organization).toBeUndefined()
+        expect(result?.fields?.activitySector).toBeUndefined()
+        expect(result?.fields?.location).toBeUndefined()
+        expect(result?.fields?.startDate).toBeUndefined()
+        expect(result?.fields?.endDate).toBeUndefined()
+        expect(result?.fields?.sourceOfInformation).toBeUndefined()
+        expect(result?.fields?.description).toBeUndefined()
+        expect(result?.fields?.review).toBeUndefined()
+      })
+    })
+  })
+
+  BddTest().when('submitting the form', () => {
+    beforeEach(() => {
+      mockOnExperienceAdded = vi.fn()
+      mountForm(mockOnExperienceAdded)
+    })
+
+    BddTest().and('data is valid', () => {
+      beforeEach(() => {
+        setFormValues(validData)
+      })
+
+      BddTest().then('it should call onExperienceAdded callback on success', async () => {
+        await composableResult.form.handleSubmit()
+
+        await vi.waitFor(() => {
+          expect(mockOnExperienceAdded).toHaveBeenCalledTimes(1)
+        })
+      })
+
+      BddTest().then('isFormValid should be true when all conditions met', async () => {
+        await vi.waitFor(() => {
+          expect(composableResult.isFormValid.value).toBe(true)
+        })
+      })
+    })
+
+    BddTest().and('isOngoing is true', () => {
+      beforeEach(() => {
+        setFormValues({
+          ...validData,
+          endDate: '2025-12',
+          isOngoing: true
+        })
+      })
+
+      BddTest().then('it should not send endDate in the request', async () => {
+        await composableResult.form.handleSubmit()
+
+        await vi.waitFor(() => {
+          expect(mockOnExperienceAdded).toHaveBeenCalledTimes(1)
+        })
+      })
+    })
+
+    BddTest().and('submission fails', () => {
+      beforeEach(() => {
+        server.use(createDeclaredExperienceErrorHandler)
+        setFormValues(validData)
+      })
+
+      BddTest().then('it should not call onExperienceAdded callback', async () => {
+        await composableResult.form.handleSubmit()
+
+        await vi.waitFor(() => {
+          expect(composableResult.isSubmitting.value).toBe(false)
+        })
+
+        expect(mockOnExperienceAdded).not.toHaveBeenCalled()
+      })
+
+      BddTest().then('it should set isSubmitting back to false', async () => {
+        await composableResult.form.handleSubmit()
+
+        await vi.waitFor(() => {
+          expect(composableResult.isSubmitting.value).toBe(false)
+        })
+      })
+    })
+  })
+})

--- a/src/features/student/personalCareer/components/overlays/AddDeclaredExperienceDrawer/use-add-declared-experience-form/use-add-declared-experience-form.ts
+++ b/src/features/student/personalCareer/components/overlays/AddDeclaredExperienceDrawer/use-add-declared-experience-form/use-add-declared-experience-form.ts
@@ -1,0 +1,90 @@
+import type { EExperienceType } from '@/api/avenir-esr'
+import type { BaseApiException } from '@/common/exceptions'
+import type { DeclaredExperienceFormData } from '@/features/student/personalCareer/types/forms.types'
+import { formatYearMonthToDate } from '@/common/utils'
+import { useDeclaredExperienceFormValidators } from '@/features/student/personalCareer/composables/use-declared-experience-form-validators/use-declared-experience-form-validators'
+import { useCreateDeclaredExperienceMutation } from '@/features/student/personalCareer/queries/use-declared-experiences.query'
+import { useToasterStore } from '@/store'
+import { useForm } from '@tanstack/vue-form'
+import { useI18n } from 'vue-i18n'
+
+export function useAddDeclaredExperienceForm (onExperienceAdded?: () => void) {
+  const { t } = useI18n()
+  const { addErrorMessage } = useToasterStore()
+
+  const onCreateDeclaredExperienceError = (error: BaseApiException) => {
+    addErrorMessage({
+      title: t('student.personalCareer.overlays.AddDeclaredExperienceDrawer.errors.createDeclaredExperience'),
+      description: error.message
+    })
+  }
+
+  const validators = useDeclaredExperienceFormValidators()
+
+  const { mutate: createDeclaredExperience, isPending } = useCreateDeclaredExperienceMutation({ onError: onCreateDeclaredExperienceError })
+
+  const form = useForm({
+    defaultValues: {
+      title: '',
+      type: '',
+      organization: '',
+      activitySector: '',
+      location: '',
+      startDate: '',
+      endDate: '',
+      isOngoing: false,
+      sourceOfInformation: '',
+      description: '',
+      review: '',
+      link: ''
+    } as DeclaredExperienceFormData,
+    validators: {
+      onSubmit ({ value }: { value: DeclaredExperienceFormData }) {
+        return {
+          fields: {
+            title: validators.validateTitle(value.title),
+            type: validators.validateType(value.type),
+            organization: validators.validateOrganization(value.organization),
+            activitySector: validators.validateActivitySector(value.activitySector),
+            location: validators.validateLocation(value.location),
+            startDate: validators.validateStartDate(value.startDate),
+            endDate: validators.validateEndDate(value.endDate, value.startDate, { isRequired: !value.isOngoing }),
+            sourceOfInformation: validators.validateSourceOfInformation(value.sourceOfInformation),
+            description: validators.validateDescription(value.description),
+            review: validators.validateReview(value.review)
+          }
+        }
+      }
+    },
+    onSubmit: ({ value }: { value: DeclaredExperienceFormData }) => {
+      createDeclaredExperience({
+        title: value.title,
+        experienceType: value.type as EExperienceType,
+        organization: value.organization,
+        activitySector: value.activitySector || undefined,
+        location: value.location || undefined,
+        description: value.description || undefined,
+        sourceOfInformation: value.sourceOfInformation || undefined,
+        summary: value.review || undefined,
+        externalLink: value.link || undefined,
+        startDate: formatYearMonthToDate(value.startDate),
+        endDate: value.isOngoing ? undefined : formatYearMonthToDate(value.endDate) || undefined
+      }, {
+        onSuccess: () => {
+          onExperienceAdded?.()
+        }
+      })
+    }
+  })
+
+  const isFormValid = computed(() => {
+    const state = form.useStore(state => state)
+    return state.value.isDirty && state.value.isValid && !state.value.isValidating
+  })
+
+  return {
+    form,
+    isFormValid,
+    isSubmitting: isPending
+  }
+}

--- a/src/features/student/personalCareer/components/overlays/AddDeclaredProgramDrawer/AddDeclaredProgramDrawer.vue
+++ b/src/features/student/personalCareer/components/overlays/AddDeclaredProgramDrawer/AddDeclaredProgramDrawer.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ConfirmationModal } from '@/common/components'
+import { ConfirmationModal, FormCancelConfirmButtons } from '@/common/components'
 import { useModal } from '@/common/composables'
 import DeclaredProgramDescriptionFormField from '@/features/student/personalCareer/components/interactions/formFields/DeclaredProgramDescriptionFormField/DeclaredProgramDescriptionFormField.vue'
 import DeclaredProgramLinkFormField from '@/features/student/personalCareer/components/interactions/formFields/DeclaredProgramLinkFormField/DeclaredProgramLinkFormField.vue'
@@ -11,7 +11,7 @@ import DeclaredProgramTitleFormField from '@/features/student/personalCareer/com
 import { useAddDeclaredProgramForm } from '@/features/student/personalCareer/components/overlays/AddDeclaredProgramDrawer/use-add-declared-program-form/use-add-declared-program-form'
 import { usePersonalCareerStore } from '@/features/student/personalCareer/stores/personalCareer.store'
 import { useToasterStore } from '@/store'
-import { AvAccordion, AvAccordionsGroup, AvCancelConfirmButtons, AvDrawer, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
+import { AvAccordion, AvAccordionsGroup, AvDrawer, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
 import { useI18n } from 'vue-i18n'
 
 const { t } = useI18n()
@@ -109,16 +109,11 @@ const activeAccordion = ref(0)
         v-memo="[isFormValid, isSubmitting]"
         class="av-row av-justify-end av-p-md"
       >
-        <AvCancelConfirmButtons
-          :cancel-label="t('global.buttons.cancel')"
-          :confirm-label="t('global.buttons.save')"
-          :cancel-icon="MDI_ICONS.CLOSE_CIRCLE_OUTLINE"
-          :confirm-icon="MDI_ICONS.CONTENT_SAVE_OUTLINE"
-          :cancel-disabled="isSubmitting"
-          :confirm-disabled="!isFormValid || isSubmitting"
-          :confirm-is-loading="isSubmitting"
-          @cancel="handleCancel"
-          @confirm="form.handleSubmit"
+        <FormCancelConfirmButtons
+          :is-submitting="isSubmitting"
+          :is-form-valid="isFormValid"
+          @handle-cancel="handleCancel"
+          @handle-submit="form.handleSubmit"
         />
       </div>
     </template>

--- a/src/features/student/personalCareer/composables/use-declared-experience-form-validators/use-declared-experience-form-validators.test.ts
+++ b/src/features/student/personalCareer/composables/use-declared-experience-form-validators/use-declared-experience-form-validators.test.ts
@@ -1,0 +1,279 @@
+import {
+  useDeclaredExperienceFormValidators
+} from '@/features/student/personalCareer/composables/use-declared-experience-form-validators/use-declared-experience-form-validators'
+import {
+  DECLARED_EXPERIENCE_ACTIVITY_SECTOR_MAX_LENGTH,
+  DECLARED_EXPERIENCE_DESCRIPTION_MAX_LENGTH,
+  DECLARED_EXPERIENCE_LOCATION_MAX_LENGTH,
+  DECLARED_EXPERIENCE_ORGANIZATION_MAX_LENGTH,
+  DECLARED_EXPERIENCE_REVIEW_MAX_LENGTH,
+  DECLARED_EXPERIENCE_SOURCE_OF_INFORMATION_MAX_LENGTH,
+  DECLARED_EXPERIENCE_TITLE_MAX_LENGTH
+} from '@/features/student/personalCareer/config'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { mountComposable } from 'tests/utils'
+import { beforeEach, expect, vi } from 'vitest'
+
+BddTest().given('a declared experience form validators composable', () => {
+  let composableResult: ReturnType<typeof useDeclaredExperienceFormValidators>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    const result = mountComposable(() => useDeclaredExperienceFormValidators(), {
+      useI18n: true
+    })
+    composableResult = result.result
+  })
+
+  BddTest().when('the composable is initialized', () => {
+    BddTest().then('it should return all validation functions', () => {
+      expect(composableResult.validateTitle).toBeDefined()
+      expect(composableResult.validateType).toBeDefined()
+      expect(composableResult.validateOrganization).toBeDefined()
+      expect(composableResult.validateActivitySector).toBeDefined()
+      expect(composableResult.validateLocation).toBeDefined()
+      expect(composableResult.validateSourceOfInformation).toBeDefined()
+      expect(composableResult.validateDescription).toBeDefined()
+      expect(composableResult.validateReview).toBeDefined()
+      expect(composableResult.validateStartDate).toBeDefined()
+      expect(composableResult.validateEndDate).toBeDefined()
+    })
+  })
+
+  BddTest().when('validating title', () => {
+    BddTest().and('the title is empty', () => {
+      BddTest().then('it should return required error', () => {
+        const error = composableResult.validateTitle('')
+        expect(error).toBe('Ce champ est requis.')
+      })
+    })
+
+    BddTest().and('the title exceeds max length', () => {
+      BddTest().then('it should return max length error', () => {
+        const longTitle = 'a'.repeat(DECLARED_EXPERIENCE_TITLE_MAX_LENGTH + 1)
+        const error = composableResult.validateTitle(longTitle)
+        expect(error).toBe(`Veuillez limiter votre saisie à ${DECLARED_EXPERIENCE_TITLE_MAX_LENGTH} caractères`)
+      })
+    })
+
+    BddTest().and('the title is valid', () => {
+      BddTest().then('it should return undefined', () => {
+        const error = composableResult.validateTitle('Valid title')
+        expect(error).toBeUndefined()
+      })
+    })
+  })
+
+  BddTest().when('validating type', () => {
+    BddTest().and('the type is empty', () => {
+      BddTest().then('it should return required error', () => {
+        const error = composableResult.validateType('')
+        expect(error).toBe('Ce champ est requis.')
+      })
+    })
+
+    BddTest().and('the type is valid', () => {
+      BddTest().then('it should return undefined', () => {
+        const error = composableResult.validateType('PROFESSIONAL')
+        expect(error).toBeUndefined()
+      })
+    })
+  })
+
+  BddTest().when('validating organization', () => {
+    BddTest().and('the organization is empty', () => {
+      BddTest().then('it should return required error', () => {
+        const error = composableResult.validateOrganization('')
+        expect(error).toBe('Ce champ est requis.')
+      })
+    })
+
+    BddTest().and('the organization exceeds max length', () => {
+      BddTest().then('it should return max length error', () => {
+        const longOrg = 'a'.repeat(DECLARED_EXPERIENCE_ORGANIZATION_MAX_LENGTH + 1)
+        const error = composableResult.validateOrganization(longOrg)
+        expect(error).toBe(`Veuillez limiter votre saisie à ${DECLARED_EXPERIENCE_ORGANIZATION_MAX_LENGTH} caractères`)
+      })
+    })
+
+    BddTest().and('the organization is valid', () => {
+      BddTest().then('it should return undefined', () => {
+        const error = composableResult.validateOrganization('Valid organization')
+        expect(error).toBeUndefined()
+      })
+    })
+  })
+
+  BddTest().when('validating activity sector', () => {
+    BddTest().and('the activity sector is empty', () => {
+      BddTest().then('it should return undefined because it is optional', () => {
+        const error = composableResult.validateActivitySector('')
+        expect(error).toBeUndefined()
+      })
+    })
+
+    BddTest().and('the activity sector exceeds max length', () => {
+      BddTest().then('it should return max length error', () => {
+        const longSector = 'a'.repeat(DECLARED_EXPERIENCE_ACTIVITY_SECTOR_MAX_LENGTH + 1)
+        const error = composableResult.validateActivitySector(longSector)
+        expect(error).toBe(`Veuillez limiter votre saisie à ${DECLARED_EXPERIENCE_ACTIVITY_SECTOR_MAX_LENGTH} caractères`)
+      })
+    })
+
+    BddTest().and('the activity sector is valid', () => {
+      BddTest().then('it should return undefined', () => {
+        const error = composableResult.validateActivitySector('Technology')
+        expect(error).toBeUndefined()
+      })
+    })
+  })
+
+  BddTest().when('validating location', () => {
+    BddTest().and('the location is empty', () => {
+      BddTest().then('it should return undefined because it is optional', () => {
+        const error = composableResult.validateLocation('')
+        expect(error).toBeUndefined()
+      })
+    })
+
+    BddTest().and('the location exceeds max length', () => {
+      BddTest().then('it should return max length error', () => {
+        const longLocation = 'a'.repeat(DECLARED_EXPERIENCE_LOCATION_MAX_LENGTH + 1)
+        const error = composableResult.validateLocation(longLocation)
+        expect(error).toBe(`Veuillez limiter votre saisie à ${DECLARED_EXPERIENCE_LOCATION_MAX_LENGTH} caractères`)
+      })
+    })
+
+    BddTest().and('the location is valid', () => {
+      BddTest().then('it should return undefined', () => {
+        const error = composableResult.validateLocation('Paris, France')
+        expect(error).toBeUndefined()
+      })
+    })
+  })
+
+  BddTest().when('validating source of information', () => {
+    BddTest().and('the source of information is empty', () => {
+      BddTest().then('it should return undefined because it is optional', () => {
+        const error = composableResult.validateSourceOfInformation('')
+        expect(error).toBeUndefined()
+      })
+    })
+
+    BddTest().and('the source of information exceeds max length', () => {
+      BddTest().then('it should return max length error', () => {
+        const longSource = 'a'.repeat(DECLARED_EXPERIENCE_SOURCE_OF_INFORMATION_MAX_LENGTH + 1)
+        const error = composableResult.validateSourceOfInformation(longSource)
+        expect(error).toBe(`Veuillez limiter votre saisie à ${DECLARED_EXPERIENCE_SOURCE_OF_INFORMATION_MAX_LENGTH} caractères`)
+      })
+    })
+
+    BddTest().and('the source of information is valid', () => {
+      BddTest().then('it should return undefined', () => {
+        const error = composableResult.validateSourceOfInformation('LinkedIn')
+        expect(error).toBeUndefined()
+      })
+    })
+  })
+
+  BddTest().when('validating description', () => {
+    BddTest().and('the description is empty', () => {
+      BddTest().then('it should return undefined because it is optional', () => {
+        const error = composableResult.validateDescription('')
+        expect(error).toBeUndefined()
+      })
+    })
+
+    BddTest().and('the description exceeds max length', () => {
+      BddTest().then('it should return max length error', () => {
+        const longDescription = 'a'.repeat(DECLARED_EXPERIENCE_DESCRIPTION_MAX_LENGTH + 1)
+        const error = composableResult.validateDescription(longDescription)
+        expect(error).toBe(`Veuillez limiter votre saisie à ${DECLARED_EXPERIENCE_DESCRIPTION_MAX_LENGTH} caractères`)
+      })
+    })
+
+    BddTest().and('the description is valid', () => {
+      BddTest().then('it should return undefined', () => {
+        const error = composableResult.validateDescription('A valid description of the experience')
+        expect(error).toBeUndefined()
+      })
+    })
+  })
+
+  BddTest().when('validating review', () => {
+    BddTest().and('the review is empty', () => {
+      BddTest().then('it should return undefined because it is optional', () => {
+        const error = composableResult.validateReview('')
+        expect(error).toBeUndefined()
+      })
+    })
+
+    BddTest().and('the review exceeds max length', () => {
+      BddTest().then('it should return max length error', () => {
+        const longReview = 'a'.repeat(DECLARED_EXPERIENCE_REVIEW_MAX_LENGTH + 1)
+        const error = composableResult.validateReview(longReview)
+        expect(error).toBe(`Veuillez limiter votre saisie à ${DECLARED_EXPERIENCE_REVIEW_MAX_LENGTH} caractères`)
+      })
+    })
+
+    BddTest().and('the review is valid', () => {
+      BddTest().then('it should return undefined', () => {
+        const error = composableResult.validateReview('A positive review')
+        expect(error).toBeUndefined()
+      })
+    })
+  })
+
+  BddTest().when('validating start date', () => {
+    BddTest().and('the start date is empty', () => {
+      BddTest().then('it should return required error', () => {
+        const error = composableResult.validateStartDate('')
+        expect(error).toBe('Ce champ est requis.')
+      })
+    })
+
+    BddTest().and('the start date is valid', () => {
+      BddTest().then('it should return undefined', () => {
+        const error = composableResult.validateStartDate('2024-01')
+        expect(error).toBeUndefined()
+      })
+    })
+  })
+
+  BddTest().when('validating end date', () => {
+    BddTest().and('the end date is empty and not required (ongoing)', () => {
+      BddTest().then('it should return undefined', () => {
+        const error = composableResult.validateEndDate('', '2024-01', { isRequired: false })
+        expect(error).toBeUndefined()
+      })
+    })
+
+    BddTest().and('the end date is empty and required', () => {
+      BddTest().then('it should return required error', () => {
+        const error = composableResult.validateEndDate('', '2024-01', { isRequired: true })
+        expect(error).toBe('Ce champ est requis.')
+      })
+    })
+
+    BddTest().and('the end date is before start date', () => {
+      BddTest().then('it should return chronological error', () => {
+        const error = composableResult.validateEndDate('2023-06', '2024-01', { isRequired: true })
+        expect(error).toBe('La date de fin doit être postérieure à la date de début')
+      })
+    })
+
+    BddTest().and('the end date is after start date', () => {
+      BddTest().then('it should return undefined', () => {
+        const error = composableResult.validateEndDate('2024-06', '2024-01', { isRequired: true })
+        expect(error).toBeUndefined()
+      })
+    })
+
+    BddTest().and('the end date equals start date', () => {
+      BddTest().then('it should return undefined', () => {
+        const error = composableResult.validateEndDate('2024-01', '2024-01', { isRequired: true })
+        expect(error).toBeUndefined()
+      })
+    })
+  })
+})

--- a/src/features/student/personalCareer/composables/use-declared-experience-form-validators/use-declared-experience-form-validators.ts
+++ b/src/features/student/personalCareer/composables/use-declared-experience-form-validators/use-declared-experience-form-validators.ts
@@ -1,0 +1,77 @@
+import type { DeclaredExperienceFormData } from '@/features/student/personalCareer/types/forms.types'
+import { useFormValidators, type ValidationOptions } from '@/common/composables/use-form-validators/use-form-validators'
+import {
+  DECLARED_EXPERIENCE_ACTIVITY_SECTOR_MAX_LENGTH,
+  DECLARED_EXPERIENCE_DESCRIPTION_MAX_LENGTH,
+  DECLARED_EXPERIENCE_LOCATION_MAX_LENGTH,
+  DECLARED_EXPERIENCE_ORGANIZATION_MAX_LENGTH,
+  DECLARED_EXPERIENCE_REVIEW_MAX_LENGTH,
+  DECLARED_EXPERIENCE_SOURCE_OF_INFORMATION_MAX_LENGTH,
+  DECLARED_EXPERIENCE_TITLE_MAX_LENGTH
+} from '@/features/student/personalCareer/config'
+
+export function useDeclaredExperienceFormValidators () {
+  const { validateRequired, validateMaxLength, validateDateInterval } = useFormValidators()
+
+  function validateTitle (title: DeclaredExperienceFormData['title']) {
+    return validateRequired(title) ?? validateMaxLength(title, DECLARED_EXPERIENCE_TITLE_MAX_LENGTH)
+  }
+
+  function validateType (type: DeclaredExperienceFormData['type']) {
+    return validateRequired(type)
+  }
+
+  function validateOrganization (organization: DeclaredExperienceFormData['organization']) {
+    return validateRequired(organization) ?? validateMaxLength(organization, DECLARED_EXPERIENCE_ORGANIZATION_MAX_LENGTH)
+  }
+
+  function validateActivitySector (activitySector: DeclaredExperienceFormData['activitySector']) {
+    return validateMaxLength(activitySector, DECLARED_EXPERIENCE_ACTIVITY_SECTOR_MAX_LENGTH)
+  }
+
+  function validateLocation (location: DeclaredExperienceFormData['location']) {
+    return validateMaxLength(location, DECLARED_EXPERIENCE_LOCATION_MAX_LENGTH)
+  }
+
+  function validateSourceOfInformation (sourceOfInformation: DeclaredExperienceFormData['sourceOfInformation']) {
+    return validateMaxLength(sourceOfInformation, DECLARED_EXPERIENCE_SOURCE_OF_INFORMATION_MAX_LENGTH)
+  }
+
+  function validateDescription (description: DeclaredExperienceFormData['description']) {
+    return validateMaxLength(description, DECLARED_EXPERIENCE_DESCRIPTION_MAX_LENGTH)
+  }
+
+  function validateReview (review: DeclaredExperienceFormData['review']) {
+    return validateMaxLength(review, DECLARED_EXPERIENCE_REVIEW_MAX_LENGTH)
+  }
+
+  function validateStartDate (startDate: DeclaredExperienceFormData['startDate']) {
+    return validateRequired(startDate)
+  }
+
+  function validateEndDate (
+    endDate: DeclaredExperienceFormData['endDate'],
+    startDate: DeclaredExperienceFormData['startDate'],
+    options: ValidationOptions = { isRequired: false }
+  ) {
+    return validateDateInterval({
+      startDate,
+      endDate,
+      format: 'yyyy-MM',
+      isOnGoing: !options.isRequired
+    })
+  }
+
+  return {
+    validateActivitySector,
+    validateDescription,
+    validateEndDate,
+    validateLocation,
+    validateOrganization,
+    validateReview,
+    validateSourceOfInformation,
+    validateStartDate,
+    validateTitle,
+    validateType
+  }
+}

--- a/src/features/student/personalCareer/composables/use-declared-program-form-validators/use-declared-program-form-validators.test.ts
+++ b/src/features/student/personalCareer/composables/use-declared-program-form-validators/use-declared-program-form-validators.test.ts
@@ -274,14 +274,14 @@ BddTest().given('a declared program form validator composable', () => {
   BddTest().when('validating end date', () => {
     BddTest().and('the end date is empty and not required', () => {
       BddTest().then('it should return undefined', () => {
-        const error = composableResult.validateEndDate('', '')
+        const error = composableResult.validateEndDate('', '2025/02')
         expect(error).toBeUndefined()
       })
     })
 
     BddTest().and('the end date is undefined and not required', () => {
       BddTest().then('it should return undefined', () => {
-        const error = composableResult.validateEndDate(undefined as unknown as string, '')
+        const error = composableResult.validateEndDate('', '2025/02')
         expect(error).toBeUndefined()
       })
     })

--- a/src/features/student/personalCareer/composables/use-declared-program-form-validators/use-declared-program-form-validators.ts
+++ b/src/features/student/personalCareer/composables/use-declared-program-form-validators/use-declared-program-form-validators.ts
@@ -1,5 +1,5 @@
 import type { DeclaredProgramFormData } from '@/features/student/personalCareer/types/forms.types'
-import { useFormValidators } from '@/common/composables/use-form-validators/use-form-validators'
+import { useFormValidators, type ValidationOptions } from '@/common/composables/use-form-validators/use-form-validators'
 import {
   DECLARED_PROGRAM_DESCRIPTION_MAX_LENGTH,
   DECLARED_PROGRAM_ORGANIZATION_MAX_LENGTH,
@@ -7,17 +7,6 @@ import {
   DECLARED_PROGRAM_SOURCE_OF_INFORMATION_MAX_LENGTH,
   DECLARED_PROGRAM_TITLE_MAX_LENGTH
 } from '@/features/student/personalCareer/config'
-import { isBefore, parse } from 'date-fns'
-import { useI18n } from 'vue-i18n'
-
-interface ValidationOptions {
-  isRequired?: boolean
-  maxLength?: number
-}
-
-const defaultValidationOptions: ValidationOptions = {
-  isRequired: false
-}
 
 /**
  * Composable providing validation functions for declared program form fields.
@@ -25,8 +14,7 @@ const defaultValidationOptions: ValidationOptions = {
  * @returns An object containing validation functions for each form field.
  */
 export function useDeclaredProgramFormValidators () {
-  const { t } = useI18n()
-  const { validateRequired, validateMaxLength } = useFormValidators()
+  const { validateRequired, validateMaxLength, validateDateInterval } = useFormValidators()
 
   function validateTitle (title: DeclaredProgramFormData['title']) {
     return validateRequired(title) ?? validateMaxLength(title, DECLARED_PROGRAM_TITLE_MAX_LENGTH)
@@ -52,22 +40,13 @@ export function useDeclaredProgramFormValidators () {
     return validateRequired(startDate)
   }
 
-  function validateEndDate (endDate: DeclaredProgramFormData['endDate'], startDate: DeclaredProgramFormData['startDate'], options: ValidationOptions = defaultValidationOptions) {
-    if (options.isRequired) {
-      const requiredError = validateRequired(endDate)
-      if (requiredError) {
-        return requiredError
-      }
-    }
-
-    if (endDate && startDate) {
-      const parsedEndDate = parse(endDate, 'yyyy-MM', new Date())
-      const parsedStartDate = parse(startDate, 'yyyy-MM', new Date())
-
-      if (isBefore(parsedEndDate, parsedStartDate)) {
-        return t('student.personalCareer.interactions.formFields.DeclaredProgramPeriodFormField.errors.endDateBeforeStartDate')
-      }
-    }
+  function validateEndDate (endDate: DeclaredProgramFormData['endDate'], startDate: DeclaredProgramFormData['startDate'], options: ValidationOptions = { isRequired: false }) {
+    return validateDateInterval({
+      startDate,
+      endDate,
+      format: 'yyyy-MM',
+      isOnGoing: !options.isRequired
+    })
   }
 
   return {

--- a/src/features/student/personalCareer/locales/en.json
+++ b/src/features/student/personalCareer/locales/en.json
@@ -104,9 +104,7 @@
             "createDeclaredExperience": "Error creating declared experience"
           },
           "sections": {
-            "addExperience": "Add my experience",
-            "associateExperience": "Associate my experience",
-            "specifyExperience": "Specify my experience"
+            "addExperience": "Add my experience"
           },
           "success": "Declared experience added successfully",
           "title": "Add a declared experience"

--- a/src/features/student/personalCareer/locales/en.json
+++ b/src/features/student/personalCareer/locales/en.json
@@ -12,12 +12,12 @@
       },
       "interactions": {
         "formFields": {
+          "DeclaredExperiencePeriodFormField": {
+            "ongoing": "Ongoing"
+          },
           "DeclaredProgramPeriodFormField": {
             "endDate": "End date",
             "endDatePlaceholder": "MM/YYYY",
-            "errors": {
-              "endDateBeforeStartDate": "End date must be after start date"
-            },
             "label": "Period",
             "ongoing": "Ongoing",
             "startDate": "Start date",
@@ -44,6 +44,11 @@
           "DeclaredExperienceOrganizationInput": {
             "label": "Company / Organization",
             "placeholder": "Name"
+          },
+          "DeclaredExperiencePeriodInput": {
+            "endLabel": "End date",
+            "label": "Period",
+            "startLabel": "Start date"
           },
           "DeclaredExperienceReviewTextarea": {
             "label": "Review / Reflection"
@@ -91,6 +96,21 @@
         }
       },
       "overlays": {
+        "AddDeclaredExperienceDrawer": {
+          "confirmationModal": {
+            "description": "Are you sure you want to cancel adding your experience?"
+          },
+          "errors": {
+            "createDeclaredExperience": "Error creating declared experience"
+          },
+          "sections": {
+            "addExperience": "Add my experience",
+            "associateExperience": "Associate my experience",
+            "specifyExperience": "Specify my experience"
+          },
+          "success": "Declared experience added successfully",
+          "title": "Add a declared experience"
+        },
         "AddDeclaredProgramDrawer": {
           "confirmationModal": {
             "description": "Are you sure you want to cancel? Unsaved changes will be lost."
@@ -115,8 +135,8 @@
         "DeleteDeclaredProgramConfirmModal": {
           "description": "This action will result in the deletion of any associated links.",
           "error": "An error occurred while deleting the program. | An error occurred while deleting the programs.",
-          "title": "Are you sure you want to delete this program? | Are you sure you want to delete these programs?",
-          "success": "Program deleted successfully. | Programs deleted successfully."
+          "success": "Program deleted successfully. | Programs deleted successfully.",
+          "title": "Are you sure you want to delete this program? | Are you sure you want to delete these programs?"
         }
       },
       "views": {

--- a/src/features/student/personalCareer/locales/fr.json
+++ b/src/features/student/personalCareer/locales/fr.json
@@ -104,9 +104,7 @@
             "createDeclaredExperience": "Erreur lors de la création de l'expérience déclarée"
           },
           "sections": {
-            "addExperience": "Ajouter mon expérience",
-            "associateExperience": "Associer mon expérience",
-            "specifyExperience": "Préciser mon expérience"
+            "addExperience": "Ajouter mon expérience"
           },
           "success": "Expérience déclarée ajoutée avec succès",
           "title": "Ajouter une expérience déclarée"
@@ -195,11 +193,6 @@
           "ExperiencesSection": {
             "AmsTab": {
               "title": "Mes AMS"
-            },
-            "DeclaredExperiencesMoreActionsDropdown": {
-              "add": "Ajouter une expérience",
-              "delete": "Supprimer une expérience",
-              "share": "Partager une expérience"
             },
             "breadcrumb": "Mes expériences",
             "DeclaredExperiencesMoreActionsDropdown": {

--- a/src/features/student/personalCareer/locales/fr.json
+++ b/src/features/student/personalCareer/locales/fr.json
@@ -12,12 +12,12 @@
       },
       "interactions": {
         "formFields": {
+          "DeclaredExperiencePeriodFormField": {
+            "ongoing": "En cours"
+          },
           "DeclaredProgramPeriodFormField": {
             "endDate": "Date de fin",
             "endDatePlaceholder": "MM/AAAA",
-            "errors": {
-              "endDateBeforeStartDate": "La date de fin doit être postérieure à la date de début"
-            },
             "label": "Période",
             "ongoing": "En cours",
             "startDate": "Date de début",
@@ -44,6 +44,11 @@
           "DeclaredExperienceOrganizationInput": {
             "label": "Entreprise / Organisme",
             "placeholder": "Nom"
+          },
+          "DeclaredExperiencePeriodInput": {
+            "endLabel": "Date de fin",
+            "label": "Période",
+            "startLabel": "Date de début"
           },
           "DeclaredExperienceReviewTextarea": {
             "label": "Bilan / Prise de recul"
@@ -91,6 +96,21 @@
         }
       },
       "overlays": {
+        "AddDeclaredExperienceDrawer": {
+          "confirmationModal": {
+            "description": "Souhaitez-vous abandonner l’ajout de votre expérience ?"
+          },
+          "errors": {
+            "createDeclaredExperience": "Erreur lors de la création de l'expérience déclarée"
+          },
+          "sections": {
+            "addExperience": "Ajouter mon expérience",
+            "associateExperience": "Associer mon expérience",
+            "specifyExperience": "Préciser mon expérience"
+          },
+          "success": "Expérience déclarée ajoutée avec succès",
+          "title": "Ajouter une expérience déclarée"
+        },
         "AddDeclaredProgramDrawer": {
           "confirmationModal": {
             "description": "Êtes-vous sûr de vouloir annuler ? Les modifications non enregistrées seront perdues."
@@ -115,8 +135,8 @@
         "DeleteDeclaredProgramConfirmModal": {
           "description": "Cette action entrainera la suppression des éventuelles associations.",
           "error": "Une erreur est survenue lors de la suppression de la formation. | Une erreur est survenue lors de la suppression des formations.",
-          "title": "Êtes-vous certain(e) de vouloir supprimer cette formation ? | Êtes-vous certain(e) de vouloir supprimer ces formations ?",
-          "success": "Formation supprimée avec succès. | Formations supprimées avec succès."
+          "success": "Formation supprimée avec succès. | Formations supprimées avec succès.",
+          "title": "Êtes-vous certain(e) de vouloir supprimer cette formation ? | Êtes-vous certain(e) de vouloir supprimer ces formations ?"
         }
       },
       "views": {
@@ -175,6 +195,11 @@
           "ExperiencesSection": {
             "AmsTab": {
               "title": "Mes AMS"
+            },
+            "DeclaredExperiencesMoreActionsDropdown": {
+              "add": "Ajouter une expérience",
+              "delete": "Supprimer une expérience",
+              "share": "Partager une expérience"
             },
             "breadcrumb": "Mes expériences",
             "DeclaredExperiencesMoreActionsDropdown": {

--- a/src/features/student/personalCareer/queries/use-declared-experiences.query.test.ts
+++ b/src/features/student/personalCareer/queries/use-declared-experiences.query.test.ts
@@ -1,20 +1,31 @@
+import type { DeclaredExperienceRequest } from '@/api/avenir-esr'
+import type { MutationArgs } from '@/types'
 import type { Ref } from 'vue'
 import {
+  createDeclaredExperienceErrorHandler,
   declaredExperienceDetailedQueryErrorHandler,
   declaredExperiencesQueryEmptyHandler,
   declaredExperiencesQueryErrorHandler
 } from '@/__mocks__/msw/handlers/student/declaredExperiences.handlers'
 import { server } from '@/__mocks__/msw/server'
+import { useInvalidateQuery } from '@/common/composables'
 import {
   type DeclaredExperienceDetailedViewQueryReturnType,
   type DeclaredExperiencesViewQueryReturnType,
+  useCreateDeclaredExperienceMutation,
   useDeclaredExperienceDetailedViewQuery,
   useDeclaredExperiencesViewQuery
 } from '@/features/student/personalCareer/queries/use-declared-experiences.query'
 import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { flushPromises } from '@vue/test-utils'
 import { mountQueryComposable } from 'tests/utils'
-import { beforeEach, expect, vi } from 'vitest'
+import { beforeEach, expect, type MockedFunction, type MockInstance, vi } from 'vitest'
+
+vi.mock('@/common/composables', async () => {
+  return {
+    useInvalidateQuery: vi.fn()
+  }
+})
 
 BddTest().given('a declared experiences view query', () => {
   let queryResult: DeclaredExperiencesViewQueryReturnType
@@ -206,6 +217,217 @@ BddTest().given('a declared experience detailed view query', () => {
 
     BddTest().then('it should return undefined', () => {
       expect(queryResult.data.value).toBeUndefined()
+    })
+  })
+})
+
+BddTest().given('a useCreateDeclaredExperienceMutation composable', async () => {
+  let createDeclaredExperienceSpy: MockInstance<(declaredExperienceRequest: DeclaredExperienceRequest, options?: RequestInit | undefined) => Promise<any>>
+  let mutationResult: ReturnType<typeof useCreateDeclaredExperienceMutation>
+
+  const mockUseInvalidateQuery = useInvalidateQuery as MockedFunction<typeof useInvalidateQuery>
+  const mockInvalidateFunction = vi.fn()
+  const mockOnSuccess = vi.fn()
+  const mockOnError = vi.fn()
+  const mutationArgs: MutationArgs = {
+    onSuccess: mockOnSuccess,
+    onError: mockOnError
+  }
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    vi.restoreAllMocks()
+
+    createDeclaredExperienceSpy = vi.spyOn<typeof import('@/api/avenir-esr'), 'createDeclaredExperience'>(
+      await import('@/api/avenir-esr'),
+    'createDeclaredExperience'
+    )
+
+    mockUseInvalidateQuery.mockReturnValue(mockInvalidateFunction)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  BddTest().and('a valid experience request and success callback', () => {
+    const experienceRequest: DeclaredExperienceRequest = {
+      title: 'New Experience',
+      organization: 'Test Organization',
+      startDate: '2024-01-01',
+      endDate: '2024-12-31',
+      description: 'Test description'
+    }
+
+    BddTest().when('the mutation is called with mutateAsync', () => {
+      beforeEach(async () => {
+        mutationResult = mountQueryComposable(() => useCreateDeclaredExperienceMutation(mutationArgs))
+        await mutationResult.mutateAsync(experienceRequest)
+        await flushPromises()
+      })
+
+      BddTest().then('it should call the createDeclaredExperience API with correct parameters', () => {
+        expect(createDeclaredExperienceSpy).toHaveBeenCalledWith(experienceRequest)
+        expect(createDeclaredExperienceSpy).toHaveBeenCalledTimes(1)
+      })
+
+      BddTest().then('it should return the expected success response', () => {
+        expect(mutationResult.data.value).toBeDefined()
+        expect(mutationResult.data.value).toMatchObject({
+          id: expect.any(String),
+          title: expect.any(String),
+          organization: expect.any(String)
+        })
+      })
+
+      BddTest().then('it should mark the mutation as successful', () => {
+        expect(mutationResult.isSuccess.value).toBe(true)
+        expect(mutationResult.isError.value).toBe(false)
+        expect(mutationResult.isPending.value).toBe(false)
+      })
+
+      BddTest().then('it should call the invalidation function', () => {
+        expect(mockUseInvalidateQuery).toHaveBeenCalledTimes(1)
+        expect(mockInvalidateFunction).toHaveBeenCalledTimes(1)
+      })
+
+      BddTest().then('it should call the custom onSuccess callback', () => {
+        expect(mockOnSuccess).toHaveBeenCalledTimes(1)
+        expect(mockOnSuccess).toHaveBeenCalledWith(
+          expect.objectContaining({
+            id: expect.any(String),
+            title: expect.any(String)
+          }),
+          experienceRequest
+        )
+      })
+
+      BddTest().then('it should not call the onError callback', () => {
+        expect(mockOnError).not.toHaveBeenCalled()
+      })
+    })
+
+    BddTest().when('the mutation is called with mutate', () => {
+      beforeEach(async () => {
+        mutationResult = mountQueryComposable(() => useCreateDeclaredExperienceMutation(mutationArgs))
+        mutationResult.mutate(experienceRequest)
+        await flushPromises()
+      })
+
+      BddTest().then('it should call the createDeclaredExperience API with correct parameters', () => {
+        expect(createDeclaredExperienceSpy).toHaveBeenCalledWith(experienceRequest)
+        expect(createDeclaredExperienceSpy).toHaveBeenCalledTimes(1)
+      })
+
+      BddTest().then('it should call the custom onSuccess callback', () => {
+        expect(mockOnSuccess).toHaveBeenCalledTimes(1)
+      })
+
+      BddTest().then('it should call the invalidation function', () => {
+        expect(mockInvalidateFunction).toHaveBeenCalledTimes(1)
+      })
+    })
+  })
+
+  BddTest().and('no success or error callbacks', () => {
+    const experienceRequest: DeclaredExperienceRequest = {
+      title: 'New Experience',
+      organization: 'Test Organization',
+      startDate: '2024-01-01'
+    }
+    const mutationArgs: MutationArgs = {}
+
+    BddTest().when('the mutation is called without callbacks', () => {
+      beforeEach(async () => {
+        mutationResult = mountQueryComposable(() => useCreateDeclaredExperienceMutation(mutationArgs))
+        await mutationResult.mutateAsync(experienceRequest)
+        await flushPromises()
+      })
+
+      BddTest().then('it should call the createDeclaredExperience API with correct parameters', () => {
+        expect(createDeclaredExperienceSpy).toHaveBeenCalledWith(experienceRequest)
+        expect(createDeclaredExperienceSpy).toHaveBeenCalledTimes(1)
+      })
+
+      BddTest().then('it should still call the invalidation function', () => {
+        expect(mockInvalidateFunction).toHaveBeenCalledTimes(1)
+      })
+
+      BddTest().then('it should mark the mutation as successful', () => {
+        expect(mutationResult.isSuccess.value).toBe(true)
+        expect(mutationResult.isError.value).toBe(false)
+      })
+
+      BddTest().then('it should return the expected response', () => {
+        expect(mutationResult.data.value).toBeDefined()
+      })
+    })
+  })
+
+  BddTest().and('an invalid request with error callback', () => {
+    const experienceRequest: DeclaredExperienceRequest = {
+      title: '',
+      organization: '',
+      startDate: 'invalid-date'
+    }
+
+    BddTest().when('the mutation encounters an error', () => {
+      beforeEach(async () => {
+        server.use(createDeclaredExperienceErrorHandler)
+        mutationResult = mountQueryComposable(() => useCreateDeclaredExperienceMutation(mutationArgs))
+        await mutationResult.mutateAsync(experienceRequest).catch(() => {})
+        await flushPromises()
+      })
+
+      BddTest().then('it should call the createDeclaredExperience API with the invalid request', () => {
+        expect(createDeclaredExperienceSpy).toHaveBeenCalledWith(experienceRequest)
+        expect(createDeclaredExperienceSpy).toHaveBeenCalledTimes(1)
+      })
+
+      BddTest().then('it should mark the mutation as error', () => {
+        expect(mutationResult.isError.value).toBe(true)
+        expect(mutationResult.isSuccess.value).toBe(false)
+        expect(mutationResult.isPending.value).toBe(false)
+      })
+
+      BddTest().then('it should contain the error information', () => {
+        expect(mutationResult.error.value).toBeDefined()
+      })
+
+      BddTest().then('it should call the custom onError callback', () => {
+        expect(mockOnError).toHaveBeenCalledTimes(1)
+      })
+
+      BddTest().then('it should not call the onSuccess callback', () => {
+        expect(mockOnSuccess).not.toHaveBeenCalled()
+      })
+
+      BddTest().then('it should not call the invalidation function on error', () => {
+        expect(mockInvalidateFunction).not.toHaveBeenCalled()
+      })
+    })
+
+    BddTest().when('the mutation is called using mutate with error', () => {
+      beforeEach(async () => {
+        server.use(createDeclaredExperienceErrorHandler)
+        mutationResult = mountQueryComposable(() => useCreateDeclaredExperienceMutation(mutationArgs))
+        mutationResult.mutate(experienceRequest)
+        await flushPromises()
+      })
+
+      BddTest().then('it should call the createDeclaredExperience API with the invalid request', () => {
+        expect(createDeclaredExperienceSpy).toHaveBeenCalledWith(experienceRequest)
+        expect(createDeclaredExperienceSpy).toHaveBeenCalledTimes(1)
+      })
+
+      BddTest().then('it should contain the error information', () => {
+        expect(mutationResult.error.value).toBeDefined()
+        expect(mutationResult.isError.value).toBe(true)
+      })
+
+      BddTest().then('it should call the custom onError callback', () => {
+        expect(mockOnError).toHaveBeenCalledTimes(1)
+      })
     })
   })
 })

--- a/src/features/student/personalCareer/queries/use-declared-experiences.query.ts
+++ b/src/features/student/personalCareer/queries/use-declared-experiences.query.ts
@@ -1,6 +1,8 @@
 import type { BaseApiException } from '@/common/exceptions'
 import type { MutationArgs } from '@/types'
 import {
+  createDeclaredExperience,
+  type DeclaredExperienceRequest,
   type DeclaredExperienceViewDTO,
   deleteDeclaredExperiences,
   getDeclaredExperience,
@@ -59,6 +61,20 @@ export function useDeclaredExperiencesViewQuery ({
     declaredExperiences,
     pageInfo
   }
+}
+
+export function useCreateDeclaredExperienceMutation ({ onError, onSuccess }: MutationArgs = {}) {
+  const invalidateDeclaredExperiencesViewQuery = useInvalidateQuery([...declaredExperiencesViewQueryKey])
+  return useMutation<DeclaredExperienceViewDTO, BaseApiException, DeclaredExperienceRequest>({
+    mutationFn: async (declaredExperienceRequest: DeclaredExperienceRequest): Promise<DeclaredExperienceViewDTO> => {
+      return await createDeclaredExperience(declaredExperienceRequest)
+    },
+    onSuccess: async (data, variables) => {
+      await invalidateDeclaredExperiencesViewQuery()
+      onSuccess?.(data, variables)
+    },
+    onError
+  })
 }
 
 export interface DeclaredExperienceDetailedViewQueryProps {

--- a/src/features/student/personalCareer/stores/personalCareer.store.test.ts
+++ b/src/features/student/personalCareer/stores/personalCareer.store.test.ts
@@ -17,10 +17,14 @@ BddTest().given('a personal career store', () => {
       expect(store.showAddDeclaredProgramDrawer).toBeDefined()
       expect(store.displayAddDeclaredProgramDrawer).toBeDefined()
       expect(store.hideAddDeclaredProgramDrawer).toBeDefined()
+      expect(store.showAddDeclaredExperienceDrawer).toBeDefined()
+      expect(store.displayAddDeclaredExperienceDrawer).toBeDefined()
+      expect(store.hideAddDeclaredExperienceDrawer).toBeDefined()
     })
 
     BddTest().then('it should have drawer initially hidden', () => {
       expect(store.showAddDeclaredProgramDrawer).toBe(false)
+      expect(store.showAddDeclaredExperienceDrawer).toBe(false)
     })
 
     BddTest().then('it should provide declared programs pagination state', () => {
@@ -76,6 +80,42 @@ BddTest().given('a personal career store', () => {
 
         store.displayAddDeclaredProgramDrawer()
         expect(store.showAddDeclaredProgramDrawer).toBe(true)
+      })
+    })
+
+    BddTest().and('displaying the add declared experience drawer', () => {
+      beforeEach(() => {
+        store.displayAddDeclaredExperienceDrawer()
+      })
+
+      BddTest().then('it should set showAddDeclaredExperienceDrawer to true', () => {
+        expect(store.showAddDeclaredExperienceDrawer).toBe(true)
+      })
+    })
+
+    BddTest().and('hiding the add declared experience drawer', () => {
+      beforeEach(() => {
+        store.displayAddDeclaredExperienceDrawer()
+        store.hideAddDeclaredExperienceDrawer()
+      })
+
+      BddTest().then('it should set showAddDeclaredExperienceDrawer to false', () => {
+        expect(store.showAddDeclaredExperienceDrawer).toBe(false)
+      })
+    })
+
+    BddTest().and('toggling experience drawer visibility multiple times', () => {
+      BddTest().then('it should correctly update the state', () => {
+        expect(store.showAddDeclaredExperienceDrawer).toBe(false)
+
+        store.displayAddDeclaredExperienceDrawer()
+        expect(store.showAddDeclaredExperienceDrawer).toBe(true)
+
+        store.hideAddDeclaredExperienceDrawer()
+        expect(store.showAddDeclaredExperienceDrawer).toBe(false)
+
+        store.displayAddDeclaredExperienceDrawer()
+        expect(store.showAddDeclaredExperienceDrawer).toBe(true)
       })
     })
 

--- a/src/features/student/personalCareer/stores/personalCareer.store.ts
+++ b/src/features/student/personalCareer/stores/personalCareer.store.ts
@@ -11,6 +11,12 @@ export const usePersonalCareerStore = defineStore('personalCareer', () => {
     hideDrawer: hideAddDeclaredProgramDrawer
   } = useDrawer()
 
+  const {
+    showDrawer: showAddDeclaredExperienceDrawer,
+    displayDrawer: displayAddDeclaredExperienceDrawer,
+    hideDrawer: hideAddDeclaredExperienceDrawer
+  } = useDrawer()
+
   const declaredProgramsPageSizeSelected = ref<PageSizes>(DEFAULT_PAGE_SIZE)
   const declaredProgramsCurrentPage = ref(0)
 
@@ -21,6 +27,9 @@ export const usePersonalCareerStore = defineStore('personalCareer', () => {
     showAddDeclaredProgramDrawer,
     displayAddDeclaredProgramDrawer,
     hideAddDeclaredProgramDrawer,
+    showAddDeclaredExperienceDrawer,
+    displayAddDeclaredExperienceDrawer,
+    hideAddDeclaredExperienceDrawer,
     declaredProgramsCurrentPage,
     declaredProgramsPageSizeSelected,
     declaredExperiencesCurrentPage,

--- a/src/features/student/personalCareer/types/forms.types.ts
+++ b/src/features/student/personalCareer/types/forms.types.ts
@@ -1,8 +1,12 @@
 import type {
+  useAddDeclaredExperienceForm
+} from '@/features/student/personalCareer/components/overlays/AddDeclaredExperienceDrawer/use-add-declared-experience-form/use-add-declared-experience-form'
+import type {
   useAddDeclaredProgramForm
 } from '@/features/student/personalCareer/components/overlays/AddDeclaredProgramDrawer/use-add-declared-program-form/use-add-declared-program-form'
 
 export type AddDeclaredProgramForm = ReturnType<typeof useAddDeclaredProgramForm>['form']
+export type AddDeclaredExperienceForm = ReturnType<typeof useAddDeclaredExperienceForm>['form']
 
 export interface DeclaredProgramFormData {
   title: string
@@ -14,4 +18,19 @@ export interface DeclaredProgramFormData {
   startDate: string
   endDate: string
   isOngoing: boolean
+}
+
+export interface DeclaredExperienceFormData {
+  title: string
+  type: string
+  organization: string
+  activitySector: string
+  location: string
+  startDate: string
+  endDate: string
+  isOngoing: boolean
+  sourceOfInformation: string
+  description: string
+  review: string
+  link: string
 }

--- a/src/features/student/personalCareer/views/DeclaredProgramUpdateView/components/DeclaredProgramUpdateForm/DeclaredProgramUpdateForm.test.ts
+++ b/src/features/student/personalCareer/views/DeclaredProgramUpdateView/components/DeclaredProgramUpdateForm/DeclaredProgramUpdateForm.test.ts
@@ -108,7 +108,6 @@ BddTest().given('a declared program update form component', () => {
 
       const buttons = getCancelConfirmButtons()
       expect(buttons.exists()).toBe(true)
-      expect(buttons.props('cancelIsLoading')).toBe(true)
       expect(buttons.props('confirmIsLoading')).toBe(true)
     })
 
@@ -129,7 +128,6 @@ BddTest().given('a declared program update form component', () => {
       const buttons = getCancelConfirmButtons()
       expect(buttons.exists()).toBe(true)
       expect(buttons.props('confirmDisabled')).toBe(false)
-      expect(buttons.props('cancelIsLoading')).toBe(false)
     })
   })
 

--- a/src/features/student/personalCareer/views/DeclaredProgramUpdateView/components/DeclaredProgramUpdateForm/DeclaredProgramUpdateForm.vue
+++ b/src/features/student/personalCareer/views/DeclaredProgramUpdateView/components/DeclaredProgramUpdateForm/DeclaredProgramUpdateForm.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import type { DeclaredProgramDetailedDTO } from '@/api/avenir-esr'
-import { CreationUpdateDateDetails } from '@/common/components'
+import { CreationUpdateDateDetails, FormCancelConfirmButtons } from '@/common/components'
 import DeclaredProgramDescriptionFormField
   from '@/features/student/personalCareer/components/interactions/formFields/DeclaredProgramDescriptionFormField/DeclaredProgramDescriptionFormField.vue'
 import DeclaredProgramLinkFormField
@@ -16,7 +16,7 @@ import DeclaredProgramSourceOfInformationFormField
 import DeclaredProgramTitleFormField
   from '@/features/student/personalCareer/components/interactions/formFields/DeclaredProgramTitleFormField/DeclaredProgramTitleFormField.vue'
 import { useUpdateDeclaredProgramForm } from '@/features/student/personalCareer/views/DeclaredProgramUpdateView/components/use-update-declared-program-form/use-update-declared-program-form'
-import { AvCancelConfirmButtons, AvCard, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
+import { AvCard } from '@avenirs-esr/avenirs-dsav'
 import capitalize from 'lodash-es/capitalize'
 import { useI18n } from 'vue-i18n'
 
@@ -110,16 +110,11 @@ const createdAtPrefix = computed(() =>
         class="av-row av-justify-end"
         data-testid="update-declared-program-form__actions"
       >
-        <AvCancelConfirmButtons
-          :cancel-label="t('global.buttons.cancel')"
-          :confirm-label="t('global.buttons.save')"
-          :cancel-icon="MDI_ICONS.CLOSE_CIRCLE_OUTLINE"
-          :confirm-icon="MDI_ICONS.CONTENT_SAVE_OUTLINE"
-          :cancel-is-loading="isSubmitting"
-          :confirm-disabled="!isFormValid"
-          :confirm-is-loading="isSubmitting"
-          @cancel="handleCancel"
-          @confirm="handleSubmit"
+        <FormCancelConfirmButtons
+          :is-submitting="isSubmitting"
+          :is-form-valid="isFormValid"
+          @handle-cancel="handleCancel"
+          @handle-submit="handleSubmit"
         />
       </div>
     </template>

--- a/src/features/student/personalCareer/views/PersonalCareerView/sections/ExperiencesSection/components/DeclaredExperiencesMoreActionsDropdown/DeclaredExperiencesMoreActionsDropdown.stub.ts
+++ b/src/features/student/personalCareer/views/PersonalCareerView/sections/ExperiencesSection/components/DeclaredExperiencesMoreActionsDropdown/DeclaredExperiencesMoreActionsDropdown.stub.ts
@@ -1,0 +1,26 @@
+export const DeclaredExperiencesMoreActionsDropdownStub = defineComponent({
+  name: 'DeclaredExperiencesMoreActionsDropdown',
+  emits: ['addSelected', 'shareSelected', 'deleteSelected'],
+  template: `
+    <div class="declared-experiences-more-actions-dropdown-stub">
+      <button
+        data-testid="add"
+        @click="$emit('addSelected')"
+      >
+        Ajouter
+      </button>
+      <button
+        data-testid="share"
+        @click="$emit('shareSelected')"
+      >
+        Partager
+      </button>
+      <button
+        data-testid="delete"
+        @click="$emit('deleteSelected')"
+      >
+        Supprimer
+      </button>
+    </div>
+  `
+})

--- a/src/features/student/personalCareer/views/PersonalCareerView/sections/ExperiencesSection/components/DeclaredExperiencesMoreActionsDropdown/DeclaredExperiencesMoreActionsDropdown.vue
+++ b/src/features/student/personalCareer/views/PersonalCareerView/sections/ExperiencesSection/components/DeclaredExperiencesMoreActionsDropdown/DeclaredExperiencesMoreActionsDropdown.vue
@@ -9,7 +9,7 @@ const emit = defineEmits<{
 }>()
 const { t } = useI18n()
 
-enum ExperiencesMoreActionsDropdownEvents {
+enum DeclaredExperiencesMoreActionsDropdownEvents {
   ADD = 'add',
   DELETE = 'delete',
   SHARE = 'share',
@@ -17,17 +17,17 @@ enum ExperiencesMoreActionsDropdownEvents {
 
 const menuItems = computed<AvDropdownItem[]>(() => [
   {
-    name: ExperiencesMoreActionsDropdownEvents.ADD,
+    name: DeclaredExperiencesMoreActionsDropdownEvents.ADD,
     icon: MDI_ICONS.PLUS_CIRCLE_OUTLINE,
     label: t('student.personalCareer.views.PersonalCareerView.ExperiencesSection.DeclaredExperiencesMoreActionsDropdown.add')
   },
   {
-    name: ExperiencesMoreActionsDropdownEvents.SHARE,
+    name: DeclaredExperiencesMoreActionsDropdownEvents.SHARE,
     icon: MDI_ICONS.SHARE_VARIANT_OUTLINE,
     label: t('student.personalCareer.views.PersonalCareerView.ExperiencesSection.DeclaredExperiencesMoreActionsDropdown.share')
   },
   {
-    name: ExperiencesMoreActionsDropdownEvents.DELETE,
+    name: DeclaredExperiencesMoreActionsDropdownEvents.DELETE,
     icon: MDI_ICONS.TRASH_CAN_OUTLINE,
     label: t('student.personalCareer.views.PersonalCareerView.ExperiencesSection.DeclaredExperiencesMoreActionsDropdown.delete')
   },
@@ -35,13 +35,13 @@ const menuItems = computed<AvDropdownItem[]>(() => [
 
 function handleItemSelected (itemName: string) {
   switch (itemName) {
-    case ExperiencesMoreActionsDropdownEvents.ADD:
+    case DeclaredExperiencesMoreActionsDropdownEvents.ADD:
       emit('addSelected')
       break
-    case ExperiencesMoreActionsDropdownEvents.DELETE:
+    case DeclaredExperiencesMoreActionsDropdownEvents.DELETE:
       emit('deleteSelected')
       break
-    case ExperiencesMoreActionsDropdownEvents.SHARE:
+    case DeclaredExperiencesMoreActionsDropdownEvents.SHARE:
       emit('shareSelected')
       break
   }

--- a/src/features/student/personalCareer/views/PersonalCareerView/sections/ExperiencesSection/components/DeclaredExperiencesMoreActionsDropdown/DeclaredExperiencesMoreActionsDropdown.vue
+++ b/src/features/student/personalCareer/views/PersonalCareerView/sections/ExperiencesSection/components/DeclaredExperiencesMoreActionsDropdown/DeclaredExperiencesMoreActionsDropdown.vue
@@ -15,27 +15,23 @@ enum ExperiencesMoreActionsDropdownEvents {
   SHARE = 'share',
 }
 
-const menuItems = computed<AvDropdownItem[]>(() => {
-  const items = [
-    {
-      name: ExperiencesMoreActionsDropdownEvents.ADD,
-      icon: MDI_ICONS.PLUS_CIRCLE_OUTLINE,
-      label: t('student.personalCareer.views.PersonalCareerView.ExperiencesSection.DeclaredExperiencesMoreActionsDropdown.add')
-    },
-    {
-      name: ExperiencesMoreActionsDropdownEvents.SHARE,
-      icon: MDI_ICONS.SHARE_VARIANT_OUTLINE,
-      label: t('student.personalCareer.views.PersonalCareerView.ExperiencesSection.DeclaredExperiencesMoreActionsDropdown.share')
-    },
-    {
-      name: ExperiencesMoreActionsDropdownEvents.DELETE,
-      icon: MDI_ICONS.TRASH_CAN_OUTLINE,
-      label: t('student.personalCareer.views.PersonalCareerView.ExperiencesSection.DeclaredExperiencesMoreActionsDropdown.delete')
-    },
-  ]
-
-  return items
-})
+const menuItems = computed<AvDropdownItem[]>(() => [
+  {
+    name: ExperiencesMoreActionsDropdownEvents.ADD,
+    icon: MDI_ICONS.PLUS_CIRCLE_OUTLINE,
+    label: t('student.personalCareer.views.PersonalCareerView.ExperiencesSection.DeclaredExperiencesMoreActionsDropdown.add')
+  },
+  {
+    name: ExperiencesMoreActionsDropdownEvents.SHARE,
+    icon: MDI_ICONS.SHARE_VARIANT_OUTLINE,
+    label: t('student.personalCareer.views.PersonalCareerView.ExperiencesSection.DeclaredExperiencesMoreActionsDropdown.share')
+  },
+  {
+    name: ExperiencesMoreActionsDropdownEvents.DELETE,
+    icon: MDI_ICONS.TRASH_CAN_OUTLINE,
+    label: t('student.personalCareer.views.PersonalCareerView.ExperiencesSection.DeclaredExperiencesMoreActionsDropdown.delete')
+  },
+])
 
 function handleItemSelected (itemName: string) {
   switch (itemName) {

--- a/src/features/student/personalCareer/views/PersonalCareerView/sections/ExperiencesSection/components/DeclaredExperiencesTab/DeclaredExperiencesTab.test.ts
+++ b/src/features/student/personalCareer/views/PersonalCareerView/sections/ExperiencesSection/components/DeclaredExperiencesTab/DeclaredExperiencesTab.test.ts
@@ -4,6 +4,7 @@ import { server } from '@/__mocks__/msw/server'
 import { LoaderStub } from '@/common/components/Loader/Loader.stub'
 import { PaginationStub } from '@/common/components/Pagination/Pagination.stub'
 import { DeclaredExperienceCardStub } from '@/features/student/personalCareer/components/cards/DeclaredExperienceCard/DeclaredExperienceCard.stub'
+import { DeclaredExperiencesMoreActionsDropdownStub } from '@/features/student/personalCareer/views/PersonalCareerView/sections/ExperiencesSection/components/DeclaredExperiencesMoreActionsDropdown/DeclaredExperiencesMoreActionsDropdown.stub'
 import DeclaredExperiencesTab from '@/features/student/personalCareer/views/PersonalCareerView/sections/ExperiencesSection/components/DeclaredExperiencesTab/DeclaredExperiencesTab.vue'
 import { PageSizes } from '@avenirs-esr/avenirs-dsav'
 import { AvIconTextStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
@@ -26,10 +27,13 @@ vi.mock('@/common/composables/use-base-api-exception-toast/use-base-api-exceptio
   useBaseApiExceptionToast: vi.fn()
 }))
 
+const mockDisplayAddDeclaredExperienceDrawer = vi.fn()
+
 vi.mock('@/features/student/personalCareer/stores/personalCareer.store', () => ({
   usePersonalCareerStore: vi.fn(() => ({
     declaredExperiencesCurrentPage: ref(0),
-    declaredExperiencesPageSizeSelected: ref(PageSizes.FOUR)
+    declaredExperiencesPageSizeSelected: ref(PageSizes.FOUR),
+    displayAddDeclaredExperienceDrawer: mockDisplayAddDeclaredExperienceDrawer
   }))
 }))
 
@@ -40,6 +44,11 @@ BddTest().given('a declared experiences tab', () => {
     DeclaredExperienceCard: DeclaredExperienceCardStub,
     Pagination: PaginationStub,
     Loader: LoaderStub,
+    AddDeclaredExperienceDrawer: defineComponent({
+      name: 'AddDeclaredExperienceDrawer',
+      template: '<div data-testid="add-declared-experience-drawer-stub"></div>'
+    }),
+    DeclaredExperiencesMoreActionsDropdown: DeclaredExperiencesMoreActionsDropdownStub,
     AvIconText: AvIconTextStub
   }
 
@@ -72,6 +81,11 @@ BddTest().given('a declared experiences tab', () => {
       const pagination = wrapper.findComponent({ name: 'Pagination' })
       expect(pagination.exists()).toBe(true)
     })
+
+    BddTest().then('it should render the more actions dropdown', () => {
+      const dropdown = wrapper.findComponent({ name: 'DeclaredExperiencesMoreActionsDropdown' })
+      expect(dropdown.exists()).toBe(true)
+    })
   })
 
   BddTest().when('declared experiences data is loaded', () => {
@@ -96,6 +110,17 @@ BddTest().given('a declared experiences tab', () => {
     BddTest().then('it should not display the loader', () => {
       const loaderSpinner = wrapper.find('[data-testid="loader-stub"]')
       expect(loaderSpinner.exists()).toBe(false)
+    })
+  })
+
+  BddTest().when('the add action is triggered', () => {
+    beforeEach(async () => {
+      const dropdown = wrapper.findComponent({ name: 'DeclaredExperiencesMoreActionsDropdown' })
+      await dropdown.find('[data-testid="add"]').trigger('click')
+    })
+
+    BddTest().then('it should call the displayAddDeclaredExperienceDrawer action', () => {
+      expect(mockDisplayAddDeclaredExperienceDrawer).toHaveBeenCalledTimes(1)
     })
   })
 

--- a/src/features/student/personalCareer/views/PersonalCareerView/sections/ExperiencesSection/components/DeclaredExperiencesTab/DeclaredExperiencesTab.vue
+++ b/src/features/student/personalCareer/views/PersonalCareerView/sections/ExperiencesSection/components/DeclaredExperiencesTab/DeclaredExperiencesTab.vue
@@ -2,16 +2,21 @@
 import { Loader, Pagination } from '@/common/components'
 import { useBaseApiExceptionToast, useModal, usePagination } from '@/common/composables'
 import DeclaredExperienceCard from '@/features/student/personalCareer/components/cards/DeclaredExperienceCard/DeclaredExperienceCard.vue'
+import AddDeclaredExperienceDrawer
+  from '@/features/student/personalCareer/components/overlays/AddDeclaredExperienceDrawer/AddDeclaredExperienceDrawer.vue'
 import { useDeclaredExperiencesViewQuery } from '@/features/student/personalCareer/queries/use-declared-experiences.query'
 import { usePersonalCareerStore } from '@/features/student/personalCareer/stores/personalCareer.store'
 import DeclaredExperiencesMoreActionsDropdown
   from '@/features/student/personalCareer/views/PersonalCareerView/sections/ExperiencesSection/components/DeclaredExperiencesMoreActionsDropdown/DeclaredExperiencesMoreActionsDropdown.vue'
 import DeleteDeclaredExperiencesModal from '@/features/student/personalCareer/views/PersonalCareerView/sections/ExperiencesSection/components/DeleteDeclaredExperiencesModal/DeleteDeclaredExperiencesModal.vue'
+import DeclaredExperiencesMoreActionsDropdown
+  from '@/features/student/personalCareer/views/PersonalCareerView/sections/ExperiencesSection/components/DeclaredExperiencesMoreActionsDropdown/DeclaredExperiencesMoreActionsDropdown.vue'
 import { AvIconText, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
 import { useI18n } from 'vue-i18n'
 
 const { t } = useI18n()
 const personalCareerStore = usePersonalCareerStore()
+const { displayAddDeclaredExperienceDrawer } = personalCareerStore
 
 const {
   currentPage,
@@ -83,5 +88,6 @@ useBaseApiExceptionToast(error)
       @close="hideModal"
       @confirm="hideModal"
     />
+    <AddDeclaredExperienceDrawer />
   </div>
 </template>

--- a/src/features/student/personalCareer/views/PersonalCareerView/sections/ExperiencesSection/components/DeclaredExperiencesTab/DeclaredExperiencesTab.vue
+++ b/src/features/student/personalCareer/views/PersonalCareerView/sections/ExperiencesSection/components/DeclaredExperiencesTab/DeclaredExperiencesTab.vue
@@ -9,14 +9,11 @@ import { usePersonalCareerStore } from '@/features/student/personalCareer/stores
 import DeclaredExperiencesMoreActionsDropdown
   from '@/features/student/personalCareer/views/PersonalCareerView/sections/ExperiencesSection/components/DeclaredExperiencesMoreActionsDropdown/DeclaredExperiencesMoreActionsDropdown.vue'
 import DeleteDeclaredExperiencesModal from '@/features/student/personalCareer/views/PersonalCareerView/sections/ExperiencesSection/components/DeleteDeclaredExperiencesModal/DeleteDeclaredExperiencesModal.vue'
-import DeclaredExperiencesMoreActionsDropdown
-  from '@/features/student/personalCareer/views/PersonalCareerView/sections/ExperiencesSection/components/DeclaredExperiencesMoreActionsDropdown/DeclaredExperiencesMoreActionsDropdown.vue'
 import { AvIconText, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
 import { useI18n } from 'vue-i18n'
 
 const { t } = useI18n()
 const personalCareerStore = usePersonalCareerStore()
-const { displayAddDeclaredExperienceDrawer } = personalCareerStore
 
 const {
   currentPage,
@@ -46,6 +43,7 @@ useBaseApiExceptionToast(error)
   <div class="av-col av-gap-md">
     <DeclaredExperiencesMoreActionsDropdown
       @delete-selected="displayModal"
+      @add-selected="personalCareerStore.displayAddDeclaredExperienceDrawer"
     />
     <AvIconText
       icon-color="var(--text2)"

--- a/src/features/student/selfKnowledge/components/overlays/AddSelfKnowledgeCategoryElementDrawer/AddSelfKnowledgeCategoryElementDrawer.vue
+++ b/src/features/student/selfKnowledge/components/overlays/AddSelfKnowledgeCategoryElementDrawer/AddSelfKnowledgeCategoryElementDrawer.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ConfirmationModal } from '@/common/components'
+import { ConfirmationModal, FormCancelConfirmButtons } from '@/common/components'
 import { useModal } from '@/common/composables'
 import CategoryElementDescriptionTextareaFormField from '@/features/student/selfKnowledge/components/interactions/formFields/CategoryElementDescriptionTextareaFormField/CategoryElementDescriptionTextareaFormField.vue'
 import CategoryElementRatingRadioButtonSetFormField from '@/features/student/selfKnowledge/components/interactions/formFields/CategoryElementRatingRadioButtonSetFormField/CategoryElementRatingRadioButtonSetFormField.vue'
@@ -8,7 +8,7 @@ import { useAddSelfKnowledgeCategoryElementForm } from '@/features/student/selfK
 import { useSelfKnowledgeStore } from '@/features/student/selfKnowledge/stores/self-knowledge.store'
 import { getSelfKnowledgeCategoryIcon } from '@/features/student/selfKnowledge/utils/category.utils'
 import { useToasterStore } from '@/store'
-import { AvAccordion, AvAccordionsGroup, AvCancelConfirmButtons, AvDrawer, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
+import { AvAccordion, AvAccordionsGroup, AvDrawer, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
 import capitalize from 'lodash-es/capitalize'
 import { useI18n } from 'vue-i18n'
 
@@ -129,15 +129,12 @@ const drawerTitle = computed(() => {
 
     <template #footer>
       <div class="av-row av-justify-end av-p-md">
-        <AvCancelConfirmButtons
+        <FormCancelConfirmButtons
           :cancel-label="t('global.buttons.exit')"
-          :confirm-label="t('global.buttons.save')"
-          :cancel-icon="MDI_ICONS.CLOSE_CIRCLE_OUTLINE"
-          :confirm-icon="MDI_ICONS.CONTENT_SAVE_OUTLINE"
-          :confirm-disabled="!isFormValid"
-          :confirm-is-loading="isSubmitting"
-          @cancel="handleCancel"
-          @confirm="onSave"
+          :is-submitting="isSubmitting"
+          :is-form-valid="isFormValid"
+          @handle-cancel="handleCancel"
+          @handle-submit="onSave"
         />
       </div>
     </template>

--- a/src/features/student/selfKnowledge/views/SelfKnowledgeElementUpdateView/components/SelfKnowledgeElementUpdateForm/SelfKnowledgeElementUpdateForm.vue
+++ b/src/features/student/selfKnowledge/views/SelfKnowledgeElementUpdateView/components/SelfKnowledgeElementUpdateForm/SelfKnowledgeElementUpdateForm.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { SelfKnowledgeElementDetailsDTO } from '@/api/avenir-esr'
-import { ConfirmationModal, CreationUpdateDateDetails } from '@/common/components'
+import { ConfirmationModal, CreationUpdateDateDetails, FormCancelConfirmButtons } from '@/common/components'
 import { useModal } from '@/common/composables'
 import CategoryElementDescriptionTextareaFormField
   from '@/features/student/selfKnowledge/components/interactions/formFields/CategoryElementDescriptionTextareaFormField/CategoryElementDescriptionTextareaFormField.vue'
@@ -12,7 +12,6 @@ import {
   useUpdateSelfKnowledgeElementForm
 } from '@/features/student/selfKnowledge/views/SelfKnowledgeElementUpdateView/components/SelfKnowledgeElementUpdateForm/use-update-self-knowledge-element-form/use-update-self-knowledge-element-form'
 import { useToasterStore } from '@/store'
-import { AvCancelConfirmButtons, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
 import capitalize from 'lodash-es/capitalize'
 import { useI18n } from 'vue-i18n'
 
@@ -83,15 +82,13 @@ function confirmCancel () {
   </form>
 
   <div class="av-row av-justify-end av-p-md">
-    <AvCancelConfirmButtons
+    <FormCancelConfirmButtons
       :cancel-label="t('global.buttons.cancel')"
       :confirm-label="t('student.selfKnowledge.views.SelfKnowledgeCategoryView.selfKnowledgeElementUpdate.buttons.save')"
-      :confirm-disabled="!isFormValid"
-      :confirm-is-loading="isSubmitting"
-      :cancel-icon="MDI_ICONS.CLOSE_CIRCLE_OUTLINE"
-      :confirm-icon="MDI_ICONS.CONTENT_SAVE_OUTLINE"
-      @cancel="displayConfirmationModal"
-      @confirm="onSubmit"
+      :is-submitting="isSubmitting"
+      :is-form-valid="isFormValid"
+      @handle-cancel="displayConfirmationModal"
+      @handle-submit="onSubmit"
     />
   </div>
   <ConfirmationModal

--- a/src/features/student/traces/views/StudentToolsTracesView/components/StudentToolsTracesAddTraceDrawer/StudentToolsTracesAddTraceDrawer.vue
+++ b/src/features/student/traces/views/StudentToolsTracesView/components/StudentToolsTracesAddTraceDrawer/StudentToolsTracesAddTraceDrawer.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ConfirmationModal } from '@/common/components'
+import { ConfirmationModal, FormCancelConfirmButtons } from '@/common/components'
 import { useModal } from '@/common/composables'
 import { useTracesStore } from '@/features/student/traces/stores/traces.store'
 import CreateTraceFormDeclarationItems from '@/features/student/traces/views/StudentToolsTracesView/components/StudentToolsTracesAddTraceDrawer/components/CreateTraceFormDeclarationItems/CreateTraceFormDeclarationItems.vue'
@@ -8,7 +8,7 @@ import {
   useCreateTraceForm
 } from '@/features/student/traces/views/StudentToolsTracesView/components/StudentToolsTracesAddTraceDrawer/use-create-tarce-form/use-create-trace-form'
 import { useToasterStore } from '@/store'
-import { AvAccordion, AvAccordionsGroup, AvCancelConfirmButtons, AvDrawer, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
+import { AvAccordion, AvAccordionsGroup, AvDrawer, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
 import { useI18n } from 'vue-i18n'
 
 const { t } = useI18n()
@@ -106,15 +106,12 @@ async function onSave () {
 
     <template #footer>
       <div class="student-tools-traces-add-trace-drawer__footer">
-        <AvCancelConfirmButtons
+        <FormCancelConfirmButtons
           :cancel-label="t('global.buttons.exit')"
-          :confirm-label="t('global.buttons.save')"
-          :cancel-icon="MDI_ICONS.CLOSE_CIRCLE_OUTLINE"
-          :confirm-icon="MDI_ICONS.CONTENT_SAVE_OUTLINE"
-          :confirm-disabled="!isFormValid"
-          :confirm-is-loading="isSubmitting"
-          @cancel="handleCancel"
-          @confirm="onSave"
+          :is-submitting="isSubmitting"
+          :is-form-valid="isFormValid"
+          @handle-cancel="handleCancel"
+          @handle-submit="onSave"
         />
       </div>
     </template>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -44,8 +44,8 @@
       "createdAt": "Created on {date}",
       "createdAtWithPrefix": "{prefix} created on {date}",
       "dateTimeAt": "{date} at {time}",
-      "updatedAt": "Updated on {date}",
-      "endDateBeforeStartDate": "End date must be after start date"
+      "endDateBeforeStartDate": "End date must be after start date",
+      "updatedAt": "Updated on {date}"
     },
     "detail": "Detail",
     "error": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -44,7 +44,8 @@
       "createdAt": "Created on {date}",
       "createdAtWithPrefix": "{prefix} created on {date}",
       "dateTimeAt": "{date} at {time}",
-      "updatedAt": "Updated on {date}"
+      "updatedAt": "Updated on {date}",
+      "endDateBeforeStartDate": "End date must be after start date"
     },
     "detail": "Detail",
     "error": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -44,7 +44,8 @@
       "createdAt": "Créé le {date}",
       "createdAtWithPrefix": "{prefix} créé le {date}",
       "dateTimeAt": "{date} à {time}",
-      "updatedAt": "Modifié le {date}"
+      "updatedAt": "Modifié le {date}",
+      "endDateBeforeStartDate": "La date de fin doit être postérieure à la date de début"
     },
     "detail": "Détail",
     "error": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -44,8 +44,8 @@
       "createdAt": "Créé le {date}",
       "createdAtWithPrefix": "{prefix} créé le {date}",
       "dateTimeAt": "{date} à {time}",
-      "updatedAt": "Modifié le {date}",
-      "endDateBeforeStartDate": "La date de fin doit être postérieure à la date de début"
+      "endDateBeforeStartDate": "La date de fin doit être postérieure à la date de début",
+      "updatedAt": "Modifié le {date}"
     },
     "detail": "Détail",
     "error": {

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -4,12 +4,13 @@ import { useInvalidateQuery } from '@/common/composables/use-invalidate-query/us
 import { BaseApiErrorCode, type BaseApiException } from '@/common/exceptions'
 import { i18n } from '@/plugins/vue-i18n/vue-i18n'
 import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { useForm } from '@tanstack/vue-form'
 import { QueryClient, type QueryClientConfig, type UseQueryDefinedReturnType, VueQueryPlugin } from '@tanstack/vue-query'
 import { type ComponentMountingOptions, flushPromises, mount, RouterLinkStub } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import { createMockQueryError, mockAddErrorMessage } from 'tests/mocks'
 import { expect, type Mock, type MockedFunction, type MockInstance } from 'vitest'
-import { type Component, createApp, type Plugin } from 'vue'
+import { type Component, createApp, h, type Plugin } from 'vue'
 
 /**
  * Options to configure the mounting of a component under test.
@@ -381,4 +382,77 @@ export async function mountWithRouter<T> (component: Component, options?: Compon
 
   await wrapper.vm.$nextTick()
   return wrapper
+}
+
+export interface CreateFormFieldTestWrapperOptions<TFormData, TFieldName extends keyof TFormData> {
+  formFieldComponent: Component
+  fieldName: TFieldName
+  defaultValue: TFormData[TFieldName]
+  useValidator: () => (value: TFormData[TFieldName]) => string | undefined
+}
+
+/**
+ * Creates a test wrapper component for form field testing with TanStack Form.
+ *
+ * @template TForm - The form type (e.g., AddDeclaredExperienceForm)
+ * @template TFormData - The form data type (e.g., DeclaredExperienceFormData)
+ * @template TFieldName - The field name key from TFormData
+ * @param {CreateFormFieldTestWrapperOptions} options - Configuration options for the wrapper
+ * @param {Component} options.formFieldComponent - The form field component to test
+ * @param {TFieldName} options.fieldName - The name of the field in the form
+ * @param {TFormData[TFieldName]} options.defaultValue - The default value for the field
+ * @param {() => (value: TFormData[TFieldName]) => string | undefined} options.useValidator - A factory function that returns the validator (called inside setup to support composables using useI18n)
+ * @returns {Component} A test wrapper component with form handling
+ *
+ * @example
+ * const TestWrapper = createFormFieldTestWrapper<AddDeclaredExperienceForm, DeclaredExperienceFormData, 'location'>({
+ *   formFieldComponent: DeclaredExperienceLocationFormField,
+ *   fieldName: 'location',
+ *   defaultValue: '',
+ *   useValidator: () => useDeclaredExperienceFormValidators().validateLocation
+ * })
+ *
+ * // Then in tests:
+ * const wrapper = mount(TestWrapper, { global: { stubs } })
+ * await wrapper.find('form').trigger('submit')
+ */
+export function createFormFieldTestWrapper<
+  TForm,
+  TFormData,
+  TFieldName extends keyof TFormData
+> ({
+  formFieldComponent,
+  fieldName,
+  defaultValue,
+  useValidator
+}: CreateFormFieldTestWrapperOptions<TFormData, TFieldName>) {
+  return defineComponent({
+    components: {
+      FormFieldComponent: formFieldComponent
+    },
+    setup () {
+      const validate = useValidator()
+      const form = useForm({
+        defaultValues: {
+          [fieldName]: defaultValue
+        } as TFormData,
+        validators: {
+          onSubmit ({ value }: { value: TFormData }) {
+            return { fields: { [fieldName]: validate(value[fieldName]) } }
+          }
+        }
+      }) as unknown as TForm
+
+      return { form }
+    },
+    render () {
+      const handleSubmit = (e: Event) => {
+        e.preventDefault()
+        ;(this.form as { handleSubmit: () => void }).handleSubmit()
+      }
+      return h('form', { onSubmit: handleSubmit }, [
+        h(formFieldComponent, { form: this.form })
+      ])
+    }
+  })
 }


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> This PR implements the "Add Declared Experience" drawer feature, allowing students to create new declared experiences (professional, academic, personal, etc.) in their personal career portfolio.

**Key changes:**
- Created `AddDeclaredExperienceDrawer` component with full form handling
- Implemented form field components for all experience fields (title, type, organization, activity sector, location, period, source of information, description, review, link)
- Added `useAddDeclaredExperienceForm` composable with TanStack Form validation
- Created `useDeclaredExperienceFormValidators` for reusable validation logic
- Added `useCreateDeclaredExperienceMutation` query for API integration
- Updated `personalCareer.store` to manage drawer visibility state
- Added `DeclaredExperiencesMoreActionsDropdown` component for triggering the drawer
- Added comprehensive unit tests for all new components and composables (4000+ lines of tests)

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/957

---

### Documentation
> - Added French and English translations for all form labels, placeholders, and error messages
> - Form validation rules documented in the validator composable

---

### Target Branch
> `develop`

---

### Additional Notes
> - The drawer uses the design system's `AvDrawer` component with unsaved changes confirmation
> - Period field supports "ongoing" experiences (no end date required)
> - Form validators are shared between add and update forms via `useDeclaredExperienceFormValidators`
> - All form fields have max length validation as per configuration constants

---

### Known Limitations or Side Effects
> - None identified

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [x] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [x] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process