### PR TITLE
feat(1047): SelfKnowledgeMainSection - add UpdateProfileDrawer

### DIFF
--- a/src/features/student/selfKnowledge/components/SelfKnowledgeMainSection/SelfKnowledgeMainSection.test.ts
+++ b/src/features/student/selfKnowledge/components/SelfKnowledgeMainSection/SelfKnowledgeMainSection.test.ts
@@ -6,6 +6,7 @@ import { selfKnowledgeCategoriesErrorHandler } from '@/__mocks__/msw/handlers/st
 import { server } from '@/__mocks__/msw/server'
 import SelfKnowledgeMainSection from '@/features/student/selfKnowledge/components/SelfKnowledgeMainSection/SelfKnowledgeMainSection.vue'
 import { ProfileCardStub } from '@/features/student/user/components/cards/ProfileCard/ProfileCard.stub'
+import { UpdateProfileDrawerStub } from '@/features/student/user/components/overlays/UpdateProfileDrawer/UpdateProfileDrawer.stub'
 import { AvButtonStub, AvIconTextStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { mountComponent } from 'tests/utils'
 
@@ -30,7 +31,8 @@ BddTest().given('a self knowledge section component', () => {
     AvIconText: AvIconTextStub,
     AddSelfKnowledgeCategoriesModal: AddSelfKnowledgeCategoriesModalStub,
     ProfileCard: ProfileCardStub,
-    SelfKnowledgeCategoryElementsPaginatorCard: SelfKnowledgeCategoryElementsPaginatorCardStub
+    SelfKnowledgeCategoryElementsPaginatorCard: SelfKnowledgeCategoryElementsPaginatorCardStub,
+    UpdateProfileDrawer: UpdateProfileDrawerStub
   }
 
   const getAddButton = () => {
@@ -83,7 +85,12 @@ BddTest().given('a self knowledge section component', () => {
       expect(profileCard.exists()).toBe(false)
     })
 
-    BddTest().and('the profile card is loaded', () => {
+    BddTest().then('it should not render the display update profile drawer button initially', () => {
+      const button = wrapper.find('[data-testid="display-update-profile-drawer-button"]')
+      expect(button.exists()).toBe(false)
+    })
+
+    BddTest().and('the student summary is loaded', () => {
       beforeEach(async () => {
         await vi.waitFor(() => {
           const profileCard = wrapper.findComponent(ProfileCardStub)
@@ -91,9 +98,32 @@ BddTest().given('a self knowledge section component', () => {
         })
       })
 
+      BddTest().then('it should render the profile card', () => {
+        const profileCard = wrapper.findComponent(ProfileCardStub)
+        expect(profileCard.exists()).toBe(true)
+      })
+
       BddTest().then('it should pass correct student summary props', () => {
         const profileCard = wrapper.findComponent(ProfileCardStub)
         expect(profileCard.props('studentSummary')).toEqual(mockedProfileOverview)
+      })
+
+      BddTest().then('it should render the display update profile drawer button', () => {
+        const button = wrapper.find('[data-testid="display-update-profile-drawer-button"]')
+        expect(button.exists()).toBe(true)
+      })
+
+      BddTest().and('the display update profile drawer button is clicked', () => {
+        beforeEach(async () => {
+          const button = wrapper.find('[data-testid="display-update-profile-drawer-button"]')
+          await button.trigger('click')
+        })
+
+        BddTest().then('it should display the update profile drawer', () => {
+          const drawer = wrapper.findComponent(UpdateProfileDrawerStub)
+          expect(drawer.exists()).toBe(true)
+          expect(drawer.props('show')).toBe(true)
+        })
       })
     })
 

--- a/src/features/student/selfKnowledge/components/SelfKnowledgeMainSection/SelfKnowledgeMainSection.vue
+++ b/src/features/student/selfKnowledge/components/SelfKnowledgeMainSection/SelfKnowledgeMainSection.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
-import { useModal } from '@/common/composables'
+import { useDrawer, useModal } from '@/common/composables'
 import SelfKnowledgeCategoryElementsPaginatorCard from '@/features/student/selfKnowledge/components/cards/SelfKnowledgeCategoryElementsPaginatorCard/SelfKnowledgeCategoryElementsPaginatorCard.vue'
 import AddSelfKnowledgeCategoriesModal from '@/features/student/selfKnowledge/components/modals/AddSelfKnowledgeCategoriesModal/AddSelfKnowledgeCategoriesModal.vue'
 import AddSelfKnowledgeCategoryElementDrawer
   from '@/features/student/selfKnowledge/components/overlays/AddSelfKnowledgeCategoryElementDrawer/AddSelfKnowledgeCategoryElementDrawer.vue'
 import { useSelfKnowledgeCategoriesQuery } from '@/features/student/selfKnowledge/queries/self-knowledge.query/self-knowledge.query'
 import { ProfileCard, useStudentSummaryQuery } from '@/features/student/user'
+import UpdateProfileDrawer from '@/features/student/user/components/overlays/UpdateProfileDrawer/UpdateProfileDrawer.vue'
 import { AvButton, AvIconText, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
 import { useI18n } from 'vue-i18n'
 
@@ -15,7 +16,7 @@ const {
   hideModal: hideAddCategoryModal,
   showModal: showAddCategoryModal
 } = useModal()
-
+const { showDrawer, displayDrawer, hideDrawer } = useDrawer()
 const { categories } = useSelfKnowledgeCategoriesQuery()
 const { data: studentSummary } = useStudentSummaryQuery()
 </script>
@@ -30,6 +31,20 @@ const { data: studentSummary } = useStudentSummaryQuery()
       text-color="var(--title)"
       gap="0.75rem"
     />
+
+    <div
+      v-if="studentSummary"
+      class="av-row av-justify-end"
+    >
+      <AvButton
+        :icon="MDI_ICONS.PENCIL_OUTLINE"
+        :label="t('global.buttons.update')"
+        variant="OUTLINED"
+        small
+        data-testid="display-update-profile-drawer-button"
+        @click="displayDrawer"
+      />
+    </div>
 
     <ProfileCard
       v-if="studentSummary"
@@ -60,4 +75,12 @@ const { data: studentSummary } = useStudentSummaryQuery()
     @confirm="hideAddCategoryModal"
   />
   <AddSelfKnowledgeCategoryElementDrawer />
+
+  <UpdateProfileDrawer
+    v-if="studentSummary"
+    :key="showDrawer ? 'drawer-open' : 'drawer-closed'"
+    :student-summary="studentSummary"
+    :show="showDrawer"
+    :on-close="hideDrawer"
+  />
 </template>

--- a/src/features/student/user/components/cards/StudentOverviewWidget/StudentOverviewWidget.test.ts
+++ b/src/features/student/user/components/cards/StudentOverviewWidget/StudentOverviewWidget.test.ts
@@ -4,6 +4,7 @@ import { getProfileErrorHandler } from '@/__mocks__/msw/handlers/student/overvie
 import { server } from '@/__mocks__/msw/server'
 import { ProfileCardStub } from '@/features/student/user/components/cards/ProfileCard/ProfileCard.stub'
 import StudentOverviewWidget from '@/features/student/user/components/cards/StudentOverviewWidget/StudentOverviewWidget.vue'
+import { UpdateProfileDrawerStub } from '@/features/student/user/components/overlays/UpdateProfileDrawer/UpdateProfileDrawer.stub'
 import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { mountComponent } from 'tests/utils'
 import { beforeEach, expect, vi } from 'vitest'
@@ -13,11 +14,7 @@ BddTest().given('a student overview widget', () => {
 
   const stubs = {
     ProfileCard: ProfileCardStub,
-    UpdateProfileDrawer: {
-      name: 'UpdateProfileDrawer',
-      props: ['show'],
-      template: '<div class="update-profile-drawer" />'
-    }
+    UpdateProfileDrawer: UpdateProfileDrawerStub
   }
 
   BddTest().when('the component is mounted', () => {

--- a/src/features/student/user/components/overlays/UpdateProfileDrawer/UpdateProfileDrawer.stub.ts
+++ b/src/features/student/user/components/overlays/UpdateProfileDrawer/UpdateProfileDrawer.stub.ts
@@ -1,0 +1,5 @@
+export const UpdateProfileDrawerStub = defineComponent({
+  name: 'UpdateProfileDrawer',
+  props: ['show'],
+  template: '<div class="update-profile-drawer" />'
+})


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
<!-- Describe the changes introduced by this pull request. -->

:sparkles: SelfKnowledgeMainSection - add UpdateProfileDrawer

---

### Reference to an Issue, Feature, Task, User Story or another PR
<!-- Mention related issue numbers or links (e.g. Closes #123, Implements #456). -->

Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1047

---

### Target Branch
<!-- Which branch is this PR targeting (e.g. `main`, `develop`)? -->

develop

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [x] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [x] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and detaiils for the update process

---