### PR TITLE
feat(1131): add UnsubscribeActivitiesConfirmModal to ProjectActivityDetailedView

### DIFF
--- a/api-specs/avenir-esr.swagger.json
+++ b/api-specs/avenir-esr.swagger.json
@@ -1821,7 +1821,7 @@
     },
 
     "/me/activity-progresses/unsubscribe": {
-      "post": {
+      "delete": {
         "tags": [
           "activity-progresses-controller"
         ],

--- a/src/__mocks__/msw/handlers/student/activities.handlers.ts
+++ b/src/__mocks__/msw/handlers/student/activities.handlers.ts
@@ -40,7 +40,7 @@ export const activityNavigationQuery = http.get(`*${getGetActivityNavigationUrl(
   })
 })
 
-const unsubscribeActivityProgressesHandler = http.post(`*${getUnsubscribeActivityProgressesUrl()}`, async ({ request }) => {
+const unsubscribeActivityProgressesHandler = http.delete(`*${getUnsubscribeActivityProgressesUrl()}`, async ({ request }) => {
   const activitiesIds = await request.json() as string[]
 
   if (activitiesIds.length === 0) {

--- a/src/features/student/buildProject/locales/en.json
+++ b/src/features/student/buildProject/locales/en.json
@@ -7,6 +7,9 @@
             "label": "New"
           }
         },
+        "buttons": {
+          "unsubscribe": "Unsubscribe"
+        },
         "declaredActivityStatus": {
           "COMPLETED": "Completed",
           "IN_PROGRESS": "In progress",
@@ -34,6 +37,13 @@
           "SELF_KNOWLEDGE": "Self-knowledge",
           "TRAJECTORIES": "My trajectories",
           "TRANSVERSAL": "Transversal"
+        },
+        "views": {
+          "ProjectActivityDetailedView": {
+            "ActivityDetailedDropdown": {
+              "triggerLabel": "Manage my activity"
+            }
+          }
         }
       },
       "mindMap": {

--- a/src/features/student/buildProject/locales/fr.json
+++ b/src/features/student/buildProject/locales/fr.json
@@ -7,6 +7,9 @@
             "label": "Nouveau"
           }
         },
+        "buttons": {
+          "unsubscribe": "Me désinscrire"
+        },
         "declaredActivityStatus": {
           "COMPLETED": "Terminée",
           "IN_PROGRESS": "En cours",
@@ -34,6 +37,13 @@
           "SELF_KNOWLEDGE": "Me connaître",
           "TRAJECTORIES": "Mes trajectoires",
           "TRANSVERSAL": "Transverse"
+        },
+        "views": {
+          "ProjectActivityDetailedView": {
+            "ActivityDetailedDropdown": {
+              "triggerLabel": "Gérer mon activité"
+            }
+          }
         }
       },
       "mindMap": {
@@ -95,8 +105,7 @@
         "ProjectActivitiesCatalogView": {
           "periodTitle": "Période de réalisation",
           "previewTitle": "Extrait de l'activité",
-          "title": "Toutes les activités disponibles",
-          "unsubscribe": "Se désinscrire"
+          "title": "Toutes les activités disponibles"
         },
         "projectActivitiesView": {
           "ActivityLibraryCard": {

--- a/src/features/student/buildProject/views/ProjectActivitiesCatalogView/components/ActivityPreview/ActivityPreview.test.ts
+++ b/src/features/student/buildProject/views/ProjectActivitiesCatalogView/components/ActivityPreview/ActivityPreview.test.ts
@@ -61,7 +61,7 @@ BddTest().given('an activity preview', () => {
     BddTest().then('it should render the unsubscribe button', () => {
       const unsubscribeButton = wrapper.findComponent(AvButtonStub).find('[data-testid="unsubscribe-button"]')
       expect(unsubscribeButton.exists()).toBe(true)
-      expect(unsubscribeButton.text()).toBe('Se désinscrire')
+      expect(unsubscribeButton.text()).toBe('Me désinscrire')
     })
 
     BddTest().then('it should render the unsubscribe confirmation modal', () => {

--- a/src/features/student/buildProject/views/ProjectActivitiesCatalogView/components/ActivityPreview/ActivityPreview.vue
+++ b/src/features/student/buildProject/views/ProjectActivitiesCatalogView/components/ActivityPreview/ActivityPreview.vue
@@ -73,7 +73,7 @@ const { showModal, displayModal, hideModal } = useModal()
           <AvButton
             variant="OUTLINED"
             theme="PRIMARY"
-            :label="t('student.buildProject.views.ProjectActivitiesCatalogView.unsubscribe')"
+            :label="t('student.buildProject.activities.buttons.unsubscribe')"
             :icon="MDI_ICONS.TRASH_CAN_OUTLINE"
             data-testid="unsubscribe-button"
             @click="displayModal"

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/ProjectActivityDetailedView.test.ts
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/ProjectActivityDetailedView.test.ts
@@ -5,6 +5,8 @@ import { server } from '@/__mocks__/msw/server'
 import { LoaderStub } from '@/common/components/Loader/Loader.stub'
 import { PageTitleStub } from '@/common/components/PageTitle/PageTitle.stub'
 import { ROUTES } from '@/common/constants'
+import { UnsubscribeActivitiesConfirmModalStub } from '@/features/student/buildProject/components/modals/UnsubscribeActivitiesConfirmModal/UnsubscribeActivitiesConfirmModal.stub'
+import { ActivityDetailedDropdownStub } from '@/features/student/buildProject/views/ProjectActivityDetailedView/components/overlays/ActivityDetailedDropdown/ActivityDetailedDropdown.stub'
 import ProjectActivityDetailedView, { type ProjectActivityDetailedViewProps } from '@/features/student/buildProject/views/ProjectActivityDetailedView/ProjectActivityDetailedView.vue'
 import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { mountComponent } from 'tests/utils'
@@ -15,7 +17,9 @@ BddTest().given('a project activity detailed view', () => {
 
   const stubs = {
     PageTitle: PageTitleStub,
-    Loader: LoaderStub
+    Loader: LoaderStub,
+    UnsubscribeActivitiesConfirmModal: UnsubscribeActivitiesConfirmModalStub,
+    ActivityDetailedDropdown: ActivityDetailedDropdownStub
   }
 
   BddTest().when('the view is mounted with a valid activity', () => {
@@ -69,6 +73,45 @@ BddTest().given('a project activity detailed view', () => {
       })
       expect(breadcrumbLinks[2]).toEqual({
         text: 'Mes activités'
+      })
+    })
+
+    BddTest().and('the user clicks the unsubscribe button in the activity detailed dropdown', () => {
+      beforeEach(async () => {
+        const unsubscribeButton = wrapper.findComponent(ActivityDetailedDropdownStub)
+        unsubscribeButton.vm.$emit('unsubscribeSelected')
+      })
+
+      BddTest().then('it should show the UnsubscribeActivitiesConfirmModal', () => {
+        const modal = wrapper.findComponent(UnsubscribeActivitiesConfirmModalStub)
+        expect(modal.exists()).toBe(true)
+        expect(modal.props('show')).toBe(true)
+      })
+    })
+
+    BddTest().and('the user confirms the unsubscription in the UnsubscribeActivitiesConfirmModal', () => {
+      beforeEach(async () => {
+        const modal = wrapper.findComponent(UnsubscribeActivitiesConfirmModalStub)
+        modal.vm.$emit('unsubscribed')
+      })
+
+      BddTest().then('it should hide the UnsubscribeActivitiesConfirmModal', () => {
+        const modal = wrapper.findComponent(UnsubscribeActivitiesConfirmModalStub)
+        expect(modal.exists()).toBe(true)
+        expect(modal.props('show')).toBe(false)
+      })
+    })
+
+    BddTest().and('the user cancels the unsubscription in the UnsubscribeActivitiesConfirmModal', () => {
+      beforeEach(async () => {
+        const modal = wrapper.findComponent(UnsubscribeActivitiesConfirmModalStub)
+        modal.vm.$emit('cancel')
+      })
+
+      BddTest().then('it should hide the UnsubscribeActivitiesConfirmModal', () => {
+        const modal = wrapper.findComponent(UnsubscribeActivitiesConfirmModalStub)
+        expect(modal.exists()).toBe(true)
+        expect(modal.props('show')).toBe(false)
       })
     })
   })

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/ProjectActivityDetailedView.vue
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/ProjectActivityDetailedView.vue
@@ -1,9 +1,12 @@
 <script setup lang="ts">
 import Loader from '@/common/components/Loader/Loader.vue'
 import PageTitle from '@/common/components/PageTitle/PageTitle.vue'
+import { useModal } from '@/common/composables'
 import { ROUTES } from '@/common/constants'
 import ActivityErrorMessage from '@/features/student/buildProject/components/feedback/ActivityErrorMessage/ActivityErrorMessage.vue'
+import UnsubscribeActivitiesConfirmModal from '@/features/student/buildProject/components/modals/UnsubscribeActivitiesConfirmModal/UnsubscribeActivitiesConfirmModal.vue'
 import { useActivityDetailQuery } from '@/features/student/buildProject/queries/use-activities.query/use-activities.query'
+import ActivityDetailedDropdown from '@/features/student/buildProject/views/ProjectActivityDetailedView/components/overlays/ActivityDetailedDropdown/ActivityDetailedDropdown.vue'
 import { useI18n } from 'vue-i18n'
 
 export interface ProjectActivityDetailedViewProps {
@@ -14,6 +17,7 @@ const { id } = defineProps<ProjectActivityDetailedViewProps>()
 
 const { t } = useI18n()
 const { activityDetail, isLoading, isError, error } = useActivityDetailQuery(id)
+const { showModal, displayModal, hideModal } = useModal()
 
 const breadcrumbLinks = computed(() => [
   { text: t('student.global.navigation.tabs.home'), to: ROUTES.STUDENT.HOME },
@@ -43,6 +47,17 @@ const breadcrumbLinks = computed(() => [
           </span>
         </template>
       </PageTitle>
+
+      <div class="av-row av-justify-end">
+        <ActivityDetailedDropdown @unsubscribe-selected="displayModal" />
+      </div>
+
+      <UnsubscribeActivitiesConfirmModal
+        :show="showModal"
+        :activities="[{ id: activityDetail.id, title: activityDetail.title }]"
+        @cancel="hideModal"
+        @unsubscribed="hideModal"
+      />
     </template>
   </Loader>
 

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/overlays/ActivityDetailedDropdown/ActivityDetailedDropdown.stub.ts
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/overlays/ActivityDetailedDropdown/ActivityDetailedDropdown.stub.ts
@@ -1,0 +1,5 @@
+export const ActivityDetailedDropdownStub = defineComponent({
+  name: 'ActivityDetailedDropdown',
+  emits: ['updateSelected', 'unsubscribeSelected'],
+  template: '<div class="activity-detailed-dropdown-stub" />'
+})

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/overlays/ActivityDetailedDropdown/ActivityDetailedDropdown.test.ts
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/overlays/ActivityDetailedDropdown/ActivityDetailedDropdown.test.ts
@@ -1,0 +1,47 @@
+import ActivityDetailedDropdown from '@/features/student/buildProject/views/ProjectActivityDetailedView/components/overlays/ActivityDetailedDropdown/ActivityDetailedDropdown.vue'
+import { AvDropdownStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { beforeEach, expect } from 'vitest'
+
+BddTest().given('an activity detailed dropdown', () => {
+  let wrapper: VueWrapper<InstanceType<typeof ActivityDetailedDropdown>>
+
+  const stubs = {
+    AvDropdown: AvDropdownStub
+  }
+
+  beforeEach(() => {
+    wrapper = mount(ActivityDetailedDropdown, { global: { stubs } })
+  })
+
+  BddTest().when('the component is mounted', () => {
+    BddTest().then('it should render the dropdown with two menu items', () => {
+      const dropdown = wrapper.findComponent({ name: 'AvDropdown' })
+      expect(dropdown.exists()).toBe(true)
+      expect(dropdown.props('items')).toHaveLength(2)
+    })
+
+    BddTest().then('it should pass correct props to dropdown', () => {
+      const dropdown = wrapper.findComponent({ name: 'AvDropdown' })
+      expect(dropdown.props('items')).toHaveLength(2)
+      expect(dropdown.props('triggerAriaLabel')).toBe('Gérer mon activité')
+      expect(dropdown.props('triggerLabel')).toBe('Gérer mon activité')
+    })
+  })
+
+  BddTest().when('the update button is clicked', () => {
+    BddTest().then('it should emit the updateSelected event', async () => {
+      const updateButton = wrapper.find('[data-name="update"]')
+      await updateButton.trigger('click')
+      expect(wrapper.emitted('updateSelected')).toHaveLength(1)
+    })
+  })
+
+  BddTest().when('the unsubscribe button is clicked', () => {
+    BddTest().then('it should emit the unsubscribeSelected event', async () => {
+      const unsubscribeButton = wrapper.find('[data-name="unsubscribe"]')
+      await unsubscribeButton.trigger('click')
+      expect(wrapper.emitted('unsubscribeSelected')).toHaveLength(1)
+    })
+  })
+})

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/overlays/ActivityDetailedDropdown/ActivityDetailedDropdown.vue
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/overlays/ActivityDetailedDropdown/ActivityDetailedDropdown.vue
@@ -1,0 +1,50 @@
+<script lang="ts" setup>
+import { AvDropdown, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
+import { useI18n } from 'vue-i18n'
+
+const emit = defineEmits<{
+  (e: 'updateSelected'): void
+  (e: 'unsubscribeSelected'): void
+}>()
+
+enum ActivityDetailedDropdownEvents {
+  UPDATE = 'update',
+  UNSUBSCRIBE = 'unsubscribe',
+}
+
+const { t } = useI18n()
+
+const menuItems = computed(() => [
+  {
+    name: ActivityDetailedDropdownEvents.UPDATE,
+    icon: MDI_ICONS.PENCIL_OUTLINE,
+    label: t('global.buttons.update')
+  },
+  {
+    name: ActivityDetailedDropdownEvents.UNSUBSCRIBE,
+    icon: MDI_ICONS.TRASH_CAN_OUTLINE,
+    label: t('student.buildProject.activities.buttons.unsubscribe')
+  }
+])
+
+function handleItemSelected (itemName: string) {
+  switch (itemName) {
+    case ActivityDetailedDropdownEvents.UPDATE:
+      emit('updateSelected')
+      break
+    case ActivityDetailedDropdownEvents.UNSUBSCRIBE:
+      emit('unsubscribeSelected')
+      break
+  }
+}
+</script>
+
+<template>
+  <AvDropdown
+    :items="menuItems"
+    :trigger-aria-label="t('student.buildProject.activities.views.ProjectActivityDetailedView.ActivityDetailedDropdown.triggerLabel')"
+    :trigger-label="t('student.buildProject.activities.views.ProjectActivityDetailedView.ActivityDetailedDropdown.triggerLabel')"
+    width="max-content"
+    @item-selected="handleItemSelected"
+  />
+</template>

--- a/src/features/student/personalCareer/views/DeclaredProgramDetailedView/DeclaredProgramDetailedView.test.ts
+++ b/src/features/student/personalCareer/views/DeclaredProgramDetailedView/DeclaredProgramDetailedView.test.ts
@@ -1,5 +1,9 @@
 import type { DeclaredProgramViewDTO } from '@/api/avenir-esr'
-import { declaredProgramDetailedHandler, declaredProgramDetailedLoadingHandler, declaredProgramsQueryErrorHandler } from '@/__mocks__/msw/handlers/student/declaredPrograms.handlers'
+import {
+  declaredProgramDetailedHandler,
+  declaredProgramDetailedLoadingHandler,
+  declaredProgramsQueryErrorHandler,
+} from '@/__mocks__/msw/handlers/student/declaredPrograms.handlers'
 import { server } from '@/__mocks__/msw/server'
 import { LoaderStub } from '@/common/components/Loader/Loader.stub'
 import { PageTitleStub } from '@/common/components/PageTitle/PageTitle.stub'
@@ -11,7 +15,7 @@ import DeclaredProgramDetailedView from '@/features/student/personalCareer/views
 import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { flushPromises, type VueWrapper } from '@vue/test-utils'
 import { mountComponent } from 'tests/utils'
-import { beforeEach, expect, vi } from 'vitest'
+import { afterEach, beforeEach, expect, vi } from 'vitest'
 import { nextTick } from 'vue'
 
 const routerPush = vi.fn()
@@ -99,6 +103,10 @@ BddTest().given('a declared program detailed view component', () => {
     vi.clearAllMocks()
     mockRouteId.value = 'declared-program-1'
     mockShowModal.value = false
+  })
+
+  afterEach(() => {
+    wrapper?.unmount()
   })
 
   BddTest().when('the component is mounted', () => {

--- a/src/features/student/personalCareer/views/DeclaredProgramUpdateView/DeclaredProgramUpdateView.test.ts
+++ b/src/features/student/personalCareer/views/DeclaredProgramUpdateView/DeclaredProgramUpdateView.test.ts
@@ -10,7 +10,7 @@ import DeclaredProgramUpdateView from '@/features/student/personalCareer/views/D
 import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { flushPromises, type VueWrapper } from '@vue/test-utils'
 import { mountComponent } from 'tests/utils'
-import { beforeEach, expect, vi } from 'vitest'
+import { afterEach, beforeEach, expect, vi } from 'vitest'
 import { nextTick } from 'vue'
 
 const routerPush = vi.fn()
@@ -122,6 +122,10 @@ BddTest().given('a declared program update view component', () => {
     showConfirmationModal.value = false
 
     mockCanLeave.mockResolvedValue(true)
+  })
+
+  afterEach(() => {
+    wrapper?.unmount()
   })
 
   BddTest().when('the component is mounted', () => {


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
This PR introduces an unsubscribe confirmation flow in the detailed activity view to prevent accidental unsubscription and improve user safety in activity management.

**Main changes:**
- ✨ Adds `UnsubscribeActivitiesConfirmModal` integration in `ProjectActivityDetailedView`
- 💬 Adds and updates related i18n strings in EN/FR locales
- ✅ Extends and updates unit tests around detailed activity and related views/components
- 🔧 Updates API spec/MSW handler fixtures aligned with the new behavior

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1131

---

### Documentation
- Test coverage updated for detailed activity view and dropdown interactions
- Locale files updated for new modal labels/messages
- API/mock artifacts adjusted to keep test/dev contracts consistent

---

### Target Branch
`develop`

---

### Additional Notes
Implementation is focused on confirmation UX at the point of unsubscription in the student build-project activity detailed flow, with corresponding test updates to preserve behavior consistency.

---

### Known Limitations or Side Effects
No known functional side effects. Scope is limited to unsubscribe confirmation workflow and associated test/i18n updates.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [x] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [x] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process
