### PR TITLE
feat(1132): add unsubscribe modal to activities library

### DIFF
--- a/api-specs/avenir-esr.swagger.json
+++ b/api-specs/avenir-esr.swagger.json
@@ -1859,12 +1859,12 @@
         }
       }
     },
-    "/me/activity-progresses/unsubscribe": {
+    "/me/activity-progress/unsubscribe": {
       "delete": {
         "tags": [
-          "activity-progresses-controller"
+          "declared-activity-controller"
         ],
-        "operationId": "unsubscribeActivityProgresses",
+        "operationId": "unsubscribe",
         "requestBody": {
           "content": {
             "application/json": {

--- a/src/__mocks__/fixtures/student/activities.fixtures.ts
+++ b/src/__mocks__/fixtures/student/activities.fixtures.ts
@@ -229,6 +229,30 @@ export function createMockedPagedResponseDeclaredActivityViewDTO (
   }
 }
 
+const allDeclaredActivitiesLarge: DeclaredActivityViewDTO[] = []
+for (let i = 0; i < 10; i++) {
+  allDeclaredActivitiesLarge.push(...allDeclaredActivities.map(activity => ({
+    ...activity,
+    id: `${activity.id}-${i + 1}`,
+    title: `${activity.title} (${i + 1})`
+  })))
+}
+
+export function createLargeMockedPagedResponseDeclaredActivityViewDTO (
+  pageSize: number,
+  page: number
+): PagedResponseDeclaredActivityViewDTO {
+  const start = page * pageSize
+  const end = start + pageSize
+  const paginatedActivities = allDeclaredActivitiesLarge.slice(start, end)
+  const totalPages = Math.ceil(allDeclaredActivitiesLarge.length / pageSize)
+
+  return {
+    data: paginatedActivities,
+    page: { pageSize, totalElements: allDeclaredActivitiesLarge.length, totalPages, page }
+  }
+}
+
 export const mockedActivityDetail: ActivityDetailDTO = {
   id: 'activity-1',
   title: 'Activité “Connaissance de soi” : Définir ses valeurs',

--- a/src/__mocks__/msw/handlers/student/activities.handlers.ts
+++ b/src/__mocks__/msw/handlers/student/activities.handlers.ts
@@ -1,5 +1,6 @@
 import {
   activitiesNavigationMock,
+  createLargeMockedPagedResponseDeclaredActivityViewDTO,
   createMockedPagedResponseDeclaredActivityViewDTO,
   mockedActivityDetail
 } from '@/__mocks__/fixtures/student/activities.fixtures'
@@ -10,7 +11,7 @@ import {
   getGetActivityDetailUrl,
   getGetActivityNavigationUrl,
   getGetDeclaredActivitiesViewUrl,
-  getUnsubscribeActivityProgressesUrl,
+  getUnsubscribeUrl,
   type PagedResponseDeclaredActivityViewDTO,
 } from '@/api/avenir-esr'
 import { http, HttpResponse } from 'msw'
@@ -46,7 +47,7 @@ export const activityNavigationQuery = http.get(`*${getGetActivityNavigationUrl(
   })
 })
 
-const unsubscribeActivityProgressesHandler = http.delete(`*${getUnsubscribeActivityProgressesUrl()}`, async ({ request }) => {
+const unsubscribeActivityProgressHandler = http.delete(`*${getUnsubscribeUrl()}`, async ({ request }) => {
   const activitiesIds = await request.json() as string[]
 
   if (activitiesIds.length === 0) {
@@ -76,6 +77,21 @@ export const libraryActivitiesErrorHandler = http.get(`*${getGetDeclaredActiviti
       }
     }
   )
+})
+
+export const largeLibraryActivitiesHandler = http.get(`*${getGetDeclaredActivitiesViewUrl()}`, ({ request }) => {
+  const url = new URL(request.url)
+  const page = Number.parseInt(url.searchParams.get('page') ?? '0')
+  const pageSize = Number.parseInt(url.searchParams.get('pageSize') ?? '10')
+
+  const mockData = createLargeMockedPagedResponseDeclaredActivityViewDTO(pageSize, page)
+
+  return HttpResponse.json<PagedResponseDeclaredActivityViewDTO>(mockData, {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json'
+    }
+  })
 })
 
 export const activitiesHandlers = [
@@ -117,5 +133,5 @@ export const activitiesHandlers = [
       }
     })
   }),
-  unsubscribeActivityProgressesHandler,
+  unsubscribeActivityProgressHandler,
 ]

--- a/src/common/components/Pagination/Pagination.stub.ts
+++ b/src/common/components/Pagination/Pagination.stub.ts
@@ -1,6 +1,6 @@
 export const PaginationStub = defineComponent({
   name: 'Pagination',
-  props: ['pageInfo', 'pageSizeSelected', 'onUpdateCurrentPage', 'onUpdatePageSize'],
+  props: ['pageInfo', 'pageSizeSelected', 'withoutPageSizePicker', 'onUpdateCurrentPage', 'onUpdatePageSize'],
   template: `
       <div class="pagination-stub">
         <button class="emit-current-page" @click="onUpdateCurrentPage(5)">Page 5</button>

--- a/src/common/components/Pagination/Pagination.vue
+++ b/src/common/components/Pagination/Pagination.vue
@@ -15,11 +15,12 @@ import { useI18n } from 'vue-i18n'
 export interface PaginationProps {
   pageInfo: PageInfoDTO
   pageSizeSelected: PageSizes
+  withoutPageSizePicker?: boolean
   onUpdateCurrentPage: (page: number) => void
   onUpdatePageSize: (pageSize: PageSizes) => void
 }
 
-const { pageInfo, pageSizeSelected, onUpdateCurrentPage, onUpdatePageSize } = defineProps<PaginationProps>()
+const { pageInfo, pageSizeSelected, withoutPageSizePicker = false, onUpdateCurrentPage, onUpdatePageSize } = defineProps<PaginationProps>()
 
 defineSlots<{
   default?: Slot
@@ -43,9 +44,15 @@ function handleSelectChange (val: AvTagPickerOption): void {
 
 <template>
   <div class="pagination">
-    <div class="av-row av-wrap av-align-center av-justify-between av-gap-md">
+    <div
+      class="av-row av-wrap av-align-center av-gap-md"
+      :class="{
+        'av-justify-end': withoutPageSizePicker,
+        'av-justify-between': !withoutPageSizePicker,
+      }"
+    >
       <AvPageSizePicker
-        v-if="!isMobile && totalPages > 0"
+        v-if="!isMobile && totalPages > 0 && !withoutPageSizePicker"
         :label="t('global.pageSizePicker.label')"
         :page-size-selected="pageSizeSelected"
         :handle-select-change="handleSelectChange"

--- a/src/common/composables/use-infinite-scroll-pagination/use-infinite-scroll-pagination.test.ts
+++ b/src/common/composables/use-infinite-scroll-pagination/use-infinite-scroll-pagination.test.ts
@@ -26,8 +26,6 @@ function createTestItems (count: number, startId = 1): TestItem[] {
   }))
 }
 
-const getItemId = (item: TestItem) => item.id
-
 BddTest().given('useInfiniteScrollPagination composable', () => {
   BddTest().when('initialized with empty items', () => {
     const fetchedItems = ref<TestItem[]>([])
@@ -40,7 +38,6 @@ BddTest().given('useInfiniteScrollPagination composable', () => {
       pageInfo,
       isFetching,
       page,
-      getItemId
     })
 
     BddTest().then('items should be empty', () => {
@@ -70,7 +67,6 @@ BddTest().given('useInfiniteScrollPagination composable', () => {
         pageInfo,
         isFetching,
         page,
-        getItemId
       })
       items = result.items
 
@@ -102,7 +98,6 @@ BddTest().given('useInfiniteScrollPagination composable', () => {
         pageInfo,
         isFetching,
         page,
-        getItemId
       })
       items = result.items
       loadMore = result.loadMore
@@ -147,7 +142,6 @@ BddTest().given('useInfiniteScrollPagination composable', () => {
         pageInfo,
         isFetching,
         page,
-        getItemId
       })
       items = result.items
       loadMore = result.loadMore
@@ -160,12 +154,13 @@ BddTest().given('useInfiniteScrollPagination composable', () => {
       ]
     })
 
-    BddTest().then('duplicates should be filtered out', () => {
-      expect(items.value).toHaveLength(4)
+    BddTest().then('duplicates should not be filtered out', () => {
+      expect(items.value).toHaveLength(5)
       expect(items.value.map(i => i.id)).toEqual([
         'item-1',
         'item-2',
         'item-3',
+        'item-2',
         'item-4'
       ])
     })
@@ -186,7 +181,6 @@ BddTest().given('useInfiniteScrollPagination composable', () => {
         pageInfo,
         isFetching,
         page,
-        getItemId
       })
       loadMore = result.loadMore
 
@@ -213,7 +207,6 @@ BddTest().given('useInfiniteScrollPagination composable', () => {
         pageInfo,
         isFetching,
         page,
-        getItemId
       })
       loadMore = result.loadMore
 
@@ -241,7 +234,6 @@ BddTest().given('useInfiniteScrollPagination composable', () => {
         pageInfo,
         isFetching,
         page,
-        getItemId
       })
       items = result.items
       resetPagination = result.resetPagination
@@ -283,7 +275,6 @@ BddTest().given('useInfiniteScrollPagination composable', () => {
         pageInfo,
         isFetching,
         page,
-        getItemId: (item: CustomItem) => item.uuid
       })
       items = result.items
       loadMore = result.loadMore
@@ -296,9 +287,9 @@ BddTest().given('useInfiniteScrollPagination composable', () => {
       ]
     })
 
-    BddTest().then('should deduplicate using custom id extractor', () => {
-      expect(items.value).toHaveLength(3)
-      expect(items.value.map(i => i.uuid)).toEqual(['uuid-1', 'uuid-2', 'uuid-3'])
+    BddTest().then('it should keep duplicates', () => {
+      expect(items.value).toHaveLength(4)
+      expect(items.value.map(i => i.uuid)).toEqual(['uuid-1', 'uuid-2', 'uuid-2', 'uuid-3'])
     })
   })
 })

--- a/src/common/composables/use-infinite-scroll-pagination/use-infinite-scroll-pagination.ts
+++ b/src/common/composables/use-infinite-scroll-pagination/use-infinite-scroll-pagination.ts
@@ -13,8 +13,6 @@ export interface UseInfiniteScrollPaginationParams<T> {
   isFetching: Ref<boolean>
   /** Current page number (0-based) */
   page: Ref<number>
-  /** Function to extract unique identifier from an item */
-  getItemId: (item: T) => string
 }
 
 /**
@@ -45,7 +43,6 @@ export interface UseInfiniteScrollPaginationResult<T> {
  *  - `pageInfo` (Ref<PageInfoDTO>) : pagination metadata,
  *  - `isFetching` (Ref<boolean>) : loading state indicator,
  *  - `page` (Ref<number>) : current page number,
- *  - `getItemId` (function) : function to extract unique item identifier.
  * @returns {UseInfiniteScrollPaginationResult<T>} Object containing :
  *  - `items` (Ref<T[]>) : accumulated items from all loaded pages,
  *  - `loadMore` (function) : method that loads the next page,
@@ -56,8 +53,7 @@ export function useInfiniteScrollPagination<T> ({
   fetchedItems,
   pageInfo,
   isFetching,
-  page,
-  getItemId
+  page
 }: UseInfiniteScrollPaginationParams<T>): UseInfiniteScrollPaginationResult<T> {
   const items = ref<T[]>([]) as Ref<T[]>
 
@@ -66,13 +62,10 @@ export function useInfiniteScrollPagination<T> ({
       items.value = newItems
     }
     else {
-      const existingIds = new Set(items.value.map(item => getItemId(item)))
       const merged = [...items.value]
 
       newItems.forEach((item) => {
-        if (!existingIds.has(getItemId(item))) {
-          merged.push(item)
-        }
+        merged.push(item)
       })
 
       items.value = merged

--- a/src/features/student/buildProject/composables/activities/use-paginated-library-activities/use-paginated-library-activities.test.ts
+++ b/src/features/student/buildProject/composables/activities/use-paginated-library-activities/use-paginated-library-activities.test.ts
@@ -1,0 +1,144 @@
+import type { DeclaredActivityViewDTO } from '@/api/avenir-esr'
+import { largeLibraryActivitiesHandler } from '@/__mocks__/msw/handlers/student/activities.handlers'
+import { server } from '@/__mocks__/msw/server'
+import { usePaginatedLibraryActivities } from '@/features/student/buildProject/composables/activities/use-paginated-library-activities/use-paginated-library-activities'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { mountComposable } from 'tests/utils'
+import { beforeEach, expect, vi } from 'vitest'
+
+BddTest().given('the usePaginatedLibraryActivities composable', () => {
+  let composableResult: ReturnType<typeof usePaginatedLibraryActivities>
+
+  const mountPaginatedComposable = () => {
+    server.use(largeLibraryActivitiesHandler)
+    const { result } = mountComposable(() => usePaginatedLibraryActivities(), { useTanstack: true })
+    composableResult = result
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  BddTest().when('the first page is loaded', () => {
+    beforeEach(async () => {
+      mountPaginatedComposable()
+
+      await vi.waitFor(() => {
+        expect(composableResult.activities.value.length).toBeGreaterThan(0)
+      })
+    })
+
+    BddTest().then('it should load the first page into activities', () => {
+      const activities = composableResult.activities.value
+
+      expect(activities.length).toBe(10)
+      expect(activities[0]).toHaveProperty('id')
+      expect(activities[0]).toHaveProperty('title')
+      expect(composableResult.page.value).toBe(0)
+    })
+
+    BddTest().then('pageInfo should be consistent with the paginated response', () => {
+      const pageInfo = composableResult.pageInfo.value
+
+      expect(pageInfo).toBeDefined()
+      expect(pageInfo!.page).toBe(0)
+      expect(pageInfo!.pageSize).toBe(10)
+      expect(pageInfo!.totalElements).toBeGreaterThan(0)
+      expect(pageInfo!.totalPages).toBeGreaterThan(0)
+    })
+  })
+
+  BddTest().when('loadMoreActivities is called and more pages are available', () => {
+    let firstPageActivities: DeclaredActivityViewDTO[]
+
+    beforeEach(async () => {
+      mountPaginatedComposable()
+
+      await vi.waitFor(() => {
+        expect(composableResult.activities.value.length).toBe(10)
+      })
+
+      firstPageActivities = [...composableResult.activities.value]
+
+      composableResult.loadMoreActivities()
+
+      await vi.waitFor(() => {
+        expect(composableResult.activities.value.length).toBeGreaterThan(
+          firstPageActivities.length
+        )
+      })
+    })
+
+    BddTest().then('it should increment the page index', () => {
+      expect(composableResult.page.value).toBe(1)
+    })
+
+    BddTest().then('it should accumulate activities from multiple pages', () => {
+      const activities = composableResult.activities.value
+
+      expect(activities.length).toBe(20)
+
+      const uniqueIds = new Set(activities.map(activity => activity.id))
+      expect(uniqueIds.size).toBe(activities.length)
+    })
+  })
+
+  BddTest().when('loadMoreActivities is called multiple times', () => {
+    beforeEach(async () => {
+      mountPaginatedComposable()
+
+      await vi.waitFor(() => {
+        expect(composableResult.activities.value.length).toBe(10)
+      })
+
+      composableResult.loadMoreActivities()
+      await vi.waitFor(() => {
+        expect(composableResult.page.value).toBe(1)
+        expect(composableResult.activities.value.length).toBe(20)
+      })
+
+      composableResult.loadMoreActivities()
+      await vi.waitFor(() => {
+        expect(composableResult.page.value).toBe(2)
+        expect(composableResult.activities.value.length).toBe(30)
+      })
+    })
+
+    BddTest().then('it should continue accumulating activities across pages', () => {
+      const activities = composableResult.activities.value
+
+      expect(activities.length).toBe(30)
+
+      const uniqueIds = new Set(activities.map(activity => activity.id))
+      expect(uniqueIds.size).toBe(activities.length)
+    })
+  })
+
+  BddTest().when('resetPagination is called', () => {
+    let pageAfterReset: number
+    let activitiesLengthAfterReset: number
+
+    beforeEach(async () => {
+      mountPaginatedComposable()
+
+      await vi.waitFor(() => {
+        expect(composableResult.activities.value.length).toBe(10)
+      })
+
+      composableResult.loadMoreActivities()
+      await vi.waitFor(() => {
+        expect(composableResult.page.value).toBe(1)
+      })
+
+      composableResult.resetPagination()
+
+      pageAfterReset = composableResult.page.value
+      activitiesLengthAfterReset = composableResult.activities.value.length
+    })
+
+    BddTest().then('it should reset page to 0 and clear activities', () => {
+      expect(pageAfterReset).toBe(0)
+      expect(activitiesLengthAfterReset).toBe(0)
+    })
+  })
+})

--- a/src/features/student/buildProject/composables/activities/use-paginated-library-activities/use-paginated-library-activities.ts
+++ b/src/features/student/buildProject/composables/activities/use-paginated-library-activities/use-paginated-library-activities.ts
@@ -1,0 +1,54 @@
+import type { DeclaredActivityViewDTO, PageInfoDTO } from '@/api/avenir-esr'
+import { useInfiniteScrollPagination } from '@/common/composables'
+import { useLibraryActivitiesQuery } from '@/features/student/buildProject/queries/use-activities.query/use-activities.query'
+import { type ComputedRef, type Ref, toValue } from 'vue'
+
+export interface UsePaginatedLibraryActivitiesResult {
+  activities: Ref<DeclaredActivityViewDTO[]>
+  pageInfo: Ref<PageInfoDTO | undefined>
+  page: Ref<number>
+  isFetching: Ref<boolean>
+  loadMoreActivities: () => void
+  resetPagination: () => void
+  hasMoreActivities: ComputedRef<boolean>
+}
+
+export function usePaginatedLibraryActivities (): UsePaginatedLibraryActivitiesResult {
+  const page = ref(0)
+  const pageSize = ref(10)
+
+  const queryParams = computed(() => ({
+    page: toValue(page),
+    pageSize: toValue(pageSize)
+  }))
+
+  const {
+    pageInfo: fetchedPageInfo,
+    libraryActivities: fetchedActivities,
+    isFetching
+  } = useLibraryActivitiesQuery(queryParams)
+
+  const pageInfo = computed(() => fetchedPageInfo.value ?? { page: page.value, pageSize: 10, totalElements: 0, totalPages: 0 })
+
+  const {
+    items: activities,
+    hasMoreItems: hasMoreActivities,
+    loadMore: loadMoreActivities,
+    resetPagination
+  } = useInfiniteScrollPagination({
+    fetchedItems: fetchedActivities,
+    pageInfo,
+    isFetching,
+    page
+  })
+
+  return {
+    activities,
+    pageInfo,
+    page,
+    isFetching,
+    hasMoreActivities,
+    loadMoreActivities,
+    resetPagination
+  }
+}

--- a/src/features/student/buildProject/locales/en.json
+++ b/src/features/student/buildProject/locales/en.json
@@ -134,7 +134,14 @@
             },
             "tabTitle": "All available activities ({count})"
           },
-          "title": "My activities"
+          "title": "My activities",
+          "UnsubscribeActivitiesModal": {
+            "confirm": "Unsubscribe from the selected activity ({count}) | Unsubscribe from the selected activities ({count})",
+            "description": "You cannot unsubscribe from mandatory activities.",
+            "error": "An error occurred while unsubscribing from the activity. Please try again later. | An error occurred while unsubscribing from the {count} activities. Please try again later.",
+            "success": "Successfully unsubscribed from the activity. | Successfully unsubscribed from the {count} activities.",
+            "title": "No activity to unsubscribe from | Which activity would you like to unsubscribe from? | Which activities would you like to unsubscribe from?"
+          }
         }
       }
     }

--- a/src/features/student/buildProject/locales/fr.json
+++ b/src/features/student/buildProject/locales/fr.json
@@ -133,7 +133,14 @@
             },
             "tabTitle": "Toutes les activités disponibles ({count})"
           },
-          "title": "Mes activités"
+          "title": "Mes activités",
+          "UnsubscribeActivitiesModal": {
+            "confirm": "Me désinscrire de l'activité sélectionnée ({count}) | Me désinscrire des activités sélectionnées ({count})",
+            "description": "Vous ne pouvez pas vous désinscrire des activités obligatoires.",
+            "error": "Une erreur est survenue lors de la désinscription de l'activité. Veuillez réessayer plus tard. | Une erreur est survenue lors de la désinscription des {count} activités. Veuillez réessayer plus tard.",
+            "success": "Désinscription de l'activité réussie. | Désinscription des {count} activités réussie.",
+            "title": "Aucune activité à laquelle se désinscrire | De quelle activité souhaitez-vous vous désinscrire ? | De quelles activités souhaitez-vous vous désinscrire ?"
+          }
         }
       }
     }

--- a/src/features/student/buildProject/queries/use-activities.query/use-activities.query.test.ts
+++ b/src/features/student/buildProject/queries/use-activities.query/use-activities.query.test.ts
@@ -146,7 +146,7 @@ BddTest().given('the useActivityDetailQuery composable', () => {
 })
 
 BddTest().given('the useUnsubscribeActivitiesMutation composable', () => {
-  let unsubscribeActivityProgressesSpy: MockInstance<
+  let unsubscribeActivityProgressSpy: MockInstance<
     (activityIds: string[], options?: RequestInit | undefined) => Promise<string>
   >
   let useInvalidateQuerySpy: MockInstance<typeof useInvalidateQuery>
@@ -165,9 +165,9 @@ BddTest().given('the useUnsubscribeActivitiesMutation composable', () => {
     vi.clearAllMocks()
     vi.restoreAllMocks()
 
-    unsubscribeActivityProgressesSpy = vi.spyOn<typeof import('@/api/avenir-esr'), 'unsubscribeActivityProgresses'>(
+    unsubscribeActivityProgressSpy = vi.spyOn<typeof import('@/api/avenir-esr'), 'unsubscribe'>(
       await import('@/api/avenir-esr'),
-    'unsubscribeActivityProgresses',
+    'unsubscribe',
     )
 
     useInvalidateQuerySpy = vi.spyOn<typeof import('@/common/composables'), 'useInvalidateQuery'>(
@@ -191,9 +191,9 @@ BddTest().given('the useUnsubscribeActivitiesMutation composable', () => {
         await flushPromises()
       })
 
-      BddTest().then('it should call the unsubscribeActivityProgresses API with correct parameters', () => {
-        expect(unsubscribeActivityProgressesSpy).toHaveBeenCalledWith(elementsIds)
-        expect(unsubscribeActivityProgressesSpy).toHaveBeenCalledTimes(1)
+      BddTest().then('it should call the unsubscribeActivityProgress API with correct parameters', () => {
+        expect(unsubscribeActivityProgressSpy).toHaveBeenCalledWith(elementsIds)
+        expect(unsubscribeActivityProgressSpy).toHaveBeenCalledTimes(1)
       })
 
       BddTest().then('it should return the expected success response', () => {
@@ -228,9 +228,9 @@ BddTest().given('the useUnsubscribeActivitiesMutation composable', () => {
         await flushPromises()
       })
 
-      BddTest().then('it should call the unsubscribeActivityProgresses API with correct parameters', () => {
-        expect(unsubscribeActivityProgressesSpy).toHaveBeenCalledWith(elementsIds)
-        expect(unsubscribeActivityProgressesSpy).toHaveBeenCalledTimes(1)
+      BddTest().then('it should call the unsubscribeActivityProgress API with correct parameters', () => {
+        expect(unsubscribeActivityProgressSpy).toHaveBeenCalledWith(elementsIds)
+        expect(unsubscribeActivityProgressSpy).toHaveBeenCalledTimes(1)
       })
 
       BddTest().then('it should call the custom onSuccess callback', () => {
@@ -255,9 +255,9 @@ BddTest().given('the useUnsubscribeActivitiesMutation composable', () => {
         await flushPromises()
       })
 
-      BddTest().then('it should call the unsubscribeActivityProgresses API with correct parameters', () => {
-        expect(unsubscribeActivityProgressesSpy).toHaveBeenCalledWith(elementsIds)
-        expect(unsubscribeActivityProgressesSpy).toHaveBeenCalledTimes(1)
+      BddTest().then('it should call the unsubscribeActivityProgress API with correct parameters', () => {
+        expect(unsubscribeActivityProgressSpy).toHaveBeenCalledWith(elementsIds)
+        expect(unsubscribeActivityProgressSpy).toHaveBeenCalledTimes(1)
       })
 
       BddTest().then('it should still call the invalidation function', () => {
@@ -286,9 +286,9 @@ BddTest().given('the useUnsubscribeActivitiesMutation composable', () => {
         await flushPromises()
       })
 
-      BddTest().then('it should call the unsubscribeActivityProgresses API with the invalid parameters', () => {
-        expect(unsubscribeActivityProgressesSpy).toHaveBeenCalledWith(elementsIds)
-        expect(unsubscribeActivityProgressesSpy).toHaveBeenCalledTimes(1)
+      BddTest().then('it should call the unsubscribeActivityProgress API with the invalid parameters', () => {
+        expect(unsubscribeActivityProgressSpy).toHaveBeenCalledWith(elementsIds)
+        expect(unsubscribeActivityProgressSpy).toHaveBeenCalledTimes(1)
       })
 
       BddTest().then('it should mark the mutation as error', () => {
@@ -323,9 +323,9 @@ BddTest().given('the useUnsubscribeActivitiesMutation composable', () => {
         await flushPromises()
       })
 
-      BddTest().then('it should call the unsubscribeActivityProgresses API with the invalid parameters', () => {
-        expect(unsubscribeActivityProgressesSpy).toHaveBeenCalledWith(elementsIds)
-        expect(unsubscribeActivityProgressesSpy).toHaveBeenCalledTimes(1)
+      BddTest().then('it should call the unsubscribeActivityProgress API with the invalid parameters', () => {
+        expect(unsubscribeActivityProgressSpy).toHaveBeenCalledWith(elementsIds)
+        expect(unsubscribeActivityProgressSpy).toHaveBeenCalledTimes(1)
       })
 
       BddTest().then('it should contain the error information', () => {
@@ -350,9 +350,9 @@ BddTest().given('the useUnsubscribeActivitiesMutation composable', () => {
         await flushPromises()
       })
 
-      BddTest().then('it should call the unsubscribeActivityProgresses API with the invalid parameters', () => {
-        expect(unsubscribeActivityProgressesSpy).toHaveBeenCalledWith(elementsIds)
-        expect(unsubscribeActivityProgressesSpy).toHaveBeenCalledTimes(1)
+      BddTest().then('it should call the unsubscribeActivityProgress API with the invalid parameters', () => {
+        expect(unsubscribeActivityProgressSpy).toHaveBeenCalledWith(elementsIds)
+        expect(unsubscribeActivityProgressSpy).toHaveBeenCalledTimes(1)
       })
 
       BddTest().then('it should mark the mutation as error', () => {
@@ -387,9 +387,9 @@ BddTest().given('the useUnsubscribeActivitiesMutation composable', () => {
         await flushPromises()
       })
 
-      BddTest().then('it should call the unsubscribeActivityProgresses API with the invalid parameters', () => {
-        expect(unsubscribeActivityProgressesSpy).toHaveBeenCalledWith(elementsIds)
-        expect(unsubscribeActivityProgressesSpy).toHaveBeenCalledTimes(1)
+      BddTest().then('it should call the unsubscribeActivityProgress API with the invalid parameters', () => {
+        expect(unsubscribeActivityProgressSpy).toHaveBeenCalledWith(elementsIds)
+        expect(unsubscribeActivityProgressSpy).toHaveBeenCalledTimes(1)
       })
 
       BddTest().then('it should contain the error information', () => {

--- a/src/features/student/buildProject/queries/use-activities.query/use-activities.query.ts
+++ b/src/features/student/buildProject/queries/use-activities.query/use-activities.query.ts
@@ -1,6 +1,15 @@
 import type { BaseApiException } from '@/common/exceptions/base-api-exception/base-api.exception'
 import type { MutationArgs } from '@/types'
-import { type ActivityDetailDTO, type ActivityNavigationDTO, getActivityDetail, getActivityNavigation, getDeclaredActivitiesView, type GetDeclaredActivitiesViewParams, type PagedResponseDeclaredActivityViewDTO, unsubscribeActivityProgresses } from '@/api/avenir-esr'
+import {
+  type ActivityDetailDTO,
+  type ActivityNavigationDTO,
+  getActivityDetail,
+  getActivityNavigation,
+  getDeclaredActivitiesView,
+  type GetDeclaredActivitiesViewParams,
+  type PagedResponseDeclaredActivityViewDTO,
+  unsubscribe
+} from '@/api/avenir-esr'
 import { useInvalidateQuery } from '@/common/composables'
 import { commonQueryKeys } from '@/features/student/global'
 import { useMutation, useQuery, type UseQueryReturnType } from '@tanstack/vue-query'
@@ -53,7 +62,7 @@ export function useUnsubscribeActivitiesMutation ({ onError, onSuccess }: Mutati
   const invalidateQueryKey = useInvalidateQuery()
   return useMutation<string, BaseApiException, UnsubscribeActivitiesVariables>({
     mutationFn: async ({ activitiesIds }: UnsubscribeActivitiesVariables): Promise<string> => {
-      return await unsubscribeActivityProgresses(activitiesIds)
+      return await unsubscribe(activitiesIds)
     },
     onSuccess: async (data, variables) => {
       await Promise.all(

--- a/src/features/student/buildProject/views/ProjectActivitiesCatalogView/ProjectActivitiesCatalogView.vue
+++ b/src/features/student/buildProject/views/ProjectActivitiesCatalogView/ProjectActivitiesCatalogView.vue
@@ -39,7 +39,7 @@ const breadcrumbLinks = computed(() => [
   />
   <div
     data-testid="activities-layout"
-    class="av-justify-center av-my-md"
+    class="av-justify-center av-my-md av-gap-sm"
     :class="[isMobile ? 'av-column' : 'av-row']"
   >
     <ActivitiesSelectNavigation v-if="isMobile" />

--- a/src/features/student/buildProject/views/ProjectActivitiesCatalogView/components/ActivitiesSideNavigation/ActivitiesSideNavigation.vue
+++ b/src/features/student/buildProject/views/ProjectActivitiesCatalogView/components/ActivitiesSideNavigation/ActivitiesSideNavigation.vue
@@ -20,7 +20,7 @@ const isSideMenuCollapsed = ref(false)
 const { activities: activitiesRef, isLoading, isError } = useActivitiesNavigationQuery()
 
 const DEFAULT_PARENT_ICON = MDI_ICONS.BOOK_OPEN_VARIANT
-const CHILD_ICON = MDI_ICONS.TARGET_ARROW
+const CHILD_ICON = ICONS.ACTIVITY
 
 function isEActivityThematic (value: string): value is EActivityThematic {
   return Object.values(EActivityThematic).includes(value as EActivityThematic)

--- a/src/features/student/buildProject/views/ProjectActivitiesView/components/ActivityLibraryCard/ActivityLibraryCard.test.ts
+++ b/src/features/student/buildProject/views/ProjectActivitiesView/components/ActivityLibraryCard/ActivityLibraryCard.test.ts
@@ -8,7 +8,7 @@ import {
 import ActivityLibraryCard from '@/features/student/buildProject/views/ProjectActivitiesView/components/ActivityLibraryCard/ActivityLibraryCard.vue'
 import { FloatingIconCardStub } from '@/features/student/global/components/cards/FloatingIconCard/FloatingIconCard.stub'
 import { AvBadgeStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
-import { mount, type VueWrapper } from '@vue/test-utils'
+import { mount, RouterLinkStub, type VueWrapper } from '@vue/test-utils'
 import { beforeEach, expect, vi } from 'vitest'
 
 const mockIsMobile = ref(false)
@@ -30,7 +30,8 @@ BddTest().given('an ActivityLibraryCard', () => {
     FloatingIconCard: FloatingIconCardStub,
     ActivityStatusBadge: ActivityStatusBadgeStub,
     ActivityThematicBadge: ActivityThematicBadgeStub,
-    AvBadge: AvBadgeStub
+    AvBadge: AvBadgeStub,
+    RouterLink: RouterLinkStub
   }
 
   const baseActivity = {

--- a/src/features/student/buildProject/views/ProjectActivitiesView/components/ActivityLibraryCard/ActivityLibraryCard.vue
+++ b/src/features/student/buildProject/views/ProjectActivitiesView/components/ActivityLibraryCard/ActivityLibraryCard.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { DeclaredActivityViewDTO } from '@/api/avenir-esr'
+import { ROUTES } from '@/common/constants'
 import ActivityStatusBadge from '@/features/student/buildProject/components/badges/ActivityStatusBadge/ActivityStatusBadge.vue'
 import ActivityThematicBadge from '@/features/student/buildProject/components/badges/ActivityThematicBadge/ActivityThematicBadge.vue'
 import { FloatingIconCard } from '@/features/student/global'
@@ -30,7 +31,10 @@ const titleClasses = computed(() => isMobile.value
 </script>
 
 <template>
-  <div class="activity-library-card">
+  <RouterLink
+    :to="{ name: ROUTES.STUDENT.PROJECT_ACTIVITIES_DETAILED.name, params: { id: activity.id, theme: activity.thematic } }"
+    class="activity-library-card"
+  >
     <FloatingIconCard
       :title="activity.title"
       :icon-options="iconOptions"
@@ -67,7 +71,7 @@ const titleClasses = computed(() => isMobile.value
         </div>
       </template>
     </FloatingIconCard>
-  </div>
+  </RouterLink>
 </template>
 
 <style lang="scss" scoped>

--- a/src/features/student/buildProject/views/ProjectActivitiesView/components/ActivityLibraryTab/ActivityLibraryTab.test.ts
+++ b/src/features/student/buildProject/views/ProjectActivitiesView/components/ActivityLibraryTab/ActivityLibraryTab.test.ts
@@ -2,13 +2,22 @@ import type { VueWrapper } from '@vue/test-utils'
 import { libraryActivitiesErrorHandler } from '@/__mocks__/msw/handlers/student/activities.handlers'
 import { server } from '@/__mocks__/msw/server'
 import { LoaderStub } from '@/common/components/Loader/Loader.stub'
+import { PaginationStub } from '@/common/components/Pagination/Pagination.stub'
 import { ActivityErrorMessageStub } from '@/features/student/buildProject/components/feedback/ActivityErrorMessage/ActivityErrorMessage.stub'
-import { useProjectActivitiesStore } from '@/features/student/buildProject/stores/activities.store'
 import { ActivityLibraryCardStub } from '@/features/student/buildProject/views/ProjectActivitiesView/components/ActivityLibraryCard/ActivityLibraryCard.stub'
 import ActivityLibraryTab from '@/features/student/buildProject/views/ProjectActivitiesView/components/ActivityLibraryTab/ActivityLibraryTab.vue'
-import { AvIconTextStub, AvPaginationStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { AvIconTextStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { createUsePaginationMock } from 'tests/mocks/mockUsePagination'
 import { mountComponent } from 'tests/utils'
 import { beforeEach, expect, vi } from 'vitest'
+
+let paginationMock: ReturnType<typeof createUsePaginationMock>
+
+vi.mock('@/common/composables/use-pagination/use-pagination', () => {
+  return {
+    usePagination: vi.fn(() => paginationMock)
+  }
+})
 
 BddTest().given('an ActivityLibraryTab', () => {
   let wrapper: VueWrapper<InstanceType<typeof ActivityLibraryTab>>
@@ -17,26 +26,29 @@ BddTest().given('an ActivityLibraryTab', () => {
     ActivityLibraryCard: ActivityLibraryCardStub,
     ActivityErrorMessage: ActivityErrorMessageStub,
     AvIconText: AvIconTextStub,
-    AvPagination: AvPaginationStub,
+    Pagination: PaginationStub,
     Loader: LoaderStub
   }
 
   beforeEach(() => {
     vi.clearAllMocks()
+
+    paginationMock = createUsePaginationMock()
+
     wrapper = mountComponent(ActivityLibraryTab, { global: { stubs } })
   })
 
-  BddTest().when('the component is mounted', () => {
+  BddTest().when('the component is mounted without loaded data', () => {
     BddTest().then('it should render the root element', () => {
       expect(wrapper.find('[data-testid="activity-library-tab"]').exists()).toBe(true)
     })
 
-    BddTest().then('it should render the title', () => {
-      expect(wrapper.findComponent(AvIconTextStub).exists()).toBe(true)
+    BddTest().then('it should not render the title', () => {
+      expect(wrapper.findComponent(AvIconTextStub).exists()).toBe(false)
     })
   })
 
-  BddTest().when('data is loaded', () => {
+  BddTest().when('the component is mounted with loaded data', () => {
     beforeEach(async () => {
       await vi.waitFor(() => {
         const cards = wrapper.findAllComponents(ActivityLibraryCardStub)
@@ -50,11 +62,19 @@ BddTest().given('an ActivityLibraryTab', () => {
     })
 
     BddTest().then('it should render the pagination', () => {
-      expect(wrapper.findComponent(AvPaginationStub).exists()).toBe(true)
+      expect(wrapper.findComponent(PaginationStub).exists()).toBe(true)
     })
 
     BddTest().then('it should not render the error message', () => {
       expect(wrapper.find('[data-testid="activity-error-message-stub"]').exists()).toBe(false)
+    })
+
+    BddTest().and('the user clicks on the current page update button', () => {
+      BddTest().then('it should update current page and page size in the mock', async () => {
+        await wrapper.find('.emit-current-page').trigger('click')
+        expect(paginationMock.onUpdateCurrentPage).toHaveBeenCalledWith(5)
+        expect(paginationMock.currentPage.value).toBe(5)
+      })
     })
   })
 
@@ -73,24 +93,6 @@ BddTest().given('an ActivityLibraryTab', () => {
 
     BddTest().then('it should not render activity cards', () => {
       expect(wrapper.findAllComponents(ActivityLibraryCardStub)).toHaveLength(0)
-    })
-  })
-
-  BddTest().when('the user changes the page', () => {
-    let store: ReturnType<typeof useProjectActivitiesStore>
-
-    beforeEach(async () => {
-      store = useProjectActivitiesStore()
-      await vi.waitFor(() => {
-        const cards = wrapper.findAllComponents(ActivityLibraryCardStub)
-        expect(cards.length).toBeGreaterThan(0)
-      })
-      wrapper.findComponent(AvPaginationStub).vm.$emit('update:current-page', 1)
-      await wrapper.vm.$nextTick()
-    })
-
-    BddTest().then('it should update the current page in the store', () => {
-      expect(store.libraryCurrentPage).toBe(1)
     })
   })
 })

--- a/src/features/student/buildProject/views/ProjectActivitiesView/components/ActivityLibraryTab/ActivityLibraryTab.vue
+++ b/src/features/student/buildProject/views/ProjectActivitiesView/components/ActivityLibraryTab/ActivityLibraryTab.vue
@@ -1,70 +1,84 @@
 <script setup lang="ts">
 import Loader from '@/common/components/Loader/Loader.vue'
+import Pagination from '@/common/components/Pagination/Pagination.vue'
+import { useModal, usePagination } from '@/common/composables'
 import ActivityErrorMessage from '@/features/student/buildProject/components/feedback/ActivityErrorMessage/ActivityErrorMessage.vue'
 import { useLibraryActivitiesQuery } from '@/features/student/buildProject/queries/use-activities.query/use-activities.query'
 import { useProjectActivitiesStore } from '@/features/student/buildProject/stores/activities.store'
 import ActivityLibraryCard from '@/features/student/buildProject/views/ProjectActivitiesView/components/ActivityLibraryCard/ActivityLibraryCard.vue'
-import { AvIconText, AvPagination, getPaginationPages, RI_ICONS } from '@avenirs-esr/avenirs-dsav'
+import ActivityLibraryDropdown from '@/features/student/buildProject/views/ProjectActivitiesView/components/overlays/ActivityLibraryDropdown/ActivityLibraryDropdown.vue'
+import UnsubscribeActivitiesModal from '@/features/student/buildProject/views/ProjectActivitiesView/components/overlays/UnsubscribeActivitiesModal/UnsubscribeActivitiesModal.vue'
+import { AvIconText, RI_ICONS } from '@avenirs-esr/avenirs-dsav'
 import { useI18n } from 'vue-i18n'
 
 const { t } = useI18n()
 
 const activitiesStore = useProjectActivitiesStore()
 
+const {
+  currentPage,
+  pageSizeSelected,
+  onUpdateCurrentPage,
+  onUpdatePageSize
+} = usePagination(toRef(activitiesStore, 'currentPage'), toRef(activitiesStore, 'pageSizeSelected'))
+
 const params = computed(() => ({
-  page: activitiesStore.libraryCurrentPage,
-  pageSize: activitiesStore.libraryPageSizeSelected,
+  page: currentPage.value,
+  pageSize: pageSizeSelected.value,
 }))
 
 const { libraryActivities, pageInfo, isLoading, isError, error } = useLibraryActivitiesQuery(params)
-
-const totalPages = computed(() => pageInfo.value?.totalPages ?? 0)
-const pages = computed(() => getPaginationPages(totalPages))
+const { showModal, displayModal, hideModal } = useModal()
 </script>
 
 <template>
   <div
-    class="av-col av-gap-xl"
+    class="av-col av-gap-xl av-pt-md"
     data-testid="activity-library-tab"
   >
-    <AvIconText
-      :icon="RI_ICONS.BOOK_SHELF_LINE"
-      icon-color="var(--text2)"
-      :text="t('student.buildProject.views.projectActivitiesView.ActivityLibraryTab.tabTitle', { count: pageInfo?.totalElements ?? 0 })"
-      text-color="var(--text1)"
-      typography-class="n5"
-      data-testid="activity-library-tab-title"
-    />
-
     <ActivityErrorMessage :error />
 
     <Loader
       :is-loading="isLoading && !isError"
       size="2xl"
     >
-      <div class="av-col av-gap-sm">
-        <AvPagination
-          :aria-label="t('student.buildProject.views.projectActivitiesView.ActivityLibraryTab.pagination.ariaLabel')"
-          :current-page="pageInfo?.page ?? 0"
-          :pages="pages"
-          class="av-row av-justify-end"
-          data-testid="activity-library-tab-pagination"
-          compact
-          :prev-page-label="t('global.avPagination.prevPageTitle')"
-          :next-page-label="t('global.avPagination.nextPageTitle')"
-          :compact-current-page-label="t('global.avPagination.current', {
-            current: (pageInfo?.page ?? 0) + 1,
-            total: totalPages,
-          })"
-          @update:current-page="(page) => activitiesStore.libraryCurrentPage = page"
+      <div class="av-col av-gap-md">
+        <div class="av-row av-justify-end">
+          <ActivityLibraryDropdown @unsubscribe-selected="displayModal" />
+        </div>
+
+        <AvIconText
+          :icon="RI_ICONS.BOOK_SHELF_LINE"
+          icon-color="var(--text2)"
+          :text="t('student.buildProject.views.projectActivitiesView.ActivityLibraryTab.tabTitle', { count: pageInfo?.totalElements ?? 0 })"
+          text-color="var(--text1)"
+          typography-class="n5"
+          data-testid="activity-library-tab-title"
         />
 
-        <ActivityLibraryCard
-          v-for="activity in libraryActivities"
-          :key="activity.id"
-          :activity="activity"
-        />
+        <Pagination
+          v-if="pageInfo"
+          :page-info="pageInfo"
+          :page-size-selected="pageSizeSelected"
+          without-page-size-picker
+          :on-update-current-page="onUpdateCurrentPage"
+          :on-update-page-size="onUpdatePageSize"
+        >
+          <div class="av-col av-gap-md">
+            <ActivityLibraryCard
+              v-for="activity in libraryActivities"
+              :key="activity.id"
+              :activity="activity"
+            />
+          </div>
+        </Pagination>
       </div>
     </Loader>
   </div>
+
+  <UnsubscribeActivitiesModal
+    :show="showModal"
+    @cancel="hideModal"
+    @unsubscribed="hideModal"
+  />
 </template>

--- a/src/features/student/buildProject/views/ProjectActivitiesView/components/cards/ActivityCompactCard/ActivityCompactCard.stub.ts
+++ b/src/features/student/buildProject/views/ProjectActivitiesView/components/cards/ActivityCompactCard/ActivityCompactCard.stub.ts
@@ -1,0 +1,5 @@
+export const ActivityCompactCardStub = defineComponent({
+  name: 'ActivityCompactCard',
+  props: ['title'],
+  template: '<div class="activity-compact-card-stub">{{ title }}</div>'
+})

--- a/src/features/student/buildProject/views/ProjectActivitiesView/components/cards/ActivityCompactCard/ActivityCompactCard.test.ts
+++ b/src/features/student/buildProject/views/ProjectActivitiesView/components/cards/ActivityCompactCard/ActivityCompactCard.test.ts
@@ -1,0 +1,27 @@
+import type { VueWrapper } from '@vue/test-utils'
+import { ValorizedBadgeStub } from '@/common/components/ValorizedBadge/ValorizedBadge.stub'
+import ActivityCompactCard, { type ActivityCompactCardProps } from '@/features/student/buildProject/views/ProjectActivitiesView/components/cards/ActivityCompactCard/ActivityCompactCard.vue'
+import { FloatingIconCardStub } from '@/features/student/global/components/cards/FloatingIconCard/FloatingIconCard.stub'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { mountComponent } from 'tests/utils'
+
+BddTest().given('an activity compact card', () => {
+  let wrapper: VueWrapper<InstanceType<typeof ActivityCompactCard>>
+
+  const stubs = { FloatingIconCard: FloatingIconCardStub, ValorizedBadge: ValorizedBadgeStub }
+
+  const props: ActivityCompactCardProps = {
+    title: 'Element Title',
+  }
+
+  BddTest().when('the component is mounted', () => {
+    beforeEach(() => {
+      wrapper = mountComponent(ActivityCompactCard, { props, global: { stubs } })
+    })
+
+    BddTest().then('it should render the floating icon card', () => {
+      const card = wrapper.findComponent(FloatingIconCardStub)
+      expect(card.exists()).toBe(true)
+    })
+  })
+})

--- a/src/features/student/buildProject/views/ProjectActivitiesView/components/cards/ActivityCompactCard/ActivityCompactCard.vue
+++ b/src/features/student/buildProject/views/ProjectActivitiesView/components/cards/ActivityCompactCard/ActivityCompactCard.vue
@@ -1,0 +1,37 @@
+<script lang="ts" setup>
+import FloatingIconCard from '@/features/student/global/components/cards/FloatingIconCard/FloatingIconCard.vue'
+import { ICONS } from '@/features/student/global/icons'
+
+export interface ActivityCompactCardProps {
+  title: string
+}
+
+defineProps<ActivityCompactCardProps>()
+
+const iconOptions = computed(() => ({
+  name: ICONS.ACTIVITY,
+  color: 'var(--icon)',
+  bottom: '-2.5rem',
+  borderColor: 'var(--other-border-skill-card)'
+}))
+</script>
+
+<template>
+  <FloatingIconCard
+    :title="title"
+    title-color="var(--text1)"
+    color="var(--surface-background)"
+    :icon-options="iconOptions"
+    border-color="var(--other-border-skill-card)"
+    :header-rows="2"
+    height="5.75rem"
+    title-typography-classes="caption-regular"
+  />
+</template>
+
+<style lang="scss" scoped>
+.floating-icon-card {
+  min-width: 13.75rem !important;
+  max-width: 13.75rem !important;
+}
+</style>

--- a/src/features/student/buildProject/views/ProjectActivitiesView/components/overlays/ActivitiesSelector/ActivitiesSelector.stub.ts
+++ b/src/features/student/buildProject/views/ProjectActivitiesView/components/overlays/ActivitiesSelector/ActivitiesSelector.stub.ts
@@ -1,0 +1,6 @@
+export const ActivitiesSelectorStub = defineComponent({
+  name: 'ActivitiesSelectorStub',
+  props: ['activities', 'readonly', 'modelValue'],
+  emits: ['update:modelValue'],
+  template: `<div class="activities-selector-stub"></div>`
+})

--- a/src/features/student/buildProject/views/ProjectActivitiesView/components/overlays/ActivitiesSelector/ActivitiesSelector.test.ts
+++ b/src/features/student/buildProject/views/ProjectActivitiesView/components/overlays/ActivitiesSelector/ActivitiesSelector.test.ts
@@ -1,0 +1,129 @@
+import { ActivityCompactCardStub } from '@/features/student/buildProject/views/ProjectActivitiesView/components/cards/ActivityCompactCard/ActivityCompactCard.stub'
+import ActivitiesSelector, { type ActivitiesSelectorProps } from '@/features/student/buildProject/views/ProjectActivitiesView/components/overlays/ActivitiesSelector/ActivitiesSelector.vue'
+import { SelectorOverlayStub } from '@/features/student/global/components/interaction/SelectorOverlay/SelectorOverlay.stub'
+import { AvIconStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { beforeEach, expect } from 'vitest'
+
+BddTest().given('an activities selector', () => {
+  let wrapper: VueWrapper<InstanceType<typeof ActivitiesSelector>>
+
+  const stubs = {
+    AvIcon: AvIconStub,
+    ActivityCompactCard: ActivityCompactCardStub,
+    SelectorOverlay: SelectorOverlayStub
+  }
+
+  BddTest().and('no activities are given', () => {
+    const props: ActivitiesSelectorProps = {
+      activities: [],
+    }
+
+    BddTest().when('the component is mounted', () => {
+      beforeEach(() => {
+        wrapper = mount(ActivitiesSelector, { props, global: { stubs } })
+      })
+
+      BddTest().then('it should render no elements', () => {
+        const cards = wrapper.findAllComponents(ActivityCompactCardStub)
+        expect(cards).toHaveLength(0)
+      })
+    })
+  })
+
+  BddTest().and('one element is given', () => {
+    const props: ActivitiesSelectorProps = {
+      activities: [
+        {
+          id: '1',
+          title: 'Activity 1',
+        }
+      ],
+    }
+
+    BddTest().when('the component is mounted', () => {
+      beforeEach(() => {
+        wrapper = mount(ActivitiesSelector, { props, global: { stubs } })
+      })
+
+      BddTest().then('it should render the activity', () => {
+        const card = wrapper.findComponent(ActivityCompactCardStub)
+        expect(card.exists()).toBe(true)
+        expect(card.props('title')).toEqual(props.activities[0].title)
+      })
+
+      BddTest().and('the activity is clicked', () => {
+        beforeEach(async () => {
+          expect(wrapper.find('[data-testid="selector-overlay"]').exists()).toBe(true)
+          await wrapper.find('[data-testid="selector-overlay"]').trigger('click')
+        })
+
+        BddTest().then('it should update the model with the activity id', () => {
+          expect(wrapper.emitted('update:modelValue')).toBeTruthy()
+          expect(wrapper.emitted('update:modelValue')?.[0][0]).toEqual([props.activities[0].id])
+        })
+
+        BddTest().and('the activity is clicked again', () => {
+          beforeEach(async () => {
+            expect(wrapper.find('[data-testid="selector-overlay"]').exists()).toBe(true)
+            await wrapper.find('[data-testid="selector-overlay"]').trigger('click')
+          })
+
+          BddTest().then('it should update the model to remove the activity id', () => {
+            expect(wrapper.emitted('update:modelValue')?.[1][0]).toEqual([])
+          })
+        })
+      })
+    })
+  })
+
+  BddTest().and('many activities are given', () => {
+    const props: ActivitiesSelectorProps = {
+      activities: [
+        {
+          id: '1',
+          title: 'Activity 1',
+        },
+        {
+          id: '2',
+          title: 'Activity 2',
+        }
+      ],
+    }
+
+    BddTest().when('the component is mounted', () => {
+      beforeEach(() => {
+        wrapper = mount(ActivitiesSelector, { props, global: { stubs } })
+      })
+
+      BddTest().then('it should render the activities', () => {
+        const cards = wrapper.findAllComponents(ActivityCompactCardStub)
+        expect(cards).toHaveLength(2)
+        expect(cards[0].props('title')).toEqual(props.activities[0].title)
+        expect(cards[1].props('title')).toEqual(props.activities[1].title)
+      })
+    })
+  })
+
+  BddTest().and('readonly is given', () => {
+    const props: ActivitiesSelectorProps = {
+      activities: [
+        {
+          id: '1',
+          title: 'Activity 1',
+        }
+      ],
+      readonly: true
+    }
+
+    BddTest().when('the component is mounted', () => {
+      beforeEach(() => {
+        wrapper = mount(ActivitiesSelector, { props, global: { stubs } })
+      })
+
+      BddTest().then('it should not render the overlay', () => {
+        expect(wrapper.find('[data-testid="selector-overlay"]').exists()).toBe(false)
+      })
+    })
+  })
+})

--- a/src/features/student/buildProject/views/ProjectActivitiesView/components/overlays/ActivitiesSelector/ActivitiesSelector.vue
+++ b/src/features/student/buildProject/views/ProjectActivitiesView/components/overlays/ActivitiesSelector/ActivitiesSelector.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+import type { ActivityItemNavigationDTO } from '@/api/avenir-esr'
+import ActivityCompactCard from '@/features/student/buildProject/views/ProjectActivitiesView/components/cards/ActivityCompactCard/ActivityCompactCard.vue'
+import SelectorOverlay from '@/features/student/global/components/interaction/SelectorOverlay/SelectorOverlay.vue'
+
+export interface ActivitiesSelectorProps {
+  activities: ActivityItemNavigationDTO[]
+  readonly?: boolean
+}
+
+const { activities } = defineProps<ActivitiesSelectorProps>()
+
+const selectedActivityIds = defineModel<string[]>({ default: [] })
+
+const selectableActivities = computed(() => {
+  return activities.map(activity => ({
+    value: activity.id,
+    label: activity.title
+  }))
+})
+</script>
+
+<template>
+  <div class="av-row av-justify-center av-gap-sm av-radius-md av-wrap">
+    <SelectorOverlay
+      v-model:selected-elements="selectedActivityIds"
+      :selectable-elements="selectableActivities"
+      checkbox-color="var(--dark-background-primary1)"
+      overlay-color="var(--dark-background-primary1)"
+      :overlay-opacity="0.25"
+      :readonly="readonly"
+    >
+      <template #default="{ label }">
+        <ActivityCompactCard :title="label" />
+      </template>
+    </SelectorOverlay>
+  </div>
+</template>

--- a/src/features/student/buildProject/views/ProjectActivitiesView/components/overlays/ActivityLibraryDropdown/ActivityLibraryDropdown.stub.ts
+++ b/src/features/student/buildProject/views/ProjectActivitiesView/components/overlays/ActivityLibraryDropdown/ActivityLibraryDropdown.stub.ts
@@ -1,0 +1,5 @@
+export const ActivityLibraryDropdownStub = defineComponent({
+  name: 'ActivityLibraryDropdown',
+  emits: ['unsubscribeSelected'],
+  template: '<div class="activity-library-dropdown-stub" />'
+})

--- a/src/features/student/buildProject/views/ProjectActivitiesView/components/overlays/ActivityLibraryDropdown/ActivityLibraryDropdown.test.ts
+++ b/src/features/student/buildProject/views/ProjectActivitiesView/components/overlays/ActivityLibraryDropdown/ActivityLibraryDropdown.test.ts
@@ -1,0 +1,39 @@
+import ActivityLibraryDropdown from '@/features/student/buildProject/views/ProjectActivitiesView/components/overlays/ActivityLibraryDropdown/ActivityLibraryDropdown.vue'
+import { AvDropdownStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { beforeEach, expect } from 'vitest'
+
+BddTest().given('an activity library dropdown', () => {
+  let wrapper: VueWrapper<InstanceType<typeof ActivityLibraryDropdown>>
+
+  const stubs = {
+    AvDropdown: AvDropdownStub
+  }
+
+  beforeEach(() => {
+    wrapper = mount(ActivityLibraryDropdown, { global: { stubs } })
+  })
+
+  BddTest().when('the component is mounted', () => {
+    BddTest().then('it should render the dropdown with one menu item', () => {
+      const dropdown = wrapper.findComponent({ name: 'AvDropdown' })
+      expect(dropdown.exists()).toBe(true)
+      expect(dropdown.props('items')).toHaveLength(1)
+    })
+
+    BddTest().then('it should pass correct props to dropdown', () => {
+      const dropdown = wrapper.findComponent({ name: 'AvDropdown' })
+      expect(dropdown.props('items')).toHaveLength(1)
+      expect(dropdown.props('triggerAriaLabel')).toBe('Plus d\'actions')
+      expect(dropdown.props('triggerLabel')).toBe('Plus d\'actions')
+    })
+  })
+
+  BddTest().when('the unsubscribe button is clicked', () => {
+    BddTest().then('it should emit the unsubscribeSelected event', async () => {
+      const unsubscribeButton = wrapper.find('[data-name="unsubscribe"]')
+      await unsubscribeButton.trigger('click')
+      expect(wrapper.emitted('unsubscribeSelected')).toHaveLength(1)
+    })
+  })
+})

--- a/src/features/student/buildProject/views/ProjectActivitiesView/components/overlays/ActivityLibraryDropdown/ActivityLibraryDropdown.vue
+++ b/src/features/student/buildProject/views/ProjectActivitiesView/components/overlays/ActivityLibraryDropdown/ActivityLibraryDropdown.vue
@@ -1,0 +1,40 @@
+<script lang="ts" setup>
+import { AvDropdown, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
+import { useI18n } from 'vue-i18n'
+
+const emit = defineEmits<{
+  (e: 'unsubscribeSelected'): void
+}>()
+
+enum ActivityDetailedDropdownEvents {
+  UNSUBSCRIBE = 'unsubscribe',
+}
+
+const { t } = useI18n()
+
+const menuItems = computed(() => [
+  {
+    name: ActivityDetailedDropdownEvents.UNSUBSCRIBE,
+    icon: MDI_ICONS.TRASH_CAN_OUTLINE,
+    label: t('student.buildProject.activities.buttons.unsubscribe')
+  }
+])
+
+function handleItemSelected (itemName: string) {
+  switch (itemName) {
+    case ActivityDetailedDropdownEvents.UNSUBSCRIBE:
+      emit('unsubscribeSelected')
+      break
+  }
+}
+</script>
+
+<template>
+  <AvDropdown
+    :items="menuItems"
+    :trigger-aria-label="t('global.buttons.moreActions')"
+    :trigger-label="t('global.buttons.moreActions')"
+    width="max-content"
+    @item-selected="handleItemSelected"
+  />
+</template>

--- a/src/features/student/buildProject/views/ProjectActivitiesView/components/overlays/UnsubscribeActivitiesModal/UnsubscribeActivitiesModal.test.ts
+++ b/src/features/student/buildProject/views/ProjectActivitiesView/components/overlays/UnsubscribeActivitiesModal/UnsubscribeActivitiesModal.test.ts
@@ -1,0 +1,145 @@
+import type { VueWrapper } from '@vue/test-utils'
+import { activityNavigationQueryError } from '@/__mocks__/msw/handlers/student/activities.handlers'
+import { server } from '@/__mocks__/msw/server'
+import { UnsubscribeActivitiesConfirmModalStub } from '@/features/student/buildProject/components/modals/UnsubscribeActivitiesConfirmModal/UnsubscribeActivitiesConfirmModal.stub'
+import { ActivitiesSelectorStub } from '@/features/student/buildProject/views/ProjectActivitiesView/components/overlays/ActivitiesSelector/ActivitiesSelector.stub'
+import UnsubscribeActivitiesModal, { type UnsubscribeActivitiesModalProps } from '@/features/student/buildProject/views/ProjectActivitiesView/components/overlays/UnsubscribeActivitiesModal/UnsubscribeActivitiesModal.vue'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { mockAddErrorMessage, mockAddSuccessMessage } from 'tests/mocks'
+import { mountComponent } from 'tests/utils'
+import { beforeEach, expect } from 'vitest'
+
+vi.mock('@/store', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/store')>()
+  return {
+    ...actual,
+    useToasterStore: () => ({
+      addSuccessMessage: mockAddSuccessMessage,
+      addErrorMessage: mockAddErrorMessage
+    })
+  }
+})
+
+const AvModalStub = defineComponent({
+  name: 'AvModal',
+  template: `
+      <div class="av-modal-stub">
+        <slot name="header" />
+        <slot />
+      </div>
+    `,
+  props: ['opened', 'id', 'closeButtonLabel', 'confirmButtonLabel', 'confirmButtonIcon', 'confirmButtonDisabled'],
+  emits: ['close', 'confirm']
+})
+
+BddTest().given('an unsubscribe activities modal', () => {
+  let wrapper: VueWrapper<InstanceType<typeof UnsubscribeActivitiesModal>>
+
+  const stubs = {
+    AvModal: AvModalStub,
+    ActivitiesSelector: ActivitiesSelectorStub,
+    UnsubscribeActivitiesConfirmModal: UnsubscribeActivitiesConfirmModalStub,
+  }
+
+  BddTest().and('no activities to delete are provided', () => {
+    const props: UnsubscribeActivitiesModalProps = {
+      show: true,
+    }
+
+    BddTest().when('the modal is rendered', () => {
+      beforeEach(async () => {
+        server.use(activityNavigationQueryError)
+
+        wrapper = mountComponent(UnsubscribeActivitiesModal, { props, global: { stubs } })
+        await vi.waitFor(() => {
+          expect(wrapper.exists()).toBe(true)
+        })
+      })
+
+      BddTest().then('it should display the correct title for zero elements', async () => {
+        await vi.waitFor(() => {
+          const header = wrapper.find('[data-testid="header"]')
+          expect(header.text()).toContain('Aucune activité à laquelle se désinscrire')
+        })
+      })
+    })
+  })
+
+  BddTest().and('many activities to delete are provided', () => {
+    const props: UnsubscribeActivitiesModalProps = {
+      show: true,
+    }
+
+    BddTest().when('the modal is rendered with the provided elements', () => {
+      beforeEach(async () => {
+        wrapper = mountComponent(UnsubscribeActivitiesModal, { props, global: { stubs } })
+        await vi.waitFor(() => {
+          const selector = wrapper.findComponent(ActivitiesSelectorStub)
+          expect(selector.exists()).toBe(true)
+        })
+      })
+
+      BddTest().then('it should display the correct title with element count', () => {
+        const header = wrapper.find('[data-testid="header"]')
+        expect(header.text()).toContain('De quelles activités souhaitez-vous vous désinscrire ?')
+      })
+
+      BddTest().and('many activities are selected', () => {
+        beforeEach(async () => {
+          const selector = wrapper.findComponent(ActivitiesSelectorStub)
+          await selector.vm.$emit('update:modelValue', ['activity-1', 'activity-2', 'activity-3'])
+          await wrapper.vm.$nextTick()
+        })
+
+        BddTest().then('the selectedActivityIds should be updated accordingly', () => {
+          const selector = wrapper.findComponent(ActivitiesSelectorStub)
+          expect(selector.props('modelValue')).toEqual(['activity-1', 'activity-2', 'activity-3'])
+        })
+
+        BddTest().and('the modal is closed by close event and reopened', () => {
+          beforeEach(async () => {
+            const modal = wrapper.findComponent(AvModalStub)
+            await modal.vm.$emit('close')
+
+            await wrapper.setProps({ show: true })
+          })
+
+          BddTest().then('the selectedActivityIds should be reset', () => {
+            const selector = wrapper.findComponent(ActivitiesSelectorStub)
+            expect(selector.props('modelValue')).toEqual([])
+          })
+        })
+
+        BddTest().and('the modal emits confirm event', () => {
+          beforeEach(async () => {
+            const modal = wrapper.findComponent(AvModalStub)
+            modal.vm.$emit('confirm')
+          })
+
+          BddTest().then('the confirm unsubscribe modal should be shown', () => {
+            const confirmModal = wrapper.findComponent(UnsubscribeActivitiesConfirmModalStub)
+            expect(confirmModal.props('show')).toBe(true)
+          })
+
+          BddTest().and('the confirm unsubscribe modal emits unsubscribed event', () => {
+            beforeEach(async () => {
+              const confirmModal = wrapper.findComponent(UnsubscribeActivitiesConfirmModalStub)
+              confirmModal.vm.$emit('unsubscribed')
+            })
+
+            BddTest().then('the unsubscribe activities modal should emit unsubscribed event', async () => {
+              await vi.waitFor(() => expect(wrapper.emitted()).toHaveProperty('unsubscribed'))
+            })
+
+            BddTest().then('the confirm unsubscribe modal should be hidden', async () => {
+              await vi.waitFor(() => {
+                const confirmModal = wrapper.findComponent(UnsubscribeActivitiesConfirmModalStub)
+                expect(confirmModal.props('show')).toBe(false)
+              })
+            })
+          })
+        })
+      })
+    })
+  })
+})

--- a/src/features/student/buildProject/views/ProjectActivitiesView/components/overlays/UnsubscribeActivitiesModal/UnsubscribeActivitiesModal.vue
+++ b/src/features/student/buildProject/views/ProjectActivitiesView/components/overlays/UnsubscribeActivitiesModal/UnsubscribeActivitiesModal.vue
@@ -1,0 +1,112 @@
+<script lang="ts" setup>
+import { useModal } from '@/common/composables'
+import { INFINITE_SCROLL_BOTTOM_DISTANCE } from '@/common/constants'
+import UnsubscribeActivitiesConfirmModal from '@/features/student/buildProject/components/modals/UnsubscribeActivitiesConfirmModal/UnsubscribeActivitiesConfirmModal.vue'
+import { usePaginatedLibraryActivities } from '@/features/student/buildProject/composables/activities/use-paginated-library-activities/use-paginated-library-activities'
+import ActivitiesSelector from '@/features/student/buildProject/views/ProjectActivitiesView/components/overlays/ActivitiesSelector/ActivitiesSelector.vue'
+import { AvModal, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
+import { useInfiniteScroll } from '@vueuse/core'
+import { useI18n } from 'vue-i18n'
+
+export interface UnsubscribeActivitiesModalProps {
+  show: boolean
+}
+
+defineProps<UnsubscribeActivitiesModalProps>()
+
+const emit = defineEmits<{
+  (e: 'cancel'): void
+  (e: 'unsubscribed'): void
+}>()
+
+const { t } = useI18n()
+const {
+  showModal: showConfirmModal,
+  displayModal: displayConfirmModal,
+  hideModal: hideConfirmModal
+} = useModal()
+
+const {
+  activities,
+  isFetching,
+  hasMoreActivities,
+  loadMoreActivities,
+} = usePaginatedLibraryActivities()
+
+function onUnsubscribeSuccess () {
+  hideConfirmModal()
+  emit('unsubscribed')
+  resetSelectedActivities()
+}
+
+const selectedActivityIds = ref<string[]>([])
+
+function resetSelectedActivities () {
+  selectedActivityIds.value = []
+}
+
+function onCancel () {
+  resetSelectedActivities()
+  emit('cancel')
+}
+
+const activitiesContainer = ref<HTMLElement | null>(null)
+
+useInfiniteScroll(
+  activitiesContainer,
+  loadMoreActivities,
+  {
+    distance: INFINITE_SCROLL_BOTTOM_DISTANCE,
+    canLoadMore: () => !isFetching.value && hasMoreActivities.value
+  }
+)
+</script>
+
+<template>
+  <AvModal
+    :opened="show"
+    :close-button-label="t('global.buttons.cancel')"
+    :confirm-button-label="t('student.buildProject.views.projectActivitiesView.UnsubscribeActivitiesModal.confirm', { count: selectedActivityIds.length })"
+    :confirm-button-icon="MDI_ICONS.TRASH_CAN_OUTLINE"
+    :confirm-button-disabled="selectedActivityIds.length === 0"
+    @close="onCancel"
+    @confirm="displayConfirmModal"
+  >
+    <template #header>
+      <div
+        class="av-col av-gap-sm av-w-full"
+        data-testid="header"
+      >
+        <div class="av-row av-justify-center">
+          <span class="b2-regular av-text-text1">
+            {{ t('student.buildProject.views.projectActivitiesView.UnsubscribeActivitiesModal.title', { count: activities.length }) }}
+          </span>
+        </div>
+        <div class="av-row av-justify-center">
+          <span class="b2-light av-text-text1">
+            {{ t('student.buildProject.views.projectActivitiesView.UnsubscribeActivitiesModal.description') }}
+          </span>
+        </div>
+      </div>
+    </template>
+
+    <div
+      ref="activitiesContainer"
+      class="av-col av-gap-sm"
+      style="max-height: 400px; overflow-y: auto;"
+    >
+      <ActivitiesSelector
+        v-if="activities.length > 0"
+        v-model="selectedActivityIds"
+        :activities="activities"
+      />
+    </div>
+  </AvModal>
+
+  <UnsubscribeActivitiesConfirmModal
+    :show="showConfirmModal"
+    :activities="activities.filter(activity => selectedActivityIds.includes(activity.id))"
+    @cancel="hideConfirmModal"
+    @unsubscribed="onUnsubscribeSuccess"
+  />
+</template>

--- a/src/features/student/global/components/interaction/SelectorOverlay/SelectorOverlay.stub.ts
+++ b/src/features/student/global/components/interaction/SelectorOverlay/SelectorOverlay.stub.ts
@@ -28,6 +28,7 @@ export const SelectorOverlayStub = defineComponent({
             role="button"
             class="selector-overlay-stub__element"
             :class="{ 'selector-overlay-stub__element--selected': selectedElements.includes(element.value) }"
+            data-testid="selector-overlay"
             @click="$emit('update:selectedElements', toggleSelection(element.value))"
             @keydown.enter="$emit('update:selectedElements', toggleSelection(element.value))"
             @keydown.space="$emit('update:selectedElements', toggleSelection(element.value))"

--- a/src/features/student/global/components/interaction/SelectorOverlay/SelectorOverlay.vue
+++ b/src/features/student/global/components/interaction/SelectorOverlay/SelectorOverlay.vue
@@ -66,6 +66,7 @@ function getAriaLabel (elementValue: string, elementLabel: string) {
       :aria-pressed="selectedElements.includes(element.value)"
       class="selector-overlay__checkbox av-row av-px-xs av-py-xs av-justify-end"
       :class="{ 'selector-overlay__checkbox--selected': selectedElements.includes(element.value) }"
+      data-testid="selector-overlay"
       @click="() => onSelectElement(element.value)"
       @keydown.enter="() => onSelectElement(element.value)"
       @keydown.space="() => onSelectElement(element.value)"

--- a/src/features/student/personalCareer/composables/use-paginated-declared-experiences/use-paginated-declared-experiences.ts
+++ b/src/features/student/personalCareer/composables/use-paginated-declared-experiences/use-paginated-declared-experiences.ts
@@ -31,7 +31,6 @@ export function usePaginatedDeclaredExperiences ({ pageSize }: { pageSize?: Ref<
     pageInfo,
     isFetching,
     page,
-    getItemId: (experience: DeclaredExperienceViewDTO) => experience.id
   })
 
   return {

--- a/src/features/student/personalCareer/composables/use-paginated-declared-programs/use-paginated-declared-programs.ts
+++ b/src/features/student/personalCareer/composables/use-paginated-declared-programs/use-paginated-declared-programs.ts
@@ -41,7 +41,6 @@ export function usePaginatedDeclaredPrograms ({
     pageInfo,
     isFetching,
     page,
-    getItemId: (program: DeclaredProgramViewDTO) => program.id
   })
 
   return {

--- a/src/features/student/selfKnowledge/composables/use-self-knowledge-paginated-elements/use-self-knowledge-paginated-elements.ts
+++ b/src/features/student/selfKnowledge/composables/use-self-knowledge-paginated-elements/use-self-knowledge-paginated-elements.ts
@@ -49,7 +49,6 @@ export function useSelfKnowledgePaginatedElements ({
     pageInfo,
     isFetching,
     page,
-    getItemId: (el: SelfKnowledgeElementViewDTO) => el.id
   })
 
   watch(categoryId, () => {


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
This PR introduces an unsubscribe flow in the student activities library by adding a dedicated modal and wiring it across activity selection components.

**Main changes:**
- ✨ Adds `UnsubscribeActivitiesModal` and integrates it in the activities library flow
- 💄 Updates activity library UI components (`ActivityCompactCard`, `ActivitiesSelector`, `ActivityLibraryDropdown`, tabs) to expose unsubscribe actions
- ♻️ Improves pagination/composable behavior for library activities and aligns shared infinite-scroll pagination usage
- 🌐 Updates related translations (`en.json`, `fr.json`)
- ✅ Adds and updates unit tests, stubs, fixtures, and MSW handlers for the new unsubscribe scenarios

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1132

---

### Documentation
- Test coverage extended for activities library interactions and modal behavior
- Mock fixtures and API handlers updated to support unsubscribe-related cases
- No additional runtime configuration required

**Modified scope (high level):**
- Activities library views and overlays
- Build project activities composables
- Shared pagination components/composables
- Locales and test/mocking infrastructure

---

### Target Branch
`develop`

---

### Additional Notes
This implementation keeps the unsubscribe behavior inside the existing activities library UX, minimizing navigation changes while improving clarity around user intent. The work also standardizes pagination behavior used by activities lists.

---

### Known Limitations or Side Effects
No known functional side effects identified. Validation remains focused on frontend unit/integration scope.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [ ] No unnecessary code (e.g., debug logs, commented code)
- [ ] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process
