### PR TITLE
feat(1118): add activity subscription

### DIFF
--- a/api-specs/avenir-esr.swagger.json
+++ b/api-specs/avenir-esr.swagger.json
@@ -4517,6 +4517,9 @@
           "executionPeriodInfo": {
             "type": "string"
           },
+          "isSubscribed": {
+            "type": "boolean"
+          },
           "createdAt": {
             "type": "string",
             "format": "date-time"

--- a/src/__mocks__/fixtures/student/activities.fixtures.ts
+++ b/src/__mocks__/fixtures/student/activities.fixtures.ts
@@ -1,6 +1,9 @@
 import {
   type ActivityDetailDTO,
   type ActivityNavigationDTO,
+  ActivityThematic,
+  type DeclaredActivity,
+  DeclaredActivityStatus,
   type DeclaredActivityViewDTO,
   EActivityThematic,
   EDeclaredActivityStatus,
@@ -157,6 +160,24 @@ export const activitiesNavigationMock: ActivityNavigationDTO[] = [
   }
 ]
 
+export const mockedDeclaredActivity: DeclaredActivity = {
+  id: 'declared-activity-1',
+  createdAt: '2024-01-01T00:00:00Z',
+  updatedAt: '2024-01-01T00:00:00Z',
+  activity: {
+    id: 'activity-1',
+    title: 'Activité “Connaissance de soi” : Définir ses valeurs',
+    thematic: ActivityThematic.TRAJECTORIES,
+    summary: 'Activité faisant partie de la catégorie Connaissance de soi. Activité au cours de laquelle l’étudiant.e détermine des valeurs auxquelles il/elle est attaché.e et réfléchit à la façon dont ces valeurs s’incarnent dans ses comportements et ses pratiques quotidiennes. Cette activité constitue un préalable aux activités axées sur le projet de vie.',
+    executionPeriodInfo: '- À réaliser en amont d’un entretien avec un.e conseiller/conseillère ou chargé.e d’orientation et/ou d’insertion professionnelle\n- avant une autre activité si parcours d’activités Cofolio',
+  },
+  hasStarted: true,
+  reflection: 'Je me rends compte que mes valeurs sont l\'autonomie, la créativité et l\'impact social. Je vois que je les incarnent dans mon engagement associatif, mes projets personnels et mon choix de stage l\'été dernier.',
+  startDate: '2024-01-01T00:00:00Z',
+  endDate: '2024-06-30T00:00:00Z',
+  status: DeclaredActivityStatus.IN_PROGRESS
+}
+
 // TODO: changes this to activities returned by seeder in dev
 export const mockedDeclaredActivityViewDTO: DeclaredActivityViewDTO = {
   id: 'declared-activity-1',
@@ -267,3 +288,5 @@ export const mockedActivityDetail: ActivityDetailDTO = {
   createdAt: '2024-01-01T00:00:00Z',
   updatedAt: '2024-01-01T00:00:00Z'
 }
+
+export const mockedSubscribedActivityDetail: ActivityDetailDTO = { ...mockedActivityDetail, isSubscribed: true }

--- a/src/__mocks__/msw/handlers/student/activities.handlers.ts
+++ b/src/__mocks__/msw/handlers/student/activities.handlers.ts
@@ -2,15 +2,18 @@ import {
   activitiesNavigationMock,
   createLargeMockedPagedResponseDeclaredActivityViewDTO,
   createMockedPagedResponseDeclaredActivityViewDTO,
-  mockedActivityDetail
+  mockedActivityDetail,
+  mockedDeclaredActivity
 } from '@/__mocks__/fixtures/student/activities.fixtures'
 import {
   type ActivityDetailDTO,
   type ActivityNavigationDTO,
+  type DeclaredActivity,
   EErrorCode,
   getGetActivityDetailUrl,
   getGetActivityNavigationUrl,
   getGetDeclaredActivitiesViewUrl,
+  getSubscribeUrl,
   getUnsubscribeUrl,
   type PagedResponseDeclaredActivityViewDTO,
 } from '@/api/avenir-esr'
@@ -40,6 +43,21 @@ export const activityNavigationQueryError = http.get(`*${getGetActivityNavigatio
 
 export const activityNavigationQuery = http.get(`*${getGetActivityNavigationUrl()}`, async () => {
   return HttpResponse.json<ActivityNavigationDTO[]>(activitiesNavigationMock, {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json',
+    }
+  })
+})
+
+const subscribeActivityProgressHandler = http.post(`*${getSubscribeUrl(':activityId')}`, async ({ params }) => {
+  const { activityId } = params
+
+  if (activityId === 'INVALID_ACTIVITY_ID') {
+    return HttpResponse.json({ error: 'Invalid activity ID' }, { status: 400 })
+  }
+
+  return HttpResponse.json<DeclaredActivity>(mockedDeclaredActivity, {
     status: 200,
     headers: {
       'Content-Type': 'application/json',
@@ -94,6 +112,38 @@ export const largeLibraryActivitiesHandler = http.get(`*${getGetDeclaredActiviti
   })
 })
 
+export const activityDetailHandler = http.get(`*${getGetActivityDetailUrl(':activityId')}`, async ({ params }) => {
+  const { activityId } = params
+
+  if (activityId === 'INVALID_ACTIVITY_ID') {
+    return HttpResponse.json(
+      { code: EErrorCode.ACTIVITY_NOT_FOUND, message: 'Activity not found' },
+      {
+        status: 404,
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      }
+    )
+  }
+
+  if (activityId === 'SUBSCRIBED_ACTIVITY_ID') {
+    return HttpResponse.json<ActivityDetailDTO>({ ...mockedActivityDetail, isSubscribed: true }, {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    })
+  }
+
+  return HttpResponse.json<ActivityDetailDTO>(mockedActivityDetail, {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json'
+    }
+  })
+})
+
 export const activitiesHandlers = [
   http.get(`*${getGetDeclaredActivitiesViewUrl()}`, ({ request }) => {
     const url = new URL(request.url)
@@ -111,27 +161,7 @@ export const activitiesHandlers = [
     })
   }),
   activityNavigationQuery,
-  http.get(`*${getGetActivityDetailUrl(':activityId')}`, async ({ params }) => {
-    const { activityId } = params
-
-    if (activityId === 'INVALID_ACTIVITY_ID') {
-      return HttpResponse.json(
-        { code: EErrorCode.ACTIVITY_NOT_FOUND, message: 'Activity not found' },
-        {
-          status: 404,
-          headers: {
-            'Content-Type': 'application/json'
-          }
-        }
-      )
-    }
-
-    return HttpResponse.json<ActivityDetailDTO>(mockedActivityDetail, {
-      status: 200,
-      headers: {
-        'Content-Type': 'application/json'
-      }
-    })
-  }),
+  activityDetailHandler,
+  subscribeActivityProgressHandler,
   unsubscribeActivityProgressHandler,
 ]

--- a/src/features/student/buildProject/locales/en.json
+++ b/src/features/student/buildProject/locales/en.json
@@ -8,6 +8,7 @@
           }
         },
         "buttons": {
+          "subscribe": "Subscribe to the activity",
           "unsubscribe": "Unsubscribe"
         },
         "declaredActivityStatus": {
@@ -39,6 +40,22 @@
           "TRANSVERSAL": "Transversal"
         },
         "views": {
+          "ProjectActivitiesCatalogView": {
+            "overlays": {
+              "ActivitySubscribeModal": {
+                "error": "An error occurred while subscribing to the activity. Please try again later.",
+                "success": "You have successfully subscribed. Find this activity in your activity library.",
+                "title": "Subscribe to the activity {title}"
+              },
+              "CancelSubscribeActivityModal": {
+                "title": "Are you sure you want to cancel your subscription to the activity?"
+              }
+            },
+            "periodTitle": "Execution period",
+            "previewTitle": "Activity preview",
+            "title": "All available activities",
+            "unsubscribe": "Unsubscribe"
+          },
           "ProjectActivityDetailedView": {
             "ActivityDetailedDropdown": {
               "triggerLabel": "Manage my activity"
@@ -102,12 +119,6 @@
         }
       },
       "views": {
-        "ProjectActivitiesCatalogView": {
-          "periodTitle": "Execution period",
-          "previewTitle": "Activity preview",
-          "title": "All available activities",
-          "unsubscribe": "Unsubscribe"
-        },
         "projectActivitiesView": {
           "ActivityLibraryCard": {
             "period": "Personal achievement period"

--- a/src/features/student/buildProject/locales/fr.json
+++ b/src/features/student/buildProject/locales/fr.json
@@ -8,6 +8,7 @@
           }
         },
         "buttons": {
+          "subscribe": "M'inscrire à l'activité",
           "unsubscribe": "Me désinscrire"
         },
         "declaredActivityStatus": {
@@ -39,6 +40,21 @@
           "TRANSVERSAL": "Transverse"
         },
         "views": {
+          "ProjectActivitiesCatalogView": {
+            "overlays": {
+              "ActivitySubscribeModal": {
+                "error": "Une erreur est survenue lors de l'inscription à l'activité. Veuillez réessayer plus tard.",
+                "success": "Vous êtes inscrit.e avec succès. Retrouvez cette activité dans votre bibliothèque d’activités.",
+                "title": "Inscription à l’activité {title}"
+              },
+              "CancelSubscribeActivityModal": {
+                "title": "Êtes-vous certain(e) de vouloir abandonner l’inscription à l’activité ?"
+              }
+            },
+            "periodTitle": "Période de réalisation",
+            "previewTitle": "Extrait de l'activité",
+            "title": "Toutes les activités disponibles"
+          },
           "ProjectActivityDetailedView": {
             "ActivityDetailedDropdown": {
               "triggerLabel": "Gérer mon activité"
@@ -102,11 +118,6 @@
         }
       },
       "views": {
-        "ProjectActivitiesCatalogView": {
-          "periodTitle": "Période de réalisation",
-          "previewTitle": "Extrait de l'activité",
-          "title": "Toutes les activités disponibles"
-        },
         "projectActivitiesView": {
           "ActivityLibraryCard": {
             "period": "Période de réalisation personnelle"

--- a/src/features/student/buildProject/queries/use-activities.query/use-activities.query.test.ts
+++ b/src/features/student/buildProject/queries/use-activities.query/use-activities.query.test.ts
@@ -9,13 +9,15 @@ import {
   libraryActivitiesErrorHandler,
 } from '@/__mocks__/msw/handlers/student/activities.handlers'
 import { server } from '@/__mocks__/msw/server'
-import { type ActivityDetailDTO, type ActivityNavigationDTO, EActivityThematic, type getDeclaredActivitiesView } from '@/api/avenir-esr'
+import { type ActivityDetailDTO, type ActivityNavigationDTO, type DeclaredActivity, EActivityThematic, type getDeclaredActivitiesView } from '@/api/avenir-esr'
 import {
+  type SubscribeActivityVariables,
   type UnsubscribeActivitiesVariables,
   useActivitiesNavigationQuery,
   useActivityDetailQuery,
   useCountLibraryActivities,
   useLibraryActivitiesQuery,
+  useSubscribeActivityMutation,
   useUnsubscribeActivitiesMutation,
 } from '@/features/student/buildProject/queries/use-activities.query/use-activities.query'
 import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
@@ -140,6 +142,201 @@ BddTest().given('the useActivityDetailQuery composable', () => {
 
       BddTest().then('it should not fetch data', () => {
         expect(queryResult.data.value).toBeUndefined()
+      })
+    })
+  })
+})
+
+BddTest().given('the useSubscribeActivityMutation composable', () => {
+  let subscribeActivitySpy: MockInstance<
+    (activityId: string, options?: RequestInit | undefined) => Promise<DeclaredActivity>
+  >
+  let useInvalidateQuerySpy: MockInstance<typeof useInvalidateQuery>
+  let mutationResult: ReturnType<typeof useSubscribeActivityMutation>
+
+  const mockInvalidateFunction = vi.fn()
+
+  const mockOnSuccess = vi.fn()
+  const mockOnError = vi.fn()
+  const mutationArgs = {
+    onSuccess: mockOnSuccess,
+    onError: mockOnError,
+  }
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    vi.restoreAllMocks()
+
+    subscribeActivitySpy = vi.spyOn<typeof import('@/api/avenir-esr'), 'subscribe'>(
+      await import('@/api/avenir-esr'),
+    'subscribe',
+    )
+
+    useInvalidateQuerySpy = vi.spyOn<typeof import('@/common/composables'), 'useInvalidateQuery'>(
+      await import('@/common/composables'),
+    'useInvalidateQuery',
+    ).mockReturnValue(mockInvalidateFunction)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  BddTest().and('valid activity ID and success callback', () => {
+    const activityId = 'activity-1-id'
+    const variables: SubscribeActivityVariables = { activityId }
+
+    BddTest().when('the mutation is called with mutateAsync', () => {
+      beforeEach(async () => {
+        mutationResult = mountQueryComposable(() => useSubscribeActivityMutation(mutationArgs))
+        await mutationResult.mutateAsync(variables)
+        await flushPromises()
+      })
+
+      BddTest().then('it should call the subscribeActivity API with correct parameters', () => {
+        expect(subscribeActivitySpy).toHaveBeenCalledWith(activityId)
+        expect(subscribeActivitySpy).toHaveBeenCalledTimes(1)
+      })
+
+      BddTest().then('it should return the expected success response', () => {
+        expect(mutationResult.data.value).toBeDefined()
+      })
+
+      BddTest().then('it should mark the mutation as successful', () => {
+        expect(mutationResult.isSuccess.value).toBe(true)
+        expect(mutationResult.isError.value).toBe(false)
+        expect(mutationResult.isPending.value).toBe(false)
+      })
+
+      BddTest().then('it should call the invalidation function', () => {
+        expect(useInvalidateQuerySpy).toHaveBeenCalledTimes(1)
+        expect(mockInvalidateFunction).toHaveBeenCalledTimes(1)
+      })
+
+      BddTest().then('it should call the custom onSuccess callback', () => {
+        expect(mockOnSuccess).toHaveBeenCalledTimes(1)
+        expect(mockOnSuccess).toHaveBeenCalledWith(mutationResult.data.value, variables)
+      })
+
+      BddTest().then('it should not call the onError callback', () => {
+        expect(mockOnError).not.toHaveBeenCalled()
+      })
+    })
+
+    BddTest().when('the mutation is called with mutate', () => {
+      beforeEach(async () => {
+        mutationResult = mountQueryComposable(() => useSubscribeActivityMutation(mutationArgs))
+        mutationResult.mutate(variables)
+        await flushPromises()
+      })
+
+      BddTest().then('it should call the subscribeActivity API with correct parameters', () => {
+        expect(subscribeActivitySpy).toHaveBeenCalledWith(activityId)
+        expect(subscribeActivitySpy).toHaveBeenCalledTimes(1)
+      })
+
+      BddTest().then('it should call the custom onSuccess callback', () => {
+        expect(mockOnSuccess).toHaveBeenCalledTimes(1)
+      })
+
+      BddTest().then('it should call the invalidation function', () => {
+        expect(mockInvalidateFunction).toHaveBeenCalledTimes(1)
+      })
+    })
+  })
+
+  BddTest().and('no success or error callbacks', () => {
+    const activityId = 'activity-1-id'
+    const variables: SubscribeActivityVariables = { activityId }
+    const mutationArgs = {}
+
+    BddTest().when('the mutation is called without callbacks', () => {
+      beforeEach(async () => {
+        mutationResult = mountQueryComposable(() => useSubscribeActivityMutation(mutationArgs))
+        await mutationResult.mutateAsync(variables)
+        await flushPromises()
+      })
+
+      BddTest().then('it should call the subscribeActivity API with correct parameters', () => {
+        expect(subscribeActivitySpy).toHaveBeenCalledWith(activityId)
+        expect(subscribeActivitySpy).toHaveBeenCalledTimes(1)
+      })
+
+      BddTest().then('it should still call the invalidation function', () => {
+        expect(mockInvalidateFunction).toHaveBeenCalledTimes(1)
+      })
+
+      BddTest().then('it should mark the mutation as successful', () => {
+        expect(mutationResult.isSuccess.value).toBe(true)
+        expect(mutationResult.isError.value).toBe(false)
+      })
+
+      BddTest().then('it should return the expected response', () => {
+        expect(mutationResult.data.value).toBeDefined()
+      })
+    })
+  })
+
+  BddTest().and('an invalid activity id with error callback', () => {
+    const activityId = 'INVALID_ACTIVITY_ID'
+    const variables: SubscribeActivityVariables = { activityId }
+
+    BddTest().when('the mutation encounters an error', () => {
+      beforeEach(async () => {
+        mutationResult = mountQueryComposable(() => useSubscribeActivityMutation(mutationArgs))
+        await mutationResult.mutateAsync(variables).catch(() => {})
+        await flushPromises()
+      })
+
+      BddTest().then('it should call the subscribeActivity API with the invalid parameters', () => {
+        expect(subscribeActivitySpy).toHaveBeenCalledWith(activityId)
+        expect(subscribeActivitySpy).toHaveBeenCalledTimes(1)
+      })
+
+      BddTest().then('it should mark the mutation as error', () => {
+        expect(mutationResult.isError.value).toBe(true)
+        expect(mutationResult.isSuccess.value).toBe(false)
+        expect(mutationResult.isPending.value).toBe(false)
+      })
+
+      BddTest().then('it should contain the error information', () => {
+        expect(mutationResult.error.value).toBeDefined()
+      })
+
+      BddTest().then('it should call the custom onError callback', () => {
+        expect(mockOnError).toHaveBeenCalledTimes(1)
+      })
+
+      BddTest().then('it should not call the onSuccess callback', () => {
+        expect(mockOnSuccess).not.toHaveBeenCalled()
+      })
+
+      BddTest().then('it should not call the invalidation function on error', () => {
+        expect(mockInvalidateFunction).not.toHaveBeenCalled()
+      })
+    })
+
+    BddTest().when('the mutation is called using mutate with error', () => {
+      let mutationResult: ReturnType<typeof useSubscribeActivityMutation>
+
+      beforeEach(async () => {
+        mutationResult = mountQueryComposable(() => useSubscribeActivityMutation(mutationArgs))
+        mutationResult.mutate(variables)
+        await flushPromises()
+      })
+
+      BddTest().then('it should call the subscribeActivity API with the invalid parameters', () => {
+        expect(subscribeActivitySpy).toHaveBeenCalledWith(activityId)
+        expect(subscribeActivitySpy).toHaveBeenCalledTimes(1)
+      })
+
+      BddTest().then('it should contain the error information', () => {
+        expect(mutationResult.error.value).toBeDefined()
+        expect(mutationResult.isError.value).toBe(true)
+      })
+
+      BddTest().then('it should call the custom onError callback', () => {
+        expect(mockOnError).toHaveBeenCalledTimes(1)
       })
     })
   })

--- a/src/features/student/buildProject/queries/use-activities.query/use-activities.query.ts
+++ b/src/features/student/buildProject/queries/use-activities.query/use-activities.query.ts
@@ -3,11 +3,13 @@ import type { MutationArgs } from '@/types'
 import {
   type ActivityDetailDTO,
   type ActivityNavigationDTO,
+  type DeclaredActivity,
   getActivityDetail,
   getActivityNavigation,
   getDeclaredActivitiesView,
   type GetDeclaredActivitiesViewParams,
   type PagedResponseDeclaredActivityViewDTO,
+  subscribe,
   unsubscribe
 } from '@/api/avenir-esr'
 import { useInvalidateQuery } from '@/common/composables'
@@ -51,6 +53,24 @@ export function useCountLibraryActivities (params?: MaybeRef<GetDeclaredActiviti
   return useQuery<PagedResponseDeclaredActivityViewDTO, BaseApiException, number>({
     ...useLibraryActivitiesCommonQueryOptions(params),
     select: data => data.page.totalElements,
+  })
+}
+
+export interface SubscribeActivityVariables {
+  activityId: string
+}
+
+export function useSubscribeActivityMutation ({ onError, onSuccess }: MutationArgs<DeclaredActivity, SubscribeActivityVariables> = {}) {
+  const invalidateQueryKey = useInvalidateQuery()
+  return useMutation<DeclaredActivity, BaseApiException, SubscribeActivityVariables>({
+    mutationFn: async ({ activityId }: SubscribeActivityVariables): Promise<DeclaredActivity> => {
+      return await subscribe(activityId)
+    },
+    onSuccess: async (data, variables) => {
+      await invalidateQueryKey([...activityDetailsQueryKey, variables.activityId])
+      onSuccess?.(data, variables)
+    },
+    onError
   })
 }
 

--- a/src/features/student/buildProject/views/ProjectActivitiesCatalogView/ProjectActivitiesCatalogView.vue
+++ b/src/features/student/buildProject/views/ProjectActivitiesCatalogView/ProjectActivitiesCatalogView.vue
@@ -33,26 +33,33 @@ const breadcrumbLinks = computed(() => [
 
 <template>
   <PageTitle
-    :title="t('student.buildProject.views.ProjectActivitiesCatalogView.title')"
+    :title="t('student.buildProject.activities.views.ProjectActivitiesCatalogView.title')"
     :breadcrumb-links="breadcrumbLinks"
     :back="ROUTES.STUDENT.HOME"
   />
   <div
     data-testid="activities-layout"
-    class="av-justify-center av-my-md av-gap-sm"
+    class="av-my-md av-gap-sm"
     :class="[isMobile ? 'av-column' : 'av-row']"
   >
-    <ActivitiesSelectNavigation v-if="isMobile" />
-    <ActivitiesSideNavigation v-else />
-    <Loader
-      :is-loading="isLoading && !isError"
-      size="2xl"
+    <div
+      v-if="isMobile"
+      class="av-row av-flex-fill av-justify-center"
     >
-      <ActivityPreview
-        v-if="activityDetail"
-        :activity="activityDetail"
-      />
-    </Loader>
+      <ActivitiesSelectNavigation />
+    </div>
+    <ActivitiesSideNavigation v-else />
+    <div class="av-row av-flex-fill av-justify-center">
+      <Loader
+        :is-loading="isLoading && !isError"
+        size="2xl"
+      >
+        <ActivityPreview
+          v-if="activityDetail"
+          :activity="activityDetail"
+        />
+      </Loader>
+    </div>
   </div>
   <ActivityErrorMessage :error="error" />
 </template>

--- a/src/features/student/buildProject/views/ProjectActivitiesCatalogView/components/ActivityPreview/ActivityPreview.test.ts
+++ b/src/features/student/buildProject/views/ProjectActivitiesCatalogView/components/ActivityPreview/ActivityPreview.test.ts
@@ -1,7 +1,8 @@
-import { mockedActivityDetail } from '@/__mocks__/fixtures/student/activities.fixtures'
+import { mockedActivityDetail, mockedSubscribedActivityDetail } from '@/__mocks__/fixtures/student/activities.fixtures'
 import { ActivityThematicBadgeStub } from '@/features/student/buildProject/components/badges/ActivityThematicBadge/ActivityThematicBadge.stub'
 import { UnsubscribeActivitiesConfirmModalStub } from '@/features/student/buildProject/components/modals/UnsubscribeActivitiesConfirmModal/UnsubscribeActivitiesConfirmModal.stub'
 import ActivityPreview, { type ActivityPreviewProps } from '@/features/student/buildProject/views/ProjectActivitiesCatalogView/components/ActivityPreview/ActivityPreview.vue'
+import { SubscribeActivityModalStub } from '@/features/student/buildProject/views/ProjectActivitiesCatalogView/components/overlays/SubscribeActivityModal/SubscribeActivityModal.stub'
 import { AvButtonStub, AvCardStub, AvIconTextStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { type DOMWrapper, mount, type VueWrapper } from '@vue/test-utils'
 import { beforeEach, expect } from 'vitest'
@@ -10,19 +11,129 @@ BddTest().given('an activity preview', () => {
   let wrapper: VueWrapper<InstanceType<typeof ActivityPreview>>
   let bannerImage: DOMWrapper<Element>
 
-  const props: ActivityPreviewProps = {
-    activity: mockedActivityDetail
-  }
-
   const stubs = {
     AvButton: AvButtonStub,
     AvCard: AvCardStub,
     AvIconText: AvIconTextStub,
     UnsubscribeActivitiesConfirmModal: UnsubscribeActivitiesConfirmModalStub,
+    SubscribeActivityModal: SubscribeActivityModalStub,
     ActivityThematicBadge: ActivityThematicBadgeStub
   }
 
-  BddTest().when('the component is mounted', () => {
+  function getUnsubscribeButton () {
+    return wrapper.findAllComponents(AvButtonStub).find(btn => btn.attributes('data-testid') === 'unsubscribe-button')
+  }
+
+  function getSubscribeButton () {
+    return wrapper.findAllComponents(AvButtonStub).find(btn => btn.attributes('data-testid') === 'subscribe-button')
+  }
+
+  BddTest().when('the component is mounted with an unsubscribed activity', () => {
+    const props: ActivityPreviewProps = {
+      activity: mockedActivityDetail
+    }
+
+    beforeEach(() => {
+      wrapper = mount(ActivityPreview, { props, global: { stubs } })
+    })
+
+    BddTest().then('it should render the activity banner', () => {
+      bannerImage = wrapper.find('[data-testid="activity-banner"]')
+      expect(bannerImage.exists()).toBe(true)
+      expect(bannerImage.attributes('src')).toBe(mockedSubscribedActivityDetail.banner!.url)
+      expect(bannerImage.attributes('alt')).toBe(mockedSubscribedActivityDetail.banner!.fileName)
+    })
+
+    BddTest().then('it should render the activity title', () => {
+      const title = wrapper.findComponent(AvIconTextStub)
+      expect(title.exists()).toBe(true)
+      expect(title.props('text')).toBe(mockedSubscribedActivityDetail.title)
+    })
+
+    BddTest().then('it should render the activity thematic badge', () => {
+      const badge = wrapper.findComponent(ActivityThematicBadgeStub)
+      expect(badge.exists()).toBe(true)
+      expect(badge.text()).toBe(mockedSubscribedActivityDetail.thematic)
+    })
+
+    BddTest().then('it should render the activity summary', () => {
+      const summary = wrapper.find('[data-testid="activity-summary"]')
+      expect(summary.exists()).toBe(true)
+      expect(summary.text()).toBe(mockedSubscribedActivityDetail.summary)
+    })
+
+    BddTest().then('it should render the execution period info', () => {
+      const executionPeriodInfo = wrapper.find('[data-testid="activity-execution-period-info"]')
+      expect(executionPeriodInfo.exists()).toBe(true)
+      expect(executionPeriodInfo.text()).toBe(mockedSubscribedActivityDetail.executionPeriodInfo)
+    })
+
+    BddTest().then('it should not render the unsubscribe button', () => {
+      const unsubscribeButton = getUnsubscribeButton()
+      expect(unsubscribeButton).toBeUndefined()
+    })
+
+    BddTest().then('it should not render the unsubscribe confirmation modal', () => {
+      const modal = wrapper.findComponent(UnsubscribeActivitiesConfirmModalStub)
+      expect(modal.exists()).toBe(false)
+    })
+
+    BddTest().then('it should render the subscribe button', () => {
+      const subscribeButton = getSubscribeButton()
+      expect(subscribeButton).toBeDefined()
+      expect(subscribeButton!.exists()).toBe(true)
+      expect(subscribeButton!.text()).toBe('M\'inscrire à l\'activité')
+    })
+
+    BddTest().then('it should render the subscribe modal', () => {
+      const modal = wrapper.findComponent(SubscribeActivityModalStub)
+      expect(modal.exists()).toBe(true)
+      expect(modal.props('show')).toBe(false)
+      expect(modal.props('activity')).toEqual({ id: mockedSubscribedActivityDetail.id, title: mockedSubscribedActivityDetail.title })
+    })
+
+    BddTest().and('the user clicks the subscribe button', () => {
+      beforeEach(() => {
+        const subscribeButton = getSubscribeButton()
+        subscribeButton!.trigger('click')
+      })
+
+      BddTest().then('it should display the subscribe modal', () => {
+        const modal = wrapper.findComponent(SubscribeActivityModalStub)
+        expect(modal.props('show')).toBe(true)
+      })
+
+      BddTest().and('the user cancels the subscribe action', () => {
+        beforeEach(() => {
+          const modal = wrapper.findComponent(SubscribeActivityModalStub)
+          modal.vm.$emit('cancel')
+        })
+
+        BddTest().then('it should hide the subscribe modal', () => {
+          const modal = wrapper.findComponent(SubscribeActivityModalStub)
+          expect(modal.props('show')).toBe(false)
+        })
+      })
+
+      BddTest().and('the user confirms the subscribe action', () => {
+        beforeEach(() => {
+          const modal = wrapper.findComponent(SubscribeActivityModalStub)
+          modal.vm.$emit('subscribed')
+        })
+
+        BddTest().then('it should hide the subscribe modal', () => {
+          const modal = wrapper.findComponent(SubscribeActivityModalStub)
+          expect(modal.props('show')).toBe(false)
+        })
+      })
+    })
+  })
+
+  BddTest().when('the component is mounted with a subscribed activity', () => {
+    const props: ActivityPreviewProps = {
+      activity: mockedSubscribedActivityDetail
+    }
+
     beforeEach(() => {
       wrapper = mount(ActivityPreview, { props, global: { stubs } })
     })
@@ -59,9 +170,10 @@ BddTest().given('an activity preview', () => {
     })
 
     BddTest().then('it should render the unsubscribe button', () => {
-      const unsubscribeButton = wrapper.findComponent(AvButtonStub).find('[data-testid="unsubscribe-button"]')
-      expect(unsubscribeButton.exists()).toBe(true)
-      expect(unsubscribeButton.text()).toBe('Me désinscrire')
+      const unsubscribeButton = getUnsubscribeButton()
+      expect(unsubscribeButton).toBeDefined()
+      expect(unsubscribeButton!.exists()).toBe(true)
+      expect(unsubscribeButton!.text()).toBe('Me désinscrire')
     })
 
     BddTest().then('it should render the unsubscribe confirmation modal', () => {
@@ -71,10 +183,20 @@ BddTest().given('an activity preview', () => {
       expect(modal.props('activities')).toEqual([{ id: mockedActivityDetail.id, title: mockedActivityDetail.title }])
     })
 
+    BddTest().then('it should not render the subscribe button', () => {
+      const subscribeButton = getSubscribeButton()
+      expect(subscribeButton).toBeUndefined()
+    })
+
+    BddTest().then('it should not render the subscribe modal', () => {
+      const modal = wrapper.findComponent(SubscribeActivityModalStub)
+      expect(modal.exists()).toBe(false)
+    })
+
     BddTest().and('the user clicks the unsubscribe button', () => {
       beforeEach(() => {
-        const unsubscribeButton = wrapper.findComponent(AvButtonStub).find('[data-testid="unsubscribe-button"]')
-        unsubscribeButton.trigger('click')
+        const unsubscribeButton = getUnsubscribeButton()
+        unsubscribeButton!.trigger('click')
       })
 
       BddTest().then('it should display the confirmation modal', () => {
@@ -108,7 +230,7 @@ BddTest().given('an activity preview', () => {
     })
   })
 
-  BddTest().when('the activity has no banner', () => {
+  BddTest().when('the component is mounted with an activity that has no banner', () => {
     beforeEach(() => {
       const activityWithoutBanner = { ...mockedActivityDetail, banner: undefined }
       wrapper = mount(ActivityPreview, { props: { activity: activityWithoutBanner }, global: { stubs } })

--- a/src/features/student/buildProject/views/ProjectActivitiesCatalogView/components/ActivityPreview/ActivityPreview.vue
+++ b/src/features/student/buildProject/views/ProjectActivitiesCatalogView/components/ActivityPreview/ActivityPreview.vue
@@ -3,8 +3,9 @@ import type { ActivityDetailDTO } from '@/api/avenir-esr'
 import { useModal } from '@/common/composables'
 import ActivityThematicBadge from '@/features/student/buildProject/components/badges/ActivityThematicBadge/ActivityThematicBadge.vue'
 import UnsubscribeActivitiesConfirmModal from '@/features/student/buildProject/components/modals/UnsubscribeActivitiesConfirmModal/UnsubscribeActivitiesConfirmModal.vue'
+import SubscribeActivityModal from '@/features/student/buildProject/views/ProjectActivitiesCatalogView/components/overlays/SubscribeActivityModal/SubscribeActivityModal.vue'
 import { ICONS } from '@/features/student/global/icons'
-import { AvButton, AvCard, AvIconText, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
+import { AvButton, AvCard, AvIconText, MDI_ICONS, PH_ICONS } from '@avenirs-esr/avenirs-dsav'
 import { useI18n } from 'vue-i18n'
 
 export interface ActivityPreviewProps {
@@ -14,7 +15,8 @@ export interface ActivityPreviewProps {
 defineProps<ActivityPreviewProps>()
 
 const { t } = useI18n()
-const { showModal, displayModal, hideModal } = useModal()
+const { showModal: showUnsubscribeModal, displayModal: displayUnsubscribeModal, hideModal: hideUnsubscribeModal } = useModal()
+const { showModal: showSubscribeModal, displayModal: displaySubscribeModal, hideModal: hideSubscribeModal } = useModal()
 </script>
 
 <template>
@@ -51,7 +53,7 @@ const { showModal, displayModal, hideModal } = useModal()
       <div class="av-col av-gap-sm">
         <div class="av-col av-row--md av-justify-between--md av-gap-xl">
           <div class="av-col av-flex-fill av-gap-md">
-            <span class="n4">{{ t('student.buildProject.views.ProjectActivitiesCatalogView.previewTitle') }}</span>
+            <span class="n4">{{ t('student.buildProject.activities.views.ProjectActivitiesCatalogView.previewTitle') }}</span>
             <span
               class="s2-regular"
               data-testid="activity-summary"
@@ -60,7 +62,7 @@ const { showModal, displayModal, hideModal } = useModal()
             </span>
           </div>
           <div class="av-col av-flex-fill av-gap-md">
-            <span class="n4">{{ t('student.buildProject.views.ProjectActivitiesCatalogView.periodTitle') }}</span>
+            <span class="n4">{{ t('student.buildProject.activities.views.ProjectActivitiesCatalogView.periodTitle') }}</span>
             <span
               class="s2-bold"
               data-testid="activity-execution-period-info"
@@ -71,12 +73,24 @@ const { showModal, displayModal, hideModal } = useModal()
         </div>
         <div class="av-row av-justify-end av-gap-md">
           <AvButton
+            v-if="activity.isSubscribed"
             variant="OUTLINED"
             theme="PRIMARY"
             :label="t('student.buildProject.activities.buttons.unsubscribe')"
             :icon="MDI_ICONS.TRASH_CAN_OUTLINE"
+            small
             data-testid="unsubscribe-button"
-            @click="displayModal"
+            @click="displayUnsubscribeModal"
+          />
+          <AvButton
+            v-else
+            variant="OUTLINED"
+            theme="PRIMARY"
+            :label="t('student.buildProject.activities.buttons.subscribe')"
+            :icon="PH_ICONS.NOTE_PENCIL"
+            small
+            data-testid="subscribe-button"
+            @click="displaySubscribeModal"
           />
         </div>
       </div>
@@ -84,10 +98,19 @@ const { showModal, displayModal, hideModal } = useModal()
   </div>
 
   <UnsubscribeActivitiesConfirmModal
-    :show="showModal"
+    v-if="activity.isSubscribed"
+    :show="showUnsubscribeModal"
     :activities="[{ id: activity.id, title: activity.title }]"
-    @cancel="hideModal"
-    @unsubscribed="hideModal"
+    @cancel="hideUnsubscribeModal"
+    @unsubscribed="hideUnsubscribeModal"
+  />
+
+  <SubscribeActivityModal
+    v-else
+    :show="showSubscribeModal"
+    :activity="{ id: activity.id, title: activity.title }"
+    @cancel="hideSubscribeModal"
+    @subscribed="hideSubscribeModal"
   />
 </template>
 

--- a/src/features/student/buildProject/views/ProjectActivitiesCatalogView/components/overlays/CancelSubscribeActivityConfirmModal/CancelSubscribeActivityConfirmModal.stub.ts
+++ b/src/features/student/buildProject/views/ProjectActivitiesCatalogView/components/overlays/CancelSubscribeActivityConfirmModal/CancelSubscribeActivityConfirmModal.stub.ts
@@ -1,0 +1,13 @@
+export const CancelSubscribeActivityConfirmModalStub = defineComponent({
+  name: 'CancelSubscribeActivityConfirmModal',
+  props: {
+    show: {
+      type: Boolean,
+      required: true
+    }
+  },
+  emits: ['cancel', 'confirm'],
+  template: `<div v-if="show">
+    <p>CancelSubscribeActivityConfirmModalStub</p>
+  </div>`
+})

--- a/src/features/student/buildProject/views/ProjectActivitiesCatalogView/components/overlays/CancelSubscribeActivityConfirmModal/CancelSubscribeActivityConfirmModal.test.ts
+++ b/src/features/student/buildProject/views/ProjectActivitiesCatalogView/components/overlays/CancelSubscribeActivityConfirmModal/CancelSubscribeActivityConfirmModal.test.ts
@@ -1,0 +1,52 @@
+import { ConfirmationModalStub } from '@/common/components/ConfirmationModal/ConfirmationModal.stub'
+import CancelSubscribeActivityConfirmModal from '@/features/student/buildProject/views/ProjectActivitiesCatalogView/components/overlays/CancelSubscribeActivityConfirmModal/CancelSubscribeActivityConfirmModal.vue'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { mount, type VueWrapper } from '@vue/test-utils'
+
+BddTest().given('a cancel subscribe activity confirmation modal', () => {
+  let wrapper: VueWrapper<InstanceType<typeof CancelSubscribeActivityConfirmModal>>
+
+  const stubs = {
+    ConfirmationModal: ConfirmationModalStub
+  }
+
+  BddTest().when('the component is mounted', () => {
+    beforeEach(() => {
+      wrapper = mount(CancelSubscribeActivityConfirmModal, { props: { show: true }, global: { stubs } })
+    })
+
+    BddTest().then('it should render the confirmation modal', () => {
+      const confirmationModal = wrapper.findComponent(ConfirmationModalStub)
+      expect(confirmationModal.exists()).toBe(true)
+      expect(confirmationModal.props('show')).toBe(true)
+    })
+
+    BddTest().then('it should render the title', () => {
+      const title = wrapper.find('[data-testid="cancel-subscribe-activity-confirm-modal__header"]')
+      expect(title.exists()).toBe(true)
+      expect(title.text()).toBe('Êtes-vous certain(e) de vouloir abandonner l’inscription à l’activité ?')
+    })
+
+    BddTest().and('the user cancels the action', () => {
+      beforeEach(() => {
+        const confirmationModal = wrapper.findComponent(ConfirmationModalStub)
+        confirmationModal.vm.$emit('close')
+      })
+
+      BddTest().then('it should emit the cancel event', () => {
+        expect(wrapper.emitted('cancel')).toBeTruthy()
+      })
+    })
+
+    BddTest().and('the user confirms the action', () => {
+      beforeEach(() => {
+        const confirmationModal = wrapper.findComponent(ConfirmationModalStub)
+        confirmationModal.vm.$emit('confirm')
+      })
+
+      BddTest().then('it should emit the confirm event', () => {
+        expect(wrapper.emitted('confirm')).toBeTruthy()
+      })
+    })
+  })
+})

--- a/src/features/student/buildProject/views/ProjectActivitiesCatalogView/components/overlays/CancelSubscribeActivityConfirmModal/CancelSubscribeActivityConfirmModal.vue
+++ b/src/features/student/buildProject/views/ProjectActivitiesCatalogView/components/overlays/CancelSubscribeActivityConfirmModal/CancelSubscribeActivityConfirmModal.vue
@@ -1,0 +1,38 @@
+<script lang="ts" setup>
+import ConfirmationModal from '@/common/components/ConfirmationModal/ConfirmationModal.vue'
+import { useI18n } from 'vue-i18n'
+
+export interface CancelSubscribeActivityConfirmModalProps {
+  show: boolean
+}
+
+defineProps<CancelSubscribeActivityConfirmModalProps>()
+
+defineEmits<{
+  (e: 'cancel'): void
+  (e: 'confirm'): void
+}>()
+
+const { t } = useI18n()
+</script>
+
+<template>
+  <ConfirmationModal
+    :show="show"
+    @close="$emit('cancel')"
+    @confirm="$emit('confirm')"
+  >
+    <template #header>
+      <div
+        class="av-row av-flex-fill"
+        data-testid="cancel-subscribe-activity-confirm-modal__header"
+      >
+        <span class="b2-bold av-text-text1">
+          {{ t('student.buildProject.activities.views.ProjectActivitiesCatalogView.overlays.CancelSubscribeActivityModal.title') }}
+        </span>
+      </div>
+    </template>
+
+    <div />
+  </ConfirmationModal>
+</template>

--- a/src/features/student/buildProject/views/ProjectActivitiesCatalogView/components/overlays/SubscribeActivityModal/SubscribeActivityModal.stub.ts
+++ b/src/features/student/buildProject/views/ProjectActivitiesCatalogView/components/overlays/SubscribeActivityModal/SubscribeActivityModal.stub.ts
@@ -1,0 +1,17 @@
+export const SubscribeActivityModalStub = defineComponent({
+  name: 'SubscribeActivityModal',
+  props: {
+    show: {
+      type: Boolean,
+      required: true
+    },
+    activity: {
+      type: Object as () => { id: string, title: string },
+      required: true
+    }
+  },
+  emits: ['subscribed', 'cancel'],
+  template: `<div v-if="show">
+    <p>SubscribeActivityModalStub for activity: {{ activity.title }}</p>
+  </div>`
+})

--- a/src/features/student/buildProject/views/ProjectActivitiesCatalogView/components/overlays/SubscribeActivityModal/SubscribeActivityModal.test.ts
+++ b/src/features/student/buildProject/views/ProjectActivitiesCatalogView/components/overlays/SubscribeActivityModal/SubscribeActivityModal.test.ts
@@ -1,0 +1,157 @@
+import type { VueWrapper } from '@vue/test-utils'
+import { ConfirmationModalStub } from '@/common/components/ConfirmationModal/ConfirmationModal.stub'
+import { CancelSubscribeActivityConfirmModalStub } from '@/features/student/buildProject/views/ProjectActivitiesCatalogView/components/overlays/CancelSubscribeActivityConfirmModal/CancelSubscribeActivityConfirmModal.stub'
+import SubscribeActivityModal, { type SubscribeActivityModalProps } from '@/features/student/buildProject/views/ProjectActivitiesCatalogView/components/overlays/SubscribeActivityModal/SubscribeActivityModal.vue'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { mountComponent } from 'tests/utils'
+import { beforeEach, expect, vi } from 'vitest'
+
+const mockAddErrorMessage = vi.fn()
+const mockAddSuccessMessage = vi.fn()
+
+vi.mock('@/store', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/store')>()
+  return {
+    ...actual,
+    useToasterStore: () => ({
+      addErrorMessage: mockAddErrorMessage,
+      addSuccessMessage: mockAddSuccessMessage
+    })
+  }
+})
+
+BddTest().given('a subscribe activity modal', () => {
+  let wrapper: VueWrapper<InstanceType<typeof SubscribeActivityModal>>
+
+  const stubs = {
+    ConfirmationModal: ConfirmationModalStub,
+    CancelSubscribeActivityConfirmModal: CancelSubscribeActivityConfirmModalStub
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  BddTest().when('the component is mounted with a valid activity', () => {
+    const props: SubscribeActivityModalProps = {
+      show: true,
+      activity: { id: 'activity-id', title: 'Activity Title', }
+    }
+    beforeEach(() => {
+      wrapper = mountComponent(SubscribeActivityModal, { props, global: { stubs } })
+    })
+
+    BddTest().then('it should render the confirmation modal', () => {
+      const modal = wrapper.findComponent(ConfirmationModalStub)
+      expect(modal.exists()).toBe(true)
+      expect(modal.props('show')).toBe(true)
+    })
+
+    BddTest().then('it should render the title', () => {
+      const title = wrapper.find('[data-testid="subscribe-activity-modal__header"]')
+      expect(title.exists()).toBe(true)
+      expect(title.text()).toBe(`Inscription à l’activité ${props.activity.title}`)
+    })
+
+    BddTest().then('it should render the cancel subscribe activity confirm modal', () => {
+      const modal = wrapper.findComponent(CancelSubscribeActivityConfirmModalStub)
+      expect(modal.exists()).toBe(true)
+    })
+
+    BddTest().and('the user cancels the action', () => {
+      beforeEach(() => {
+        const modal = wrapper.findComponent(ConfirmationModalStub)
+        modal.vm.$emit('close')
+      })
+
+      BddTest().then('it should show the cancel subscribe activity confirm modal', () => {
+        const modal = wrapper.findComponent(CancelSubscribeActivityConfirmModalStub)
+        expect(modal.exists()).toBe(true)
+        expect(modal.props('show')).toBe(true)
+      })
+
+      BddTest().and('the user cancels the cancellation', () => {
+        beforeEach(() => {
+          const modal = wrapper.findComponent(CancelSubscribeActivityConfirmModalStub)
+          modal.vm.$emit('cancel')
+        })
+
+        BddTest().then('it should hide the cancel subscribe activity confirm modal', () => {
+          const modal = wrapper.findComponent(CancelSubscribeActivityConfirmModalStub)
+          expect(modal.exists()).toBe(true)
+          expect(modal.props('show')).toBe(false)
+        })
+      })
+
+      BddTest().and('the user confirms the cancellation', () => {
+        beforeEach(() => {
+          const modal = wrapper.findComponent(CancelSubscribeActivityConfirmModalStub)
+          modal.vm.$emit('confirm')
+        })
+
+        BddTest().then('it should emit the cancel event', async () => {
+          await vi.waitFor(() => {
+            expect(wrapper.emitted('cancel')).toBeTruthy()
+          })
+        })
+      })
+    })
+
+    BddTest().and('the user confirms the subscription', () => {
+      beforeEach(() => {
+        const modal = wrapper.findComponent(ConfirmationModalStub)
+        modal.vm.$emit('confirm')
+      })
+
+      BddTest().then('it should not add an error message', () => {
+        expect(mockAddErrorMessage).not.toHaveBeenCalled()
+      })
+
+      BddTest().then('it should add a success message', async () => {
+        await vi.waitFor(() => {
+          expect(mockAddSuccessMessage).toHaveBeenCalledWith('Vous êtes inscrit.e avec succès. Retrouvez cette activité dans votre bibliothèque d’activités.')
+        })
+      })
+
+      BddTest().then('it should emit the subscribed event', async () => {
+        await vi.waitFor(() => {
+          expect(wrapper.emitted('subscribed')).toBeTruthy()
+        })
+      })
+    })
+  })
+
+  BddTest().when('the component is mounted with an invalid activity', () => {
+    const props: SubscribeActivityModalProps = {
+      show: true,
+      activity: { id: 'INVALID_ACTIVITY_ID', title: 'Activity Title', }
+    }
+    beforeEach(() => {
+      wrapper = mountComponent(SubscribeActivityModal, { props, global: { stubs } })
+    })
+
+    BddTest().and('the user confirms the subscription', () => {
+      beforeEach(() => {
+        const modal = wrapper.findComponent(ConfirmationModalStub)
+        modal.vm.$emit('confirm')
+      })
+
+      BddTest().then('it should add an error message', async () => {
+        await vi.waitFor(() => {
+          expect(mockAddErrorMessage).toHaveBeenCalledWith({
+            title: 'Une erreur est survenue lors de l\'inscription à l\'activité. Veuillez réessayer plus tard.',
+            description: expect.any(String)
+          })
+        })
+      })
+
+      BddTest().then('it should not add a success message', async () => {
+        expect(mockAddSuccessMessage).not.toHaveBeenCalled()
+      })
+
+      BddTest().then('it should not emit the subscribed event', async () => {
+        expect(wrapper.emitted('subscribed')).toBeFalsy()
+      })
+    })
+  })
+})

--- a/src/features/student/buildProject/views/ProjectActivitiesCatalogView/components/overlays/SubscribeActivityModal/SubscribeActivityModal.vue
+++ b/src/features/student/buildProject/views/ProjectActivitiesCatalogView/components/overlays/SubscribeActivityModal/SubscribeActivityModal.vue
@@ -1,0 +1,77 @@
+<script lang="ts" setup>
+import ConfirmationModal from '@/common/components/ConfirmationModal/ConfirmationModal.vue'
+import { useModal } from '@/common/composables'
+import { useSubscribeActivityMutation } from '@/features/student/buildProject/queries/use-activities.query/use-activities.query'
+import CancelSubscribeActivityConfirmModal from '@/features/student/buildProject/views/ProjectActivitiesCatalogView/components/overlays/CancelSubscribeActivityConfirmModal/CancelSubscribeActivityConfirmModal.vue'
+import { useToasterStore } from '@/store'
+import { useI18n } from 'vue-i18n'
+
+export interface SubscribeActivityModalProps {
+  show: boolean
+  activity: {
+    id: string
+    title: string
+  }
+}
+
+defineProps<SubscribeActivityModalProps>()
+
+const emit = defineEmits<{
+  (e: 'cancel'): void
+  (e: 'subscribed'): void
+}>()
+
+const { t } = useI18n()
+const {
+  showModal: showCancelSubscribeConfirmModal,
+  displayModal: displayCancelSubscribeConfirmModal,
+  hideModal: hideCancelSubscribeConfirmModal
+} = useModal()
+const { addSuccessMessage, addErrorMessage } = useToasterStore()
+
+const { mutate: subscribe } = useSubscribeActivityMutation({
+  onSuccess: () => {
+    addSuccessMessage(t('student.buildProject.activities.views.ProjectActivitiesCatalogView.overlays.ActivitySubscribeModal.success'))
+    emit('subscribed')
+  },
+  onError: (error) => {
+    addErrorMessage({
+      title: t('student.buildProject.activities.views.ProjectActivitiesCatalogView.overlays.ActivitySubscribeModal.error'),
+      description: error.message
+    })
+  }
+})
+
+function onConfirmCancelSubscribe () {
+  hideCancelSubscribeConfirmModal()
+
+  setTimeout(() => {
+    emit('cancel')
+  }, 10)
+}
+</script>
+
+<template>
+  <ConfirmationModal
+    :show="show"
+    @close="displayCancelSubscribeConfirmModal"
+    @confirm="subscribe({ activityId: activity.id })"
+  >
+    <template #header>
+      <div
+        class="av-row av-flex-fill"
+        data-testid="subscribe-activity-modal__header"
+      >
+        <span class="b2-bold av-text-text1">
+          {{ t('student.buildProject.activities.views.ProjectActivitiesCatalogView.overlays.ActivitySubscribeModal.title', { title: activity.title }) }}
+        </span>
+      </div>
+    </template>
+
+    <CancelSubscribeActivityConfirmModal
+      :show="showCancelSubscribeConfirmModal"
+      @cancel="hideCancelSubscribeConfirmModal"
+      @confirm="onConfirmCancelSubscribe"
+    />
+  </ConfirmationModal>
+</template>


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
This PR introduces activity subscription management in the student project activities catalog, including subscribe and cancel-subscription user flows.

**Main changes:**
- ✨ Adds subscription and unsubscription interactions in the activities catalog view
- ✨ Adds `SubscribeActivityModal` and `CancelSubscribeActivityConfirmModal` components with tests and stubs
- ♻️ Extends activities query logic to support subscription state updates
- 💬 Updates i18n messages (FR/EN) related to activity subscription actions
- ✅ Adds and updates unit tests for queries, preview component, and new modals
- 🔧 Updates API spec and MSW/fixtures to support subscription-related scenarios

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1118

---

### Documentation
- Test coverage updated for activity subscription workflows
- API contract/mocks aligned with subscription behavior

**Modified files (summary):**
- `src/features/student/buildProject/pages/ProjectActivitiesCatalogView/ProjectActivitiesCatalogView.vue`
- `src/features/student/buildProject/pages/ProjectActivitiesCatalogView/components/ActivityPreview/ActivityPreview.vue`
- `src/features/student/buildProject/pages/ProjectActivitiesCatalogView/components/modals/SubscribeActivityModal/SubscribeActivityModal.vue`
- `src/features/student/buildProject/pages/ProjectActivitiesCatalogView/components/modals/CancelSubscribeActivityConfirmModal/CancelSubscribeActivityConfirmModal.vue`
- `src/features/student/buildProject/hooks/queries/use-activities.query/use-activities.query.ts`
- Related tests, fixtures, MSW handlers, locales, and API specs

---

### Target Branch
`develop`

---

### Additional Notes
This PR keeps the UX focused on explicit confirmation for subscription changes and ensures consistency between backend contract, mock handlers, and frontend tests.

---

### Known Limitations or Side Effects
No known limitations or side effects identified at this stage.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [x] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [x] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process
