### PR TITLE
test(1119): add US#979 E2E tests

### DIFF
--- a/api-specs/avenir-esr.swagger.json
+++ b/api-specs/avenir-esr.swagger.json
@@ -1005,7 +1005,7 @@
         "tags": [
           "declared-activity-controller"
         ],
-        "operationId": "subscribe",
+        "operationId": "subscribeActivity",
         "parameters": [
           {
             "name": "activityId",
@@ -1017,6 +1017,15 @@
             }
           }
         ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SubscribeDeclaredActivityRequestDTO"
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -1935,7 +1944,7 @@
         "tags": [
           "declared-activity-controller"
         ],
-        "operationId": "unsubscribe",
+        "operationId": "unsubscribeActivitiesProgresses",
         "requestBody": {
           "content": {
             "application/json": {
@@ -3524,6 +3533,23 @@
             "minLength": 0
           }
         }
+      },
+      "SubscribeDeclaredActivityRequestDTO": {
+        "type": "object",
+        "properties": {
+          "startDate": {
+            "type": "string",
+            "format": "date"
+          },
+          "endDate": {
+            "type": "string",
+            "format": "date"
+          }
+        },
+        "required": [
+          "endDate",
+          "startDate"
+        ]
       },
       "PictureDTO": {
         "type": "object",
@@ -5227,6 +5253,10 @@
             "type": "string",
             "format": "uuid"
           },
+          "activityId": {
+            "type": "string",
+            "format": "uuid"
+          },
           "title": {
             "type": "string"
           },
@@ -5269,6 +5299,7 @@
         },
         "required": [
           "id",
+          "activityId",
           "status",
           "summary",
           "thematic",

--- a/e2e/framework/shared/base/BaseObject.ts
+++ b/e2e/framework/shared/base/BaseObject.ts
@@ -14,4 +14,8 @@ export abstract class BaseObject {
   async isVisible () {
     await expect(this.root).toBeVisible()
   }
+
+  async isHidden () {
+    await expect(this.root).toBeHidden()
+  }
 }

--- a/e2e/framework/student/lifeProject/activitiesCatalog/StudentProjectActivitiesCatalog.ts
+++ b/e2e/framework/student/lifeProject/activitiesCatalog/StudentProjectActivitiesCatalog.ts
@@ -14,7 +14,7 @@ class StudentProjectActivitiesCatalogPage {
   private selectedThematic?: string
   private selectedActivityId?: string
 
-  private static readonly DEFAULT_THEME = EActivityThematic.SELF_KNOWLEDGE
+  private static readonly DEFAULT_THEMATIC = EActivityThematic.SELF_KNOWLEDGE
   private static readonly DEFAULT_ACTIVITY_ID = '3f7c9a2e-5d44-4b7a-9c6f-2a6e8e91b1a1'
 
   constructor (public page: Page) {}
@@ -23,9 +23,9 @@ class StudentProjectActivitiesCatalogPage {
   private selectNav () { return new ActivitiesSelectNavigation(this.page) }
   private activityPreview () { return new ActivityPreview(this.page) }
 
-  private buildCatalogUrl (theme: string, id: string) {
+  private buildCatalogUrl (thematic: string, id: string) {
     return STUDENT_ROUTES.PROJECT.ACTIVITIES_CATALOG
-      .replace(':theme', theme)
+      .replace(':thematic', thematic)
       .replace(':id', id)
   }
 
@@ -43,7 +43,7 @@ class StudentProjectActivitiesCatalogPage {
   @Given('the student opens the project activities catalog page')
   async openCatalogPage () {
     const url = this.buildCatalogUrl(
-      StudentProjectActivitiesCatalogPage.DEFAULT_THEME,
+      StudentProjectActivitiesCatalogPage.DEFAULT_THEMATIC,
       StudentProjectActivitiesCatalogPage.DEFAULT_ACTIVITY_ID,
     )
     await this.page.goto(url)
@@ -57,7 +57,7 @@ class StudentProjectActivitiesCatalogPage {
     expect(viewport?.width).toBeLessThanOrEqual(AV_BREAKPOINTS.md)
 
     const url = this.buildCatalogUrl(
-      StudentProjectActivitiesCatalogPage.DEFAULT_THEME,
+      StudentProjectActivitiesCatalogPage.DEFAULT_THEMATIC,
       StudentProjectActivitiesCatalogPage.DEFAULT_ACTIVITY_ID,
     )
     await this.page.goto(url)

--- a/e2e/framework/student/lifeProject/activitiesCatalog/StudentProjectActivitiesCatalog.ts
+++ b/e2e/framework/student/lifeProject/activitiesCatalog/StudentProjectActivitiesCatalog.ts
@@ -4,6 +4,7 @@ import { STUDENT_ROUTES } from '@e2e/framework/shared/constants/routes'
 import { AV_BREAKPOINTS } from '@e2e/framework/shared/utils/dimension'
 import { ActivitiesSelectNavigation } from '@e2e/framework/student/lifeProject/activitiesCatalog/componentObjects/ActivitiesSelectNavigation'
 import { ActivitiesSideNavigation } from '@e2e/framework/student/lifeProject/activitiesCatalog/componentObjects/ActivitiesSideNavigation'
+import { ActivityPreview } from '@e2e/framework/student/lifeProject/activitiesCatalog/componentObjects/ActivityPreview'
 import { expect, type Page } from '@playwright/test'
 import { Fixture, Given, Then, When } from 'playwright-bdd/decorators'
 
@@ -20,6 +21,7 @@ class StudentProjectActivitiesCatalogPage {
 
   private sideNav () { return new ActivitiesSideNavigation(this.page) }
   private selectNav () { return new ActivitiesSelectNavigation(this.page) }
+  private activityPreview () { return new ActivityPreview(this.page) }
 
   private buildCatalogUrl (theme: string, id: string) {
     return STUDENT_ROUTES.PROJECT.ACTIVITIES_CATALOG
@@ -171,5 +173,101 @@ class StudentProjectActivitiesCatalogPage {
   @Then('the first thematic in select navigation last activity is {string}')
   async verifyFirstThematicLastActivityInSelectNav (title: string) {
     await this.selectNav().verifyLastActivityTitleOfFirstThematic(title)
+  }
+
+  @Then('the activity preview is visible')
+  async verifyActivityPreviewVisible () {
+    await this.activityPreview().verifyVisible()
+  }
+
+  @Then('the activity preview is correctly displayed')
+  async verifyActivityPreviewCorrectlyDisplayed () {
+    await this.activityPreview().verify()
+  }
+
+  @Then('the activity preview subscribe button is visible')
+  async verifyActivityPreviewSubscribeButtonVisible () {
+    await this.activityPreview().verifySubscribeButton()
+  }
+
+  @When('the user clicks on the activity preview subscribe button')
+  async clickActivityPreviewSubscribeButton () {
+    await this.activityPreview().clickSubscribeButton()
+  }
+
+  @Then('the subscribe activity modal is displayed')
+  async verifySubscribeActivityModal () {
+    await this.activityPreview().verifySubscribeActivityModal()
+  }
+
+  @When('the user clicks on the activity preview subscribe modal confirm button')
+  async clickSubscribeModalConfirmButton () {
+    await this.activityPreview().clickSubscribeModalConfirmButton()
+  }
+
+  @When('the user clicks on the activity preview subscribe modal cancel button')
+  async clickSubscribeModalCancelButton () {
+    await this.activityPreview().clickSubscribeModalCancelButton()
+  }
+
+  @Then('the cancel subscribe activity confirm modal is displayed')
+  async verifyCancelSubscribeActivityConfirmModal () {
+    await this.activityPreview().verifyCancelSubscribeActivityConfirmModal()
+  }
+
+  @Then('the cancel subscribe activity confirm modal is hidden')
+  async verifyCancelSubscribeActivityConfirmModalHidden () {
+    await this.activityPreview().verifyCancelSubscribeActivityConfirmModalHidden()
+  }
+
+  @When('the user clicks on the activity preview subscribe modal cancel button and confirms')
+  async clickSubscribeModalCancelButtonAndConfirm () {
+    await this.activityPreview().clickSubscribeModalCancelButtonAndConfirm()
+  }
+
+  @When('the user clicks on the activity preview subscribe modal cancel button and cancels')
+  async clickSubscribeModalCancelButtonAndCancel () {
+    await this.activityPreview().clickSubscribeModalCancelButtonAndCancel()
+  }
+
+  @Then('the subscribe activity modal is hidden')
+  async verifySubscribeActivityModalHidden () {
+    await this.activityPreview().verifySubscribeActivityModalHidden()
+  }
+
+  @Then('the activity preview subscribe button is hidden')
+  async verifyActivityPreviewSubscribeButtonHidden () {
+    await this.activityPreview().verifySubscribeButtonHidden()
+  }
+
+  @Then('the activity preview unsubscribe button is visible')
+  async verifyActivityPreviewUnsubscribeButtonVisible () {
+    await this.activityPreview().verifyUnsubscribeButton()
+  }
+
+  @When('the user clicks on the activity preview unsubscribe button')
+  async clickActivityPreviewUnsubscribeButton () {
+    await this.activityPreview().clickUnsubscribeButton()
+  }
+
+  @Then('the unsubscribe activities confirm modal is displayed')
+  async verifyUnsubscribeActivitiesConfirmModal () {
+    await this.activityPreview().verifyUnsubscribeActivitiesConfirmModal()
+  }
+
+  @When('the user clicks on the activity preview unsubscribe activities confirm modal confirm button')
+  async clickUnsubscribeActivitiesConfirmModalConfirmButton () {
+    await this.activityPreview().clickUnsubscribeActivitiesConfirmModalConfirmButton()
+  }
+
+  @Then('the activity preview unsubscribe activities confirm modal is hidden')
+  async verifyUnsubscribeActivitiesConfirmModalHidden () {
+    const unsubscribeActivitiesConfirmModal = this.activityPreview().getUnsubscribeActivitiesConfirmModal()
+    await unsubscribeActivitiesConfirmModal.verifyHidden()
+  }
+
+  @Then('the activity preview unsubscribe button is hidden')
+  async verifyActivityPreviewUnsubscribeButtonHidden () {
+    await this.activityPreview().verifyUnsubscribeButtonHidden()
   }
 }

--- a/e2e/framework/student/lifeProject/activitiesCatalog/componentObjects/ActivityPreview.ts
+++ b/e2e/framework/student/lifeProject/activitiesCatalog/componentObjects/ActivityPreview.ts
@@ -57,7 +57,6 @@ export class ActivityPreview extends BaseObject {
 
   async verifyBanner () {
     await expect(this.getBanner()).toBeVisible()
-    // await expect(this.getBanner()).toHaveAttribute('src', 'http://localhost:5173/apim/storage/activities/bb831c0a-e7ef-489a-9537-a376f612e7e5')
     await expect(this.getBanner()).toHaveAttribute('alt', 'definir-ses-valeurs-banner.png')
   }
 

--- a/e2e/framework/student/lifeProject/activitiesCatalog/componentObjects/ActivityPreview.ts
+++ b/e2e/framework/student/lifeProject/activitiesCatalog/componentObjects/ActivityPreview.ts
@@ -1,0 +1,177 @@
+import { BaseObject } from '@e2e/framework/shared/base/BaseObject'
+import { t } from '@e2e/framework/shared/utils/i18n'
+import { waitForPageLoad } from '@e2e/framework/shared/utils/waits'
+import { SubscribeActivityModal } from '@e2e/framework/student/lifeProject/activitiesCatalog/componentObjects/SubscribeActivityModal'
+import { UnsubscribeActivitiesConfirmModal } from '@e2e/framework/student/lifeProject/activitiesCatalog/componentObjects/UnsubscribeActivitiesConfirmModal'
+import { expect, type Page } from '@playwright/test'
+
+export class ActivityPreview extends BaseObject {
+  constructor (protected page: Page) {
+    super(page.getByTestId('activity-preview'), page)
+  }
+
+  getBanner () {
+    return this.root.getByTestId('activity-banner')
+  }
+
+  getTitle () {
+    return this.root.getByTestId('activity-title')
+  }
+
+  getThematicBadge () {
+    return this.root.getByTestId('activity-thematic-badge')
+  }
+
+  getSummary () {
+    return this.root.getByTestId('activity-summary')
+  }
+
+  getExecutionPeriodInfo () {
+    return this.root.getByTestId('activity-execution-period-info')
+  }
+
+  getUnsubscribeButton () {
+    return this.root.getByTestId('unsubscribe-button')
+  }
+
+  getSubscribeButton () {
+    return this.root.getByTestId('subscribe-button')
+  }
+
+  getUnsubscribeActivitiesConfirmModal () {
+    return new UnsubscribeActivitiesConfirmModal(this.page)
+  }
+
+  getSubscribeActivityModal () {
+    return new SubscribeActivityModal(this.page)
+  }
+
+  async verifyVisible () {
+    await this.isVisible()
+    await expect(this.getBanner()).toBeVisible()
+    await expect(this.getTitle()).toBeVisible()
+    await expect(this.getSummary()).toBeVisible()
+    await expect(this.getExecutionPeriodInfo()).toBeVisible()
+    await expect(this.getThematicBadge()).toBeVisible()
+  }
+
+  async verifyBanner () {
+    await expect(this.getBanner()).toBeVisible()
+    // await expect(this.getBanner()).toHaveAttribute('src', 'http://localhost:5173/apim/storage/activities/bb831c0a-e7ef-489a-9537-a376f612e7e5')
+    await expect(this.getBanner()).toHaveAttribute('alt', 'definir-ses-valeurs-banner.png')
+  }
+
+  async verifyTitle () {
+    const expectedText = 'Définir ses valeurs'
+    await expect(this.getTitle()).toBeVisible()
+    await expect(this.getTitle()).toHaveText(expectedText)
+  }
+
+  async verifyThematicBadge () {
+    const expectedText = t('student.buildProject.activities.thematics.SELF_KNOWLEDGE')
+    await expect(this.getThematicBadge()).toBeVisible()
+    await expect(this.getThematicBadge()).toHaveText(expectedText)
+  }
+
+  async verifySummary () {
+    const expectedText = 'Activité faisant partie de la catégorie Connaissance de soi. Elle permet à l’étudiant.e d’identifier les valeurs essentielles qui orientent ses choix et d’analyser la manière dont elles se traduisent dans ses comportements quotidiens. Cette réflexion constitue une base structurante pour construire un projet personnel et professionnel cohérent.'
+    await expect(this.getSummary()).toBeVisible()
+    await expect(this.getSummary()).toHaveText(expectedText)
+  }
+
+  async verifyExecutionPeriodInfo () {
+    const expectedText = 'À réaliser en amont d’un entretien avec un.e conseiller/ conseillère d’orientation ou avant d’engager un parcours structuré d’activités Cofolio.'
+    await expect(this.getExecutionPeriodInfo()).toBeVisible()
+    await expect(this.getExecutionPeriodInfo()).toHaveText(expectedText)
+  }
+
+  async verifySubscribeButton () {
+    const expectedText = t('student.buildProject.activities.buttons.subscribe')
+    await expect(this.getSubscribeButton()).toBeVisible()
+    await expect(this.getSubscribeButton()).toHaveText(expectedText)
+  }
+
+  async verifySubscribeButtonHidden () {
+    await expect(this.getSubscribeButton()).toBeHidden()
+  }
+
+  async verifyUnsubscribeButton () {
+    const expectedText = t('student.buildProject.activities.buttons.unsubscribe')
+    await expect(this.getUnsubscribeButton()).toBeVisible()
+    await expect(this.getUnsubscribeButton()).toHaveText(expectedText)
+  }
+
+  async verifyUnsubscribeButtonHidden () {
+    await expect(this.getUnsubscribeButton()).toBeHidden()
+  }
+
+  async verify () {
+    await this.verifyVisible()
+    await this.verifyBanner()
+    await this.verifyTitle()
+    await this.verifyThematicBadge()
+    await this.verifySummary()
+    await this.verifyExecutionPeriodInfo()
+    await this.verifySubscribeButton()
+  }
+
+  async clickSubscribeButton () {
+    await this.getSubscribeButton().click()
+    await waitForPageLoad(this.page)
+  }
+
+  async verifySubscribeActivityModal () {
+    const subscribeActivityModal = this.getSubscribeActivityModal()
+    await subscribeActivityModal.verify()
+  }
+
+  async clickSubscribeModalConfirmButton () {
+    const subscribeActivityModal = this.getSubscribeActivityModal()
+    await subscribeActivityModal.clickConfirm()
+  }
+
+  async clickSubscribeModalCancelButton () {
+    const subscribeActivityModal = this.getSubscribeActivityModal()
+    await subscribeActivityModal.clickCancel()
+  }
+
+  async clickSubscribeModalCancelButtonAndConfirm () {
+    const subscribeActivityModal = this.getSubscribeActivityModal()
+    await subscribeActivityModal.clickCancelAndConfirm()
+  }
+
+  async clickSubscribeModalCancelButtonAndCancel () {
+    const subscribeActivityModal = this.getSubscribeActivityModal()
+    await subscribeActivityModal.clickCancelAndCancel()
+  }
+
+  async verifySubscribeActivityModalHidden () {
+    const subscribeActivityModal = this.getSubscribeActivityModal()
+    await subscribeActivityModal.verifyHidden()
+  }
+
+  async verifyCancelSubscribeActivityConfirmModal () {
+    const subscribeActivityModal = this.getSubscribeActivityModal()
+    await subscribeActivityModal.verifyCancelSubscribeActivityConfirmModal()
+  }
+
+  async verifyCancelSubscribeActivityConfirmModalHidden () {
+    const subscribeActivityModal = this.getSubscribeActivityModal()
+    await subscribeActivityModal.verifyCancelSubscribeActivityConfirmModalHidden()
+  }
+
+  async clickUnsubscribeButton () {
+    await this.getUnsubscribeButton().click()
+    await waitForPageLoad(this.page)
+  }
+
+  async verifyUnsubscribeActivitiesConfirmModal () {
+    const unsubscribeActivitiesConfirmModal = this.getUnsubscribeActivitiesConfirmModal()
+    await unsubscribeActivitiesConfirmModal.verify()
+  }
+
+  async clickUnsubscribeActivitiesConfirmModalConfirmButton () {
+    const unsubscribeActivitiesConfirmModal = this.getUnsubscribeActivitiesConfirmModal()
+    await unsubscribeActivitiesConfirmModal.clickConfirm()
+  }
+}

--- a/e2e/framework/student/lifeProject/activitiesCatalog/componentObjects/CancelSubscribeActivityConfirmModal.ts
+++ b/e2e/framework/student/lifeProject/activitiesCatalog/componentObjects/CancelSubscribeActivityConfirmModal.ts
@@ -1,0 +1,60 @@
+import { BaseObject } from '@e2e/framework/shared/base/BaseObject'
+import { t } from '@e2e/framework/shared/utils/i18n'
+import { waitForPageLoad } from '@e2e/framework/shared/utils/waits'
+import { expect, type Page } from '@playwright/test'
+
+export class CancelSubscribeActivityConfirmModal extends BaseObject {
+  constructor (protected page: Page) {
+    super(page.getByTestId('cancel-subscribe-activity-confirm-modal'), page)
+  }
+
+  private getModalRoot () {
+    return this.page?.getByTestId('cancel-subscribe-activity-confirm-modal') ?? this.root
+  }
+
+  private getCancelButton () {
+    return this.getModalRoot().getByTestId('cancel-button')
+  }
+
+  private getConfirmButton () {
+    return this.getModalRoot().getByTestId('confirm-button')
+  }
+
+  private getTitle () {
+    return this.getModalRoot().getByTestId('cancel-subscribe-activity-confirm-modal__title')
+  }
+
+  async verify () {
+    await this.verifyVisible()
+
+    const expectedCancelButtonText = t('global.buttons.cancel')
+    await expect(this.getCancelButton()).toBeVisible()
+    await expect(this.getCancelButton()).toHaveText(expectedCancelButtonText)
+
+    const expectedConfirmButtonText = t('global.buttons.confirm')
+    await expect(this.getConfirmButton()).toBeVisible()
+    await expect(this.getConfirmButton()).toHaveText(expectedConfirmButtonText)
+
+    const expectedTitle = t('student.buildProject.activities.views.ProjectActivitiesCatalogView.overlays.CancelSubscribeActivityModal.title')
+    await expect(this.getTitle()).toBeVisible()
+    await expect(this.getTitle()).toHaveText(expectedTitle)
+  }
+
+  async verifyVisible () {
+    await expect(this.getTitle()).toBeVisible()
+  }
+
+  async verifyHidden () {
+    await this.isHidden()
+  }
+
+  async clickCancel () {
+    await this.getCancelButton().click()
+    await waitForPageLoad(this.page)
+  }
+
+  async clickConfirm () {
+    await this.getConfirmButton().click()
+    await waitForPageLoad(this.page)
+  }
+}

--- a/e2e/framework/student/lifeProject/activitiesCatalog/componentObjects/SubscribeActivityModal.ts
+++ b/e2e/framework/student/lifeProject/activitiesCatalog/componentObjects/SubscribeActivityModal.ts
@@ -1,0 +1,92 @@
+import { BaseObject } from '@e2e/framework/shared/base/BaseObject'
+import { t } from '@e2e/framework/shared/utils/i18n'
+import { waitForPageLoad } from '@e2e/framework/shared/utils/waits'
+import { CancelSubscribeActivityConfirmModal } from '@e2e/framework/student/lifeProject/activitiesCatalog/componentObjects/CancelSubscribeActivityConfirmModal'
+import { expect, type Page } from '@playwright/test'
+
+export class SubscribeActivityModal extends BaseObject {
+  constructor (protected page: Page) {
+    super(page.getByTestId('subscribe-activity-modal'), page)
+  }
+
+  private getModalRoot () {
+    return this.page?.getByTestId('subscribe-activity-modal') ?? this.root
+  }
+
+  private getCancelButton () {
+    return this.getModalRoot().getByTestId('cancel-button')
+  }
+
+  private getConfirmButton () {
+    return this.getModalRoot().getByTestId('confirm-button')
+  }
+
+  private getTitle () {
+    return this.getModalRoot().getByTestId('subscribe-activity-modal__title')
+  }
+
+  getCancelSubscribeActivityConfirmModal () {
+    return new CancelSubscribeActivityConfirmModal(this.page)
+  }
+
+  async verifyVisible () {
+    await this.isVisible()
+    await expect(this.getCancelButton()).toBeVisible()
+    await expect(this.getConfirmButton()).toBeVisible()
+    await expect(this.getTitle()).toBeVisible()
+  }
+
+  async verifyHidden () {
+    await this.isHidden()
+  }
+
+  async verify () {
+    await this.verifyVisible()
+
+    const expectedCancelButtonText = t('global.buttons.cancel')
+    await expect(this.getCancelButton()).toBeVisible()
+    await expect(this.getCancelButton()).toHaveText(expectedCancelButtonText)
+
+    const expectedConfirmButtonText = t('global.buttons.confirm')
+    await expect(this.getConfirmButton()).toBeVisible()
+    await expect(this.getConfirmButton()).toHaveText(expectedConfirmButtonText)
+
+    const expectedTitle = t('student.buildProject.activities.views.ProjectActivitiesCatalogView.overlays.ActivitySubscribeModal.title', { title: 'Définir ses valeurs' })
+    await expect(this.getTitle()).toBeVisible()
+    await expect(this.getTitle()).toHaveText(expectedTitle)
+  }
+
+  async clickCancel () {
+    await this.getCancelButton().click()
+    await waitForPageLoad(this.page)
+  }
+
+  async verifyCancelSubscribeActivityConfirmModal () {
+    const cancelSubscribeActivityConfirmModal = this.getCancelSubscribeActivityConfirmModal()
+    await cancelSubscribeActivityConfirmModal.verify()
+  }
+
+  async verifyCancelSubscribeActivityConfirmModalHidden () {
+    const cancelSubscribeActivityConfirmModal = this.getCancelSubscribeActivityConfirmModal()
+    await cancelSubscribeActivityConfirmModal.verifyHidden()
+  }
+
+  async clickCancelAndConfirm () {
+    await this.clickCancel()
+    const cancelSubscribeActivityConfirmModal = this.getCancelSubscribeActivityConfirmModal()
+    await cancelSubscribeActivityConfirmModal.verify()
+    await cancelSubscribeActivityConfirmModal.clickConfirm()
+  }
+
+  async clickCancelAndCancel () {
+    await this.clickCancel()
+    const cancelSubscribeActivityConfirmModal = this.getCancelSubscribeActivityConfirmModal()
+    await cancelSubscribeActivityConfirmModal.verify()
+    await cancelSubscribeActivityConfirmModal.clickCancel()
+  }
+
+  async clickConfirm () {
+    await this.getConfirmButton().click()
+    await waitForPageLoad(this.page)
+  }
+}

--- a/e2e/framework/student/lifeProject/activitiesCatalog/componentObjects/UnsubscribeActivitiesConfirmModal.ts
+++ b/e2e/framework/student/lifeProject/activitiesCatalog/componentObjects/UnsubscribeActivitiesConfirmModal.ts
@@ -1,0 +1,40 @@
+import { BaseObject } from '@e2e/framework/shared/base/BaseObject'
+import { t } from '@e2e/framework/shared/utils/i18n'
+import { waitForPageLoad } from '@e2e/framework/shared/utils/waits'
+import { expect, type Page } from '@playwright/test'
+
+export class UnsubscribeActivitiesConfirmModal extends BaseObject {
+  constructor (protected page: Page) {
+    super(page.getByTestId('unsubscribe-activities-confirm-modal'), page)
+  }
+
+  private getModalRoot () {
+    return this.page?.getByTestId('unsubscribe-activities-confirm-modal') ?? this.root
+  }
+
+  private getConfirmButton () {
+    return this.getModalRoot().getByTestId('confirm-button')
+  }
+
+  async verifyVisible () {
+    await this.isVisible()
+    await expect(this.getConfirmButton()).toBeVisible()
+  }
+
+  async verifyHidden () {
+    await this.isHidden()
+  }
+
+  async verify () {
+    await this.verifyVisible()
+
+    const expectedConfirmButtonText = t('global.buttons.confirm')
+    await expect(this.getConfirmButton()).toBeVisible()
+    await expect(this.getConfirmButton()).toHaveText(expectedConfirmButtonText)
+  }
+
+  async clickConfirm () {
+    await this.getConfirmButton().click()
+    await waitForPageLoad(this.page)
+  }
+}

--- a/e2e/tests/student/lifeProject/activitiesCatalog/activitiesCatalog.feature
+++ b/e2e/tests/student/lifeProject/activitiesCatalog/activitiesCatalog.feature
@@ -27,3 +27,50 @@ Feature: Student Project Activities Catalog Page
       And the first thematic in side navigation has at least 1 activity
       And the first thematic in side navigation first activity is "Définir ses valeurs"
       And the first thematic in side navigation last activity is "Identifier ses centres d’intérêt"
+
+  Rule: Activity preview - Desktop
+
+    @high @preview
+    Scenario: Student can see the activity preview
+      Then the activity preview is visible
+      And the activity preview is correctly displayed
+      And the activity preview subscribe button is visible
+
+  Rule: Activity subscription - Desktop
+
+    Background:
+      When the user clicks on the activity preview subscribe button
+
+      @high @subsribe
+      Scenario: Student can see the subscribe activity modal
+        Then the subscribe activity modal is displayed
+
+      @medium @subscribe
+      Scenario: Student can see the cancel subscribe modal
+        When the user clicks on the activity preview subscribe modal cancel button
+        Then the cancel subscribe activity confirm modal is displayed
+
+      @low @subscribe
+      Scenario: Student can confirm the cancel subscribe modal
+        When the user clicks on the activity preview subscribe modal cancel button and confirms
+        Then the cancel subscribe activity confirm modal is hidden
+        And the subscribe activity modal is hidden
+
+      @low @subscribe
+      Scenario: Student can cancel the cancel subscribe modal
+        When the user clicks on the activity preview subscribe modal cancel button and cancels
+        Then the cancel subscribe activity confirm modal is hidden
+        And the subscribe activity modal is displayed
+
+      @high @subscribe
+      Scenario: Student can subscribe to the activity and unsubscribe from it right after
+        When the user clicks on the activity preview subscribe modal confirm button
+        Then the subscribe activity modal is hidden
+        And the activity preview unsubscribe button is visible
+        And the activity preview subscribe button is hidden
+        When the user clicks on the activity preview unsubscribe button
+        Then the unsubscribe activities confirm modal is displayed
+        When the user clicks on the activity preview unsubscribe activities confirm modal confirm button
+        Then the activity preview unsubscribe activities confirm modal is hidden
+        And the activity preview subscribe button is visible
+        And the activity preview unsubscribe button is hidden

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "avenirs-cofolio-client",
       "version": "0.0.0",
       "dependencies": {
-        "@avenirs-esr/avenirs-dsav": "^0.1.156",
+        "@avenirs-esr/avenirs-dsav": "^0.1.158",
         "@tanstack/vue-form": "^1.15.0",
         "@tanstack/vue-query": "^5.74.9",
         "@vue-flow/core": "^1.48.0",
@@ -392,9 +392,9 @@
       }
     },
     "node_modules/@avenirs-esr/avenirs-dsav": {
-      "version": "0.1.156",
-      "resolved": "https://registry.npmjs.org/@avenirs-esr/avenirs-dsav/-/avenirs-dsav-0.1.156.tgz",
-      "integrity": "sha512-98pYvYL8arSLKffg7AgbVxwLL1chuYyNwdJLIOgmWPfY3lQjGCIfjB8rfz+l8V+3H+8CbaeyUyJtfn+Av1Qyuw==",
+      "version": "0.1.158",
+      "resolved": "https://registry.npmjs.org/@avenirs-esr/avenirs-dsav/-/avenirs-dsav-0.1.158.tgz",
+      "integrity": "sha512-ODElseeJotqAeZ36a2Q8xl2Un8Nx/5tUNYLIDkJoXbtDmrTDCzqFusEhK3uue5AS16Lv5GN/HTVrI4yMQhjhWg==",
       "dependencies": {
         "@vueuse/core": "^13.9.0",
         "date-fns": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
-    "@avenirs-esr/avenirs-dsav": "^0.1.156",
+    "@avenirs-esr/avenirs-dsav": "^0.1.158",
     "@tanstack/vue-form": "^1.15.0",
     "@tanstack/vue-query": "^5.74.9",
     "@vue-flow/core": "^1.48.0",

--- a/src/__mocks__/fixtures/student/activities.fixtures.ts
+++ b/src/__mocks__/fixtures/student/activities.fixtures.ts
@@ -182,6 +182,7 @@ export const mockedDeclaredActivity: DeclaredActivity = {
 // TODO: changes this to activities returned by seeder in dev
 export const mockedDeclaredActivityViewDTO: DeclaredActivityViewDTO = {
   id: 'declared-activity-1',
+  activityId: 'declared-activity-1',
   title: 'Activité "Connaissance de soi" : Définir ses valeurs',
   thematic: EActivityThematic.SELF_KNOWLEDGE,
   status: EDeclaredActivityStatus.IN_PROGRESS,
@@ -194,6 +195,7 @@ const allDeclaredActivities: DeclaredActivityViewDTO[] = [
   mockedDeclaredActivityViewDTO,
   {
     id: 'declared-activity-2',
+    activityId: 'declared-activity-2',
     title: 'Activité "CV" : Construire son parcours',
     thematic: EActivityThematic.RESUMES,
     status: EDeclaredActivityStatus.SUBSCRIBED,
@@ -201,6 +203,7 @@ const allDeclaredActivities: DeclaredActivityViewDTO[] = [
   },
   {
     id: 'declared-activity-3',
+    activityId: 'declared-activity-3',
     title: 'Activité "Trajectoires" : Explorer ses voies',
     thematic: EActivityThematic.TRAJECTORIES,
     status: EDeclaredActivityStatus.COMPLETED,
@@ -210,6 +213,7 @@ const allDeclaredActivities: DeclaredActivityViewDTO[] = [
   },
   {
     id: 'declared-activity-4',
+    activityId: 'declared-activity-4',
     title: 'Activité "Expériences" : Valoriser ses expériences',
     thematic: EActivityThematic.EXPERIENCES,
     status: EDeclaredActivityStatus.IN_PROGRESS,
@@ -218,6 +222,7 @@ const allDeclaredActivities: DeclaredActivityViewDTO[] = [
   },
   {
     id: 'declared-activity-5',
+    activityId: 'declared-activity-5',
     title: 'Activité "Trajectoires" : Construire son projet professionnel',
     thematic: EActivityThematic.TRAJECTORIES,
     status: EDeclaredActivityStatus.SUBSCRIBED,
@@ -225,6 +230,7 @@ const allDeclaredActivities: DeclaredActivityViewDTO[] = [
   },
   {
     id: 'declared-activity-6',
+    activityId: 'declared-activity-6',
     title: 'Activité "Connaissance de soi" : Identifier ses compétences',
     thematic: EActivityThematic.SELF_KNOWLEDGE,
     status: EDeclaredActivityStatus.COMPLETED,
@@ -256,6 +262,7 @@ for (let i = 0; i < 10; i++) {
   allDeclaredActivitiesLarge.push(...allDeclaredActivities.map(activity => ({
     ...activity,
     id: `${activity.id}-${i + 1}`,
+    activityId: `${activity.activityId}-${i + 1}`,
     title: `${activity.title} (${i + 1})`
   })))
 }

--- a/src/__mocks__/msw/handlers/student/activities.handlers.ts
+++ b/src/__mocks__/msw/handlers/student/activities.handlers.ts
@@ -18,8 +18,8 @@ import {
   getGetDeclaredActivitiesViewUrl,
   getGetDeclaredActivityDetailsUrl,
   getGetLatestActivitiesViewUrl,
-  getSubscribeUrl,
-  getUnsubscribeUrl,
+  getSubscribeActivityUrl,
+  getUnsubscribeActivitiesProgressesUrl,
   type PagedResponseDeclaredActivityViewDTO,
 } from '@/api/avenir-esr'
 import { delay, http, HttpResponse } from 'msw'
@@ -55,7 +55,7 @@ export const activityNavigationQuery = http.get(`*${getGetActivityNavigationUrl(
   })
 })
 
-const subscribeActivityProgressHandler = http.post(`*${getSubscribeUrl(':activityId')}`, async ({ params }) => {
+const subscribeActivityProgressHandler = http.post(`*${getSubscribeActivityUrl(':activityId')}`, async ({ params }) => {
   const { activityId } = params
 
   if (activityId === 'INVALID_ACTIVITY_ID') {
@@ -70,7 +70,7 @@ const subscribeActivityProgressHandler = http.post(`*${getSubscribeUrl(':activit
   })
 })
 
-const unsubscribeActivityProgressHandler = http.delete(`*${getUnsubscribeUrl()}`, async ({ request }) => {
+const unsubscribeActivityProgressHandler = http.delete(`*${getUnsubscribeActivitiesProgressesUrl()}`, async ({ request }) => {
   const activitiesIds = await request.json() as string[]
 
   if (activitiesIds.length === 0) {

--- a/src/common/components/ConfirmationModal/ConfirmationModal.vue
+++ b/src/common/components/ConfirmationModal/ConfirmationModal.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
+import type { Slot } from 'vue'
 import { AvModal, type AvModalProps } from '@avenirs-esr/avenirs-dsav'
-import { type Slot, useAttrs } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 export interface ConfirmationModalProps extends Omit<AvModalProps, 'closeButtonLabel'> {
@@ -22,7 +22,6 @@ defineSlots<{
 }>()
 
 const { t } = useI18n()
-const attrs = useAttrs()
 </script>
 
 <template>
@@ -31,7 +30,7 @@ const attrs = useAttrs()
     :opened="show"
     :close-button-label="t('global.buttons.cancel')"
     :confirm-button-label="confirmButtonLabel ?? t('global.buttons.confirm')"
-    v-bind="attrs"
+    v-bind="$attrs"
   >
     <template
       v-if="$slots.header"

--- a/src/common/components/ConfirmationModal/ConfirmationModal.vue
+++ b/src/common/components/ConfirmationModal/ConfirmationModal.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
-import type { Slot } from 'vue'
 import { AvModal, type AvModalProps } from '@avenirs-esr/avenirs-dsav'
+import { type Slot, useAttrs } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 export interface ConfirmationModalProps extends Omit<AvModalProps, 'closeButtonLabel'> {
@@ -10,6 +10,10 @@ export interface ConfirmationModalProps extends Omit<AvModalProps, 'closeButtonL
   closeButtonLabel?: string
 }
 
+defineOptions({
+  inheritAttrs: false
+})
+
 defineProps<ConfirmationModalProps>()
 
 defineSlots<{
@@ -18,6 +22,7 @@ defineSlots<{
 }>()
 
 const { t } = useI18n()
+const attrs = useAttrs()
 </script>
 
 <template>
@@ -26,7 +31,7 @@ const { t } = useI18n()
     :opened="show"
     :close-button-label="t('global.buttons.cancel')"
     :confirm-button-label="confirmButtonLabel ?? t('global.buttons.confirm')"
-    v-bind="$attrs"
+    v-bind="attrs"
   >
     <template
       v-if="$slots.header"

--- a/src/features/student/buildProject/components/cards/ActivityCard/ActivityCard.vue
+++ b/src/features/student/buildProject/components/cards/ActivityCard/ActivityCard.vue
@@ -22,7 +22,7 @@ const iconOptions = {
 
 <template>
   <RouterLink
-    :to="{ name: ROUTES.STUDENT.PROJECT_ACTIVITIES_CATALOG.name, params: { id: activity.id, theme: activity.thematic } }"
+    :to="{ name: ROUTES.STUDENT.PROJECT_ACTIVITIES_CATALOG.name, params: { id: activity.id, thematic: activity.thematic } }"
     class="activity-card"
   >
     <FloatingIconCard

--- a/src/features/student/buildProject/components/modals/UnsubscribeActivitiesConfirmModal/UnsubscribeActivitiesConfirmModal.vue
+++ b/src/features/student/buildProject/components/modals/UnsubscribeActivitiesConfirmModal/UnsubscribeActivitiesConfirmModal.vue
@@ -42,6 +42,7 @@ function onConfirm () {
 <template>
   <ConfirmationModal
     :show="show"
+    data-testid="unsubscribe-activities-confirm-modal"
     @close="$emit('cancel')"
     @confirm="onConfirm"
   >

--- a/src/features/student/buildProject/queries/use-activities.query/use-activities.query.test.ts
+++ b/src/features/student/buildProject/queries/use-activities.query/use-activities.query.test.ts
@@ -15,7 +15,8 @@ import {
   type DeclaredActivity,
   type DeclaredActivityDetailsDTO,
   EActivityThematic,
-  type getDeclaredActivitiesView
+  type getDeclaredActivitiesView,
+  type SubscribeDeclaredActivityRequestDTO
 } from '@/api/avenir-esr'
 import {
   type SubscribeActivityVariables,
@@ -157,7 +158,7 @@ BddTest().given('the useActivityDetailQuery composable', () => {
 
 BddTest().given('the useSubscribeActivityMutation composable', () => {
   let subscribeActivitySpy: MockInstance<
-    (activityId: string, options?: RequestInit | undefined) => Promise<DeclaredActivity>
+    (activityId: string, params: SubscribeDeclaredActivityRequestDTO, options?: RequestInit | undefined) => Promise<DeclaredActivity>
   >
   let useInvalidateQuerySpy: MockInstance<typeof useInvalidateQuery>
   let mutationResult: ReturnType<typeof useSubscribeActivityMutation>
@@ -175,9 +176,9 @@ BddTest().given('the useSubscribeActivityMutation composable', () => {
     vi.clearAllMocks()
     vi.restoreAllMocks()
 
-    subscribeActivitySpy = vi.spyOn<typeof import('@/api/avenir-esr'), 'subscribe'>(
+    subscribeActivitySpy = vi.spyOn<typeof import('@/api/avenir-esr'), 'subscribeActivity'>(
       await import('@/api/avenir-esr'),
-    'subscribe',
+    'subscribeActivity',
     )
 
     useInvalidateQuerySpy = vi.spyOn<typeof import('@/common/composables'), 'useInvalidateQuery'>(
@@ -202,7 +203,7 @@ BddTest().given('the useSubscribeActivityMutation composable', () => {
       })
 
       BddTest().then('it should call the subscribeActivity API with correct parameters', () => {
-        expect(subscribeActivitySpy).toHaveBeenCalledWith(activityId)
+        expect(subscribeActivitySpy).toHaveBeenCalledWith(activityId, expect.anything())
         expect(subscribeActivitySpy).toHaveBeenCalledTimes(1)
       })
 
@@ -239,7 +240,7 @@ BddTest().given('the useSubscribeActivityMutation composable', () => {
       })
 
       BddTest().then('it should call the subscribeActivity API with correct parameters', () => {
-        expect(subscribeActivitySpy).toHaveBeenCalledWith(activityId)
+        expect(subscribeActivitySpy).toHaveBeenCalledWith(activityId, expect.anything())
         expect(subscribeActivitySpy).toHaveBeenCalledTimes(1)
       })
 
@@ -266,7 +267,7 @@ BddTest().given('the useSubscribeActivityMutation composable', () => {
       })
 
       BddTest().then('it should call the subscribeActivity API with correct parameters', () => {
-        expect(subscribeActivitySpy).toHaveBeenCalledWith(activityId)
+        expect(subscribeActivitySpy).toHaveBeenCalledWith(activityId, expect.anything())
         expect(subscribeActivitySpy).toHaveBeenCalledTimes(1)
       })
 
@@ -297,7 +298,7 @@ BddTest().given('the useSubscribeActivityMutation composable', () => {
       })
 
       BddTest().then('it should call the subscribeActivity API with the invalid parameters', () => {
-        expect(subscribeActivitySpy).toHaveBeenCalledWith(activityId)
+        expect(subscribeActivitySpy).toHaveBeenCalledWith(activityId, expect.anything())
         expect(subscribeActivitySpy).toHaveBeenCalledTimes(1)
       })
 
@@ -334,7 +335,7 @@ BddTest().given('the useSubscribeActivityMutation composable', () => {
       })
 
       BddTest().then('it should call the subscribeActivity API with the invalid parameters', () => {
-        expect(subscribeActivitySpy).toHaveBeenCalledWith(activityId)
+        expect(subscribeActivitySpy).toHaveBeenCalledWith(activityId, expect.anything())
         expect(subscribeActivitySpy).toHaveBeenCalledTimes(1)
       })
 
@@ -370,9 +371,9 @@ BddTest().given('the useUnsubscribeActivitiesMutation composable', () => {
     vi.clearAllMocks()
     vi.restoreAllMocks()
 
-    unsubscribeActivityProgressSpy = vi.spyOn<typeof import('@/api/avenir-esr'), 'unsubscribe'>(
+    unsubscribeActivityProgressSpy = vi.spyOn<typeof import('@/api/avenir-esr'), 'unsubscribeActivitiesProgresses'>(
       await import('@/api/avenir-esr'),
-    'unsubscribe',
+    'unsubscribeActivitiesProgresses',
     )
 
     useInvalidateQuerySpy = vi.spyOn<typeof import('@/common/composables'), 'useInvalidateQuery'>(

--- a/src/features/student/buildProject/queries/use-activities.query/use-activities.query.ts
+++ b/src/features/student/buildProject/queries/use-activities.query/use-activities.query.ts
@@ -17,8 +17,8 @@ import {
   getLatestActivitiesView,
   type PagedResponseActivityOverviewDTO,
   type PagedResponseDeclaredActivityViewDTO,
-  subscribe,
-  unsubscribe
+  subscribeActivity,
+  unsubscribeActivitiesProgresses
 } from '@/api/avenir-esr'
 import { useInvalidateQuery } from '@/common/composables'
 import { commonQueryKeys } from '@/features/student/global'
@@ -181,7 +181,8 @@ export function useSubscribeActivityMutation ({ onError, onSuccess }: MutationAr
   const invalidateQueryKey = useInvalidateQuery()
   return useMutation<DeclaredActivity, BaseApiException, SubscribeActivityVariables>({
     mutationFn: async ({ activityId }: SubscribeActivityVariables): Promise<DeclaredActivity> => {
-      return await subscribe(activityId)
+      // TODO: startDate and endDate US#???
+      return await subscribeActivity(activityId, { startDate: new Date().toISOString(), endDate: new Date().toISOString() })
     },
     onSuccess: async (data, variables) => {
       await invalidateQueryKey([...activityDetailsQueryKey, variables.activityId])
@@ -199,7 +200,7 @@ export function useUnsubscribeActivitiesMutation ({ onError, onSuccess }: Mutati
   const invalidateQueryKey = useInvalidateQuery()
   return useMutation<string, BaseApiException, UnsubscribeActivitiesVariables>({
     mutationFn: async ({ activitiesIds }: UnsubscribeActivitiesVariables): Promise<string> => {
-      return await unsubscribe(activitiesIds)
+      return await unsubscribeActivitiesProgresses(activitiesIds)
     },
     onSuccess: async (data, variables) => {
       await Promise.all(

--- a/src/features/student/buildProject/views/ProjectActivitiesCatalogView/components/ActivityPreview/ActivityPreview.vue
+++ b/src/features/student/buildProject/views/ProjectActivitiesCatalogView/components/ActivityPreview/ActivityPreview.vue
@@ -20,7 +20,10 @@ const { showModal: showSubscribeModal, displayModal: displaySubscribeModal, hide
 </script>
 
 <template>
-  <div class="av-col av-gap-lg">
+  <div
+    class="av-col av-gap-lg"
+    data-testid="activity-preview"
+  >
     <AvCard
       v-if="activity.banner"
       background-color="var(--card2)"
@@ -42,9 +45,13 @@ const { showModal: showSubscribeModal, displayModal: displaySubscribeModal, hide
       typography-class="n2"
       gap="var(--spacing-md)"
       inline
+      data-testid="activity-title"
     />
     <div class="av-row av-wrap av-gap-xs av-pl-5xl">
-      <ActivityThematicBadge :thematic="activity.thematic" />
+      <ActivityThematicBadge
+        :thematic="activity.thematic"
+        data-testid="activity-thematic-badge"
+      />
     </div>
     <AvCard
       background-color="var(--card2)"
@@ -98,7 +105,6 @@ const { showModal: showSubscribeModal, displayModal: displaySubscribeModal, hide
   </div>
 
   <UnsubscribeActivitiesConfirmModal
-    v-if="activity.isSubscribed"
     :show="showUnsubscribeModal"
     :activities="[{ id: activity.id, title: activity.title }]"
     @cancel="hideUnsubscribeModal"
@@ -106,7 +112,6 @@ const { showModal: showSubscribeModal, displayModal: displaySubscribeModal, hide
   />
 
   <SubscribeActivityModal
-    v-else
     :show="showSubscribeModal"
     :activity="{ id: activity.id, title: activity.title }"
     @cancel="hideSubscribeModal"

--- a/src/features/student/buildProject/views/ProjectActivitiesCatalogView/components/overlays/CancelSubscribeActivityConfirmModal/CancelSubscribeActivityConfirmModal.vue
+++ b/src/features/student/buildProject/views/ProjectActivitiesCatalogView/components/overlays/CancelSubscribeActivityConfirmModal/CancelSubscribeActivityConfirmModal.vue
@@ -19,6 +19,7 @@ const { t } = useI18n()
 <template>
   <ConfirmationModal
     :show="show"
+    data-testid="cancel-subscribe-activity-confirm-modal"
     @close="$emit('cancel')"
     @confirm="$emit('confirm')"
   >
@@ -27,7 +28,10 @@ const { t } = useI18n()
         class="av-row av-flex-fill"
         data-testid="cancel-subscribe-activity-confirm-modal__header"
       >
-        <span class="b2-bold av-text-text1">
+        <span
+          class="b2-bold av-text-text1"
+          data-testid="cancel-subscribe-activity-confirm-modal__title"
+        >
           {{ t('student.buildProject.activities.views.ProjectActivitiesCatalogView.overlays.CancelSubscribeActivityModal.title') }}
         </span>
       </div>

--- a/src/features/student/buildProject/views/ProjectActivitiesCatalogView/components/overlays/SubscribeActivityModal/SubscribeActivityModal.vue
+++ b/src/features/student/buildProject/views/ProjectActivitiesCatalogView/components/overlays/SubscribeActivityModal/SubscribeActivityModal.vue
@@ -54,6 +54,7 @@ function onConfirmCancelSubscribe () {
 <template>
   <ConfirmationModal
     :show="show"
+    data-testid="subscribe-activity-modal"
     @close="displayCancelSubscribeConfirmModal"
     @confirm="subscribe({ activityId: activity.id })"
   >
@@ -62,7 +63,10 @@ function onConfirmCancelSubscribe () {
         class="av-row av-flex-fill"
         data-testid="subscribe-activity-modal__header"
       >
-        <span class="b2-bold av-text-text1">
+        <span
+          class="b2-bold av-text-text1"
+          data-testid="subscribe-activity-modal__title"
+        >
           {{ t('student.buildProject.activities.views.ProjectActivitiesCatalogView.overlays.ActivitySubscribeModal.title', { title: activity.title }) }}
         </span>
       </div>

--- a/src/features/student/buildProject/views/ProjectActivitiesView/components/ActivityLibraryCard/ActivityLibraryCard.test.ts
+++ b/src/features/student/buildProject/views/ProjectActivitiesView/components/ActivityLibraryCard/ActivityLibraryCard.test.ts
@@ -39,6 +39,7 @@ BddTest().given('an ActivityLibraryCard', () => {
 
   const baseActivity = {
     id: '1',
+    activityId: '1',
     title: 'Activité "Connaissance de soi" : Définir ses valeurs',
     thematic: EActivityThematic.SELF_KNOWLEDGE,
     status: EDeclaredActivityStatus.SUBSCRIBED,

--- a/src/features/student/buildProject/views/ProjectActivitiesView/components/ActivityLibraryCard/ActivityLibraryCard.vue
+++ b/src/features/student/buildProject/views/ProjectActivitiesView/components/ActivityLibraryCard/ActivityLibraryCard.vue
@@ -30,7 +30,7 @@ const titleClasses = computed(() => isMobile.value
 
 <template>
   <RouterLink
-    :to="{ name: ROUTES.STUDENT.PROJECT_ACTIVITIES_DETAILED.name, params: { id: activity.id, theme: activity.thematic } }"
+    :to="{ name: ROUTES.STUDENT.PROJECT_ACTIVITIES_DETAILED.name, params: { id: activity.id, thematic: activity.thematic } }"
     class="activity-library-card"
   >
     <FloatingIconCard

--- a/src/features/student/buildProject/views/ProjectActivitiesView/components/overlays/ActivitiesSelector/ActivitiesSelector.vue
+++ b/src/features/student/buildProject/views/ProjectActivitiesView/components/overlays/ActivitiesSelector/ActivitiesSelector.vue
@@ -1,10 +1,9 @@
 <script setup lang="ts">
-import type { ActivityItemNavigationDTO } from '@/api/avenir-esr'
 import ActivityCompactCard from '@/features/student/buildProject/views/ProjectActivitiesView/components/cards/ActivityCompactCard/ActivityCompactCard.vue'
 import SelectorOverlay from '@/features/student/global/components/interaction/SelectorOverlay/SelectorOverlay.vue'
 
 export interface ActivitiesSelectorProps {
-  activities: ActivityItemNavigationDTO[]
+  activities: { id: string, title: string }[]
   readonly?: boolean
 }
 

--- a/src/features/student/buildProject/views/ProjectActivitiesView/components/overlays/UnsubscribeActivitiesModal/UnsubscribeActivitiesModal.vue
+++ b/src/features/student/buildProject/views/ProjectActivitiesView/components/overlays/UnsubscribeActivitiesModal/UnsubscribeActivitiesModal.vue
@@ -98,14 +98,14 @@ useInfiniteScroll(
       <ActivitiesSelector
         v-if="activities.length > 0"
         v-model="selectedActivityIds"
-        :activities="activities"
+        :activities="activities.map(activity => ({ id: activity.activityId, title: activity.title }))"
       />
     </div>
   </AvModal>
 
   <UnsubscribeActivitiesConfirmModal
     :show="showConfirmModal"
-    :activities="activities.filter(activity => selectedActivityIds.includes(activity.id))"
+    :activities="activities.filter(activity => selectedActivityIds.includes(activity.activityId))"
     @cancel="hideConfirmModal"
     @unsubscribed="onUnsubscribeSuccess"
   />


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
Ajout des tests E2E pour l'US#979 sur l'inscription et la désinscription à une activité dans le catalogue des activités du projet de vie étudiant. Le scénario "Student can subscribe to the activity" a été enrichi pour inclure la désinscription immédiatement après l'inscription, garantissant ainsi un état propre pour les tests suivants.

**Principaux changements :**
- ✅ Ajout d'un scénario E2E pour l'inscription et la désinscription à une activité
- 📝 Mise à jour du fichier activitiesCatalog.feature pour couvrir le workflow complet

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1119

---

### Documentation
- Ajout d'un scénario dans `e2e/tests/student/lifeProject/activitiesCatalog/activitiesCatalog.feature` pour tester l'inscription et la désinscription à une activité

---

### Target Branch
`develop`

---

### Additional Notes
Ce scénario assure que l'état d'abonnement de l'activité est réinitialisé à la fin du test, évitant ainsi les effets de bord sur les autres scénarios E2E.

---

### Known Limitations or Side Effects
Aucune limitation ou effet de bord connu.

---

## ✅ Checklist

- [ ] a11y tested (si le PR inclut des changements frontend)
- [ ] Tests fournis (y compris unitaires et intégration frontend/backend)
- [ ] i18n géré (textes traduits)
- [ ] Tests de performance
- [ ] Pas de code inutile (logs de debug, code commenté)
- [ ] Respect des règles de style et de formatage (lint, conventions, etc.)
- [ ] Versionnement sémantique respecté
- [ ] Ajout dans le fichier `CHANGELOG.md` de toutes les propriétés et changements de base de données et détails pour le process de mise à jour
