### PR TITLE
fix(1182): fix unsubscribe from activity feature

### DIFF
--- a/src/features/student/buildProject/queries/use-activities.query/use-activities.query.test.ts
+++ b/src/features/student/buildProject/queries/use-activities.query/use-activities.query.test.ts
@@ -414,7 +414,7 @@ BddTest().given('the useUnsubscribeActivitiesMutation composable', () => {
 
       BddTest().then('it should call the invalidation function', () => {
         expect(useInvalidateQuerySpy).toHaveBeenCalledTimes(1)
-        expect(mockInvalidateFunction).toHaveBeenCalledTimes(elementsIds.length)
+        expect(mockInvalidateFunction).toHaveBeenCalledTimes(elementsIds.length + 1)
       })
 
       BddTest().then('it should call the custom onSuccess callback', () => {
@@ -444,7 +444,7 @@ BddTest().given('the useUnsubscribeActivitiesMutation composable', () => {
       })
 
       BddTest().then('it should call the invalidation function', () => {
-        expect(mockInvalidateFunction).toHaveBeenCalledTimes(elementsIds.length)
+        expect(mockInvalidateFunction).toHaveBeenCalledTimes(elementsIds.length + 1)
       })
     })
   })
@@ -467,7 +467,7 @@ BddTest().given('the useUnsubscribeActivitiesMutation composable', () => {
       })
 
       BddTest().then('it should still call the invalidation function', () => {
-        expect(mockInvalidateFunction).toHaveBeenCalledTimes(elementsIds.length)
+        expect(mockInvalidateFunction).toHaveBeenCalledTimes(elementsIds.length + 1)
       })
 
       BddTest().then('it should mark the mutation as successful', () => {

--- a/src/features/student/buildProject/queries/use-activities.query/use-activities.query.ts
+++ b/src/features/student/buildProject/queries/use-activities.query/use-activities.query.ts
@@ -101,7 +101,7 @@ export function useCountActivitiesQuery () {
     return await getActivitiesView({
       page: 0,
       pageSize: 1
-    } as GetActivitiesViewParams)
+    })
   })
 
   return useQuery<PagedResponseActivityOverviewDTO, BaseApiException, number>({
@@ -225,6 +225,7 @@ export function useUnsubscribeActivitiesMutation ({ onError, onSuccess }: Mutati
       await Promise.all(
         variables.activitiesIds.map(activityId => invalidateQueryKey([...activityDetailsQueryKey, activityId])),
       )
+      await invalidateQueryKey(libraryActivitiesQueryKey)
       onSuccess?.(data, variables)
     },
     onError

--- a/src/features/student/buildProject/views/ProjectActivitiesView/components/overlays/UnsubscribeActivitiesModal/UnsubscribeActivitiesModal.test.ts
+++ b/src/features/student/buildProject/views/ProjectActivitiesView/components/overlays/UnsubscribeActivitiesModal/UnsubscribeActivitiesModal.test.ts
@@ -4,7 +4,7 @@ import { server } from '@/__mocks__/msw/server'
 import { UnsubscribeActivitiesConfirmModalStub } from '@/features/student/buildProject/components/modals/UnsubscribeActivitiesConfirmModal/UnsubscribeActivitiesConfirmModal.stub'
 import { ActivitiesSelectorStub } from '@/features/student/buildProject/views/ProjectActivitiesView/components/overlays/ActivitiesSelector/ActivitiesSelector.stub'
 import UnsubscribeActivitiesModal, { type UnsubscribeActivitiesModalProps } from '@/features/student/buildProject/views/ProjectActivitiesView/components/overlays/UnsubscribeActivitiesModal/UnsubscribeActivitiesModal.vue'
-import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { AvModalStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { mockAddErrorMessage, mockAddSuccessMessage } from 'tests/mocks'
 import { mountComponent } from 'tests/utils'
 import { beforeEach, expect } from 'vitest'
@@ -18,18 +18,6 @@ vi.mock('@/store', async (importOriginal) => {
       addErrorMessage: mockAddErrorMessage
     })
   }
-})
-
-const AvModalStub = defineComponent({
-  name: 'AvModal',
-  template: `
-      <div class="av-modal-stub">
-        <slot name="header" />
-        <slot />
-      </div>
-    `,
-  props: ['opened', 'id', 'closeButtonLabel', 'confirmButtonLabel', 'confirmButtonIcon', 'confirmButtonDisabled'],
-  emits: ['close', 'confirm']
 })
 
 BddTest().given('an unsubscribe activities modal', () => {

--- a/src/features/student/buildProject/views/ProjectActivitiesView/components/overlays/UnsubscribeActivitiesModal/UnsubscribeActivitiesModal.vue
+++ b/src/features/student/buildProject/views/ProjectActivitiesView/components/overlays/UnsubscribeActivitiesModal/UnsubscribeActivitiesModal.vue
@@ -27,11 +27,13 @@ const {
 } = useModal()
 
 const {
-  activities,
+  activities: activityLibrary,
   isFetching,
   hasMoreActivities,
   loadMoreActivities,
 } = usePaginatedLibraryActivities(computed(() => show))
+
+const activities = computed(() => activityLibrary.value.map(activity => ({ id: activity.activityId, title: activity.title })))
 
 function onUnsubscribeSuccess () {
   hideConfirmModal()
@@ -98,14 +100,14 @@ useInfiniteScroll(
       <ActivitiesSelector
         v-if="activities.length > 0"
         v-model="selectedActivityIds"
-        :activities="activities.map(activity => ({ id: activity.activityId, title: activity.title }))"
+        :activities="activities"
       />
     </div>
   </AvModal>
 
   <UnsubscribeActivitiesConfirmModal
     :show="showConfirmModal"
-    :activities="activities.filter(activity => selectedActivityIds.includes(activity.activityId))"
+    :activities="activities.filter(({ id }) => selectedActivityIds.includes(id))"
     @cancel="hideConfirmModal"
     @unsubscribed="onUnsubscribeSuccess"
   />

--- a/src/plugins/tanstack-query/tanstack-query.test.ts
+++ b/src/plugins/tanstack-query/tanstack-query.test.ts
@@ -16,8 +16,7 @@ BddTest().given('a tanstack query plugin', () => {
         queryClientConfig: {
           defaultOptions: {
             queries: {
-              retry: 3,
-              staleTime: 120000
+              retry: 2,
             },
             mutations: {
               retry: 1,

--- a/src/plugins/tanstack-query/tanstack-query.ts
+++ b/src/plugins/tanstack-query/tanstack-query.ts
@@ -1,16 +1,13 @@
 import type { App } from 'vue'
 import { VueQueryPlugin, type VueQueryPluginOptions } from '@tanstack/vue-query'
 
-const DEFAULT_STALE_TIME = 2 * 60 * 1000
-
 export default {
   install (app: App) {
     const queryOptions: VueQueryPluginOptions = {
       queryClientConfig: {
         defaultOptions: {
           queries: {
-            retry: 3,
-            staleTime: DEFAULT_STALE_TIME,
+            retry: 2,
           },
           mutations: {
             retry: 1,


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> Correction du bug de désinscription d'une activité : invalidation du cache de la liste des activités après désinscription, correction du composant modal pour une meilleure gestion des états, et ajustement de la configuration TanStack Query (retry réduit de 3 à 2, suppression du staleTime global).

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1182

---

### Documentation
> Aucune mise à jour documentaire requise.

---

### Target Branch
> `develop`

---

### Additional Notes
> - L'invalidation de `libraryActivitiesQueryKey` après une désinscription était manquante, ce qui empêchait la liste de se rafraîchir correctement.
> - Le cast `as GetActivitiesViewParams` dans `useCountActivitiesQuery` a été supprimé car il masquait une erreur de typage.
> - Le `staleTime` global a été retiré pour laisser TanStack Query utiliser sa valeur par défaut (`0`), évitant les données périmées lors de navigations rapides.

---

### Known Limitations or Side Effects
> Aucun effet de bord identifié.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [x] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process