### PR TITLE
feat(1133): add e2e tests for unsubscribe feature from library tab

### DIFF
--- a/e2e/framework/shared/fixtures/fixtures.ts
+++ b/e2e/framework/shared/fixtures/fixtures.ts
@@ -48,4 +48,4 @@ export const test = base.extend<Fixtures>({
   },
 })
 
-export const { BeforeScenario } = createBdd(test)
+export const { BeforeScenario, AfterScenario } = createBdd(test)

--- a/e2e/framework/student/lifeProject/activities/StudentProjectActivitiesPage.ts
+++ b/e2e/framework/student/lifeProject/activities/StudentProjectActivitiesPage.ts
@@ -1,13 +1,19 @@
 import type { test } from '@e2e/framework/shared/fixtures/fixtures'
+import type { StudentProjectActivitiesCatalogPage } from '@e2e/framework/student/lifeProject/activitiesCatalog/StudentProjectActivitiesCatalog'
 import type { Page } from '@playwright/test'
 import { BasePage } from '@e2e/framework/shared/base/BasePage'
+import { t } from '@e2e/framework/shared/utils/i18n'
 import { ActivityLibraryTab } from '@e2e/framework/student/lifeProject/activities/componentObjects/ActivityLibraryTab'
 import { AllActivitiesTabs } from '@e2e/framework/student/lifeProject/activities/componentObjects/AllActivitiesTabs'
+import { expect } from '@playwright/test'
 import { Fixture, Given, Then, When } from 'playwright-bdd/decorators'
 
 export
 @Fixture<typeof test>('studentProjectActivitiesPage')
 class StudentProjectActivitiesPage extends BasePage {
+  private unsubscribedActivityId?: string = undefined
+  private unsubscribedActivityThematic?: string = undefined
+
   constructor (public page: Page) {
     super(page)
   }
@@ -22,6 +28,13 @@ class StudentProjectActivitiesPage extends BasePage {
 
   getActivityLibraryTabItem () {
     return this.page.getByTestId('activity-library-tab-item')
+  }
+
+  async restoreActivitySubscription (catalogPage: StudentProjectActivitiesCatalogPage) {
+    if (!this.unsubscribedActivityId || !this.unsubscribedActivityThematic) {
+      return
+    }
+    await catalogPage.subscribeActivityById(this.unsubscribedActivityThematic, this.unsubscribedActivityId)
   }
 
   @Given('the all activities tab is visible')
@@ -137,5 +150,32 @@ class StudentProjectActivitiesPage extends BasePage {
   @Then('the activity library page contains elements')
   async verifyActivityLibraryPageNotEmpty () {
     await this.getActivityLibraryTab().verifyCardsNotEmpty()
+  }
+
+  @When('the user opens the unsubscribe activities modal')
+  async openUnsubscribeActivitiesModal () {
+    this.unsubscribedActivityId = await this.getActivityLibraryTab().getCardByIndex(0).getActivityId()
+    this.unsubscribedActivityThematic = await this.getActivityLibraryTab().getCardByIndex(0).getActivityThematic()
+    await this.getActivityLibraryTab().getDropdown().clickUnsubscribe()
+  }
+
+  @When('the user selects the first activity in the unsubscribe modal')
+  async selectFirstActivityInUnsubscribeModal () {
+    await this.getActivityLibraryTab().getUnsubscribeModal().selectActivityByIndex(0)
+  }
+
+  @When('the user confirms the unsubscription')
+  async confirmUnsubscription () {
+    await this.getActivityLibraryTab().getUnsubscribeModal().clickConfirm()
+  }
+
+  @When('the user confirms the final unsubscription')
+  async confirmFinalUnsubscription () {
+    await this.getActivityLibraryTab().getUnsubscribeModal().getConfirmModal().clickConfirm()
+  }
+
+  @Then('unsubscription success message is visible')
+  async verifyUnsubscribeSuccessMessageVisible () {
+    await expect(this.page.getByText(t('student.buildProject.activities.overlays.UnsubscribeActivitiesConfirmModal.success', { count: 1 }))).toBeVisible()
   }
 }

--- a/e2e/framework/student/lifeProject/activities/activities.hook.ts
+++ b/e2e/framework/student/lifeProject/activities/activities.hook.ts
@@ -1,0 +1,5 @@
+import { AfterScenario } from '@e2e/framework/shared/fixtures/fixtures'
+
+AfterScenario({ tags: '@unsubscribe-activity' }, async ({ studentProjectActivitiesPage, studentProjectActivitiesCatalogPage }) => {
+  await studentProjectActivitiesPage.restoreActivitySubscription(studentProjectActivitiesCatalogPage)
+})

--- a/e2e/framework/student/lifeProject/activities/activities.hook.ts
+++ b/e2e/framework/student/lifeProject/activities/activities.hook.ts
@@ -1,5 +1,5 @@
 import { AfterScenario } from '@e2e/framework/shared/fixtures/fixtures'
 
-AfterScenario({ tags: '@unsubscribe-activity' }, async ({ studentProjectActivitiesPage, studentProjectActivitiesCatalogPage }) => {
+AfterScenario({ tags: '@unsubscribe-activity-from-library' }, async ({ studentProjectActivitiesPage, studentProjectActivitiesCatalogPage }) => {
   await studentProjectActivitiesPage.restoreActivitySubscription(studentProjectActivitiesCatalogPage)
 })

--- a/e2e/framework/student/lifeProject/activities/componentObjects/ActivityLibraryCard.ts
+++ b/e2e/framework/student/lifeProject/activities/componentObjects/ActivityLibraryCard.ts
@@ -26,6 +26,14 @@ export class ActivityLibraryCard extends BaseObject {
     return this.root.getByTestId('activity-library-card-summary')
   }
 
+  async getActivityId (): Promise<string> {
+    return await this.root.getAttribute('data-activity-id') ?? ''
+  }
+
+  async getActivityThematic (): Promise<string> {
+    return await this.root.getAttribute('data-activity-thematic') ?? ''
+  }
+
   async verifyTitleVisible () {
     await expect(this.getTitle()).toBeVisible()
   }

--- a/e2e/framework/student/lifeProject/activities/componentObjects/ActivityLibraryDropdown.ts
+++ b/e2e/framework/student/lifeProject/activities/componentObjects/ActivityLibraryDropdown.ts
@@ -1,0 +1,22 @@
+import type { Locator, Page } from '@playwright/test'
+import { BaseObject } from '@e2e/framework/shared/base/BaseObject'
+import { t } from '@e2e/framework/shared/utils/i18n'
+
+export class ActivityLibraryDropdown extends BaseObject {
+  constructor (root: Locator, page: Page) {
+    super(root, page)
+  }
+
+  getTriggerButton () {
+    return this.root.getByRole('button')
+  }
+
+  getUnsubscribeItem () {
+    return this.page!.getByRole('button', { name: t('student.buildProject.activities.buttons.unsubscribe'), exact: true })
+  }
+
+  async clickUnsubscribe () {
+    await this.getTriggerButton().click()
+    await this.getUnsubscribeItem().click()
+  }
+}

--- a/e2e/framework/student/lifeProject/activities/componentObjects/ActivityLibraryTab.ts
+++ b/e2e/framework/student/lifeProject/activities/componentObjects/ActivityLibraryTab.ts
@@ -3,6 +3,8 @@ import { PaginationObject } from '@e2e/framework/shared/componentObjects/Paginat
 import { t } from '@e2e/framework/shared/utils/i18n'
 import { extractNumberFromText } from '@e2e/framework/shared/utils/text'
 import { ActivityLibraryCard } from '@e2e/framework/student/lifeProject/activities/componentObjects/ActivityLibraryCard'
+import { ActivityLibraryDropdown } from '@e2e/framework/student/lifeProject/activities/componentObjects/ActivityLibraryDropdown'
+import { UnsubscribeActivitiesModal } from '@e2e/framework/student/lifeProject/activities/componentObjects/UnsubscribeActivitiesModal'
 import { expect, type Page } from '@playwright/test'
 
 export class ActivityLibraryTab extends BaseObject {
@@ -32,6 +34,14 @@ export class ActivityLibraryTab extends BaseObject {
 
   getPagination () {
     return new PaginationObject(this.root.getByTestId('pagination'))
+  }
+
+  getDropdown () {
+    return new ActivityLibraryDropdown(this.root.getByTestId('activity-library-dropdown'), this.page!)
+  }
+
+  getUnsubscribeModal () {
+    return new UnsubscribeActivitiesModal(this.page!.getByTestId('unsubscribe-activities-modal'), this.page!)
   }
 
   async verifyTitleWithPositiveCount () {

--- a/e2e/framework/student/lifeProject/activities/componentObjects/UnsubscribeActivitiesModal.ts
+++ b/e2e/framework/student/lifeProject/activities/componentObjects/UnsubscribeActivitiesModal.ts
@@ -1,0 +1,29 @@
+import type { Locator, Page } from '@playwright/test'
+import { BaseObject } from '@e2e/framework/shared/base/BaseObject'
+import { UnsubscribeActivitiesConfirmModal } from '@e2e/framework/student/lifeProject/activitiesCatalog/componentObjects/UnsubscribeActivitiesConfirmModal'
+
+export class UnsubscribeActivitiesModal extends BaseObject {
+  constructor (root: Locator, page: Page) {
+    super(root, page)
+  }
+
+  getActivityItems () {
+    return this.root.getByTestId('selector-overlay')
+  }
+
+  getConfirmButton () {
+    return this.root.getByTestId('confirm-button')
+  }
+
+  getConfirmModal () {
+    return new UnsubscribeActivitiesConfirmModal(this.page!)
+  }
+
+  async selectActivityByIndex (index: number) {
+    await this.getActivityItems().nth(index).click()
+  }
+
+  async clickConfirm () {
+    await this.getConfirmButton().click()
+  }
+}

--- a/e2e/framework/student/lifeProject/activitiesCatalog/StudentProjectActivitiesCatalog.ts
+++ b/e2e/framework/student/lifeProject/activitiesCatalog/StudentProjectActivitiesCatalog.ts
@@ -42,6 +42,14 @@ class StudentProjectActivitiesCatalogPage {
     await expect.poll(() => this.page.url()).not.toBe(beforeUrl)
   }
 
+  async subscribeActivityById (thematic: string, id: string) {
+    const url = this.buildCatalogUrl(thematic, id)
+    await this.page.goto(url)
+    await this.activityPreview().verifySubscribeButton()
+    await this.activityPreview().getSubscribeButton().click()
+    await this.activityPreview().clickSubscribeModalConfirmButton()
+  }
+
   @Given('the student opens the project activities catalog page')
   async openCatalogPage () {
     const url = this.buildCatalogUrl(

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -13,7 +13,7 @@ const reviewModeIgnore = REVIEW_MODE ? ['**/*.deferred.feature.spec.js'] : []
 
 const testDir = defineBddConfig({
   features: 'tests/**/*.feature',
-  steps: ['framework/**/*Page.ts', 'framework/shared/fixtures/fixtures.ts', 'framework/shared/hooks/dataset.hook.ts']
+  steps: ['framework/**/*Page.ts', 'framework/shared/fixtures/fixtures.ts', 'framework/**/*.hook.ts']
 })
 
 const reporter: Parameters<typeof defineConfig>[0]['reporter'] = [

--- a/e2e/tests/student/lifeProject/activities/activities.feature
+++ b/e2e/tests/student/lifeProject/activities/activities.feature
@@ -121,3 +121,11 @@ Feature: Student Project Activities Page
     Scenario: Student can change the page size
       When the user changes the page size to 8
       Then the first page of activity contains less than 9 activities
+
+    @high @library-activity-tab @library-activity-unsubscribe @unsubscribe-activity
+    Scenario: Student can unsubscribe from a library activity using the more actions menu
+      When the user opens the unsubscribe activities modal
+      And the user selects the first activity in the unsubscribe modal
+      And the user confirms the unsubscription
+      And the user confirms the final unsubscription
+      Then unsubscription success message is visible

--- a/e2e/tests/student/lifeProject/activities/activities.feature
+++ b/e2e/tests/student/lifeProject/activities/activities.feature
@@ -122,7 +122,7 @@ Feature: Student Project Activities Page
       When the user changes the page size to 8
       Then the first page of activity contains less than 9 activities
 
-    @high @library-activity-tab @library-activity-unsubscribe @unsubscribe-activity
+    @high @library-activity-tab @unsubscribe-activity-from-library
     Scenario: Student can unsubscribe from a library activity using the more actions menu
       When the user opens the unsubscribe activities modal
       And the user selects the first activity in the unsubscribe modal

--- a/src/features/student/buildProject/components/modals/UnsubscribeActivitiesConfirmModal/UnsubscribeActivitiesConfirmModal.test.ts
+++ b/src/features/student/buildProject/components/modals/UnsubscribeActivitiesConfirmModal/UnsubscribeActivitiesConfirmModal.test.ts
@@ -63,7 +63,7 @@ BddTest().given('an unsubscribe activities confirmation modal', () => {
 
       BddTest().then('it should add a success message', async () => {
         await vi.waitFor(() => {
-          expect(mockAddSuccessMessage).toHaveBeenCalledWith('Désinscription de l\'activité réussie.')
+          expect(mockAddSuccessMessage).toHaveBeenCalledWith('Vous avez été désinscrit.e avec succès.')
         })
       })
 
@@ -134,7 +134,7 @@ BddTest().given('an unsubscribe activities confirmation modal', () => {
 
       BddTest().then('it should add a success message', async () => {
         await vi.waitFor(() => {
-          expect(mockAddSuccessMessage).toHaveBeenCalledWith('Désinscription des activités réussie.')
+          expect(mockAddSuccessMessage).toHaveBeenCalledWith('Vous avez été désinscrit.e avec succès.')
         })
       })
 

--- a/src/features/student/buildProject/locales/en.json
+++ b/src/features/student/buildProject/locales/en.json
@@ -32,7 +32,7 @@
           "UnsubscribeActivitiesConfirmModal": {
             "description": "This action will result in the permanent loss of all associated data and actions.",
             "error": "An error occurred while unsubscribing from the activity. Please try again later. | An error occurred while unsubscribing from the activities. Please try again later.",
-            "success": "Successfully unsubscribed from the activity. | Successfully unsubscribed from the activities.",
+            "success": "You have been successfully unsubscribed.",
             "title": "Are you sure you want to unsubscribe from this activity? | Are you sure you want to unsubscribe from these activities?"
           }
         },

--- a/src/features/student/buildProject/locales/fr.json
+++ b/src/features/student/buildProject/locales/fr.json
@@ -32,7 +32,7 @@
           "UnsubscribeActivitiesConfirmModal": {
             "description": "Cette action entraînera la perte définitive de toutes les données et actions associées.",
             "error": "Une erreur est survenue lors de la désinscription de l'activité. Veuillez réessayer plus tard. | Une erreur est survenue lors de la désinscription des activités. Veuillez réessayer plus tard.",
-            "success": "Désinscription de l'activité réussie. | Désinscription des activités réussie.",
+            "success": "Vous avez été désinscrit.e avec succès.",
             "title": "Êtes-vous certain(e) de vouloir vous désinscrire de cette activité ? | Êtes-vous certain(e) de vouloir vous désinscrire de ces activités ?"
           }
         },

--- a/src/features/student/buildProject/views/ProjectActivitiesView/components/ActivityLibraryCard/ActivityLibraryCard.vue
+++ b/src/features/student/buildProject/views/ProjectActivitiesView/components/ActivityLibraryCard/ActivityLibraryCard.vue
@@ -33,6 +33,8 @@ const titleClasses = computed(() => isMobile.value
     :to="{ name: ROUTES.STUDENT.PROJECT_ACTIVITIES_DETAILED.name, params: { id: activity.id, thematic: activity.thematic } }"
     class="activity-library-card"
     data-testid="activity-library-card"
+    :data-activity-id="activity.activityId"
+    :data-activity-thematic="activity.thematic"
   >
     <FloatingIconCard
       :title="activity.title"

--- a/src/features/student/buildProject/views/ProjectActivitiesView/components/overlays/ActivityLibraryDropdown/ActivityLibraryDropdown.vue
+++ b/src/features/student/buildProject/views/ProjectActivitiesView/components/overlays/ActivityLibraryDropdown/ActivityLibraryDropdown.vue
@@ -31,6 +31,7 @@ function handleItemSelected (itemName: string) {
 
 <template>
   <AvDropdown
+    data-testid="activity-library-dropdown"
     :items="menuItems"
     :trigger-aria-label="t('global.buttons.moreActions')"
     :trigger-label="t('global.buttons.moreActions')"

--- a/src/features/student/buildProject/views/ProjectActivitiesView/components/overlays/UnsubscribeActivitiesModal/UnsubscribeActivitiesModal.vue
+++ b/src/features/student/buildProject/views/ProjectActivitiesView/components/overlays/UnsubscribeActivitiesModal/UnsubscribeActivitiesModal.vue
@@ -67,6 +67,7 @@ useInfiniteScroll(
 <template>
   <AvModal
     :opened="show"
+    data-testid="unsubscribe-activities-modal"
     :close-button-label="t('global.buttons.cancel')"
     :confirm-button-label="t('student.buildProject.views.projectActivitiesView.UnsubscribeActivitiesModal.confirm', { count: selectedActivityIds.length })"
     :confirm-button-icon="MDI_ICONS.TRASH_CAN_OUTLINE"


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> Adds E2E tests for the unsubscription flow from the activity library tab (US#973). Implements PageObject step definitions, ComponentObjects for the activity library dropdown and unsubscribe modals, scenario-level teardown hook to restore subscription state after test, and adds missing `data-testid` attributes to Vue components.

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1133

---

### Documentation
> No documentation changes required.

---

### Target Branch
> `develop`

---

### Additional Notes
> - `ActivityLibraryDropdown` and `UnsubscribeActivitiesModal` ComponentObjects now accept a root `Locator` instead of `Page` for proper scoping following project patterns.
> - `activities.hook.ts` is co-located with the activities feature (not in shared hooks) since the teardown is specific to the unsubscribe scenario.
> - `playwright.config.ts` steps glob updated from explicit hook file paths to `framework/**/*.hook.ts` to auto-discover all feature-specific hooks.
> - `StudentProjectActivitiesCatalog.ts` gained a `subscribeActivityById` helper used by the teardown hook to restore subscription state without direct API calls.

---

### Known Limitations or Side Effects
> None.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and detaiils for the update process