### PR TITLE
feat(1168): add activity start and end date

### DIFF
--- a/e2e/framework/shared/fixtures/fixtures.ts
+++ b/e2e/framework/shared/fixtures/fixtures.ts
@@ -4,6 +4,7 @@ import { setLocaleFromPage } from '@e2e/framework/shared/utils/i18n'
 import { StudentHomePage } from '@e2e/framework/student/home/StudentHomePage'
 import { StudentProjectActivitiesPage } from '@e2e/framework/student/lifeProject/activities/StudentProjectActivitiesPage'
 import { StudentProjectActivitiesCatalogPage } from '@e2e/framework/student/lifeProject/activitiesCatalog/StudentProjectActivitiesCatalog'
+import { StudentProjectActivityDetails } from '@e2e/framework/student/lifeProject/activityDetails/StudentProjectActivityDetails'
 import { StudentTrajectoriesSelfKnowledgePage } from '@e2e/framework/student/lifeProject/selfKnowledge/StudentTrajectoriesSelfKnowledgePage'
 import { StudentGlobalSteps } from '@e2e/framework/student/shared/steps/StudentGlobalSteps'
 import { test as base, createBdd } from 'playwright-bdd'
@@ -14,6 +15,7 @@ interface Fixtures {
   studentGlobalSteps: StudentGlobalSteps
   studentHomePage: StudentHomePage
   studentProjectActivitiesPage: StudentProjectActivitiesPage
+  studentProjectActivityDetails: StudentProjectActivityDetails
   studentTrajectoriesSelfKnowledgePage: StudentTrajectoriesSelfKnowledgePage
   studentProjectActivitiesCatalogPage: StudentProjectActivitiesCatalogPage
 }
@@ -37,6 +39,10 @@ export const test = base.extend<Fixtures>({
   studentProjectActivitiesPage: async ({ page }, use) => {
     await setLocaleFromPage(page)
     await use(new StudentProjectActivitiesPage(page))
+  },
+  studentProjectActivityDetails: async ({ page }, use) => {
+    await setLocaleFromPage(page)
+    await use(new StudentProjectActivityDetails(page))
   },
   studentTrajectoriesSelfKnowledgePage: async ({ page }, use) => {
     await setLocaleFromPage(page)

--- a/e2e/framework/student/lifeProject/activities/StudentProjectActivitiesPage.ts
+++ b/e2e/framework/student/lifeProject/activities/StudentProjectActivitiesPage.ts
@@ -2,6 +2,7 @@ import type { test } from '@e2e/framework/shared/fixtures/fixtures'
 import type { StudentProjectActivitiesCatalogPage } from '@e2e/framework/student/lifeProject/activitiesCatalog/StudentProjectActivitiesCatalog'
 import type { Page } from '@playwright/test'
 import { BasePage } from '@e2e/framework/shared/base/BasePage'
+import { STUDENT_ROUTES } from '@e2e/framework/shared/constants/routes'
 import { t } from '@e2e/framework/shared/utils/i18n'
 import { ActivityLibraryTab } from '@e2e/framework/student/lifeProject/activities/componentObjects/ActivityLibraryTab'
 import { AllActivitiesTabs } from '@e2e/framework/student/lifeProject/activities/componentObjects/AllActivitiesTabs'
@@ -177,5 +178,11 @@ class StudentProjectActivitiesPage extends BasePage {
   @Then('unsubscription success message is visible')
   async verifyUnsubscribeSuccessMessageVisible () {
     await expect(this.page.getByText(t('student.buildProject.activities.overlays.UnsubscribeActivitiesConfirmModal.success', { count: 1 }))).toBeVisible()
+  }
+
+  @When('the student clicks the first library activity card')
+  async clickFirstLibraryActivityCard () {
+    await this.getActivityLibraryTab().clickFirstCard()
+    await this.page.waitForURL(new RegExp(STUDENT_ROUTES.PROJECT.ACTIVITY_DETAIL.replace(':id', '.+')))
   }
 }

--- a/e2e/framework/student/lifeProject/activities/componentObjects/ActivityLibraryTab.ts
+++ b/e2e/framework/student/lifeProject/activities/componentObjects/ActivityLibraryTab.ts
@@ -78,4 +78,8 @@ export class ActivityLibraryTab extends BaseObject {
     const count = await this.getCards().count()
     expect(count).toBeLessThan(maxCount)
   }
+
+  async clickFirstCard () {
+    await this.getCardByIndex(0).click()
+  }
 }

--- a/e2e/framework/student/lifeProject/activityDetails/StudentProjectActivityDetails.ts
+++ b/e2e/framework/student/lifeProject/activityDetails/StudentProjectActivityDetails.ts
@@ -1,0 +1,59 @@
+import type { test } from '@e2e/framework/shared/fixtures/fixtures'
+import { BasePage } from '@e2e/framework/shared/base/BasePage'
+import { ProjectActivityDetailsObject } from '@e2e/framework/student/lifeProject/activityDetails/componentObjects/ProjectActivityDetailsObject'
+import { expect, type Page } from '@playwright/test'
+import { Fixture, Then } from 'playwright-bdd/decorators'
+
+@Fixture<typeof test>('studentProjectActivityDetails')
+export class StudentProjectActivityDetails extends BasePage {
+  constructor (public page: Page) {
+    super(page)
+  }
+
+  getProjectActivityDetails () {
+    return new ProjectActivityDetailsObject(this.page.getByTestId('project-activity-details'))
+  }
+
+  getDetailTitle () {
+    return this.page.getByTestId('activity-detail-title')
+  }
+
+  getDropdown () {
+    return this.page.getByTestId('activity-detailed-dropdown')
+  }
+
+  @Then('the activity detail title is visible')
+  async verifyDetailTitleVisible () {
+    await expect(this.getDetailTitle()).toBeVisible()
+  }
+
+  @Then('the activity dropdown is visible')
+  async verifyDropdownVisible () {
+    await expect(this.getDropdown()).toBeVisible()
+  }
+
+  @Then('the activity start date is visible')
+  async verifyStartDateVisible () {
+    await this.getProjectActivityDetails().verifyPeriodInputVisible()
+  }
+
+  @Then('the activity end date is visible')
+  async verifyEndDateVisible () {
+    await this.getProjectActivityDetails().verifyPeriodInputVisible()
+  }
+
+  @Then('the activity title is visible')
+  async verifyActivityTitleVisible () {
+    await this.getProjectActivityDetails().verifyTitleVisible()
+  }
+
+  @Then('the activity summary is visible')
+  async verifyActivitySummaryVisible () {
+    await this.getProjectActivityDetails().verifySummaryVisible()
+  }
+
+  @Then('the activity execution period list is visible')
+  async verifyExecutionPeriodListVisible () {
+    await this.getProjectActivityDetails().verifyExecutionPeriodListVisible()
+  }
+}

--- a/e2e/framework/student/lifeProject/activityDetails/componentObjects/ProjectActivityDetailsObject.ts
+++ b/e2e/framework/student/lifeProject/activityDetails/componentObjects/ProjectActivityDetailsObject.ts
@@ -1,0 +1,40 @@
+import { BaseObject } from '@e2e/framework/shared/base/BaseObject'
+import { expect, type Locator } from '@playwright/test'
+
+export class ProjectActivityDetailsObject extends BaseObject {
+  constructor (protected root: Locator) {
+    super(root)
+  }
+
+  getPeriodInput () {
+    return this.root.getByTestId('activity-period-input')
+  }
+
+  getTitle () {
+    return this.root.getByTestId('activity-title')
+  }
+
+  getSummary () {
+    return this.root.getByTestId('activity-summary')
+  }
+
+  getExecutionPeriodList () {
+    return this.root.getByTestId('activity-execution-period')
+  }
+
+  async verifyPeriodInputVisible () {
+    await expect(this.getPeriodInput()).toBeVisible()
+  }
+
+  async verifyTitleVisible () {
+    await expect(this.getTitle()).toBeVisible()
+  }
+
+  async verifySummaryVisible () {
+    await expect(this.getSummary()).toBeVisible()
+  }
+
+  async verifyExecutionPeriodListVisible () {
+    await expect(this.getExecutionPeriodList()).toBeVisible()
+  }
+}

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -31,7 +31,7 @@ export default defineConfig({
   expect: {
     timeout: CI ? 10000 : 5000
   },
-  fullyParallel: true,
+  fullyParallel: false,
   forbidOnly: CI,
   retries: CI ? 2 : 2,
   workers: CI ? 2 : 5,

--- a/e2e/tests/student/lifeProject/activityDetails/activityDetails.feature
+++ b/e2e/tests/student/lifeProject/activityDetails/activityDetails.feature
@@ -1,0 +1,37 @@
+@activity-details @dataset-full
+Feature: Student Project Activity Detail Page
+
+  Background:
+    Given the student opens the project activities page
+    When the student open activity library tab
+    And the student clicks the first library activity card
+
+  Rule: Page Load
+
+    @high @activity-details
+    Scenario: Student can load activity detail page
+      Then the URL contains "/cofolio/student/project/activities/"
+
+  Rule: Activity Detail
+
+    @high @activity-details @activity-title
+    Scenario: Student can see the activity detail title
+      Then the activity detail title is visible
+
+    @high @activity-details @activity-dropdown
+    Scenario: Student can see the activity dropdown
+      Then the activity dropdown is visible
+
+    @high @activity-details @activity-period
+    Scenario: Student can see the activity start and end dates
+      Then the activity start date is visible
+      And the activity end date is visible
+
+    @high @activity-details @activity-content
+    Scenario: Student can see the activity title and summary
+      Then the activity title is visible
+      And the activity summary is visible
+
+    @high @activity-details @activity-execution-period
+    Scenario: Student can see the activity execution period list
+      Then the activity execution period list is visible

--- a/e2e/tests/student/lifeProject/activityDetails/activityDetails.mobile.feature
+++ b/e2e/tests/student/lifeProject/activityDetails/activityDetails.mobile.feature
@@ -1,0 +1,21 @@
+@activity-details @mobile @dataset-full
+Feature: Student Project Activity Detail Page (Mobile)
+
+  Background:
+    Given the student opens the project activities page
+    Given the page is displayed on mobile viewport
+    When the student open activity library tab
+    And the student clicks the first library activity card
+
+  Rule: Activity Detail - Responsive behavior
+
+    @medium @responsive @activity-details
+    Scenario: No horizontal scrolling on activity detail page
+      Then no horizontal scrolling is required
+
+    @medium @responsive @activity-details @activity-content
+    Scenario: Student can see activity detail content on mobile
+      Then the activity detail title is visible
+      And the activity title is visible
+      And the activity summary is visible
+      And the activity execution period list is visible

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/ProjectActivityDetailedView.vue
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/ProjectActivityDetailedView.vue
@@ -35,7 +35,10 @@ const breadcrumbLinks = computed(() => [
     :is-loading="isLoading && !isError"
     size="2xl"
   >
-    <template v-if="declaredActivityDetail">
+    <div
+      v-if="declaredActivityDetail"
+      class="av-col av-gap-sm"
+    >
       <PageTitle
         :title="t('global.detail')"
         :breadcrumb-links="breadcrumbLinks"
@@ -64,7 +67,7 @@ const breadcrumbLinks = computed(() => [
         @cancel="hideModal"
         @unsubscribed="hideModal"
       />
-    </template>
+    </div>
   </Loader>
 
   <ActivityErrorMessage :error="error" />

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/ProjectActivityDetailedView.vue
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/ProjectActivityDetailedView.vue
@@ -55,8 +55,13 @@ const breadcrumbLinks = computed(() => [
         </template>
       </PageTitle>
 
-      <div class="av-row av-justify-end">
-        <ActivityDetailedDropdown @unsubscribe-selected="displayModal" />
+      <div
+        class="av-row av-justify-end"
+      >
+        <ActivityDetailedDropdown
+          data-testid="activity-detailed-dropdown"
+          @unsubscribe-selected="displayModal"
+        />
       </div>
 
       <ProjectActivityDetails :declared-activity-details="declaredActivityDetail" />

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/ProjectActivityDetails/ProjectActivityDetails.test.ts
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/ProjectActivityDetails/ProjectActivityDetails.test.ts
@@ -1,6 +1,6 @@
 import { mockedDeclaredActivityDetails } from '@/__mocks__/fixtures/student/activities.fixtures'
 import ProjectActivityDetails, { type ProjectActivityDetailsProps } from '@/features/student/buildProject/views/ProjectActivityDetailedView/components/ProjectActivityDetails/ProjectActivityDetails.vue'
-import { AvCardStub, AvIconTextStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { AvCardStub, AvIconTextStub, AvPeriodInputStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { mount, type VueWrapper } from '@vue/test-utils'
 import { beforeEach, expect } from 'vitest'
 
@@ -10,9 +10,10 @@ BddTest().given('a project activity details component', () => {
   const stubs = {
     AvCard: AvCardStub,
     AvIconText: AvIconTextStub,
+    AvPeriodInput: AvPeriodInputStub,
   }
 
-  BddTest().when('the component is mounted with executionPeriodInfo containing "-" lines', () => {
+  BddTest().when('the component is mounted with executionPeriodInfo containing "-" lines and startDate and endDate', () => {
     const props: ProjectActivityDetailsProps = {
       declaredActivityDetails: mockedDeclaredActivityDetails,
     }
@@ -24,6 +25,13 @@ BddTest().given('a project activity details component', () => {
     BddTest().then('it should render the main container', () => {
       const container = wrapper.find('[data-testid="project-activity-details"]')
       expect(container.exists()).toBe(true)
+    })
+
+    BddTest().then('it should render AvPeriodInput with the correct dates', () => {
+      const periodInput = wrapper.findComponent(AvPeriodInputStub)
+      expect(periodInput.exists()).toBe(true)
+      expect(periodInput.props('startModelValue')).toBe(mockedDeclaredActivityDetails.startDate)
+      expect(periodInput.props('endModelValue')).toBe(mockedDeclaredActivityDetails.endDate)
     })
 
     BddTest().then('it should render the activity title in AvIconText', () => {
@@ -73,6 +81,25 @@ BddTest().given('a project activity details component', () => {
 
       const items = list.findAll('li')
       expect(items.length).toBe(0)
+    })
+  })
+
+  BddTest().when('the component is mounted without startDate and endDate', () => {
+    const props: ProjectActivityDetailsProps = {
+      declaredActivityDetails: {
+        ...mockedDeclaredActivityDetails,
+        startDate: undefined,
+        endDate: undefined,
+      },
+    }
+
+    beforeEach(() => {
+      wrapper = mount(ProjectActivityDetails, { props, global: { stubs } })
+    })
+
+    BddTest().then('it should not render AvPeriodInput', () => {
+      const periodInput = wrapper.findComponent(AvPeriodInputStub)
+      expect(periodInput.exists()).toBe(false)
     })
   })
 })

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/ProjectActivityDetails/ProjectActivityDetails.vue
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/ProjectActivityDetails/ProjectActivityDetails.vue
@@ -3,7 +3,7 @@ import type {
   DeclaredActivityDetailsDTO
 } from '@/api/avenir-esr'
 import { ICONS } from '@/features/student/global/icons'
-import { AvCard, AvIconText } from '@avenirs-esr/avenirs-dsav'
+import { AvCard, AvIconText, AvPeriodInput } from '@avenirs-esr/avenirs-dsav'
 import { useI18n } from 'vue-i18n'
 
 export interface ProjectActivityDetailsProps {
@@ -24,51 +24,66 @@ const executionPeriodList = computed(() => {
     .map(line => line.trim())
     .map(line => line.replace(/^-+\s*/, ''))
 })
+
+const hasPeriodInfo = computed(() => !!declaredActivityDetails.startDate || !!declaredActivityDetails.endDate)
 </script>
 
 <template>
-  <AvCard
-    background-color="var(--card2)"
-    border-color="transparent"
-    data-testid="project-activity-details"
-  >
-    <div
-      class="av-row--md av-justify-between--md av-gap-xl"
+  <div class="av-col av-gap-xxs">
+    <AvPeriodInput
+      v-if="hasPeriodInfo"
+      label=""
+      :start-model-value="declaredActivityDetails.startDate"
+      :end-model-value="declaredActivityDetails.endDate"
+      :start-label="t('global.beginning')"
+      :end-label="t('global.end')"
+      start-date-disabled
+      end-date-disabled
+      show-each-input-label
+    />
+    <AvCard
+      background-color="var(--card2)"
+      border-color="transparent"
       data-testid="project-activity-details"
     >
-      <div class="av-col av-gap-sm">
-        <AvIconText
-          :icon="ICONS.ACTIVITY"
-          icon-color="var(--icon)"
-          :text="declaredActivityDetails.activity.title"
-          text-color="var(--dark-background-primary1)"
-          typography-class="n4"
-          gap="var(--spacing-md)"
-          inline
-        />
-        <span
-          class="s2-regular"
-          data-testid="activity-summary"
-        >
-          {{ declaredActivityDetails.activity.summary }}
-        </span>
-      </div>
-      <div class="av-col av-gap-sm">
-        <span class="n4">{{ t('student.buildProject.activities.views.ProjectActivityDetailedView.ProjectActivityDetails.executionPeriodTitle') }}</span>
-        <ul
-          class="s2-regular execution-list"
-          data-testid="activity-execution-period"
-        >
-          <li
-            v-for="(item, index) in executionPeriodList"
-            :key="index"
+      <div
+        class="av-row--md av-justify-between--md av-gap-xl"
+        data-testid="project-activity-details"
+      >
+        <div class="av-col av-gap-sm">
+          <AvIconText
+            :icon="ICONS.ACTIVITY"
+            icon-color="var(--icon)"
+            :text="declaredActivityDetails.activity.title"
+            text-color="var(--dark-background-primary1)"
+            typography-class="n4"
+            gap="var(--spacing-md)"
+            inline
+          />
+          <span
+            class="s2-regular"
+            data-testid="activity-summary"
           >
-            {{ item }}
-          </li>
-        </ul>
+            {{ declaredActivityDetails.activity.summary }}
+          </span>
+        </div>
+        <div class="av-col av-gap-sm">
+          <span class="n4">{{ t('student.buildProject.activities.views.ProjectActivityDetailedView.ProjectActivityDetails.executionPeriodTitle') }}</span>
+          <ul
+            class="s2-regular execution-list"
+            data-testid="activity-execution-period"
+          >
+            <li
+              v-for="(item, index) in executionPeriodList"
+              :key="index"
+            >
+              {{ item }}
+            </li>
+          </ul>
+        </div>
       </div>
-    </div>
-  </AvCard>
+    </AvCard>
+  </div>
 </template>
 
 <style scoped lang="scss">

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/ProjectActivityDetails/ProjectActivityDetails.vue
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/ProjectActivityDetails/ProjectActivityDetails.vue
@@ -29,9 +29,13 @@ const hasPeriodInfo = computed(() => !!declaredActivityDetails.startDate || !!de
 </script>
 
 <template>
-  <div class="av-col av-gap-xxs">
+  <div
+    class="av-col av-gap-xxs"
+    data-testid="project-activity-details"
+  >
     <AvPeriodInput
       v-if="hasPeriodInfo"
+      data-testid="activity-period-input"
       label=""
       :start-model-value="declaredActivityDetails.startDate"
       :end-model-value="declaredActivityDetails.endDate"
@@ -44,14 +48,11 @@ const hasPeriodInfo = computed(() => !!declaredActivityDetails.startDate || !!de
     <AvCard
       background-color="var(--card2)"
       border-color="transparent"
-      data-testid="project-activity-details"
     >
-      <div
-        class="av-row--md av-justify-between--md av-gap-xl"
-        data-testid="project-activity-details"
-      >
+      <div class="av-row--md av-justify-between--md av-gap-xl">
         <div class="av-col av-gap-sm">
           <AvIconText
+            data-testid="activity-title"
             :icon="ICONS.ACTIVITY"
             icon-color="var(--icon)"
             :text="declaredActivityDetails.activity.title"

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -16,6 +16,7 @@
       "activeText": "On",
       "inactiveText": "Off"
     },
+    "beginning": "Beginning",
     "breadcrumb": {
       "ariaLabel": "Breadcrumb",
       "expandButtonLabel": "View breadcrumb"
@@ -50,6 +51,7 @@
       "updatedAt": "Updated on {date}"
     },
     "detail": "Detail",
+    "end": "End",
     "emptyState": {
       "defaultTitle": "No elements to display"
     },

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -16,6 +16,7 @@
       "activeText": "Oui",
       "inactiveText": "Non"
     },
+    "beginning": "Début",
     "breadcrumb": {
       "ariaLabel": "Fil d'Ariane",
       "expandButtonLabel": "Voir le fil d'Ariane"
@@ -53,6 +54,7 @@
     "emptyState": {
       "defaultTitle": "Aucun élément à afficher"
     },
+    "end": "Fin",
     "error": {
       "file": {
         "acceptType": "Le fichier ne respecte pas le format attendu.",


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> Affichage des dates de début et de fin d'une activité déclarée dans la vue détail de l'activité (`ProjectActivityDetails`). Un composant `AvPeriodInput` est affiché conditionnellement lorsque l'une des deux dates est renseignée. Les tests unitaires du composant ont été mis à jour pour couvrir ce nouveau comportement.

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1168

---

### Documentation
> Aucune mise à jour de documentation requise.

---

### Target Branch
> `develop`

---

### Additional Notes
> - Le `AvPeriodInput` est rendu en mode lecture seule (`start-date-disabled`, `end-date-disabled`)
> - La condition `hasPeriodInfo` vérifie la présence de `startDate` ou `endDate` avant d'afficher le composant
> - Les clés i18n `global.beginning` et `global.end` ont été ajoutées dans `fr.json` et `en.json`
> - Le wrapper de la vue `ProjectActivityDetailedView` a été changé de `<template>` à `<div>` pour permettre le style `av-col av-gap-sm`

---

### Known Limitations or Side Effects
> Aucune limitation connue.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [x] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process