### PR TITLE
feat(1168): add activity status badge and fix flaky e2e tests on detail page

### DIFF
--- a/e2e/framework/student/lifeProject/activityDetails/StudentProjectActivityDetails.ts
+++ b/e2e/framework/student/lifeProject/activityDetails/StudentProjectActivityDetails.ts
@@ -18,8 +18,17 @@ export class StudentProjectActivityDetails extends BasePage {
     return this.page.getByTestId('activity-detail-title')
   }
 
+  getStatus () {
+    return this.page.getByTestId('activity-status-badge')
+  }
+
   getDropdown () {
     return this.page.getByTestId('activity-detailed-dropdown')
+  }
+
+  @Then('the project activity details are loaded')
+  async verifyProjectActivityDetailsVisible () {
+    await this.getProjectActivityDetails().isVisible()
   }
 
   @Then('the activity detail title is visible')
@@ -55,5 +64,10 @@ export class StudentProjectActivityDetails extends BasePage {
   @Then('the activity execution period list is visible')
   async verifyExecutionPeriodListVisible () {
     await this.getProjectActivityDetails().verifyExecutionPeriodListVisible()
+  }
+
+  @Then('the activity status is visible')
+  async verifyActivityStatusVisible () {
+    await expect(this.getStatus()).toBeVisible()
   }
 }

--- a/e2e/tests/student/lifeProject/activityDetails/activityDetails.feature
+++ b/e2e/tests/student/lifeProject/activityDetails/activityDetails.feature
@@ -14,6 +14,9 @@ Feature: Student Project Activity Detail Page
 
   Rule: Activity Detail
 
+    Background:
+      And the project activity details are loaded
+
     @high @activity-details @activity-title
     Scenario: Student can see the activity detail title
       Then the activity detail title is visible
@@ -35,3 +38,7 @@ Feature: Student Project Activity Detail Page
     @high @activity-details @activity-execution-period
     Scenario: Student can see the activity execution period list
       Then the activity execution period list is visible
+
+    @high @activity-details @activity-status
+    Scenario: Student can see the activity status
+      Then the activity status is visible

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/ProjectActivityDetailedView.test.ts
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/ProjectActivityDetailedView.test.ts
@@ -2,9 +2,11 @@ import type { VueWrapper } from '@vue/test-utils'
 import { mockedActivityDetail, mockedDeclaredActivityDetails } from '@/__mocks__/fixtures/student/activities.fixtures'
 import { declaredActivityDetailsErrorHandler } from '@/__mocks__/msw/handlers/student/activities.handlers'
 import { server } from '@/__mocks__/msw/server'
+import { EDeclaredActivityStatus } from '@/api/avenir-esr'
 import { LoaderStub } from '@/common/components/Loader/Loader.stub'
 import { PageTitleStub } from '@/common/components/PageTitle/PageTitle.stub'
 import { ROUTES } from '@/common/constants'
+import { ActivityStatusBadgeStub } from '@/features/student/buildProject/components/badges/ActivityStatusBadge/ActivityStatusBadge.stub'
 import { UnsubscribeActivitiesConfirmModalStub } from '@/features/student/buildProject/components/modals/UnsubscribeActivitiesConfirmModal/UnsubscribeActivitiesConfirmModal.stub'
 import { ActivityDetailedDropdownStub } from '@/features/student/buildProject/views/ProjectActivityDetailedView/components/overlays/ActivityDetailedDropdown/ActivityDetailedDropdown.stub'
 import { ProjectActivityDetailsStub } from '@/features/student/buildProject/views/ProjectActivityDetailedView/components/ProjectActivityDetails/ProjectActivityDetails.stub'
@@ -19,6 +21,7 @@ BddTest().given('a project activity detailed view', () => {
   const stubs = {
     PageTitle: PageTitleStub,
     Loader: LoaderStub,
+    ActivityStatusBadge: ActivityStatusBadgeStub,
     UnsubscribeActivitiesConfirmModal: UnsubscribeActivitiesConfirmModalStub,
     ActivityDetailedDropdown: ActivityDetailedDropdownStub,
     ProjectActivityDetails: ProjectActivityDetailsStub
@@ -82,6 +85,12 @@ BddTest().given('a project activity detailed view', () => {
       const details = wrapper.findComponent(ProjectActivityDetailsStub)
       expect(details.exists()).toBe(true)
       expect(details.props('declaredActivityDetails')).toEqual(mockedDeclaredActivityDetails)
+    })
+
+    BddTest().then('it should render the ActivityStatusBadge with the correct status', () => {
+      const badge = wrapper.findComponent(ActivityStatusBadgeStub)
+      expect(badge.exists()).toBe(true)
+      expect(badge.props('status')).toBe(EDeclaredActivityStatus.IN_PROGRESS)
     })
 
     BddTest().and('the user clicks the unsubscribe button in the activity detailed dropdown', () => {

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/ProjectActivityDetailedView.vue
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/ProjectActivityDetailedView.vue
@@ -3,6 +3,7 @@ import Loader from '@/common/components/Loader/Loader.vue'
 import PageTitle from '@/common/components/PageTitle/PageTitle.vue'
 import { useModal } from '@/common/composables'
 import { ROUTES } from '@/common/constants'
+import ActivityStatusBadge from '@/features/student/buildProject/components/badges/ActivityStatusBadge/ActivityStatusBadge.vue'
 import ActivityErrorMessage from '@/features/student/buildProject/components/feedback/ActivityErrorMessage/ActivityErrorMessage.vue'
 import UnsubscribeActivitiesConfirmModal from '@/features/student/buildProject/components/modals/UnsubscribeActivitiesConfirmModal/UnsubscribeActivitiesConfirmModal.vue'
 import {
@@ -58,10 +59,16 @@ const breadcrumbLinks = computed(() => [
       <div
         class="av-row av-justify-end"
       >
-        <ActivityDetailedDropdown
-          data-testid="activity-detailed-dropdown"
-          @unsubscribe-selected="displayModal"
-        />
+        <div class="av-col av-gap-xs av-align-end">
+          <ActivityStatusBadge
+            data-testid="activity-status-badge"
+            :status="declaredActivityDetail.status"
+          />
+          <ActivityDetailedDropdown
+            data-testid="activity-detailed-dropdown"
+            @unsubscribe-selected="displayModal"
+          />
+        </div>
       </div>
 
       <ProjectActivityDetails :declared-activity-details="declaredActivityDetail" />


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> Ajout du badge de statut sur la page de détail d'une activité déclarée, mise à jour des tests unitaires associés, et correction de tests E2E instables liés au chargement asynchrone de la page de détail.

Changements :
- Ajout du composant `ActivityStatusBadge` dans `ProjectActivityDetailedView` pour afficher le statut de l'activité
- Correction du `v-if` pour prendre en compte le cas d'erreur (`&& !isError`)
- Mise à jour des tests unitaires de `ProjectActivityDetailedView` pour stubber et asserter `ActivityStatusBadge`
- Ajout d'un `Background` au niveau de la règle `Activity Detail` dans le fichier de feature E2E pour attendre que `project-activity-details` soit visible avant chaque scénario (correction de tests flaky)
- Ajout de la step definition `the project activity details are loaded` dans `StudentProjectActivityDetails`

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1168

---

### Documentation
> Aucune mise à jour de documentation requise.

---

### Target Branch
> `develop`

---

### Additional Notes
> Les tests E2E étaient instables car après `waitForURL`, la requête API pour les détails de l'activité n'avait pas encore répondu. Le `Loader` utilise `v-if/v-else`, ce qui signifie que `project-activity-details` est complètement absent du DOM pendant le chargement. En attendant explicitement que ce conteneur soit visible dans un `Background` de règle (propre à la règle `Activity Detail`), on garantit que les données sont chargées avant chaque assertion — sans impacter la règle `Page Load`.

---

### Known Limitations or Side Effects
> Aucun.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [x] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [x] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process