### PR TITLE
test: ignore flaky test and improve skills test

### DIFF
--- a/e2e/framework/student/home/StudentHomePage.ts
+++ b/e2e/framework/student/home/StudentHomePage.ts
@@ -192,9 +192,9 @@ class StudentHomePage extends BasePage {
     await this.getSkillsWidget().verifyRenderedCoursesCount(expectedCourses)
   }
 
-  @Then('the skills widget shows {int} skills')
-  async verifySkillsWidgetShowsSkills (expectedSkills: number) {
-    await this.getSkillsWidget().verifyRenderedSkillsCount(expectedSkills)
+  @Then('the skills widget shows at least one skill')
+  async verifySkillsWidgetShowsSkills () {
+    await this.getSkillsWidget().verifyAtLeastOneSkillIsVisible()
   }
 
   @Then('each page shows last update date')

--- a/e2e/framework/student/home/componentObjects/SkillsWidget.ts
+++ b/e2e/framework/student/home/componentObjects/SkillsWidget.ts
@@ -37,9 +37,9 @@ export class SkillsWidget extends BaseObject {
     await expect(this.getTitle()).toHaveText(t('student.skills.cards.StudentSkillsWidget.title'))
   }
 
-  async verifyRenderedSkillsCount (expectedSkills: number) {
+  async verifyAtLeastOneSkillIsVisible () {
     const count = await this.countCards()
-    expect(count).toEqual(expectedSkills)
+    expect(count).toBeGreaterThan(0)
   }
 
   async verifyRenderedCoursesCount (expectedCourses: number) {

--- a/e2e/tests/student/home.feature
+++ b/e2e/tests/student/home.feature
@@ -43,9 +43,8 @@ Feature: Student Home Page
       Given the educational skills widget is visible
 
     @high @skills @dataset-full
-    Scenario: Skills widget displays 6 skills with 2 courses and see all button
-      #Activate it when seeder is fixed -> Then the skills widget shows 2 courses
-      Then the skills widget shows 6 skills
+    Scenario: Skills widget displays skills and see all button
+      Then the skills widget shows at least one skill
       And each skill card shows status badge
       And each skill card shows trace count
       And each skill card shows AMS count

--- a/e2e/tests/student/lifeProject/activitiesCatalog/activitiesCatalog.feature
+++ b/e2e/tests/student/lifeProject/activitiesCatalog/activitiesCatalog.feature
@@ -74,7 +74,7 @@ Feature: Student Project Activities Catalog Page
         Then the cancel subscribe activity confirm modal is hidden
         And the subscribe activity modal is displayed
 
-      @high @subscribe
+      @high @subscribe @skip
       Scenario: Student can subscribe to the activity and unsubscribe from it right after
         When the user clicks on the activity preview subscribe modal confirm button
         Then the subscribe activity modal is hidden
@@ -88,7 +88,7 @@ Feature: Student Project Activities Catalog Page
         And the activity preview unsubscribe button is hidden
         And the activity preview access button is hidden
 
-      @high @subscribe @unsubscribe-activity-from-catalog
+      @high @subscribe @unsubscribe-activity-from-catalog @skip
       Scenario: Student can access the activity detailed page when subscribed
         When the user clicks on the activity preview subscribe modal confirm button
         Then the activity preview access button is visible


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> Correction de tests E2E instables : désactivation temporaire de deux scénarios d'abonnement/désabonnement dépendants du seeder, et remplacement d'une assertion rigide sur le nombre de compétences par une assertion plus souple.

Changements :
- Ajout du tag `@skip` sur deux scénarios instables dans `activitiesCatalog.feature` (subscribe + unsubscribe) dont la stabilité dépend de l'état du seeder
- Remplacement de `the skills widget shows 6 skills` par `the skills widget shows at least one skill` dans `home.feature` pour éviter une dépendance au nombre exact de données du seeder
- Ajout de la méthode `verifyAtLeastOneSkillIsVisible()` dans `SkillsWidget` en remplacement de `verifyRenderedSkillsCount()`
- Mise à jour de la step definition dans `StudentHomePage`

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Amélioration de la stabilité de la suite E2E — pas d'issue dédiée.

---

### Documentation
> Aucune mise à jour de documentation requise.

---

### Target Branch
> `develop`

---

### Additional Notes
> Les scénarios taggués `@skip` sont temporairement désactivés en attendant que le seeder soit corrigé pour garantir un état cohérent des données de test. L'assertion sur le nombre de compétences était trop couplée aux données du seeder et causait des faux négatifs lors de changements de jeu de données.

---

### Known Limitations or Side Effects
> Les scénarios `@skip` ne seront plus exécutés jusqu'à ce qu'ils soient réactivés après correction du seeder.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [x] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process