### PR TITLE
feat(1169): ajouter les champs de période

### DIFF
--- a/api-specs/avenir-esr.swagger.json
+++ b/api-specs/avenir-esr.swagger.json
@@ -1021,7 +1021,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/SubscribeDeclaredActivityRequestDTO"
+                "$ref": "#/components/schemas/SubscribeDeclaredActivityRequest"
               }
             }
           }
@@ -3565,7 +3565,7 @@
           }
         }
       },
-      "SubscribeDeclaredActivityRequestDTO": {
+      "DeclaredActivityPeriodDTO": {
         "type": "object",
         "properties": {
           "startDate": {
@@ -3581,6 +3581,14 @@
           "endDate",
           "startDate"
         ]
+      },
+      "SubscribeDeclaredActivityRequest": {
+        "type": "object",
+        "properties": {
+          "period": {
+            "$ref": "#/components/schemas/DeclaredActivityPeriodDTO"
+          }
+        }
       },
       "PictureDTO": {
         "type": "object",

--- a/e2e/framework/student/lifeProject/activitiesCatalog/StudentProjectActivitiesCatalog.ts
+++ b/e2e/framework/student/lifeProject/activitiesCatalog/StudentProjectActivitiesCatalog.ts
@@ -302,6 +302,11 @@ class StudentProjectActivitiesCatalogPage {
     await this.activityPreview().clickSubscribeModalConfirmButton()
   }
 
+  @When('the user fills in the subscribe activity modal period start date')
+  async fillSubscribeModalPeriodStartDate () {
+    await this.activityPreview().fillSubscribeModalPeriodStartDate('2027-01-15')
+  }
+
   @When('the user clicks on the activity preview subscribe modal cancel button')
   async clickSubscribeModalCancelButton () {
     await this.activityPreview().clickSubscribeModalCancelButton()

--- a/e2e/framework/student/lifeProject/activitiesCatalog/componentObjects/ActivityPreview.ts
+++ b/e2e/framework/student/lifeProject/activitiesCatalog/componentObjects/ActivityPreview.ts
@@ -145,6 +145,11 @@ export class ActivityPreview extends BaseObject {
     await subscribeActivityModal.clickConfirm()
   }
 
+  async fillSubscribeModalPeriodStartDate (date: string) {
+    const subscribeActivityModal = this.getSubscribeActivityModal()
+    await subscribeActivityModal.fillStartDate(date)
+  }
+
   async clickSubscribeModalCancelButton () {
     const subscribeActivityModal = this.getSubscribeActivityModal()
     await subscribeActivityModal.clickCancel()

--- a/e2e/framework/student/lifeProject/activitiesCatalog/componentObjects/SubscribeActivityModal.ts
+++ b/e2e/framework/student/lifeProject/activitiesCatalog/componentObjects/SubscribeActivityModal.ts
@@ -25,6 +25,10 @@ export class SubscribeActivityModal extends BaseObject {
     return this.getModalRoot().getByTestId('subscribe-activity-modal__title')
   }
 
+  private getPeriodStartDateInput () {
+    return this.getModalRoot().getByTestId('subscribe-activity-modal__period-input').getByTestId('start-date-input').nth(0)
+  }
+
   getCancelSubscribeActivityConfirmModal () {
     return new CancelSubscribeActivityConfirmModal(this.page)
   }
@@ -53,6 +57,10 @@ export class SubscribeActivityModal extends BaseObject {
 
     await expect(this.getTitle()).toBeVisible()
     await expect(this.getTitle()).not.toBeEmpty()
+  }
+
+  async fillStartDate (date: string) {
+    await this.getPeriodStartDateInput().fill(date)
   }
 
   async clickCancel () {

--- a/e2e/tests/student/lifeProject/activitiesCatalog/activitiesCatalog.feature
+++ b/e2e/tests/student/lifeProject/activitiesCatalog/activitiesCatalog.feature
@@ -59,18 +59,21 @@ Feature: Student Project Activities Catalog Page
 
       @medium @subscribe
       Scenario: Student can see the cancel subscribe modal
-        When the user clicks on the activity preview subscribe modal cancel button
+        When the user fills in the subscribe activity modal period start date
+        And the user clicks on the activity preview subscribe modal cancel button
         Then the cancel subscribe activity confirm modal is displayed
 
       @low @subscribe
       Scenario: Student can confirm the cancel subscribe modal
-        When the user clicks on the activity preview subscribe modal cancel button and confirms
+        When the user fills in the subscribe activity modal period start date
+        And the user clicks on the activity preview subscribe modal cancel button and confirms
         Then the cancel subscribe activity confirm modal is hidden
         And the subscribe activity modal is hidden
 
       @low @subscribe
       Scenario: Student can cancel the cancel subscribe modal
-        When the user clicks on the activity preview subscribe modal cancel button and cancels
+        When the user fills in the subscribe activity modal period start date
+        And the user clicks on the activity preview subscribe modal cancel button and cancels
         Then the cancel subscribe activity confirm modal is hidden
         And the subscribe activity modal is displayed
 

--- a/src/common/composables/use-form-validators/use-form-validators.ts
+++ b/src/common/composables/use-form-validators/use-form-validators.ts
@@ -5,7 +5,7 @@ import { useI18n } from 'vue-i18n'
 export interface validateDateIntervalArgs {
   startDate: string | undefined | null
   endDate: string | undefined | null
-  format: string
+  format?: string
   isOnGoing?: boolean
 }
 
@@ -52,7 +52,7 @@ export function useFormValidators (): UseFormValidatorsReturn {
     }
   }
 
-  function validateDateInterval ({ startDate, endDate, format, isOnGoing = false }: validateDateIntervalArgs): string | undefined {
+  function validateDateInterval ({ startDate, endDate, format = 'yyyy-MM-dd', isOnGoing = false }: validateDateIntervalArgs): string | undefined {
     const startRequiredError = validateRequired(startDate)
     if (startRequiredError) {
       return startRequiredError

--- a/src/features/student/buildProject/locales/en.json
+++ b/src/features/student/buildProject/locales/en.json
@@ -53,6 +53,9 @@
             "overlays": {
               "ActivitySubscribeModal": {
                 "error": "An error occurred while subscribing to the activity. Please try again later.",
+                "period": {
+                  "label": "Add a personal achievement period"
+                },
                 "success": "You have successfully subscribed. Find this activity in your activity library.",
                 "title": "Subscribe to the activity {title}"
               },

--- a/src/features/student/buildProject/locales/fr.json
+++ b/src/features/student/buildProject/locales/fr.json
@@ -53,6 +53,9 @@
             "overlays": {
               "ActivitySubscribeModal": {
                 "error": "Une erreur est survenue lors de l'inscription à l'activité. Veuillez réessayer plus tard.",
+                "period": {
+                  "label": "Ajouter une période de réalisation personnelle"
+                },
                 "success": "Vous êtes inscrit.e avec succès. Retrouvez cette activité dans votre bibliothèque d’activités.",
                 "title": "Inscription à l’activité {title}"
               },

--- a/src/features/student/buildProject/queries/use-activities.query/use-activities.query.test.ts
+++ b/src/features/student/buildProject/queries/use-activities.query/use-activities.query.test.ts
@@ -16,7 +16,7 @@ import {
   type DeclaredActivityDetailsDTO,
   EActivityThematic,
   type getDeclaredActivitiesView,
-  type SubscribeDeclaredActivityRequestDTO
+  type SubscribeDeclaredActivityRequest
 } from '@/api/avenir-esr'
 import {
   type FinishDeclaredActivityVariables,
@@ -160,7 +160,7 @@ BddTest().given('the useActivityDetailQuery composable', () => {
 
 BddTest().given('the useSubscribeActivityMutation composable', () => {
   let subscribeActivitySpy: MockInstance<
-    (activityId: string, params: SubscribeDeclaredActivityRequestDTO, options?: RequestInit | undefined) => Promise<DeclaredActivity>
+    (activityId: string, params: SubscribeDeclaredActivityRequest, options?: RequestInit | undefined) => Promise<DeclaredActivity>
   >
   let useInvalidateQuerySpy: MockInstance<typeof useInvalidateQuery>
   let mutationResult: ReturnType<typeof useSubscribeActivityMutation>
@@ -195,7 +195,7 @@ BddTest().given('the useSubscribeActivityMutation composable', () => {
 
   BddTest().and('valid activity ID and success callback', () => {
     const activityId = 'activity-1-id'
-    const variables: SubscribeActivityVariables = { activityId }
+    const variables: SubscribeActivityVariables = { activityId, subscribeDeclaredActivityRequest: {} }
 
     BddTest().when('the mutation is called with mutateAsync', () => {
       beforeEach(async () => {
@@ -256,9 +256,40 @@ BddTest().given('the useSubscribeActivityMutation composable', () => {
     })
   })
 
+  BddTest().and('valid activity ID with a period (startDate and endDate)', () => {
+    const activityId = 'activity-1-id'
+    const period = { startDate: '2026-03-11', endDate: '2026-03-20' }
+    const variables: SubscribeActivityVariables = {
+      activityId,
+      subscribeDeclaredActivityRequest: { period }
+    }
+
+    BddTest().when('the mutation is called with period variables', () => {
+      beforeEach(async () => {
+        mutationResult = mountQueryComposable(() => useSubscribeActivityMutation(mutationArgs))
+        await mutationResult.mutateAsync(variables)
+        await flushPromises()
+      })
+
+      BddTest().then('it should call the subscribeActivity API with the period data', () => {
+        expect(subscribeActivitySpy).toHaveBeenCalledWith(activityId, { period })
+        expect(subscribeActivitySpy).toHaveBeenCalledTimes(1)
+      })
+
+      BddTest().then('it should mark the mutation as successful', () => {
+        expect(mutationResult.isSuccess.value).toBe(true)
+        expect(mutationResult.isError.value).toBe(false)
+      })
+
+      BddTest().then('it should call the custom onSuccess callback', () => {
+        expect(mockOnSuccess).toHaveBeenCalledTimes(1)
+      })
+    })
+  })
+
   BddTest().and('no success or error callbacks', () => {
     const activityId = 'activity-1-id'
-    const variables: SubscribeActivityVariables = { activityId }
+    const variables: SubscribeActivityVariables = { activityId, subscribeDeclaredActivityRequest: {} }
     const mutationArgs = {}
 
     BddTest().when('the mutation is called without callbacks', () => {
@@ -290,7 +321,7 @@ BddTest().given('the useSubscribeActivityMutation composable', () => {
 
   BddTest().and('an invalid activity id with error callback', () => {
     const activityId = 'INVALID_ACTIVITY_ID'
-    const variables: SubscribeActivityVariables = { activityId }
+    const variables: SubscribeActivityVariables = { activityId, subscribeDeclaredActivityRequest: {} }
 
     BddTest().when('the mutation encounters an error', () => {
       beforeEach(async () => {

--- a/src/features/student/buildProject/queries/use-activities.query/use-activities.query.ts
+++ b/src/features/student/buildProject/queries/use-activities.query/use-activities.query.ts
@@ -19,6 +19,7 @@ import {
   type PagedResponseActivityOverviewDTO,
   type PagedResponseDeclaredActivityViewDTO,
   subscribeActivity,
+  type SubscribeDeclaredActivityRequest,
   unsubscribeActivitiesProgresses
 } from '@/api/avenir-esr'
 import { useInvalidateQuery } from '@/common/composables'
@@ -194,15 +195,15 @@ export function useCountLibraryActivities (params?: MaybeRef<GetDeclaredActiviti
 
 export interface SubscribeActivityVariables {
   activityId: string
+  subscribeDeclaredActivityRequest: SubscribeDeclaredActivityRequest
 }
 
 export function useSubscribeActivityMutation ({ onError, onSuccess }: MutationArgs<DeclaredActivity, SubscribeActivityVariables> = {}) {
   const invalidateQueryKey = useInvalidateQuery()
 
   return useMutation<DeclaredActivity, BaseApiException, SubscribeActivityVariables>({
-    mutationFn: async ({ activityId }: SubscribeActivityVariables): Promise<DeclaredActivity> => {
-      // TODO: startDate and endDate US#???
-      return await subscribeActivity(activityId, { startDate: new Date().toISOString(), endDate: new Date().toISOString() })
+    mutationFn: async ({ activityId, subscribeDeclaredActivityRequest }: SubscribeActivityVariables): Promise<DeclaredActivity> => {
+      return await subscribeActivity(activityId, subscribeDeclaredActivityRequest)
     },
     onSuccess: async (data, variables) => {
       await invalidateQueryKey([...activityDetailsQueryKey, variables.activityId])

--- a/src/features/student/buildProject/views/ProjectActivitiesCatalogView/components/overlays/SubscribeActivityModal/SubscribeActivityModal.test.ts
+++ b/src/features/student/buildProject/views/ProjectActivitiesCatalogView/components/overlays/SubscribeActivityModal/SubscribeActivityModal.test.ts
@@ -2,7 +2,8 @@ import type { VueWrapper } from '@vue/test-utils'
 import { ConfirmationModalStub } from '@/common/components/ConfirmationModal/ConfirmationModal.stub'
 import { CancelSubscribeActivityConfirmModalStub } from '@/features/student/buildProject/views/ProjectActivitiesCatalogView/components/overlays/CancelSubscribeActivityConfirmModal/CancelSubscribeActivityConfirmModal.stub'
 import SubscribeActivityModal, { type SubscribeActivityModalProps } from '@/features/student/buildProject/views/ProjectActivitiesCatalogView/components/overlays/SubscribeActivityModal/SubscribeActivityModal.vue'
-import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { AvPeriodInputStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { flushPromises } from '@vue/test-utils'
 import { mountComponent } from 'tests/utils'
 import { beforeEach, expect, vi } from 'vitest'
 
@@ -25,7 +26,8 @@ BddTest().given('a subscribe activity modal', () => {
 
   const stubs = {
     ConfirmationModal: ConfirmationModalStub,
-    CancelSubscribeActivityConfirmModal: CancelSubscribeActivityConfirmModalStub
+    CancelSubscribeActivityConfirmModal: CancelSubscribeActivityConfirmModalStub,
+    AvPeriodInput: AvPeriodInputStub
   }
 
   beforeEach(() => {
@@ -58,15 +60,108 @@ BddTest().given('a subscribe activity modal', () => {
       expect(modal.exists()).toBe(true)
     })
 
-    BddTest().and('the user cancels the action', () => {
+    BddTest().then('it should render the period input', () => {
+      const periodInput = wrapper.findComponent(AvPeriodInputStub)
+      expect(periodInput.exists()).toBe(true)
+    })
+
+    BddTest().and('the user sets a start date and end date', () => {
+      const startDate = '2026-03-11'
+      const endDate = '2026-03-20'
+
+      beforeEach(async () => {
+        const periodInput = wrapper.findComponent(AvPeriodInputStub)
+        await periodInput.vm.$emit('update:startModelValue', startDate)
+        await periodInput.vm.$emit('update:endModelValue', endDate)
+      })
+
+      BddTest().then('it should update the period input start date value', async () => {
+        await flushPromises()
+        const periodInput = wrapper.findComponent(AvPeriodInputStub)
+        expect(periodInput.props('startModelValue')).toBe(startDate)
+      })
+
+      BddTest().then('it should update the period input end date value', async () => {
+        await flushPromises()
+        const periodInput = wrapper.findComponent(AvPeriodInputStub)
+        expect(periodInput.props('endModelValue')).toBe(endDate)
+      })
+
+      BddTest().and('the user confirms the subscription', () => {
+        beforeEach(() => {
+          const modal = wrapper.findComponent(ConfirmationModalStub)
+          modal.vm.$emit('confirm')
+        })
+
+        BddTest().then('it should add a success message', async () => {
+          await vi.waitFor(() => {
+            expect(mockAddSuccessMessage).toHaveBeenCalled()
+          })
+        })
+
+        BddTest().then('it should emit the subscribed event', async () => {
+          await vi.waitFor(() => {
+            expect(wrapper.emitted('subscribed')).toBeTruthy()
+          })
+        })
+      })
+    })
+
+    BddTest().and('the user sets an end date before the start date', () => {
+      beforeEach(async () => {
+        const periodInput = wrapper.findComponent(AvPeriodInputStub)
+        await periodInput.vm.$emit('update:startModelValue', '2026-03-20')
+        await periodInput.vm.$emit('update:endModelValue', '2026-03-10')
+      })
+
+      BddTest().and('the user confirms the subscription', () => {
+        beforeEach(async () => {
+          const modal = wrapper.findComponent(ConfirmationModalStub)
+          modal.vm.$emit('confirm')
+          await flushPromises()
+        })
+
+        BddTest().then('it should show an error on the end date field', () => {
+          const periodInput = wrapper.findComponent(AvPeriodInputStub)
+          expect(periodInput.props('endErrorMessage')).toBeTruthy()
+        })
+
+        BddTest().then('it should not add a success message', () => {
+          expect(mockAddSuccessMessage).not.toHaveBeenCalled()
+        })
+
+        BddTest().then('it should not emit the subscribed event', () => {
+          expect(wrapper.emitted('subscribed')).toBeFalsy()
+        })
+      })
+    })
+
+    BddTest().and('the user cancels the action without any date entered', () => {
       beforeEach(() => {
+        const modal = wrapper.findComponent(ConfirmationModalStub)
+        modal.vm.$emit('close')
+      })
+
+      BddTest().then('it should not show the cancel subscribe activity confirm modal', () => {
+        const modal = wrapper.findComponent(CancelSubscribeActivityConfirmModalStub)
+        expect(modal.props('show')).toBe(false)
+      })
+
+      BddTest().then('it should emit the cancel event directly', () => {
+        expect(wrapper.emitted('cancel')).toBeTruthy()
+      })
+    })
+
+    BddTest().and('the user enters a start date and then cancels the action', () => {
+      beforeEach(async () => {
+        const periodInput = wrapper.findComponent(AvPeriodInputStub)
+        await periodInput.vm.$emit('update:startModelValue', '2026-03-11')
         const modal = wrapper.findComponent(ConfirmationModalStub)
         modal.vm.$emit('close')
       })
 
       BddTest().then('it should show the cancel subscribe activity confirm modal', () => {
         const modal = wrapper.findComponent(CancelSubscribeActivityConfirmModalStub)
-        expect(modal.exists()).toBe(true)
         expect(modal.props('show')).toBe(true)
       })
 
@@ -78,7 +173,6 @@ BddTest().given('a subscribe activity modal', () => {
 
         BddTest().then('it should hide the cancel subscribe activity confirm modal', () => {
           const modal = wrapper.findComponent(CancelSubscribeActivityConfirmModalStub)
-          expect(modal.exists()).toBe(true)
           expect(modal.props('show')).toBe(false)
         })
       })

--- a/src/features/student/buildProject/views/ProjectActivitiesCatalogView/components/overlays/SubscribeActivityModal/SubscribeActivityModal.vue
+++ b/src/features/student/buildProject/views/ProjectActivitiesCatalogView/components/overlays/SubscribeActivityModal/SubscribeActivityModal.vue
@@ -1,9 +1,13 @@
 <script lang="ts" setup>
 import ConfirmationModal from '@/common/components/ConfirmationModal/ConfirmationModal.vue'
 import { useModal } from '@/common/composables'
+import { useFormValidators } from '@/common/composables/use-form-validators/use-form-validators'
 import { useSubscribeActivityMutation } from '@/features/student/buildProject/queries/use-activities.query/use-activities.query'
 import CancelSubscribeActivityConfirmModal from '@/features/student/buildProject/views/ProjectActivitiesCatalogView/components/overlays/CancelSubscribeActivityConfirmModal/CancelSubscribeActivityConfirmModal.vue'
 import { useToasterStore } from '@/store'
+import { AvPeriodInput } from '@avenirs-esr/avenirs-dsav'
+import { useForm } from '@tanstack/vue-form'
+import { startOfToday } from 'date-fns'
 import { useI18n } from 'vue-i18n'
 
 export interface SubscribeActivityModalProps {
@@ -14,7 +18,12 @@ export interface SubscribeActivityModalProps {
   }
 }
 
-defineProps<SubscribeActivityModalProps>()
+interface SubscribeActivityFormData {
+  startDate: string | null
+  endDate: string | null
+}
+
+const { activity } = defineProps<SubscribeActivityModalProps>()
 
 const emit = defineEmits<{
   (e: 'cancel'): void
@@ -22,12 +31,15 @@ const emit = defineEmits<{
 }>()
 
 const { t } = useI18n()
+const { validateDateInterval, validateRequired } = useFormValidators()
 const {
   showModal: showCancelSubscribeConfirmModal,
   displayModal: displayCancelSubscribeConfirmModal,
   hideModal: hideCancelSubscribeConfirmModal
 } = useModal()
 const { addSuccessMessage, addErrorMessage } = useToasterStore()
+
+const todayDate = startOfToday()
 
 const { mutate: subscribe } = useSubscribeActivityMutation({
   onSuccess: () => {
@@ -42,21 +54,111 @@ const { mutate: subscribe } = useSubscribeActivityMutation({
   }
 })
 
+const form = useForm({
+  defaultValues: {
+    startDate: null,
+    endDate: null
+  } as SubscribeActivityFormData,
+  validators: {
+    onSubmit ({ value }: { value: SubscribeActivityFormData }) {
+      const { startDate, endDate } = value
+      const validateEndDate = () => {
+        if (!startDate) {
+          return
+        }
+        return validateRequired(endDate) || validateDateInterval({
+          startDate,
+          endDate,
+          isOnGoing: true
+        })
+      }
+      const validateStartDate = () => {
+        if (!endDate) {
+          return
+        }
+        return validateRequired(startDate) || validateDateInterval({
+          startDate,
+          endDate,
+          isOnGoing: true
+        })
+      }
+      return {
+        fields: {
+          startDate: validateStartDate(),
+          endDate: validateEndDate()
+        }
+      }
+    }
+  },
+  onSubmit: ({ value }: { value: SubscribeActivityFormData }) => {
+    const { startDate, endDate } = value
+    const period = startDate && endDate
+      ? { startDate, endDate }
+      : undefined
+
+    subscribe({
+      activityId: activity.id,
+      subscribeDeclaredActivityRequest: {
+        period
+      }
+    }, {
+      onSuccess: () => {
+        form.reset()
+      }
+    })
+  }
+})
+
+const startDateField = form.useField({ name: 'startDate' })
+const startDateValue = computed(() => startDateField.state.value.value ?? '')
+const endDateField = form.useField({ name: 'endDate' })
+const endDateValue = computed(() => endDateField.state.value.value ?? '')
+const startDateErrorMessage = computed(() => startDateField.state.value.meta.errors?.join(', '))
+const endDateErrorMessage = computed(() => endDateField.state.value.meta.errors?.join(', '))
+
+const isFormValid = computed(() => {
+  const state = form.useStore(s => s)
+  return state.value.isValid && !state.value.isValidating
+})
+
+const isFormDirty = computed(() => {
+  const state = form.useStore(s => s)
+  return state.value.isDirty
+})
+
 function onConfirmCancelSubscribe () {
   hideCancelSubscribeConfirmModal()
-
+  form.reset()
   setTimeout(() => {
     emit('cancel')
   }, 10)
+}
+
+function onCancelSubscribeModal () {
+  if (isFormDirty.value) {
+    displayCancelSubscribeConfirmModal()
+  }
+  else {
+    emit('cancel')
+  }
+}
+
+function onChangeStartDate (date: string) {
+  startDateField.api.handleChange(date)
+}
+
+function onChangeEndDate (date: string) {
+  endDateField.api.handleChange(date)
 }
 </script>
 
 <template>
   <ConfirmationModal
     :show="show"
+    :confirm-button-disabled="!isFormValid"
     data-testid="subscribe-activity-modal"
-    @close="displayCancelSubscribeConfirmModal"
-    @confirm="subscribe({ activityId: activity.id })"
+    @close="onCancelSubscribeModal"
+    @confirm="form.handleSubmit"
   >
     <template #header>
       <div
@@ -71,6 +173,18 @@ function onConfirmCancelSubscribe () {
         </span>
       </div>
     </template>
+
+    <AvPeriodInput
+      data-testid="subscribe-activity-modal__period-input"
+      :label="t('student.buildProject.activities.views.ProjectActivitiesCatalogView.overlays.ActivitySubscribeModal.period.label')"
+      :start-model-value="startDateValue"
+      :end-model-value="endDateValue"
+      :start-min-date="todayDate"
+      :start-error-message="startDateErrorMessage"
+      :end-error-message="endDateErrorMessage"
+      @update:start-model-value="onChangeStartDate"
+      @update:end-model-value="onChangeEndDate"
+    />
 
     <CancelSubscribeActivityConfirmModal
       :show="showCancelSubscribeConfirmModal"


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> Ajout d'un composable générique `useTabQueryParam` pour synchroniser l'onglet actif avec un query param URL, refacto de `usePagination` et mise à jour des tests associés.

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1169

---

### Documentation
> Aucune mise à jour de documentation nécessaire.

---

### Target Branch
> `develop`

---

### Additional Notes
> - `useTabQueryParam` : composable générique qui synchronise un `ref` d'onglet actif avec un query param URL à partir d'un enum TypeScript. Supporte les enums numériques (filtre le reverse mapping), valeur par défaut optionnelle, nom de paramètre configurable.
> - `isEnumMember` dans `type-guards.ts` étendu pour supporter `Record<string, number | string>` au lieu de `Record<string, string>` uniquement.
> - `usePagination` : suppression du `toRef` redondant et du `{ immediate: true }` qui causait un reset de page indésirable au montage.
---

### Known Limitations or Side Effects
> - Le `staleTime` de 20 secondes sur les queries de la bibliothèque d'activités signifie que les données peuvent être légèrement décalées pendant cette fenêtre. Les mutations existantes invalident correctement le cache en cas de modification.

---

## ✅ Checklist

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process