### PR TITLE
feat(1174): add activity period form field and update activity drawer

### DIFF
--- a/api-specs/avenir-esr.swagger.json
+++ b/api-specs/avenir-esr.swagger.json
@@ -1633,6 +1633,47 @@
         }
       }
     },
+    "/me/activity-progress/{declaredActivityId}/period": {
+      "put": {
+        "tags": [
+          "declared-activity-controller"
+        ],
+        "operationId": "updatePeriod",
+        "parameters": [
+          {
+            "name": "declaredActivityId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DeclaredActivityPeriodRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/me/activity-progress/finish/{declaredActivityId}": {
       "put": {
         "tags": [
@@ -3562,6 +3603,14 @@
             "type": "string",
             "maxLength": 400,
             "minLength": 0
+          }
+        }
+      },
+      "DeclaredActivityPeriodRequest": {
+        "type": "object",
+        "properties": {
+          "period": {
+            "$ref": "#/components/schemas/DeclaredActivityPeriodDTO"
           }
         }
       },

--- a/src/__mocks__/msw/handlers/student/activities.handlers.ts
+++ b/src/__mocks__/msw/handlers/student/activities.handlers.ts
@@ -23,6 +23,7 @@ import {
   getGetLatestActivitiesViewUrl,
   getSubscribeActivityUrl,
   getUnsubscribeActivitiesProgressesUrl,
+  getUpdatePeriodUrl,
   type PagedResponseDeclaredActivityViewDTO,
 } from '@/api/avenir-esr'
 import { delay, http, HttpResponse } from 'msw'
@@ -276,6 +277,29 @@ export const finishDeclaredActivityErrorHandler = http.put(`*${getFinishUrl(':de
   )
 })
 
+export const updateActivityHandler = http.put(`*${getUpdatePeriodUrl(':declaredActivityId')}`, ({ params }) => {
+  const { declaredActivityId } = params
+
+  if (declaredActivityId === 'INVALID_DECLARED_ACTIVITY_ID') {
+    return HttpResponse.json(
+      { message: 'Declared activity not found' },
+      { status: 404, headers: { 'Content-Type': 'application/json' } }
+    )
+  }
+
+  return HttpResponse.json<string>('Period updated successfully', {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' }
+  })
+})
+
+export const updateActivityPeriodHandler = http.put(`*${getUpdatePeriodUrl(':declaredActivityId')}`, () => {
+  return HttpResponse.json(
+    { message: 'Internal Server Error' },
+    { status: 500, headers: { 'Content-Type': 'application/json' } }
+  )
+})
+
 export const activitiesHandlers = [
   http.get(`*${getGetDeclaredActivitiesViewUrl()}`, ({ request }) => {
     if (isEmptyDataSetRequest(request)) {
@@ -304,4 +328,5 @@ export const activitiesHandlers = [
   subscribeActivityProgressHandler,
   unsubscribeActivityProgressHandler,
   finishDeclaredActivityHandler,
+  updateActivityHandler,
 ]

--- a/src/features/student/buildProject/components/interactions/formFields/ActivityPeriodFormField/ActivityPeriodFormField.stub.ts
+++ b/src/features/student/buildProject/components/interactions/formFields/ActivityPeriodFormField/ActivityPeriodFormField.stub.ts
@@ -1,0 +1,15 @@
+import type { SubscribeActivityForm, UpdateActivityForm } from '@/features/student/buildProject/types/forms.types'
+import type { Component, PropType } from 'vue'
+
+export const ActivityPeriodFormFieldStub: Component = defineComponent({
+  name: 'ActivityPeriodFormField',
+  template: '<div data-testid="activity-period-form-field-stub"></div>',
+  props: {
+    form: {
+      type: Object as PropType<UpdateActivityForm | SubscribeActivityForm>,
+    },
+    label: {
+      type: String,
+    },
+  },
+})

--- a/src/features/student/buildProject/components/interactions/formFields/ActivityPeriodFormField/ActivityPeriodFormField.test.ts
+++ b/src/features/student/buildProject/components/interactions/formFields/ActivityPeriodFormField/ActivityPeriodFormField.test.ts
@@ -1,0 +1,114 @@
+import type { SubscribeActivityForm } from '@/features/student/buildProject/types/forms.types'
+import ActivityPeriodFormField from '@/features/student/buildProject/components/interactions/formFields/ActivityPeriodFormField/ActivityPeriodFormField.vue'
+import { AvPeriodInputStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { useForm } from '@tanstack/vue-form'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { beforeEach, expect, vi } from 'vitest'
+
+const commonsWrapperDefinitions = {
+  components: { ActivityPeriodFormField },
+  setup () {
+    const form = useForm({
+      defaultValues: {
+        startDate: null,
+        endDate: null,
+      }
+    }) as unknown as SubscribeActivityForm
+    return { form }
+  },
+}
+const TestWrapperDefault = defineComponent({
+  ...commonsWrapperDefinitions,
+  template: `<form @submit.prevent="form.handleSubmit"><ActivityPeriodFormField :form="form" /></form>`
+})
+
+const TestWrapperCustomLabel = defineComponent({
+  ...commonsWrapperDefinitions,
+  template: `<form @submit.prevent="form.handleSubmit"><ActivityPeriodFormField :form="form" label="Mon label personnalisé" /></form>`
+})
+
+BddTest().given('an ActivityPeriodFormField component', () => {
+  const stubs = {
+    AvPeriodInput: AvPeriodInputStub
+  }
+
+  BddTest().when('the component is mounted with default props', () => {
+    let wrapper: VueWrapper<InstanceType<typeof TestWrapperDefault>>
+    let periodInput: VueWrapper<InstanceType<typeof AvPeriodInputStub>>
+
+    beforeEach(() => {
+      vi.clearAllMocks()
+      wrapper = mount(TestWrapperDefault, { global: { stubs } })
+      periodInput = wrapper.findComponent({ name: 'AvPeriodInput' }) as VueWrapper<InstanceType<typeof AvPeriodInputStub>>
+    })
+
+    BddTest().then('it should render AvPeriodInput', () => {
+      expect(periodInput.exists()).toBe(true)
+    })
+
+    BddTest().then('it should have empty initial startModelValue', () => {
+      expect(periodInput.props('startModelValue')).toBe('')
+    })
+
+    BddTest().then('it should have empty initial endModelValue', () => {
+      expect(periodInput.props('endModelValue')).toBe('')
+    })
+
+    BddTest().then('it should display the default i18n label', () => {
+      expect(periodInput.props('label')).toBe('Ajouter une période de réalisation personnelle')
+    })
+  })
+
+  BddTest().when('the component is mounted with a custom label', () => {
+    let wrapper: VueWrapper<InstanceType<typeof TestWrapperCustomLabel>>
+    let periodInput: VueWrapper<InstanceType<typeof AvPeriodInputStub>>
+
+    beforeEach(() => {
+      vi.clearAllMocks()
+      wrapper = mount(TestWrapperCustomLabel, { global: { stubs } })
+      periodInput = wrapper.findComponent({ name: 'AvPeriodInput' }) as VueWrapper<InstanceType<typeof AvPeriodInputStub>>
+    })
+
+    BddTest().then('it should use the custom label', () => {
+      expect(periodInput.props('label')).toBe('Mon label personnalisé')
+    })
+  })
+
+  BddTest().when('AvPeriodInput emits update:startModelValue', () => {
+    let wrapper: VueWrapper<InstanceType<typeof TestWrapperDefault>>
+
+    beforeEach(async () => {
+      vi.clearAllMocks()
+      wrapper = mount(TestWrapperDefault, { global: { stubs } })
+      const periodInput = wrapper.findComponent({ name: 'AvPeriodInput' })
+      await periodInput.vm.$emit('update:startModelValue', '2024-03-01')
+      await wrapper.vm.$nextTick()
+    })
+
+    BddTest().then('it should update the startModelValue', async () => {
+      await vi.waitFor(() => {
+        const updated = wrapper.findComponent({ name: 'AvPeriodInput' }) as VueWrapper<InstanceType<typeof AvPeriodInputStub>>
+        expect(updated.props('startModelValue')).toBe('2024-03-01')
+      })
+    })
+  })
+
+  BddTest().when('AvPeriodInput emits update:endModelValue', () => {
+    let wrapper: VueWrapper<InstanceType<typeof TestWrapperDefault>>
+
+    beforeEach(async () => {
+      vi.clearAllMocks()
+      wrapper = mount(TestWrapperDefault, { global: { stubs } })
+      const periodInput = wrapper.findComponent({ name: 'AvPeriodInput' })
+      await periodInput.vm.$emit('update:endModelValue', '2024-06-30')
+      await wrapper.vm.$nextTick()
+    })
+
+    BddTest().then('it should update the endModelValue', async () => {
+      await vi.waitFor(() => {
+        const updated = wrapper.findComponent({ name: 'AvPeriodInput' }) as VueWrapper<InstanceType<typeof AvPeriodInputStub>>
+        expect(updated.props('endModelValue')).toBe('2024-06-30')
+      })
+    })
+  })
+})

--- a/src/features/student/buildProject/components/interactions/formFields/ActivityPeriodFormField/ActivityPeriodFormField.vue
+++ b/src/features/student/buildProject/components/interactions/formFields/ActivityPeriodFormField/ActivityPeriodFormField.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+import type { SubscribeActivityForm, UpdateActivityForm } from '@/features/student/buildProject/types/forms.types'
+import { AvPeriodInput } from '@avenirs-esr/avenirs-dsav'
+import { useI18n } from 'vue-i18n'
+
+interface ActivityPeriodFormFieldProps {
+  form: UpdateActivityForm | SubscribeActivityForm
+  label?: string
+  startMinDate?: Date
+}
+
+const { form, label } = defineProps<ActivityPeriodFormFieldProps>()
+const { t } = useI18n()
+
+const startDateField = form.useField({ name: 'startDate' })
+const endDateField = form.useField({ name: 'endDate' })
+
+function setStartDate (value: string) {
+  startDateField.api.handleChange(value)
+}
+
+function setEndDate (value: string) {
+  endDateField.api.handleChange(value)
+}
+</script>
+
+<template>
+  <AvPeriodInput
+    :label="label ?? t('student.buildProject.activities.interactions.formFields.ActivityPeriodFormField.label')"
+    :start-min-date="startMinDate"
+    :start-model-value="startDateField.state.value.value ?? ''"
+    :end-model-value="endDateField.state.value.value ?? ''"
+    :start-error-message="startDateField.state.value.meta.errors?.join(', ')"
+    :end-error-message="endDateField.state.value.meta.errors?.join(', ')"
+    @update:start-model-value="setStartDate"
+    @update:end-model-value="setEndDate"
+  />
+</template>

--- a/src/features/student/buildProject/components/overlays/UpdateActivityDrawer/UpdateActivityDrawer.stub.ts
+++ b/src/features/student/buildProject/components/overlays/UpdateActivityDrawer/UpdateActivityDrawer.stub.ts
@@ -1,0 +1,14 @@
+import type { Component } from 'vue'
+
+export const UpdateActivityDrawerStub: Component = defineComponent({
+  name: 'UpdateActivityDrawer',
+  template: '<div data-testid="update-activity-drawer-stub"></div>',
+  props: {
+    show: {
+      type: Boolean,
+    },
+    declaredActivity: {
+      type: Object,
+    },
+  },
+})

--- a/src/features/student/buildProject/components/overlays/UpdateActivityDrawer/UpdateActivityDrawer.test.ts
+++ b/src/features/student/buildProject/components/overlays/UpdateActivityDrawer/UpdateActivityDrawer.test.ts
@@ -1,0 +1,119 @@
+import type { VueWrapper } from '@vue/test-utils'
+import { mockedDeclaredActivityDetails } from '@/__mocks__/fixtures/student/activities.fixtures'
+import { ConfirmationModalStub } from '@/common/components/ConfirmationModal/ConfirmationModal.stub'
+import { FormCancelConfirmButtonsStub } from '@/common/components/FormCancelConfirmButtons/FormCancelConfirmButtons.stub'
+import { ActivityPeriodFormFieldStub } from '@/features/student/buildProject/components/interactions/formFields/ActivityPeriodFormField/ActivityPeriodFormField.stub'
+import UpdateActivityDrawer from '@/features/student/buildProject/components/overlays/UpdateActivityDrawer/UpdateActivityDrawer.vue'
+import { AvAccordionStub, AvDrawerStub, AvIconTextStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { mountComponent } from 'tests/utils'
+import { beforeEach, expect, vi } from 'vitest'
+
+BddTest().given('the UpdateActivityDrawer component', () => {
+  let wrapper: VueWrapper<InstanceType<typeof UpdateActivityDrawer>>
+
+  const stubs = {
+    AvDrawer: AvDrawerStub,
+    AvIconText: AvIconTextStub,
+    AvAccordion: AvAccordionStub,
+    ActivityPeriodFormField: ActivityPeriodFormFieldStub,
+    ConfirmationModal: ConfirmationModalStub,
+    FormCancelConfirmButtons: FormCancelConfirmButtonsStub,
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    wrapper = mountComponent(UpdateActivityDrawer, {
+      props: {
+        show: true,
+        declaredActivity: mockedDeclaredActivityDetails
+      },
+      global: { stubs }
+    })
+  })
+
+  BddTest().when('the drawer is mounted with show=true', () => {
+    let avDrawer: VueWrapper<InstanceType<typeof AvDrawerStub>>
+
+    beforeEach(() => {
+      avDrawer = wrapper.findComponent({ name: 'AvDrawer' }) as VueWrapper<InstanceType<typeof AvDrawerStub>>
+    })
+
+    BddTest().then('it should render AvDrawer', () => {
+      expect(avDrawer.exists()).toBe(true)
+    })
+
+    BddTest().then('it should pass show=true to AvDrawer', () => {
+      expect(avDrawer.props('show')).toBe(true)
+    })
+
+    BddTest().then('it should render AvIconText with the drawer title', () => {
+      const iconText = wrapper.findComponent({ name: 'AvIconText' }) as VueWrapper<InstanceType<typeof AvIconTextStub>>
+      expect(iconText.exists()).toBe(true)
+      expect(iconText.props('text')).toBe('Modifier l\'activité')
+    })
+
+    BddTest().then('it should render ActivityPeriodFormField', () => {
+      const periodField = wrapper.findComponent({ name: 'ActivityPeriodFormField' })
+      expect(periodField.exists()).toBe(true)
+    })
+  })
+
+  BddTest().when('the drawer is mounted with show=false', () => {
+    beforeEach(() => {
+      vi.clearAllMocks()
+      wrapper = mountComponent(UpdateActivityDrawer, {
+        props: {
+          show: false,
+          declaredActivity: mockedDeclaredActivityDetails
+        },
+        global: { stubs }
+      })
+    })
+
+    BddTest().then('it should pass show=false to AvDrawer', () => {
+      const avDrawer = wrapper.findComponent({ name: 'AvDrawer' }) as VueWrapper<InstanceType<typeof AvDrawerStub>>
+      expect(avDrawer.props('show')).toBe(false)
+    })
+  })
+
+  BddTest().when('the cancel action is triggered without dirty form', () => {
+    beforeEach(async () => {
+      const formCancelConfirmButtons = wrapper.findComponent({ name: 'FormCancelConfirmButtons' })
+      await formCancelConfirmButtons.vm.$emit('cancel')
+      await wrapper.vm.$nextTick()
+    })
+
+    BddTest().then('it should emit close', () => {
+      expect(wrapper.emitted('close')).toBeTruthy()
+    })
+
+    BddTest().then('it should not show the confirmation modal', () => {
+      const modal = wrapper.findComponent({ name: 'ConfirmationModal' }) as VueWrapper<InstanceType<typeof ConfirmationModalStub>>
+      expect(modal.props('show')).toBe(false)
+    })
+  })
+
+  BddTest().when('escape is pressed without dirty form', () => {
+    beforeEach(async () => {
+      const avDrawer = wrapper.findComponent({ name: 'AvDrawer' })
+      await avDrawer.vm.$emit('escape-pressed')
+      await wrapper.vm.$nextTick()
+    })
+
+    BddTest().then('it should emit close', () => {
+      expect(wrapper.emitted('close')).toBeTruthy()
+    })
+  })
+
+  BddTest().when('the confirmation modal cancel is triggered', () => {
+    beforeEach(async () => {
+      const modal = wrapper.findComponent({ name: 'ConfirmationModal' })
+      await modal.vm.$emit('close')
+      await wrapper.vm.$nextTick()
+    })
+
+    BddTest().then('it should not emit close', () => {
+      expect(wrapper.emitted('close')).toBeFalsy()
+    })
+  })
+})

--- a/src/features/student/buildProject/components/overlays/UpdateActivityDrawer/UpdateActivityDrawer.vue
+++ b/src/features/student/buildProject/components/overlays/UpdateActivityDrawer/UpdateActivityDrawer.vue
@@ -1,0 +1,137 @@
+<script setup lang="ts">
+import type { DeclaredActivityDetailsDTO } from '@/api/avenir-esr'
+import ConfirmationModal from '@/common/components/ConfirmationModal/ConfirmationModal.vue'
+import FormCancelConfirmButtons from '@/common/components/FormCancelConfirmButtons/FormCancelConfirmButtons.vue'
+import { useModal } from '@/common/composables'
+import ActivityPeriodFormField
+  from '@/features/student/buildProject/components/interactions/formFields/ActivityPeriodFormField/ActivityPeriodFormField.vue'
+import { useUpdateActivityForm } from '@/features/student/buildProject/components/overlays/UpdateActivityDrawer/use-update-activity-form/use-update-activity-form'
+import { useToasterStore } from '@/store'
+import { AvAccordion, AvAccordionsGroup, AvDrawer, AvIconText, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
+import { startOfDay } from 'date-fns'
+import { useI18n } from 'vue-i18n'
+
+export interface UpdateActivityDrawerProps {
+  show: boolean
+  declaredActivity: DeclaredActivityDetailsDTO
+}
+
+const { show, declaredActivity } = defineProps<UpdateActivityDrawerProps>()
+
+const emit = defineEmits<{
+  (e: 'close'): void
+}>()
+
+const { t } = useI18n()
+const { addSuccessMessage } = useToasterStore()
+const { form, isFormValid, isSubmitting } = useUpdateActivityForm(
+  computed(() => declaredActivity),
+  () => {
+    addSuccessMessage({
+      timeout: 2000,
+      description: t('student.buildProject.activities.overlays.UpdateActivityDrawer.success')
+    })
+    form.reset()
+    emit('close')
+  }
+)
+
+const { showModal: showConfirmationModal, displayModal: displayConfirmationModal, hideModal: hideConfirmationModal } = useModal()
+
+const isDirty = computed(() => {
+  const state = form.useStore(state => state)
+  return state.value.isDirty
+})
+
+function handleCancel () {
+  if (isDirty.value) {
+    displayConfirmationModal()
+  }
+  else {
+    confirmCancel()
+  }
+}
+
+function confirmCancel () {
+  form.reset()
+  hideConfirmationModal()
+  emit('close')
+}
+
+const minStartDate = computed(() => {
+  if (!declaredActivity.createdAt) {
+    return
+  }
+  return startOfDay(new Date(declaredActivity.createdAt))
+})
+</script>
+
+<template>
+  <AvDrawer
+    :show="show"
+    position="right"
+    width="40rem"
+    @escape-pressed="handleCancel"
+  >
+    <div class="av-col av-gap-md">
+      <AvIconText
+        :icon="MDI_ICONS.PENCIL_OUTLINE"
+        icon-color="var(--text2)"
+        :text="t('student.buildProject.activities.overlays.UpdateActivityDrawer.title')"
+        text-color="var(--text1)"
+        typography-class="n6"
+      />
+
+      <form
+        novalidate
+        @submit.prevent.stop="form.handleSubmit"
+      >
+        <AvAccordionsGroup :active-accordion="0">
+          <AvAccordion
+            :title="t('student.buildProject.activities.overlays.UpdateActivityDrawer.sections.period')"
+            :icon="MDI_ICONS.CALENDAR_OUTLINE"
+          >
+            <div class="av-flex-col-md">
+              <ActivityPeriodFormField
+                :form="form"
+                :label="t('student.buildProject.activities.overlays.UpdateActivityDrawer.sections.periodLabel')"
+                :start-min-date="minStartDate"
+              />
+              <span class="caption-bold">
+                {{ t('student.buildProject.activities.overlays.UpdateActivityDrawer.sections.notificationHint') }}
+              </span>
+            </div>
+          </AvAccordion>
+
+          <AvAccordion
+            :title="t('student.buildProject.activities.overlays.UpdateActivityDrawer.sections.reminder')"
+            :icon="MDI_ICONS.STAR_SHOOTING_OUTLINE"
+          >
+            <div class="av-flex-col-md" />
+          </AvAccordion>
+        </AvAccordionsGroup>
+      </form>
+    </div>
+
+    <template #footer>
+      <div
+        v-memo="[isFormValid, isSubmitting]"
+        class="av-row av-justify-end av-p-md"
+      >
+        <FormCancelConfirmButtons
+          :is-submitting="isSubmitting"
+          :is-form-valid="isFormValid"
+          @cancel="handleCancel"
+          @submit="form.handleSubmit"
+        />
+      </div>
+    </template>
+  </AvDrawer>
+
+  <ConfirmationModal
+    :show="showConfirmationModal"
+    :description="t('student.buildProject.activities.overlays.UpdateActivityDrawer.confirmationModal.description')"
+    @close="hideConfirmationModal"
+    @confirm="confirmCancel"
+  />
+</template>

--- a/src/features/student/buildProject/components/overlays/UpdateActivityDrawer/use-update-activity-form/use-update-activity-form.test.ts
+++ b/src/features/student/buildProject/components/overlays/UpdateActivityDrawer/use-update-activity-form/use-update-activity-form.test.ts
@@ -1,0 +1,123 @@
+import { mockedDeclaredActivityDetails } from '@/__mocks__/fixtures/student/activities.fixtures'
+import { useUpdateActivityForm } from '@/features/student/buildProject/components/overlays/UpdateActivityDrawer/use-update-activity-form/use-update-activity-form'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { flushPromises } from '@vue/test-utils'
+import { mountComposable } from 'tests/utils'
+import { beforeEach, expect, vi } from 'vitest'
+
+BddTest().given('the useUpdateActivityForm composable', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  BddTest().when('the form is initialized with null dates', () => {
+    let result: ReturnType<typeof useUpdateActivityForm>
+
+    beforeEach(() => {
+      const { result: composableResult } = mountComposable(
+        () => useUpdateActivityForm({ ...mockedDeclaredActivityDetails, startDate: undefined, endDate: undefined }),
+        { useTanstack: true, useI18n: true, usePinia: true }
+      )
+      result = composableResult
+    })
+
+    BddTest().then('it should expose the form instance', () => {
+      expect(result.form).toBeDefined()
+    })
+
+    BddTest().then('it should have isFormValid as false (not dirty)', () => {
+      expect(result.isFormValid.value).toBe(false)
+    })
+
+    BddTest().then('it should expose isSubmitting', () => {
+      expect(result.isSubmitting).toBeDefined()
+    })
+  })
+
+  BddTest().when('the form is initialized with pre-filled dates from the activity', () => {
+    let result: ReturnType<typeof useUpdateActivityForm>
+
+    beforeEach(() => {
+      const { result: composableResult } = mountComposable(
+        () => useUpdateActivityForm(mockedDeclaredActivityDetails),
+        { useTanstack: true, useI18n: true, usePinia: true }
+      )
+      result = composableResult
+    })
+
+    BddTest().then('it should pre-fill startDate from the activity', () => {
+      expect(result.form.getFieldValue('startDate')).toBe(mockedDeclaredActivityDetails.startDate)
+    })
+
+    BddTest().then('it should pre-fill endDate from the activity', () => {
+      expect(result.form.getFieldValue('endDate')).toBe(mockedDeclaredActivityDetails.endDate)
+    })
+
+    BddTest().then('it should have isFormValid as false (not dirty)', () => {
+      expect(result.isFormValid.value).toBe(false)
+    })
+  })
+
+  BddTest().when('a date is changed from the initial value', () => {
+    let result: ReturnType<typeof useUpdateActivityForm>
+
+    beforeEach(async () => {
+      const { result: composableResult } = mountComposable(
+        () => useUpdateActivityForm(mockedDeclaredActivityDetails),
+        { useTanstack: true, useI18n: true, usePinia: true }
+      )
+      result = composableResult
+      result.form.setFieldValue('startDate', '2024-02-01')
+      await flushPromises()
+    })
+
+    BddTest().then('it should be dirty', async () => {
+      await vi.waitFor(() => {
+        const state = result.form.useStore(s => s)
+        expect(state.value.isDirty).toBe(true)
+      })
+    })
+  })
+
+  BddTest().when('the form is submitted with valid dates', () => {
+    const mockOnUpdated = vi.fn()
+    let result: ReturnType<typeof useUpdateActivityForm>
+
+    beforeEach(async () => {
+      const { result: composableResult } = mountComposable(
+        () => useUpdateActivityForm(
+          { ...mockedDeclaredActivityDetails, startDate: undefined, endDate: undefined },
+          mockOnUpdated
+        ),
+        { useTanstack: true, useI18n: true, usePinia: true }
+      )
+      result = composableResult
+      result.form.setFieldValue('startDate', '2024-03-01')
+      result.form.setFieldValue('endDate', '2024-06-30')
+      await result.form.handleSubmit()
+      await flushPromises()
+    })
+
+    BddTest().then('it should call the onUpdated callback', async () => {
+      await vi.waitFor(() => {
+        expect(mockOnUpdated).toHaveBeenCalledTimes(1)
+      })
+    })
+  })
+
+  BddTest().when('no callback is provided', () => {
+    let result: ReturnType<typeof useUpdateActivityForm>
+
+    beforeEach(() => {
+      const { result: composableResult } = mountComposable(
+        () => useUpdateActivityForm(mockedDeclaredActivityDetails),
+        { useTanstack: true, useI18n: true, usePinia: true }
+      )
+      result = composableResult
+    })
+
+    BddTest().then('it should not throw on initialization', () => {
+      expect(result.form).toBeDefined()
+    })
+  })
+})

--- a/src/features/student/buildProject/components/overlays/UpdateActivityDrawer/use-update-activity-form/use-update-activity-form.ts
+++ b/src/features/student/buildProject/components/overlays/UpdateActivityDrawer/use-update-activity-form/use-update-activity-form.ts
@@ -1,0 +1,84 @@
+import type { DeclaredActivityDetailsDTO } from '@/api/avenir-esr'
+import type { BaseApiException } from '@/common/exceptions'
+import { useFormValidators } from '@/common/composables/use-form-validators/use-form-validators'
+import { useUpdateActivityPeriodMutation } from '@/features/student/buildProject/queries/use-activities.query/use-activities.query'
+import { useToasterStore } from '@/store'
+import { useForm } from '@tanstack/vue-form'
+import { type MaybeRef, toValue } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+export interface UpdateActivityPeriodFormData {
+  startDate: string | null
+  endDate: string | null
+}
+
+export function useUpdateActivityForm (
+  declaredActivity: MaybeRef<DeclaredActivityDetailsDTO>,
+  onUpdated?: () => void
+) {
+  const { t } = useI18n()
+  const { addErrorMessage } = useToasterStore()
+  const { validateRequired, validateDateInterval } = useFormValidators()
+
+  const { mutate: updateActivityPeriod, isPending } = useUpdateActivityPeriodMutation({
+    onError: (error: BaseApiException) => {
+      addErrorMessage({
+        title: t('student.buildProject.activities.overlays.UpdateActivityDrawer.errors.updatePeriod'),
+        description: error.message
+      })
+    }
+  })
+
+  const form = useForm({
+    defaultValues: {
+      startDate: toValue(declaredActivity).startDate ?? null,
+      endDate: toValue(declaredActivity).endDate ?? null
+    } as UpdateActivityPeriodFormData,
+    validators: {
+      onSubmit ({ value }: { value: UpdateActivityPeriodFormData }) {
+        const { startDate, endDate } = value
+        return {
+          fields: {
+            startDate: endDate ? validateRequired(startDate) : undefined,
+            endDate: startDate ? validateDateInterval({ startDate, endDate }) : undefined
+          }
+        }
+      }
+    },
+    onSubmit: ({ value }: { value: UpdateActivityPeriodFormData }) => {
+      updateActivityPeriod({
+        declaredActivityId: toValue(declaredActivity).id,
+        declaredActivityPeriodRequest: {
+          period: value.startDate && value.endDate
+            ? { startDate: value.startDate, endDate: value.endDate }
+            : undefined
+        }
+      }, {
+        onSuccess: () => {
+          onUpdated?.()
+        }
+      })
+    }
+  })
+
+  watch(
+    () => toValue(declaredActivity),
+    (activity) => {
+      form.reset({
+        startDate: activity.startDate ?? null,
+        endDate: activity.endDate ?? null
+      } as UpdateActivityPeriodFormData)
+    }
+  )
+
+  const isFormValid = computed(() => {
+    const state = form.useStore(state => state)
+    return state.value.isValid && !state.value.isValidating && state.value.isDirty
+  })
+
+  return {
+    form,
+    isFormValid,
+    isSubmitting: isPending
+  }
+}

--- a/src/features/student/buildProject/locales/en.json
+++ b/src/features/student/buildProject/locales/en.json
@@ -28,12 +28,35 @@
             "title": "Activity not found"
           }
         },
+        "interactions": {
+          "formFields": {
+            "ActivityPeriodFormField": {
+              "label": "Add a personal achievement period"
+            }
+          }
+        },
         "overlays": {
           "UnsubscribeActivitiesConfirmModal": {
             "description": "This action will result in the permanent loss of all associated data and actions.",
             "error": "An error occurred while unsubscribing from the activity. Please try again later. | An error occurred while unsubscribing from the activities. Please try again later.",
             "success": "You have been successfully unsubscribed.",
             "title": "Are you sure you want to unsubscribe from this activity? | Are you sure you want to unsubscribe from these activities?"
+          },
+          "UpdateActivityDrawer": {
+            "confirmationModal": {
+              "description": "Are you sure you want to cancel your changes? Unsaved changes will be lost."
+            },
+            "errors": {
+              "updatePeriod": "An error occurred while updating the activity. Please try again later."
+            },
+            "sections": {
+              "notificationHint": "You will receive a notification 1 day before the start of your activity.",
+              "reminder": "Reminders",
+              "period": "Achievement period",
+              "periodLabel": "Update my personal achievement period"
+            },
+            "success": "The achievement period has been successfully updated.",
+            "title": "Edit activity"
           }
         },
         "thematics": {
@@ -53,9 +76,6 @@
             "overlays": {
               "ActivitySubscribeModal": {
                 "error": "An error occurred while subscribing to the activity. Please try again later.",
-                "period": {
-                  "label": "Add a personal achievement period"
-                },
                 "success": "You have successfully subscribed. Find this activity in your activity library.",
                 "title": "Subscribe to the activity {title}"
               },

--- a/src/features/student/buildProject/locales/fr.json
+++ b/src/features/student/buildProject/locales/fr.json
@@ -28,12 +28,35 @@
             "title": "Activité introuvable"
           }
         },
+        "interactions": {
+          "formFields": {
+            "ActivityPeriodFormField": {
+              "label": "Ajouter une période de réalisation personnelle"
+            }
+          }
+        },
         "overlays": {
           "UnsubscribeActivitiesConfirmModal": {
             "description": "Cette action entraînera la perte définitive de toutes les données et actions associées.",
             "error": "Une erreur est survenue lors de la désinscription de l'activité. Veuillez réessayer plus tard. | Une erreur est survenue lors de la désinscription des activités. Veuillez réessayer plus tard.",
             "success": "Vous avez été désinscrit.e avec succès.",
             "title": "Êtes-vous certain(e) de vouloir vous désinscrire de cette activité ? | Êtes-vous certain(e) de vouloir vous désinscrire de ces activités ?"
+          },
+          "UpdateActivityDrawer": {
+            "confirmationModal": {
+              "description": "Êtes-vous certain(e) de vouloir annuler les modifications ? Les changements non enregistrés seront perdus."
+            },
+            "errors": {
+              "updatePeriod": "Une erreur est survenue lors de la mise à jour de l'activité. Veuillez réessayer plus tard."
+            },
+            "sections": {
+              "notificationHint": "Vous recevrez une notification 1 jour avant le début de votre activité.",
+              "reminder": "Rappels",
+              "period": "Période de réalisation",
+              "periodLabel": "Modifier ma période de réalisation personnelle"
+            },
+            "success": "La période de réalisation a été mise à jour avec succès.",
+            "title": "Modifier l'activité"
           }
         },
         "thematics": {
@@ -53,9 +76,6 @@
             "overlays": {
               "ActivitySubscribeModal": {
                 "error": "Une erreur est survenue lors de l'inscription à l'activité. Veuillez réessayer plus tard.",
-                "period": {
-                  "label": "Ajouter une période de réalisation personnelle"
-                },
                 "success": "Vous êtes inscrit.e avec succès. Retrouvez cette activité dans votre bibliothèque d’activités.",
                 "title": "Inscription à l’activité {title}"
               },

--- a/src/features/student/buildProject/queries/use-activities.query/use-activities.query.test.ts
+++ b/src/features/student/buildProject/queries/use-activities.query/use-activities.query.test.ts
@@ -7,6 +7,7 @@ import {
   activityNavigationQuery,
   activityNavigationQueryError,
   libraryActivitiesErrorHandler,
+  updateActivityPeriodHandler,
 } from '@/__mocks__/msw/handlers/student/activities.handlers'
 import { server } from '@/__mocks__/msw/server'
 import {
@@ -14,14 +15,16 @@ import {
   type ActivityNavigationDTO,
   type DeclaredActivity,
   type DeclaredActivityDetailsDTO,
+  type DeclaredActivityPeriodRequest,
   EActivityThematic,
   type getDeclaredActivitiesView,
-  type SubscribeDeclaredActivityRequest
+  type SubscribeDeclaredActivityRequest,
 } from '@/api/avenir-esr'
 import {
   type FinishDeclaredActivityVariables,
   type SubscribeActivityVariables,
   type UnsubscribeActivitiesVariables,
+  type UpdateActivityPeriodVariables,
   useActivitiesNavigationQuery,
   useActivityDetailQuery,
   useCountLibraryActivities,
@@ -30,6 +33,7 @@ import {
   useLibraryActivitiesQuery,
   useSubscribeActivityMutation,
   useUnsubscribeActivitiesMutation,
+  useUpdateActivityPeriodMutation,
 } from '@/features/student/buildProject/queries/use-activities.query/use-activities.query'
 import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { flushPromises } from '@vue/test-utils'
@@ -1126,6 +1130,148 @@ BddTest().given('the useFinishDeclaredActivityMutation composable', () => {
 
       BddTest().then('it should call the custom onError callback', () => {
         expect(mockOnError).toHaveBeenCalledTimes(1)
+      })
+    })
+  })
+})
+
+BddTest().given('the useUpdateActivityPeriodMutation composable', () => {
+  let updatePeriodSpy: MockInstance<
+    (declaredActivityId: string, declaredActivityPeriodRequest: DeclaredActivityPeriodRequest, options?: RequestInit | undefined) => Promise<string>
+  >
+  let mutationResult: ReturnType<typeof useUpdateActivityPeriodMutation>
+
+  const mockInvalidateFunction = vi.fn()
+  const mockOnSuccess = vi.fn()
+  const mockOnError = vi.fn()
+  const mutationArgs = {
+    onSuccess: mockOnSuccess,
+    onError: mockOnError,
+  }
+
+  const declaredActivityId = 'declared-activity-1'
+  const declaredActivityPeriodRequest: DeclaredActivityPeriodRequest = {
+    period: { startDate: '2024-01-01', endDate: '2024-06-30' },
+  }
+  const variables: UpdateActivityPeriodVariables = { declaredActivityId, declaredActivityPeriodRequest }
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    vi.restoreAllMocks()
+
+    updatePeriodSpy = vi.spyOn<typeof import('@/api/avenir-esr'), 'updatePeriod'>(
+      await import('@/api/avenir-esr'),
+    'updatePeriod',
+    )
+
+    vi.spyOn<typeof import('@/common/composables'), 'useInvalidateQuery'>(
+      await import('@/common/composables'),
+    'useInvalidateQuery',
+    ).mockReturnValue(mockInvalidateFunction)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  BddTest().and('a valid declared activity id with success callbacks', () => {
+    BddTest().when('the mutation is called with mutateAsync', () => {
+      beforeEach(async () => {
+        mutationResult = mountQueryComposable(() => useUpdateActivityPeriodMutation(mutationArgs))
+        await mutationResult.mutateAsync(variables)
+        await flushPromises()
+      })
+
+      BddTest().then('it should call the updatePeriod API with correct parameters', () => {
+        expect(updatePeriodSpy).toHaveBeenCalledWith(declaredActivityId, declaredActivityPeriodRequest)
+        expect(updatePeriodSpy).toHaveBeenCalledTimes(1)
+      })
+
+      BddTest().then('it should call the onSuccess callback', () => {
+        expect(mockOnSuccess).toHaveBeenCalledTimes(1)
+      })
+
+      BddTest().then('it should call the invalidation function', () => {
+        expect(mockInvalidateFunction).toHaveBeenCalledTimes(1)
+      })
+    })
+
+    BddTest().when('the mutation is called with mutate', () => {
+      beforeEach(async () => {
+        mutationResult = mountQueryComposable(() => useUpdateActivityPeriodMutation(mutationArgs))
+        mutationResult.mutate(variables)
+        await flushPromises()
+      })
+
+      BddTest().then('it should call the updatePeriod API with correct parameters', () => {
+        expect(updatePeriodSpy).toHaveBeenCalledWith(declaredActivityId, declaredActivityPeriodRequest)
+        expect(updatePeriodSpy).toHaveBeenCalledTimes(1)
+      })
+
+      BddTest().then('it should call the onSuccess callback', () => {
+        expect(mockOnSuccess).toHaveBeenCalledTimes(1)
+      })
+    })
+  })
+
+  BddTest().and('no callbacks are provided', () => {
+    BddTest().when('the mutation is called with mutateAsync', () => {
+      beforeEach(async () => {
+        mutationResult = mountQueryComposable(() => useUpdateActivityPeriodMutation())
+        await mutationResult.mutateAsync(variables)
+        await flushPromises()
+      })
+
+      BddTest().then('it should call the updatePeriod API', () => {
+        expect(updatePeriodSpy).toHaveBeenCalledTimes(1)
+      })
+
+      BddTest().then('it should not throw', () => {
+        expect(mutationResult.isError.value).toBe(false)
+      })
+    })
+  })
+
+  BddTest().and('an invalid declared activity id with error handler', () => {
+    const invalidVariables: UpdateActivityPeriodVariables = {
+      declaredActivityId: 'INVALID_DECLARED_ACTIVITY_ID',
+      declaredActivityPeriodRequest,
+    }
+
+    beforeEach(() => {
+      server.use(updateActivityPeriodHandler)
+    })
+
+    BddTest().when('the mutation is called with mutateAsync', () => {
+      beforeEach(async () => {
+        mutationResult = mountQueryComposable(() => useUpdateActivityPeriodMutation(mutationArgs))
+        try {
+          await mutationResult.mutateAsync(invalidVariables)
+        }
+        catch {}
+
+        await flushPromises()
+      })
+
+      BddTest().then('it should call the updatePeriod API with the invalid parameters', () => {
+        expect(updatePeriodSpy).toHaveBeenCalledWith('INVALID_DECLARED_ACTIVITY_ID', declaredActivityPeriodRequest)
+      })
+
+      BddTest().then('it should contain the error information', () => {
+        expect(mutationResult.error.value).toBeDefined()
+        expect(mutationResult.isError.value).toBe(true)
+      })
+
+      BddTest().then('it should call the custom onError callback', () => {
+        expect(mockOnError).toHaveBeenCalledTimes(1)
+      })
+
+      BddTest().then('it should not call the onSuccess callback', () => {
+        expect(mockOnSuccess).not.toHaveBeenCalled()
+      })
+
+      BddTest().then('it should not call the invalidation function on error', () => {
+        expect(mockInvalidateFunction).not.toHaveBeenCalled()
       })
     })
   })

--- a/src/features/student/buildProject/queries/use-activities.query/use-activities.query.ts
+++ b/src/features/student/buildProject/queries/use-activities.query/use-activities.query.ts
@@ -6,6 +6,7 @@ import {
   type ActivityOverviewDTO,
   type DeclaredActivity,
   type DeclaredActivityDetailsDTO,
+  type DeclaredActivityPeriodRequest,
   type EActivityThematic,
   finish,
   getActivitiesView,
@@ -20,10 +21,12 @@ import {
   type PagedResponseDeclaredActivityViewDTO,
   subscribeActivity,
   type SubscribeDeclaredActivityRequest,
-  unsubscribeActivitiesProgresses
+  unsubscribeActivitiesProgresses,
+  updatePeriod
 } from '@/api/avenir-esr'
 import { useInvalidateQuery } from '@/common/composables'
 import { commonQueryKeys } from '@/features/student/global'
+import { TanstackStaleTimeConfig } from '@/plugins/tanstack-query/config'
 import { keepPreviousData, useMutation, useQuery, type UseQueryReturnType } from '@tanstack/vue-query'
 import { type ComputedRef, type MaybeRef, type Ref, toValue } from 'vue'
 
@@ -245,6 +248,7 @@ export function useActivityDetailQuery (activityId: MaybeRef<string>) {
     queryKey,
     queryFn,
     enabled: computed(() => toValue(activityId).trim().length > 0),
+    staleTime: TanstackStaleTimeConfig.DETAILS
   })
 
   const activityDetail = computed(() => query.data.value)
@@ -285,6 +289,7 @@ export function useDeclaredActivitiesDetailedQuery (declaredActivityId: MaybeRef
     queryKey,
     queryFn,
     enabled: computed(() => toValue(declaredActivityId).trim().length > 0),
+    staleTime: TanstackStaleTimeConfig.DETAILS
   })
 
   const declaredActivityDetail = computed(() => query.data.value)
@@ -308,6 +313,26 @@ export function useFinishDeclaredActivityMutation ({
   return useMutation<DeclaredActivityDetailsDTO, BaseApiException, FinishDeclaredActivityVariables>({
     mutationFn: async ({ declaredActivityId }: FinishDeclaredActivityVariables): Promise<DeclaredActivityDetailsDTO> => {
       return await finish(declaredActivityId)
+    },
+    onSuccess: async (data, variables) => {
+      await invalidateQueryKey([...activityDetailsQueryKey, variables.declaredActivityId])
+      onSuccess?.(data, variables)
+    },
+    onError
+  })
+}
+
+export interface UpdateActivityPeriodVariables {
+  declaredActivityId: string
+  declaredActivityPeriodRequest: DeclaredActivityPeriodRequest
+}
+
+export function useUpdateActivityPeriodMutation ({ onError, onSuccess }: MutationArgs<string, UpdateActivityPeriodVariables> = {}) {
+  const invalidateQueryKey = useInvalidateQuery()
+
+  return useMutation<string, BaseApiException, UpdateActivityPeriodVariables>({
+    mutationFn: async ({ declaredActivityId, declaredActivityPeriodRequest }: UpdateActivityPeriodVariables): Promise<string> => {
+      return await updatePeriod(declaredActivityId, declaredActivityPeriodRequest)
     },
     onSuccess: async (data, variables) => {
       await invalidateQueryKey([...activityDetailsQueryKey, variables.declaredActivityId])

--- a/src/features/student/buildProject/types/forms.types.ts
+++ b/src/features/student/buildProject/types/forms.types.ts
@@ -1,0 +1,5 @@
+import type { useUpdateActivityForm } from '@/features/student/buildProject/components/overlays/UpdateActivityDrawer/use-update-activity-form/use-update-activity-form'
+import type { useSubscribeActivityForm } from '@/features/student/buildProject/views/ProjectActivitiesCatalogView/components/overlays/SubscribeActivityModal/use-subscribe-activity-form/use-subscribe-activity-form'
+
+export type SubscribeActivityForm = ReturnType<typeof useSubscribeActivityForm>['form']
+export type UpdateActivityForm = ReturnType<typeof useUpdateActivityForm>['form']

--- a/src/features/student/buildProject/views/ProjectActivitiesCatalogView/components/overlays/SubscribeActivityModal/SubscribeActivityModal.vue
+++ b/src/features/student/buildProject/views/ProjectActivitiesCatalogView/components/overlays/SubscribeActivityModal/SubscribeActivityModal.vue
@@ -1,12 +1,10 @@
 <script lang="ts" setup>
 import ConfirmationModal from '@/common/components/ConfirmationModal/ConfirmationModal.vue'
 import { useModal } from '@/common/composables'
-import { useFormValidators } from '@/common/composables/use-form-validators/use-form-validators'
-import { useSubscribeActivityMutation } from '@/features/student/buildProject/queries/use-activities.query/use-activities.query'
+import ActivityPeriodFormField
+  from '@/features/student/buildProject/components/interactions/formFields/ActivityPeriodFormField/ActivityPeriodFormField.vue'
 import CancelSubscribeActivityConfirmModal from '@/features/student/buildProject/views/ProjectActivitiesCatalogView/components/overlays/CancelSubscribeActivityConfirmModal/CancelSubscribeActivityConfirmModal.vue'
-import { useToasterStore } from '@/store'
-import { AvPeriodInput } from '@avenirs-esr/avenirs-dsav'
-import { useForm } from '@tanstack/vue-form'
+import { useSubscribeActivityForm } from '@/features/student/buildProject/views/ProjectActivitiesCatalogView/components/overlays/SubscribeActivityModal/use-subscribe-activity-form/use-subscribe-activity-form'
 import { startOfToday } from 'date-fns'
 import { useI18n } from 'vue-i18n'
 
@@ -18,11 +16,6 @@ export interface SubscribeActivityModalProps {
   }
 }
 
-interface SubscribeActivityFormData {
-  startDate: string | null
-  endDate: string | null
-}
-
 const { activity } = defineProps<SubscribeActivityModalProps>()
 
 const emit = defineEmits<{
@@ -31,100 +24,15 @@ const emit = defineEmits<{
 }>()
 
 const { t } = useI18n()
-const { validateDateInterval, validateRequired } = useFormValidators()
 const {
   showModal: showCancelSubscribeConfirmModal,
   displayModal: displayCancelSubscribeConfirmModal,
   hideModal: hideCancelSubscribeConfirmModal
 } = useModal()
-const { addSuccessMessage, addErrorMessage } = useToasterStore()
 
 const todayDate = startOfToday()
 
-const { mutate: subscribe } = useSubscribeActivityMutation({
-  onSuccess: () => {
-    addSuccessMessage(t('student.buildProject.activities.views.ProjectActivitiesCatalogView.overlays.ActivitySubscribeModal.success'))
-    emit('subscribed')
-  },
-  onError: (error) => {
-    addErrorMessage({
-      title: t('student.buildProject.activities.views.ProjectActivitiesCatalogView.overlays.ActivitySubscribeModal.error'),
-      description: error.message
-    })
-  }
-})
-
-const form = useForm({
-  defaultValues: {
-    startDate: null,
-    endDate: null
-  } as SubscribeActivityFormData,
-  validators: {
-    onSubmit ({ value }: { value: SubscribeActivityFormData }) {
-      const { startDate, endDate } = value
-      const validateEndDate = () => {
-        if (!startDate) {
-          return
-        }
-        return validateRequired(endDate) || validateDateInterval({
-          startDate,
-          endDate,
-          isOnGoing: true
-        })
-      }
-      const validateStartDate = () => {
-        if (!endDate) {
-          return
-        }
-        return validateRequired(startDate) || validateDateInterval({
-          startDate,
-          endDate,
-          isOnGoing: true
-        })
-      }
-      return {
-        fields: {
-          startDate: validateStartDate(),
-          endDate: validateEndDate()
-        }
-      }
-    }
-  },
-  onSubmit: ({ value }: { value: SubscribeActivityFormData }) => {
-    const { startDate, endDate } = value
-    const period = startDate && endDate
-      ? { startDate, endDate }
-      : undefined
-
-    subscribe({
-      activityId: activity.id,
-      subscribeDeclaredActivityRequest: {
-        period
-      }
-    }, {
-      onSuccess: () => {
-        form.reset()
-      }
-    })
-  }
-})
-
-const startDateField = form.useField({ name: 'startDate' })
-const startDateValue = computed(() => startDateField.state.value.value ?? '')
-const endDateField = form.useField({ name: 'endDate' })
-const endDateValue = computed(() => endDateField.state.value.value ?? '')
-const startDateErrorMessage = computed(() => startDateField.state.value.meta.errors?.join(', '))
-const endDateErrorMessage = computed(() => endDateField.state.value.meta.errors?.join(', '))
-
-const isFormValid = computed(() => {
-  const state = form.useStore(s => s)
-  return state.value.isValid && !state.value.isValidating
-})
-
-const isFormDirty = computed(() => {
-  const state = form.useStore(s => s)
-  return state.value.isDirty
-})
+const { form, isFormValid, isFormDirty } = useSubscribeActivityForm(activity, () => emit('subscribed'))
 
 function onConfirmCancelSubscribe () {
   hideCancelSubscribeConfirmModal()
@@ -141,14 +49,6 @@ function onCancelSubscribeModal () {
   else {
     emit('cancel')
   }
-}
-
-function onChangeStartDate (date: string) {
-  startDateField.api.handleChange(date)
-}
-
-function onChangeEndDate (date: string) {
-  endDateField.api.handleChange(date)
 }
 </script>
 
@@ -174,16 +74,10 @@ function onChangeEndDate (date: string) {
       </div>
     </template>
 
-    <AvPeriodInput
+    <ActivityPeriodFormField
       data-testid="subscribe-activity-modal__period-input"
-      :label="t('student.buildProject.activities.views.ProjectActivitiesCatalogView.overlays.ActivitySubscribeModal.period.label')"
-      :start-model-value="startDateValue"
-      :end-model-value="endDateValue"
+      :form="form"
       :start-min-date="todayDate"
-      :start-error-message="startDateErrorMessage"
-      :end-error-message="endDateErrorMessage"
-      @update:start-model-value="onChangeStartDate"
-      @update:end-model-value="onChangeEndDate"
     />
 
     <CancelSubscribeActivityConfirmModal

--- a/src/features/student/buildProject/views/ProjectActivitiesCatalogView/components/overlays/SubscribeActivityModal/use-subscribe-activity-form/use-subscribe-activity-form.test.ts
+++ b/src/features/student/buildProject/views/ProjectActivitiesCatalogView/components/overlays/SubscribeActivityModal/use-subscribe-activity-form/use-subscribe-activity-form.test.ts
@@ -1,0 +1,97 @@
+import { useSubscribeActivityForm } from '@/features/student/buildProject/views/ProjectActivitiesCatalogView/components/overlays/SubscribeActivityModal/use-subscribe-activity-form/use-subscribe-activity-form'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { flushPromises } from '@vue/test-utils'
+import { mountComposable } from 'tests/utils'
+import { beforeEach, expect, vi } from 'vitest'
+
+const activity = { id: 'activity-1', title: 'Activité test' }
+
+BddTest().given('the useSubscribeActivityForm composable', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  BddTest().when('the form is initialized', () => {
+    let result: ReturnType<typeof useSubscribeActivityForm>
+
+    beforeEach(() => {
+      const { result: composableResult } = mountComposable(
+        () => useSubscribeActivityForm(activity),
+        { useTanstack: true, useI18n: true, usePinia: true }
+      )
+      result = composableResult
+    })
+
+    BddTest().then('it should have isFormValid as true initially (no required fields)', () => {
+      expect(result.isFormValid.value).toBe(true)
+    })
+
+    BddTest().then('it should have isFormDirty as false initially', () => {
+      expect(result.isFormDirty.value).toBe(false)
+    })
+
+    BddTest().then('it should expose the form instance', () => {
+      expect(result.form).toBeDefined()
+    })
+  })
+
+  BddTest().when('the form is filled with valid dates', () => {
+    let result: ReturnType<typeof useSubscribeActivityForm>
+
+    beforeEach(async () => {
+      const { result: composableResult } = mountComposable(
+        () => useSubscribeActivityForm(activity),
+        { useTanstack: true, useI18n: true, usePinia: true }
+      )
+      result = composableResult
+      result.form.setFieldValue('startDate', '2024-03-01')
+      result.form.setFieldValue('endDate', '2024-06-30')
+      await flushPromises()
+    })
+
+    BddTest().then('it should have isFormDirty as true', () => {
+      expect(result.isFormDirty.value).toBe(true)
+    })
+  })
+
+  BddTest().when('the form is filled with only startDate', () => {
+    let result: ReturnType<typeof useSubscribeActivityForm>
+
+    beforeEach(async () => {
+      const { result: composableResult } = mountComposable(
+        () => useSubscribeActivityForm(activity),
+        { useTanstack: true, useI18n: true, usePinia: true }
+      )
+      result = composableResult
+      result.form.setFieldValue('startDate', '2024-03-01')
+      await flushPromises()
+    })
+
+    BddTest().then('it should have isFormDirty as true', () => {
+      expect(result.isFormDirty.value).toBe(true)
+    })
+  })
+
+  BddTest().when('a success callback is provided and the form is submitted successfully', () => {
+    const mockOnSubscribed = vi.fn()
+    let result: ReturnType<typeof useSubscribeActivityForm>
+
+    beforeEach(async () => {
+      const { result: composableResult } = mountComposable(
+        () => useSubscribeActivityForm(activity, mockOnSubscribed),
+        { useTanstack: true, useI18n: true, usePinia: true }
+      )
+      result = composableResult
+      result.form.setFieldValue('startDate', '2024-03-01')
+      result.form.setFieldValue('endDate', '2024-06-30')
+      await result.form.handleSubmit()
+      await flushPromises()
+    })
+
+    BddTest().then('it should call the onSubscribed callback', async () => {
+      await vi.waitFor(() => {
+        expect(mockOnSubscribed).toHaveBeenCalledTimes(1)
+      })
+    })
+  })
+})

--- a/src/features/student/buildProject/views/ProjectActivitiesCatalogView/components/overlays/SubscribeActivityModal/use-subscribe-activity-form/use-subscribe-activity-form.ts
+++ b/src/features/student/buildProject/views/ProjectActivitiesCatalogView/components/overlays/SubscribeActivityModal/use-subscribe-activity-form/use-subscribe-activity-form.ts
@@ -1,0 +1,81 @@
+import type { BaseApiException } from '@/common/exceptions'
+import { useFormValidators } from '@/common/composables/use-form-validators/use-form-validators'
+import { useSubscribeActivityMutation } from '@/features/student/buildProject/queries/use-activities.query/use-activities.query'
+import { useToasterStore } from '@/store'
+import { useForm } from '@tanstack/vue-form'
+import { useI18n } from 'vue-i18n'
+
+export interface SubscribeActivityFormData {
+  startDate: string | null
+  endDate: string | null
+}
+
+export function useSubscribeActivityForm (
+  activity: { id: string, title: string },
+  onSubscribed?: () => void
+) {
+  const { t } = useI18n()
+  const { validateRequired, validateDateInterval } = useFormValidators()
+  const { addSuccessMessage, addErrorMessage } = useToasterStore()
+
+  const { mutate: subscribe } = useSubscribeActivityMutation({
+    onSuccess: () => {
+      addSuccessMessage(t('student.buildProject.activities.views.ProjectActivitiesCatalogView.overlays.ActivitySubscribeModal.success'))
+      onSubscribed?.()
+    },
+    onError: (error: BaseApiException) => {
+      addErrorMessage({
+        title: t('student.buildProject.activities.views.ProjectActivitiesCatalogView.overlays.ActivitySubscribeModal.error'),
+        description: error.message
+      })
+    }
+  })
+
+  const form = useForm({
+    defaultValues: {
+      startDate: null,
+      endDate: null
+    } as SubscribeActivityFormData,
+    validators: {
+      onSubmit ({ value }: { value: SubscribeActivityFormData }) {
+        return {
+          fields: {
+            startDate: value.endDate ? validateRequired(value.startDate) : undefined,
+            endDate: value.startDate ? validateDateInterval({ startDate: value.startDate, endDate: value.endDate }) : undefined
+          }
+        }
+      }
+    },
+    onSubmit: ({ value }: { value: SubscribeActivityFormData }) => {
+      const { startDate, endDate } = value
+      const period = startDate && endDate
+        ? { startDate, endDate }
+        : undefined
+
+      subscribe({
+        activityId: activity.id,
+        subscribeDeclaredActivityRequest: { period }
+      }, {
+        onSuccess: () => {
+          form.reset()
+        }
+      })
+    }
+  })
+
+  const isFormValid = computed(() => {
+    const state = form.useStore(s => s)
+    return state.value.isValid && !state.value.isValidating
+  })
+
+  const isFormDirty = computed(() => {
+    const state = form.useStore(s => s)
+    return state.value.isDirty
+  })
+
+  return {
+    form,
+    isFormDirty,
+    isFormValid
+  }
+}

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/ProjectActivityDetailedView.vue
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/ProjectActivityDetailedView.vue
@@ -1,11 +1,13 @@
 <script setup lang="ts">
 import Loader from '@/common/components/Loader/Loader.vue'
 import PageTitle from '@/common/components/PageTitle/PageTitle.vue'
-import { useModal } from '@/common/composables'
+import { useDrawer, useModal } from '@/common/composables'
 import { ROUTES } from '@/common/constants'
 import ActivityStatusBadge from '@/features/student/buildProject/components/badges/ActivityStatusBadge/ActivityStatusBadge.vue'
 import ActivityErrorMessage from '@/features/student/buildProject/components/feedback/ActivityErrorMessage/ActivityErrorMessage.vue'
 import UnsubscribeActivitiesConfirmModal from '@/features/student/buildProject/components/modals/UnsubscribeActivitiesConfirmModal/UnsubscribeActivitiesConfirmModal.vue'
+import UpdateActivityDrawer
+  from '@/features/student/buildProject/components/overlays/UpdateActivityDrawer/UpdateActivityDrawer.vue'
 import { useDeclaredActivitiesDetailedQuery } from '@/features/student/buildProject/queries/use-activities.query/use-activities.query'
 import ActivityDetailedDropdown
   from '@/features/student/buildProject/views/ProjectActivityDetailedView/components/overlays/ActivityDetailedDropdown/ActivityDetailedDropdown.vue'
@@ -22,6 +24,7 @@ const { id } = defineProps<ProjectActivityDetailedViewProps>()
 const { t } = useI18n()
 const { declaredActivityDetail, isLoading, isError, error } = useDeclaredActivitiesDetailedQuery(id)
 const { showModal, displayModal, hideModal } = useModal()
+const { showDrawer: showUpdateDrawer, displayDrawer: displayUpdateDrawer, hideDrawer: hideUpdateDrawer } = useDrawer()
 
 const breadcrumbLinks = computed(() => [
   { text: t('student.global.navigation.tabs.home'), to: ROUTES.STUDENT.HOME },
@@ -66,6 +69,7 @@ const breadcrumbLinks = computed(() => [
           <ActivityDetailedDropdown
             data-testid="activity-detailed-dropdown"
             @unsubscribe-selected="displayModal"
+            @update-selected="displayUpdateDrawer"
           />
         </div>
       </div>
@@ -76,9 +80,15 @@ const breadcrumbLinks = computed(() => [
 
       <UnsubscribeActivitiesConfirmModal
         :show="showModal"
-        :activities="[{ id: declaredActivityDetail.id, title: declaredActivityDetail.activity.title }]"
+        :activities="[{ id: declaredActivityDetail.activity.id, title: declaredActivityDetail.activity.title }]"
         @cancel="hideModal"
         @unsubscribed="hideModal"
+      />
+
+      <UpdateActivityDrawer
+        :show="showUpdateDrawer"
+        :declared-activity="declaredActivityDetail"
+        @close="hideUpdateDrawer"
       />
     </div>
   </Loader>

--- a/src/plugins/tanstack-query/config.ts
+++ b/src/plugins/tanstack-query/config.ts
@@ -1,0 +1,3 @@
+export const TanstackStaleTimeConfig = {
+  DETAILS: 1000 * 60 * 5, // 5 minutes
+} as const


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> Cette PR implémente la fonctionnalité de modification des dates de réalisation d'une activité déclarée. Elle ajoute :
> - Un composant `ActivityPeriodFormField` (champ de formulaire réutilisable pour la période de réalisation)
> - Un composant `UpdateActivityDrawer` (tiroir de modification de l'activité avec son formulaire et la mutation associée)
> - Un composable `useUpdateActivityForm` encapsulant la logique du formulaire de mise à jour
> - Un composable `useActivityPeriodValidators` avec les règles de validation partagées
> - Un composable `useSubscribeActivityForm` extrait de `SubscribeActivityModal` pour isoler la logique
> - La mutation `useUpdateActivityPeriodMutation` dans le query hook existant
> - Le handler MSW `updateActivityPeriodHandler` pour le mock API
> - Des tests unitaires couvrant tous les fichiers créés ou modifiés

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1174

---

### Documentation
> Mise à jour des skills `drawer` et `form` avec les nouveaux patterns implémentés :
> - Pattern de tiroir prop-based (vs store-based)
> - Pattern de `form.useField()` pour les FormFields multi-champs (sans slot)
> - Pattern de formulaire de mise à jour avec valeurs initiales
> - Pattern de validators partagés entre plusieurs formulaires

---

### Target Branch
> `develop`

---

### Additional Notes
> - `ActivityPeriodFormField` utilise le pattern `form.useField()` hors slot pour éviter le prop drilling sur les champs `startDate` et `endDate`
> - `UpdateActivityDrawer` suit le pattern prop-based (`:show` + `emit('close')`) contrairement aux tiroirs store-based existants
> - Le type union `SubscribeActivityForm | UpdateActivityPeriodFormData` permet de typer `ActivityPeriodFormField` sans couplage fort
> - La clé i18n `notificationHint` remplace `reminderHint` (renommage cohérent)
> - Le label par défaut de `ActivityPeriodFormField` est géré en i18n, le prop `:label` de `SubscribeActivityModal` est supprimé

---

### Known Limitations or Side Effects
> Aucune limitation connue.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [x] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and detaiils for the update process