### PR TITLE
test(1173): add US#981 e2e tests

### DIFF
--- a/e2e/framework/student/lifeProject/activityDetails/StudentProjectActivityDetails.ts
+++ b/e2e/framework/student/lifeProject/activityDetails/StudentProjectActivityDetails.ts
@@ -90,6 +90,31 @@ export class StudentProjectActivityDetails extends BasePage {
     await this.getMyPerspectiveSection().verifyVisible()
   }
 
+  @Then('the my perspective card is visible')
+  async verifyMyPerspectiveCardVisible () {
+    await this.getMyPerspectiveSection().verifyPerspectiveCardVisible()
+  }
+
+  @Then('the my perspective card is in readonly mode')
+  async verifyMyPerspectiveCardReadonly () {
+    await this.getMyPerspectiveSection().verifyPerspectiveCardReadonly()
+  }
+
+  @When('the student clicks the edit my perspective button')
+  async clickEditMyPerspectiveButton () {
+    await this.getMyPerspectiveSection().clickEditPerspectiveButton()
+  }
+
+  @Then('the my perspective card is in editable mode')
+  async verifyMyPerspectiveCardEditable () {
+    await this.getMyPerspectiveSection().verifyPerspectiveCardEditable()
+  }
+
+  @When('the student cancels the perspective edition')
+  async clickCancelEditPerspectiveButton () {
+    await this.getMyPerspectiveSection().clickCancelEditPerspectiveButton()
+  }
+
   @Then('the finish activity button is hidden')
   async verifyFinishActivityButtonHidden () {
     await this.getMyPerspectiveSection().verifyFinishButtonHidden()

--- a/e2e/framework/student/lifeProject/activityDetails/componentObjects/MyPerspectiveSectionObject.ts
+++ b/e2e/framework/student/lifeProject/activityDetails/componentObjects/MyPerspectiveSectionObject.ts
@@ -6,6 +6,34 @@ export class MyPerspectiveSectionObject extends BaseObject {
     super(root)
   }
 
+  getPerspectiveCard () {
+    return this.root.getByTestId('my-perspective-card')
+  }
+
+  getEditPerspectiveButton () {
+    return this.root.getByTestId('my-perspective-card-edit-button')
+  }
+
+  getUpdatePerspectiveInProgressBadge () {
+    return this.root.getByTestId('update-in-progress-badge')
+  }
+
+  getPerspectiveContent () {
+    return this.root.getByTestId('my-perspective-card-content')
+  }
+
+  getRichTextEditor () {
+    return this.root.getByTestId('av-rich-text-editor')
+  }
+
+  getCancelEditPerspectiveButton () {
+    return this.root.getByTestId('my-perspective-card-cancel-button')
+  }
+
+  getSavePerspectiveButton () {
+    return this.root.getByTestId('my-perspective-card-save-button')
+  }
+
   getFinishButton () {
     return this.root.getByTestId('finish-declared-activity-button')
   }
@@ -18,12 +46,57 @@ export class MyPerspectiveSectionObject extends BaseObject {
     await expect(this.root).toBeVisible()
   }
 
+  async verifyPerspectiveCardVisible () {
+    await expect(this.getPerspectiveCard()).toBeVisible()
+  }
+
+  async verifyPerspectiveCardReadonly () {
+    await expect(this.getEditPerspectiveButton()).toBeVisible()
+    await expect(this.getUpdatePerspectiveInProgressBadge()).toBeHidden()
+
+    await expect(this.getPerspectiveContent()).toBeVisible()
+    await expect(this.getRichTextEditor()).toBeHidden()
+
+    await expect(this.getSavePerspectiveButton()).toBeHidden()
+    await expect(this.getCancelEditPerspectiveButton()).toBeHidden()
+  }
+
+  async verifyPerspectiveCardEditable () {
+    await expect(this.getEditPerspectiveButton()).toBeHidden()
+    await expect(this.getUpdatePerspectiveInProgressBadge()).toBeVisible()
+
+    await expect(this.getPerspectiveContent()).toBeHidden()
+    await expect(this.getRichTextEditor()).toBeVisible()
+
+    await expect(this.getSavePerspectiveButton()).toBeHidden()
+    await expect(this.getCancelEditPerspectiveButton()).toBeVisible()
+  }
+
+  async verifyPerspectiveCardEdited () {
+    await expect(this.getEditPerspectiveButton()).toBeHidden()
+    await expect(this.getUpdatePerspectiveInProgressBadge()).toBeVisible()
+
+    await expect(this.getPerspectiveContent()).toBeHidden()
+    await expect(this.getRichTextEditor()).toBeVisible()
+
+    await expect(this.getSavePerspectiveButton()).toBeVisible()
+    await expect(this.getCancelEditPerspectiveButton()).toBeHidden()
+  }
+
+  async clickEditPerspectiveButton () {
+    await this.getEditPerspectiveButton().click()
+  }
+
   async verifyFinishButtonVisible () {
     await expect(this.getFinishButton()).toBeVisible()
   }
 
   async verifyFinishButtonHidden () {
     await expect(this.getFinishButton()).toBeHidden()
+  }
+
+  async clickCancelEditPerspectiveButton () {
+    await this.getCancelEditPerspectiveButton().click()
   }
 
   async clickFinishButton () {

--- a/e2e/tests/student/lifeProject/activityDetails/activityDetails.feature
+++ b/e2e/tests/student/lifeProject/activityDetails/activityDetails.feature
@@ -43,6 +43,39 @@ Feature: Student Project Activity Detail Page
     Scenario: Student can see the activity status
       Then the activity status is visible
 
+  Rule: My perspective
+
+    Background:
+      And the project activity details are loaded
+
+    @high @activity-details @perspective
+    Scenario: Student can edit an activity perspective
+      When the student opens the project activities page
+      And the student open activity library tab
+      And the student clicks a library activity card with in progress status
+      And the project activity details are loaded
+      And the student clicks the my perspective item in the activity side menu
+      And the my perspective section is visible
+      Then the my perspective card is visible
+      And the my perspective card is in readonly mode
+      When the student clicks the edit my perspective button
+      Then the my perspective card is in editable mode
+
+    @high @activity-details @perspective
+    Scenario: Student can cancel the edition of an activity perspective
+      When the student opens the project activities page
+      And the student open activity library tab
+      And the student clicks a library activity card with in progress status
+      And the project activity details are loaded
+      And the student clicks the my perspective item in the activity side menu
+      And the my perspective section is visible
+      Then the my perspective card is visible
+      And the my perspective card is in readonly mode
+      When the student clicks the edit my perspective button
+      Then the my perspective card is in editable mode
+      When the student cancels the perspective edition
+      Then the my perspective card is in readonly mode
+
   Rule: Finish declared activity
 
     Background:

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/cards/MyPerspectiveCard/MyPerspectiveCard.test.ts
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/cards/MyPerspectiveCard/MyPerspectiveCard.test.ts
@@ -32,6 +32,11 @@ BddTest().given('a my perspective card', () => {
     UpdateInProgressBadge: UpdateInProgressBadgeStub,
   }
 
+  const getContent = () => wrapper.find('[data-testid="my-perspective-card-content"]')
+  const getEditButton = () => wrapper.find('[data-testid="my-perspective-card-edit-button"]')
+  const getSaveButton = () => wrapper.find('[data-testid="my-perspective-card-save-button"]')
+  const getCancelButton = () => wrapper.find('[data-testid="my-perspective-card-cancel-button"]')
+
   BddTest().when('the component is mounted with a valid activityId and a perspective', () => {
     const props: MyPerspectiveCardProps = {
       activityId: 'activity-1',
@@ -56,7 +61,7 @@ BddTest().given('a my perspective card', () => {
     })
 
     BddTest().then('it should render the edit button', () => {
-      const editButton = wrapper.find('[data-testid="edit-button"]')
+      const editButton = getEditButton()
       expect(editButton.exists()).toBe(true)
     })
 
@@ -71,29 +76,29 @@ BddTest().given('a my perspective card', () => {
     })
 
     BddTest().then('it should render the perspective content', () => {
-      const content = wrapper.find('[data-testid="my-perspective"]')
+      const content = getContent()
       expect(content.exists()).toBe(true)
       expect(content.html()).toContain(props.perspective)
     })
 
     BddTest().then('it should not render the save button', () => {
-      const saveButton = wrapper.find('[data-testid="save-button"]')
+      const saveButton = getSaveButton()
       expect(saveButton.exists()).toBe(false)
     })
 
-    BddTest().then('it should render not the cancel button', () => {
-      const cancelButton = wrapper.find('[data-testid="cancel-button"]')
+    BddTest().then('it should not render the cancel button', () => {
+      const cancelButton = getCancelButton()
       expect(cancelButton.exists()).toBe(false)
     })
 
     BddTest().and('the user clicks the edit button', () => {
       beforeEach(() => {
-        const editButton = wrapper.find('[data-testid="edit-button"]')
+        const editButton = getEditButton()
         editButton.trigger('click')
       })
 
       BddTest().then('it should not render the edit button', () => {
-        const editButton = wrapper.find('[data-testid="edit-button"]')
+        const editButton = getEditButton()
         expect(editButton.exists()).toBe(false)
       })
 
@@ -110,23 +115,23 @@ BddTest().given('a my perspective card', () => {
       })
 
       BddTest().then('it should not render the save button', () => {
-        const saveButton = wrapper.find('[data-testid="save-button"]')
+        const saveButton = getSaveButton()
         expect(saveButton.exists()).toBe(false)
       })
 
       BddTest().then('it should render the cancel button', () => {
-        const cancelButton = wrapper.find('[data-testid="cancel-button"]')
+        const cancelButton = getCancelButton()
         expect(cancelButton.exists()).toBe(true)
       })
 
       BddTest().and('the user clicks the cancel button', () => {
         beforeEach(() => {
-          const cancelButton = wrapper.find('[data-testid="cancel-button"]')
+          const cancelButton = getCancelButton()
           cancelButton.trigger('click')
         })
 
         BddTest().then('it should render the edit button', () => {
-          const editButton = wrapper.find('[data-testid="edit-button"]')
+          const editButton = getEditButton()
           expect(editButton.exists()).toBe(true)
         })
 
@@ -141,18 +146,18 @@ BddTest().given('a my perspective card', () => {
         })
 
         BddTest().then('it should render the perspective content', () => {
-          const content = wrapper.find('[data-testid="my-perspective"]')
+          const content = getContent()
           expect(content.exists()).toBe(true)
           expect(content.html()).toContain(props.perspective)
         })
 
         BddTest().then('it should not render the save button', () => {
-          const saveButton = wrapper.find('[data-testid="save-button"]')
+          const saveButton = getSaveButton()
           expect(saveButton.exists()).toBe(false)
         })
 
         BddTest().then('it should not render the cancel button', () => {
-          const cancelButton = wrapper.find('[data-testid="cancel-button"]')
+          const cancelButton = getCancelButton()
           expect(cancelButton.exists()).toBe(false)
         })
       })
@@ -172,7 +177,7 @@ BddTest().given('a my perspective card', () => {
         })
 
         BddTest().then('it should enable the save button', () => {
-          const saveButton = wrapper.findAllComponents(AvButtonStub).find(button => button.attributes('data-testid') === 'save-button')
+          const saveButton = wrapper.findAllComponents(AvButtonStub).find(button => button.attributes('data-testid') === 'my-perspective-card-save-button')
           expect(saveButton?.exists()).toBe(true)
           expect(saveButton!.props('disabled')).toBe(false)
         })
@@ -192,12 +197,12 @@ BddTest().given('a my perspective card', () => {
           })
 
           BddTest().then('it should not render the perspective content', () => {
-            const content = wrapper.find('[data-testid="my-perspective"]')
+            const content = getContent()
             expect(content.exists()).toBe(false)
           })
 
           BddTest().then('it should not render the edit button', () => {
-            const editButton = wrapper.find('[data-testid="edit-button"]')
+            const editButton = getEditButton()
             expect(editButton.exists()).toBe(false)
           })
 
@@ -214,19 +219,19 @@ BddTest().given('a my perspective card', () => {
           })
 
           BddTest().then('it should render the save button', () => {
-            const saveButton = wrapper.find('[data-testid="save-button"]')
+            const saveButton = getSaveButton()
             expect(saveButton.exists()).toBe(true)
           })
 
           BddTest().then('it should not render the cancel button', () => {
-            const cancelButton = wrapper.find('[data-testid="cancel-button"]')
+            const cancelButton = getCancelButton()
             expect(cancelButton.exists()).toBe(false)
           })
         })
 
         BddTest().and('the user clicks the save button', () => {
           beforeEach(async () => {
-            const saveButton = wrapper.find('[data-testid="save-button"]')
+            const saveButton = getSaveButton()
             saveButton.trigger('click')
             await flushPromises()
           })
@@ -240,12 +245,12 @@ BddTest().given('a my perspective card', () => {
           })
 
           BddTest().then('it should render the perspective content', () => {
-            const content = wrapper.find('[data-testid="my-perspective"]')
+            const content = getContent()
             expect(content.exists()).toBe(true)
           })
 
           BddTest().then('it should render the edit button', () => {
-            const editButton = wrapper.find('[data-testid="edit-button"]')
+            const editButton = getEditButton()
             expect(editButton.exists()).toBe(true)
           })
 
@@ -260,12 +265,12 @@ BddTest().given('a my perspective card', () => {
           })
 
           BddTest().then('it should not render the save button', () => {
-            const saveButton = wrapper.find('[data-testid="save-button"]')
+            const saveButton = getSaveButton()
             expect(saveButton.exists()).toBe(false)
           })
 
           BddTest().then('it should not render the cancel button', () => {
-            const cancelButton = wrapper.find('[data-testid="cancel-button"]')
+            const cancelButton = getCancelButton()
             expect(cancelButton.exists()).toBe(false)
           })
         })
@@ -284,14 +289,14 @@ BddTest().given('a my perspective card', () => {
     })
 
     BddTest().then('it should render an empty perspective content', () => {
-      const content = wrapper.find('[data-testid="my-perspective"]')
+      const content = getContent()
       expect(content.exists()).toBe(true)
       expect(content.text()).toBe('')
     })
 
     BddTest().and('the user clicks the edit button', () => {
       beforeEach(() => {
-        const editButton = wrapper.find('[data-testid="edit-button"]')
+        const editButton = getEditButton()
         editButton.trigger('click')
       })
 
@@ -316,7 +321,7 @@ BddTest().given('a my perspective card', () => {
 
     BddTest().and('the user clicks the edit button', () => {
       beforeEach(() => {
-        const editButton = wrapper.find('[data-testid="edit-button"]')
+        const editButton = getEditButton()
         editButton.trigger('click')
       })
 
@@ -352,7 +357,7 @@ BddTest().given('a my perspective card', () => {
 
         BddTest().and('the user clicks the save button', () => {
           beforeEach(async () => {
-            const saveButton = wrapper.find('[data-testid="save-button"]')
+            const saveButton = getSaveButton()
             saveButton.trigger('click')
             await flushPromises()
           })

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/cards/MyPerspectiveCard/MyPerspectiveCard.vue
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/cards/MyPerspectiveCard/MyPerspectiveCard.vue
@@ -92,7 +92,7 @@ watch(content, () => {
             :icon="MDI_ICONS.PENCIL_OUTLINE"
             variant="OUTLINED"
             small
-            data-testid="edit-button"
+            data-testid="my-perspective-card-edit-button"
             @click="readonly = false"
           />
           <UpdateInProgressBadge
@@ -111,7 +111,7 @@ watch(content, () => {
       />
       <div
         v-else
-        data-testid="my-perspective"
+        data-testid="my-perspective-card-content"
         v-html="perspective"
       />
 
@@ -125,7 +125,7 @@ watch(content, () => {
             :disabled="!isModified"
             :is-loading="isPendingSave || isPendingAutoSave"
             small
-            data-testid="save-button"
+            data-testid="my-perspective-card-save-button"
             @click="onSave"
           />
           <AvButton
@@ -135,7 +135,7 @@ watch(content, () => {
             variant="DEFAULT"
             small
             :is-loading="isPendingAutoSave"
-            data-testid="cancel-button"
+            data-testid="my-perspective-card-cancel-button"
             @click="readonly = true"
           />
         </div>

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/tabs/MyPerspectiveTab/MyPerspectiveTab.vue
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/tabs/MyPerspectiveTab/MyPerspectiveTab.vue
@@ -41,10 +41,10 @@ function onDeclaredActivityFinished () {
 
 <template>
   <div
-    class="av-col av-gap-sm"
+    class="av-col av-gap-xl"
     data-testid="my-perspective-tab"
   >
-    <div>
+    <div class="av-pt-md">
       <MyPerspectiveCard
         :activity-id="declaredActivityDetails.id"
         :perspective="declaredActivityDetails.reflection"


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
Ce PR ajoute les tests end-to-end (e2e) pour l'US#981 sur la section "My Perspective" dans les détails d'activité projet étudiant. Il améliore la couverture de tests, la robustesse et la documentation des composants concernés.

**Principaux changements :**
- ✅ Ajout de tests e2e pour l'US#981 (feature, objets, scripts)
- 🎨 Refactor et corrections mineures sur les tests unitaires et composants liés à MyPerspectiveCard/MyPerspectiveTab
- 📝 Mise à jour de la documentation technique des tests

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1173

---

### Documentation
- Ajout/Modif : `e2e/framework/student/lifeProject/activityDetails/StudentProjectActivityDetails.ts`
- Ajout/Modif : `e2e/framework/student/lifeProject/activityDetails/componentObjects/MyPerspectiveSectionObject.ts`
- Ajout/Modif : `e2e/tests/student/lifeProject/activityDetails/activityDetails.feature`
- Modif : `src/features/student/buildProject/views/ProjectActivityDetailedView/components/cards/MyPerspectiveCard/MyPerspectiveCard.test.ts`
- Modif : `src/features/student/buildProject/views/ProjectActivityDetailedView/components/cards/MyPerspectiveCard/MyPerspectiveCard.vue`
- Modif : `src/features/student/buildProject/views/ProjectActivityDetailedView/components/tabs/MyPerspectiveTab/MyPerspectiveTab.vue`

---

### Target Branch
`develop`

---

### Additional Notes
- Les tests e2e couvrent les scénarios principaux de l'US#981.
- Les composants ont été adaptés pour une meilleure testabilité.
- Pas de breaking change pour les autres fonctionnalités.

---

### Known Limitations or Side Effects
Aucune limitation ou effet de bord connu à ce stade.

---

## ✅ Checklist

- [ ] a11y tested (si applicable)
- [ ] Tests fournis (e2e et unitaires)
- [ ] i18n géré (si applicable)
- [ ] Performance tests (non applicable)
- [ ] Pas de code inutile
- [ ] Respect des règles de style et conventions
- [ ] Versionnement sémantique respecté
- [ ] Ajout dans `CHANGELOG.md` si besoin
