### PR TITLE
feat(1209): add AssociationCard, AssociatedSkillCard and AssociatedTraceCard

### DIFF
--- a/src/features/student/global/components/cards/AssociatedSkillCard/AssociatedSkillCard.stub.ts
+++ b/src/features/student/global/components/cards/AssociatedSkillCard/AssociatedSkillCard.stub.ts
@@ -1,0 +1,14 @@
+export const AssociatedSkillCardStub = defineComponent({
+  name: 'AssociatedSkillCard',
+  props: {
+    title: {
+      type: String,
+      required: true
+    },
+    to: {
+      type: [String, Object],
+      required: true
+    }
+  },
+  template: '<div data-testid="associated-skill-card"></div>'
+})

--- a/src/features/student/global/components/cards/AssociatedSkillCard/AssociatedSkillCard.test.ts
+++ b/src/features/student/global/components/cards/AssociatedSkillCard/AssociatedSkillCard.test.ts
@@ -1,0 +1,39 @@
+import AssociatedSkillCard, { type AssociatedSkillCardProps } from '@/features/student/global/components/cards/AssociatedSkillCard/AssociatedSkillCard.vue'
+import { AssociationCardStub } from '@/features/student/global/components/cards/AssociationCard/AssociationCard.stub'
+import { ICONS } from '@/features/student/global/icons'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { expect, vi } from 'vitest'
+
+BddTest().given('an associatied skill card', () => {
+  let wrapper: VueWrapper<InstanceType<typeof AssociatedSkillCard>>
+
+  const stubs = { AssociationCard: AssociationCardStub }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  BddTest().when('the component is mounted', () => {
+    const props: AssociatedSkillCardProps = {
+      title: 'Skill',
+      to: '/test'
+    }
+
+    beforeEach(() => {
+      wrapper = mount(AssociatedSkillCard, { props, global: { stubs } })
+    })
+
+    BddTest().then('it should render the AssociationCard with the correct props', () => {
+      const associationCard = wrapper.findComponent(AssociationCardStub)
+      expect(associationCard.exists()).toBe(true)
+      expect(associationCard.props()).toMatchObject({
+        title: props.title,
+        icon: ICONS.SKILLS,
+        color: 'var(--card)',
+        backgroundColor: 'var(--dark-background-primary1)',
+        to: props.to
+      })
+    })
+  })
+})

--- a/src/features/student/global/components/cards/AssociatedSkillCard/AssociatedSkillCard.vue
+++ b/src/features/student/global/components/cards/AssociatedSkillCard/AssociatedSkillCard.vue
@@ -1,0 +1,22 @@
+<script lang="ts" setup>
+import type { RouteLocationRaw } from 'vue-router'
+import AssociationCard from '@/features/student/global/components/cards/AssociationCard/AssociationCard.vue'
+import { ICONS } from '@/features/student/global/icons'
+
+export interface AssociatedSkillCardProps {
+  title: string
+  to: RouteLocationRaw
+}
+
+const { title, to } = defineProps<AssociatedSkillCardProps>()
+</script>
+
+<template>
+  <AssociationCard
+    :title="title"
+    :icon="ICONS.SKILLS"
+    color="var(--card)"
+    background-color="var(--dark-background-primary1)"
+    :to="to"
+  />
+</template>

--- a/src/features/student/global/components/cards/AssociatedTraceCard/AssociatedTraceCard.stub.ts
+++ b/src/features/student/global/components/cards/AssociatedTraceCard/AssociatedTraceCard.stub.ts
@@ -1,0 +1,14 @@
+export const AssociatedTraceCardStub = defineComponent({
+  name: 'AssociatedTraceCard',
+  props: {
+    title: {
+      type: String,
+      required: true
+    },
+    to: {
+      type: [String, Object],
+      required: true
+    }
+  },
+  template: '<div data-testid="associated-trace-card"></div>'
+})

--- a/src/features/student/global/components/cards/AssociatedTraceCard/AssociatedTraceCard.test.ts
+++ b/src/features/student/global/components/cards/AssociatedTraceCard/AssociatedTraceCard.test.ts
@@ -1,0 +1,41 @@
+import AssociatedTraceCard, { type AssociatedTraceCardProps } from '@/features/student/global/components/cards/AssociatedTraceCard/AssociatedTraceCard.vue'
+import { AssociationCardStub } from '@/features/student/global/components/cards/AssociationCard/AssociationCard.stub'
+import { ICONS } from '@/features/student/global/icons'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { expect, vi } from 'vitest'
+
+BddTest().given('an associatied trace card', () => {
+  let wrapper: VueWrapper<InstanceType<typeof AssociatedTraceCard>>
+
+  const stubs = { AssociationCard: AssociationCardStub }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  BddTest().when('the component is mounted', () => {
+    const props: AssociatedTraceCardProps = {
+      title: 'Skill',
+      to: '/test'
+    }
+
+    beforeEach(() => {
+      wrapper = mount(AssociatedTraceCard, { props, global: { stubs } })
+    })
+
+    BddTest().then('it should render the AssociationCard with the correct props', () => {
+      const associationCard = wrapper.findComponent(AssociationCardStub)
+      expect(associationCard.exists()).toBe(true)
+      expect(associationCard.props()).toMatchObject({
+        title: props.title,
+        icon: ICONS.TRACES,
+        color: 'var(--text1)',
+        backgroundColor: 'var(--light-background-neutral)',
+        hoverBorderColor: 'var(--dark-background-primary1)',
+        iconBorderColor: 'var(--other-border-skill-card)',
+        to: props.to
+      })
+    })
+  })
+})

--- a/src/features/student/global/components/cards/AssociatedTraceCard/AssociatedTraceCard.vue
+++ b/src/features/student/global/components/cards/AssociatedTraceCard/AssociatedTraceCard.vue
@@ -1,0 +1,24 @@
+<script lang="ts" setup>
+import type { RouteLocationRaw } from 'vue-router'
+import AssociationCard from '@/features/student/global/components/cards/AssociationCard/AssociationCard.vue'
+import { ICONS } from '@/features/student/global/icons'
+
+export interface AssociatedTraceCardProps {
+  title: string
+  to: RouteLocationRaw
+}
+
+const { title, to } = defineProps<AssociatedTraceCardProps>()
+</script>
+
+<template>
+  <AssociationCard
+    :title="title"
+    :icon="ICONS.TRACES"
+    color="var(--text1)"
+    background-color="var(--light-background-neutral)"
+    hover-border-color="var(--dark-background-primary1)"
+    icon-border-color="var(--other-border-skill-card)"
+    :to="to"
+  />
+</template>

--- a/src/features/student/global/components/cards/AssociationCard/AssociationCard.stub.ts
+++ b/src/features/student/global/components/cards/AssociationCard/AssociationCard.stub.ts
@@ -1,0 +1,34 @@
+export const AssociationCardStub = defineComponent({
+  name: 'AssociationCard',
+  props: {
+    title: {
+      type: String,
+      required: true
+    },
+    icon: {
+      type: String,
+      required: true
+    },
+    color: {
+      type: String,
+      required: true
+    },
+    backgroundColor: {
+      type: String,
+      required: true
+    },
+    hoverBorderColor: {
+      type: String,
+      required: false
+    },
+    iconBorderColor: {
+      type: String,
+      required: false
+    },
+    to: {
+      type: [String, Object],
+      required: true
+    }
+  },
+  template: '<div data-testid="association-card"></div>'
+})

--- a/src/features/student/global/components/cards/AssociationCard/AssociationCard.test.ts
+++ b/src/features/student/global/components/cards/AssociationCard/AssociationCard.test.ts
@@ -1,0 +1,88 @@
+import AssociationCard, { type AssociationCardProps } from '@/features/student/global/components/cards/AssociationCard/AssociationCard.vue'
+import { FloatingIconCardStub } from '@/features/student/global/components/cards/FloatingIconCard/FloatingIconCard.stub'
+import { ICONS } from '@/features/student/global/icons'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { RouterLinkStub, type VueWrapper } from '@vue/test-utils'
+import { mountWithRouter } from 'tests/utils'
+import { expect, vi } from 'vitest'
+
+BddTest().given('an association card', () => {
+  let wrapper: VueWrapper<InstanceType<typeof AssociationCard>>
+
+  const stubs = {
+    FloatingIconCard: FloatingIconCardStub,
+    RouterLink: RouterLinkStub
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  BddTest().when('the component is mounted with base props', () => {
+    const props: AssociationCardProps = {
+      title: 'Skill',
+      icon: ICONS.SKILLS,
+      color: 'var(--color)',
+      backgroundColor: 'var(--background-color)',
+      to: '/test'
+    }
+
+    beforeEach(async () => {
+      wrapper = await mountWithRouter<typeof AssociationCard>(AssociationCard, { props, global: { stubs } })
+    })
+
+    BddTest().then('it should render the FloatingIconCard with the correct props', () => {
+      const floatingIconCard = wrapper.findComponent(FloatingIconCardStub)
+      expect(floatingIconCard.exists()).toBe(true)
+      expect(floatingIconCard.props()).toMatchObject({
+        title: props.title,
+        titleColor: props.color,
+        iconOptions: { name: props.icon, color: props.color, borderColor: props.color },
+        color: props.backgroundColor,
+        borderColorOnHover: props.backgroundColor,
+      })
+    })
+  })
+
+  BddTest().when('the component is mounted with all props and all slots', () => {
+    const props: AssociationCardProps = {
+      title: 'Skill',
+      icon: ICONS.SKILLS,
+      color: 'var(--color)',
+      backgroundColor: 'var(--background-color)',
+      hoverBorderColor: 'var(--hover-border-color)',
+      iconBorderColor: 'var(--icon-border-color)',
+      to: '/test'
+    }
+
+    const slots = {
+      body: '<div data-testid="body">Body content</div>',
+      footer: '<div data-testid="footer">Footer content</div>'
+    }
+
+    beforeEach(async () => {
+      wrapper = await mountWithRouter<typeof AssociationCard>(AssociationCard, { props, slots, global: { stubs } })
+    })
+
+    BddTest().then('it should render the FloatingIconCard with the correct props', () => {
+      const floatingIconCard = wrapper.findComponent(FloatingIconCardStub)
+      expect(floatingIconCard.exists()).toBe(true)
+      expect(floatingIconCard.props()).toMatchObject({
+        title: props.title,
+        titleColor: props.color,
+        iconOptions: { name: props.icon, color: props.color, borderColor: props.iconBorderColor },
+        color: props.backgroundColor,
+        borderColorOnHover: props.hoverBorderColor,
+      })
+    })
+
+    BddTest().then('it should render the body and footer slots', () => {
+      const body = wrapper.find('[data-testid="body"]')
+      const footer = wrapper.find('[data-testid="footer"]')
+      expect(body.exists()).toBe(true)
+      expect(body.text()).toBe('Body content')
+      expect(footer.exists()).toBe(true)
+      expect(footer.text()).toBe('Footer content')
+    })
+  })
+})

--- a/src/features/student/global/components/cards/AssociationCard/AssociationCard.vue
+++ b/src/features/student/global/components/cards/AssociationCard/AssociationCard.vue
@@ -1,0 +1,67 @@
+<script lang="ts" setup>
+import type { IconOptions } from '@/features/student/global/components/cards/FloatingIconCard/FloatingIconCard.vue'
+import type { Slot } from 'vue'
+import type { RouteLocationRaw } from 'vue-router'
+import { FloatingIconCard } from '@/features/student/global'
+
+export interface AssociationCardProps {
+  title: string
+  icon: string
+  color: string
+  backgroundColor: string
+  hoverBorderColor?: string
+  iconBorderColor?: string
+  to: RouteLocationRaw
+}
+
+const { title, icon, color, backgroundColor, hoverBorderColor, iconBorderColor, to } = defineProps<AssociationCardProps>()
+
+defineSlots<{
+  body?: Slot
+  footer?: Slot
+}>()
+
+const iconOptions: IconOptions = {
+  name: icon,
+  color,
+  borderColor: iconBorderColor ?? color,
+  bottom: '-2.5rem',
+}
+</script>
+
+<template>
+  <RouterLink
+    class="association-card av-w-full"
+    :to="to"
+    data-testid="association-card"
+  >
+    <FloatingIconCard
+      :title="title"
+      :icon-options="iconOptions"
+      :color="backgroundColor"
+      :title-color="color"
+      border-color="var(--other-border-skill-card)"
+      :border-color-on-hover="hoverBorderColor ?? backgroundColor"
+      title-typography-classes="s2-regular"
+      :header-rows="3"
+      height="21.625rem"
+    >
+      <template #body>
+        <slot name="body" />
+      </template>
+      <template #footer>
+        <slot name="footer" />
+      </template>
+    </FloatingIconCard>
+  </RouterLink>
+</template>
+
+<style lang="scss" scoped>
+@use '@avenirs-esr/avenirs-dsav/mixins' as dsav;
+
+.association-card {
+  @include dsav.min-width(md) {
+    width: 21.625rem;
+  }
+}
+</style>

--- a/src/features/student/global/components/cards/FloatingIconCard/FloatingIconCard.stub.ts
+++ b/src/features/student/global/components/cards/FloatingIconCard/FloatingIconCard.stub.ts
@@ -8,5 +8,16 @@ export const FloatingIconCardStub = defineComponent({
       <div class="card-footer"><slot name="footer" /></div>
     </div>
   `,
-  props: ['title', 'iconOptions', 'color', 'borderColor', 'borderColorOnHover', 'customTitleHeight', 'headerRows', 'height', 'titleTypographyClasses']
+  props: [
+    'title',
+    'titleColor',
+    'iconOptions',
+    'color',
+    'borderColor',
+    'borderColorOnHover',
+    'customTitleHeight',
+    'headerRows',
+    'height',
+    'titleTypographyClasses'
+  ]
 })


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
Ce PR ajoute les nouveaux composants AssociationCard, AssociatedSkillCard et AssociatedTraceCard pour enrichir la gestion des associations et des compétences dans le portfolio étudiant. Il inclut les stubs, tests unitaires et intégration dans le design system.

**Principaux changements :**
- ✨ Ajout des composants AssociationCard, AssociatedSkillCard, AssociatedTraceCard (Vue, stubs, tests)
- ✅ Ajout de tests unitaires pour chaque nouveau composant
- 🎨 Mise à jour du stub FloatingIconCard pour compatibilité

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1209

---

### Documentation
- Ajout : `src/features/student/global/components/cards/AssociationCard/AssociationCard.vue`, `.stub.ts`, `.test.ts`
- Ajout : `src/features/student/global/components/cards/AssociatedSkillCard/AssociatedSkillCard.vue`, `.stub.ts`, `.test.ts`
- Ajout : `src/features/student/global/components/cards/AssociatedTraceCard/AssociatedTraceCard.vue`, `.stub.ts`, `.test.ts`
- Modif : `src/features/student/global/components/cards/FloatingIconCard/FloatingIconCard.stub.ts`

---

### Target Branch
`develop`

---

### Additional Notes
- Les nouveaux composants sont testés et prêts à être intégrés dans les vues du portfolio.
- Les stubs facilitent les tests et la documentation.
- Pas de breaking change pour les autres fonctionnalités.

---

### Known Limitations or Side Effects
Aucune limitation ou effet de bord connu à ce stade.

---

## ✅ Checklist

- [ ] a11y tested (si applicable)
- [x] Tests fournis (unitaires)
- [ ] i18n géré (si applicable)
- [ ] Performance tests (non applicable)
- [x] Pas de code inutile
- [x] Respect des règles de style et conventions
- [ ] Versionnement sémantique respecté
- [ ] Ajout dans `CHANGELOG.md` si besoin
