### PR TITLE
feat(1211): add get activitiy associations query

### DIFF
--- a/api-specs/avenir-esr.swagger.json
+++ b/api-specs/avenir-esr.swagger.json
@@ -2052,6 +2052,76 @@
         }
       }
     },
+    "/me/activity-progress/{declaredActivityId}/associations": {
+      "get": {
+        "tags": [
+          "declared-activity-controller"
+        ],
+        "operationId": "getDeclaredActivityAssociations",
+        "parameters": [
+          {
+            "name": "declaredActivityId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeclaredActivityAssociationsDTO"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "declared-activity-controller"
+        ],
+        "operationId": "deleteDeclaredActivityAssociations",
+        "parameters": [
+          {
+            "name": "declaredActivityId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AssociationsDeleteRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/me/activity-progress/unsubscribe": {
       "delete": {
         "tags": [
@@ -3484,6 +3554,36 @@
           "title"
         ]
       },
+      "DeclaredActivityAssociationsDTO": {
+        "type": "object",
+        "properties": {
+          "traceAssociations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DeclaredActivityTraceAssociationDTO"
+            }
+          }
+        },
+        "required": [
+          "traceAssociations"
+        ]
+      },
+      "DeclaredActivityTraceAssociationDTO": {
+        "type": "object",
+        "properties": {
+          "associationId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "trace": {
+            "$ref": "#/components/schemas/TraceOverviewDTO"
+          }
+        },
+        "required": [
+          "associationId",
+          "trace"
+        ]
+      },
       "DeclaredExperienceRequest": {
         "type": "object",
         "properties": {
@@ -4877,6 +4977,21 @@
           "summary",
           "thematic",
           "title"
+        ]
+      },
+      "AssociationsDeleteRequest": {
+        "type": "object",
+        "properties": {
+          "idsToDelete": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        },
+        "required": [
+          "idsToDelete"
         ]
       },
       "EActivityThematic": {

--- a/src/__mocks__/fixtures/student/activities.fixtures.ts
+++ b/src/__mocks__/fixtures/student/activities.fixtures.ts
@@ -3,8 +3,10 @@ import {
   type ActivityNavigationDTO,
   ActivityThematic,
   type DeclaredActivity,
+  type DeclaredActivityAssociationsDTO,
   type DeclaredActivityDetailsDTO,
   DeclaredActivityStatus,
+  type DeclaredActivityTraceAssociationDTO,
   type DeclaredActivityViewDTO,
   EActivityThematic,
   EDeclaredActivityStatus,
@@ -196,6 +198,32 @@ export const mockedDeclaredActivityDetails: DeclaredActivityDetailsDTO = {
   },
   status: EDeclaredActivityStatus.IN_PROGRESS,
   finishedAt: '',
+}
+
+export function createMockedTraceAssociations (traceCount: number): DeclaredActivityTraceAssociationDTO[] {
+  const traceAssociations: DeclaredActivityTraceAssociationDTO[] = []
+
+  for (let i = 1; i <= traceCount; i++) {
+    traceAssociations.push({
+      associationId: `association-${i}`,
+      trace: {
+        traceId: `trace-${i}`,
+        title: `Trace #${i} associée à l’activité`,
+        skillCount: (i * 2) % 5,
+        AMSCount: i % 3,
+        programName: `Programme de la trace #${i} associée`,
+        isGroup: i % 2 === 0,
+        createdAt: '2024-01-01T00:00:00Z',
+        updatedAt: '2024-01-01T00:00:00Z'
+      }
+    })
+  }
+
+  return traceAssociations
+}
+
+export const mockedDeclaredActivityAssociations: DeclaredActivityAssociationsDTO = {
+  traceAssociations: createMockedTraceAssociations(6)
 }
 
 // TODO: changes this to activities returned by seeder in dev

--- a/src/__mocks__/msw/handlers/student/activities.handlers.ts
+++ b/src/__mocks__/msw/handlers/student/activities.handlers.ts
@@ -5,6 +5,7 @@ import {
   createMockedPagedResponseDeclaredActivityViewDTO,
   mockedActivityDetail,
   mockedDeclaredActivity,
+  mockedDeclaredActivityAssociations,
   mockedFinishedDeclaredActivityDetails
 } from '@/__mocks__/fixtures/student/activities.fixtures'
 import { createEmptyPaginatedDatasetResponse, isEmptyDataSetRequest } from '@/__mocks__/msw/utils'
@@ -12,6 +13,7 @@ import {
   type ActivityDetailDTO,
   type ActivityNavigationDTO,
   type DeclaredActivity,
+  type DeclaredActivityAssociationsDTO,
   type DeclaredActivityDetailsDTO,
   EErrorCode,
   getFinishUrl,
@@ -19,6 +21,7 @@ import {
   getGetActivityDetailUrl,
   getGetActivityNavigationUrl,
   getGetDeclaredActivitiesViewUrl,
+  getGetDeclaredActivityAssociationsUrl,
   getGetDeclaredActivityDetailsUrl,
   getGetLatestActivitiesViewUrl,
   getSubscribeActivityUrl,
@@ -168,6 +171,21 @@ export const declaredActivityDetailsHandler = http.get(`*${getGetDeclaredActivit
       }
     }
   )
+})
+
+export const declaredActivityAssociationsHandler = http.get(`*${getGetDeclaredActivityAssociationsUrl(':declaredActivityId')}`, async ({ params }) => {
+  const { declaredActivityId } = params
+  if (declaredActivityId === 'INVALID_DECLARED_ACTIVITY_ID') {
+    return HttpResponse.json(
+      { code: EErrorCode.ACTIVITY_NOT_FOUND, message: 'Declared activity not found' },
+      { status: 404, headers: { 'Content-Type': 'application/json' } }
+    )
+  }
+
+  return HttpResponse.json<DeclaredActivityAssociationsDTO>(mockedDeclaredActivityAssociations, {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' }
+  })
 })
 
 export const declaredActivityDetailsErrorHandler = http.get(`*${getGetDeclaredActivityDetailsUrl(':declaredActivityId')}`, () => {
@@ -390,6 +408,7 @@ export const activitiesHandlers = [
   latestActivitiesHandler,
   activityDetailHandler,
   declaredActivityDetailsHandler,
+  declaredActivityAssociationsHandler,
   subscribeActivityProgressHandler,
   unsubscribeActivityProgressHandler,
   finishDeclaredActivityHandler,

--- a/src/features/student/buildProject/locales/en.json
+++ b/src/features/student/buildProject/locales/en.json
@@ -102,6 +102,9 @@
             "ActivityDetailedSideNavigation": {
               "myPerspective": "My perspective"
             },
+            "AssociatedTracesCard": {
+              "title": "My associated trace ({count}) | My associated traces ({count})"
+            },
             "AssociateTracesModal": {
               "title": "Which trace(s) would you like to associate?"
             },

--- a/src/features/student/buildProject/locales/fr.json
+++ b/src/features/student/buildProject/locales/fr.json
@@ -101,6 +101,9 @@
             "ActivityDetailedSideNavigation": {
               "myPerspective": "Ma prise de recul"
             },
+            "AssociatedTracesCard": {
+              "title": "Ma trace associée ({count}) | Mes traces associées ({count})"
+            },
             "AssociateTracesModal": {
               "title": "Quelle(s) trace(s) souhaitez-vous associer ?"
             },

--- a/src/features/student/buildProject/queries/use-activities.query/use-activities.query.test.ts
+++ b/src/features/student/buildProject/queries/use-activities.query/use-activities.query.test.ts
@@ -2,7 +2,7 @@ import type { useInvalidateQuery } from '@/common/composables'
 import type { BaseApiException } from '@/common/exceptions'
 import type { UseQueryReturnType } from '@tanstack/vue-query'
 import type { Ref } from 'vue'
-import { activitiesNavigationMock, mockedActivityDetail } from '@/__mocks__/fixtures/student/activities.fixtures'
+import { activitiesNavigationMock, mockedActivityDetail, mockedDeclaredActivity, mockedDeclaredActivityAssociations } from '@/__mocks__/fixtures/student/activities.fixtures'
 import {
   activityNavigationQuery,
   activityNavigationQueryError,
@@ -14,6 +14,7 @@ import {
   type ActivityDetailDTO,
   type ActivityNavigationDTO,
   type DeclaredActivity,
+  type DeclaredActivityAssociationsDTO,
   type DeclaredActivityDetailsDTO,
   type DeclaredActivityPeriodRequest,
   EActivityThematic,
@@ -32,6 +33,7 @@ import {
   useCountLibraryActivities,
   useDeclaredActivitiesDetailedQuery,
   useFinishDeclaredActivityMutation,
+  useGetDeclaredActivityAssociationsQuery,
   useLibraryActivitiesQuery,
   useSubscribeActivityMutation,
   useUnsubscribeActivitiesMutation,
@@ -156,6 +158,67 @@ BddTest().given('the useActivityDetailQuery composable', () => {
 
       BddTest().then('it should have been called with invalid activity id', () => {
         expect(getActivityDetailSpy).toHaveBeenCalledWith(activityId.value)
+      })
+
+      BddTest().then('it should not fetch data', () => {
+        expect(queryResult.data.value).toBeUndefined()
+      })
+    })
+  })
+})
+
+BddTest().given('the useGetDeclaredActivityAssociationsQuery composable', () => {
+  let getDeclaredActivityAssociationsSpy: MockInstance<
+    (declaredActivityId: string, options?: RequestInit | undefined) => Promise<DeclaredActivityAssociationsDTO>
+  >
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    getDeclaredActivityAssociationsSpy = vi.spyOn<typeof import('@/api/avenir-esr'), 'getDeclaredActivityAssociations'>(
+      await import('@/api/avenir-esr'),
+    'getDeclaredActivityAssociations',
+    )
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  BddTest().and('a valid declared activity id', () => {
+    const declaredActivityId = ref(mockedDeclaredActivity.id ?? '')
+
+    BddTest().when('the query is executed', () => {
+      let queryResult: ReturnType<typeof useGetDeclaredActivityAssociationsQuery>
+
+      beforeEach(async () => {
+        queryResult = mountQueryComposable(() => useGetDeclaredActivityAssociationsQuery(declaredActivityId))
+        await flushPromises()
+      })
+
+      BddTest().then('it should have been called with declared activity id', () => {
+        expect(getDeclaredActivityAssociationsSpy).toHaveBeenCalledWith(declaredActivityId.value)
+      })
+
+      BddTest().then('it should return the mocked declared activity associations', () => {
+        expect(queryResult.data.value).toBeDefined()
+        expect(queryResult.data.value).toMatchObject(mockedDeclaredActivityAssociations)
+      })
+    })
+  })
+
+  BddTest().and('an invalid declared activity id', () => {
+    const declaredActivityId = ref('INVALID_DECLARED_ACTIVITY_ID')
+
+    BddTest().when('the query is executed', () => {
+      let queryResult: ReturnType<typeof useGetDeclaredActivityAssociationsQuery>
+
+      beforeEach(async () => {
+        queryResult = mountQueryComposable(() => useGetDeclaredActivityAssociationsQuery(declaredActivityId))
+        await flushPromises()
+      })
+
+      BddTest().then('it should have been called with invalid declared activity id', () => {
+        expect(getDeclaredActivityAssociationsSpy).toHaveBeenCalledWith(declaredActivityId.value)
       })
 
       BddTest().then('it should not fetch data', () => {

--- a/src/features/student/buildProject/queries/use-activities.query/use-activities.query.ts
+++ b/src/features/student/buildProject/queries/use-activities.query/use-activities.query.ts
@@ -5,6 +5,7 @@ import {
   type ActivityNavigationDTO,
   type ActivityOverviewDTO,
   type DeclaredActivity,
+  type DeclaredActivityAssociationsDTO,
   type DeclaredActivityDetailsDTO,
   type DeclaredActivityPeriodRequest,
   type EActivityThematic,
@@ -15,6 +16,7 @@ import {
   getActivityNavigation,
   getDeclaredActivitiesView,
   type GetDeclaredActivitiesViewParams,
+  getDeclaredActivityAssociations,
   getDeclaredActivityDetails,
   getLatestActivitiesView,
   type PagedResponseActivityOverviewDTO,
@@ -33,6 +35,7 @@ import { type ComputedRef, type MaybeRef, type Ref, toValue } from 'vue'
 
 const activitiesCommonQueryKey = [...commonQueryKeys, 'activities']
 const activityDetailsQueryKey = [...activitiesCommonQueryKey, 'details']
+const activitiesAssociationsQueryKey = [...activitiesCommonQueryKey, 'associations']
 const libraryActivitiesQueryKey = [...activitiesCommonQueryKey, 'library']
 const activityNavigationQueryKey = [...activitiesCommonQueryKey, 'navigation']
 const activitiesViewQueryKey = [...activitiesCommonQueryKey, 'view']
@@ -257,6 +260,26 @@ export function useActivityDetailQuery (activityId: MaybeRef<string>) {
   return {
     ...query,
     activityDetail,
+  }
+}
+
+export function useGetDeclaredActivityAssociationsQuery (declaredActivityId: MaybeRef<string>) {
+  const queryKey = computed(() => [...activitiesAssociationsQueryKey, toValue(declaredActivityId)])
+
+  const queryFn = computed(() => async (): Promise<DeclaredActivityAssociationsDTO> => {
+    return await getDeclaredActivityAssociations(toValue(declaredActivityId))
+  })
+
+  const query = useQuery<DeclaredActivityAssociationsDTO, BaseApiException>({
+    queryKey,
+    queryFn,
+    enabled: computed(() => toValue(declaredActivityId).trim().length > 0),
+    staleTime: TanstackStaleTimeConfig.DETAILS
+  })
+
+  return {
+    ...query,
+    declaredActivityAssociations: computed(() => query.data.value)
   }
 }
 

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/MyPerspectiveSection/MyPerspectiveSection.test.ts
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/MyPerspectiveSection/MyPerspectiveSection.test.ts
@@ -1,5 +1,6 @@
 import type { VueWrapper } from '@vue/test-utils'
 import { mockedDeclaredActivityDetails } from '@/__mocks__/fixtures/student/activities.fixtures'
+import { LoaderStub } from '@/common/components/Loader/Loader.stub'
 import MyPerspectiveSection, {
   type MyPerspectiveSectionProps,
 } from '@/features/student/buildProject/views/ProjectActivityDetailedView/components/MyPerspectiveSection/MyPerspectiveSection.vue'
@@ -15,15 +16,15 @@ BddTest().given('a my perspective section', () => {
   const stubs = {
     AvTabs: AvTabsStub,
     AvTab: AvTabStub,
+    Loader: LoaderStub,
     MyPerspectiveTab: MyPerspectiveTabStub,
     AssociatedElementsTab: AssociatedElementsTabStub,
   }
-
-  const props: MyPerspectiveSectionProps = {
-    declaredActivityDetails: mockedDeclaredActivityDetails,
-  }
-
   BddTest().when('the component is mounted', () => {
+    const props: MyPerspectiveSectionProps = {
+      declaredActivityDetails: mockedDeclaredActivityDetails,
+    }
+
     beforeEach(() => {
       wrapper = mountComponent(MyPerspectiveSection, {
         props,
@@ -65,6 +66,48 @@ BddTest().given('a my perspective section', () => {
       BddTest().then('it should update the active tab index', () => {
         const tabs = wrapper.findComponent(AvTabsStub)
         expect(tabs.props('modelValue')).toBe(1)
+      })
+
+      BddTest().then('it should render the associated elements tab content', async () => {
+        await vi.waitFor(() => {
+          const associatedElementsTab = wrapper.findComponent(AssociatedElementsTabStub)
+          expect(associatedElementsTab.exists()).toBe(false)
+        })
+      })
+    })
+  })
+
+  BddTest().when('the component is mounted with an invalid declared activity', () => {
+    const props: MyPerspectiveSectionProps = {
+      declaredActivityDetails: { ...mockedDeclaredActivityDetails, id: 'INVALID_DECLARED_ACTIVITY_ID' },
+    }
+
+    beforeEach(() => {
+      wrapper = mountComponent(MyPerspectiveSection, {
+        props,
+        global: { stubs },
+      })
+    })
+
+    BddTest().then('it should render the my perspective tab component', () => {
+      const myPerspectiveTab = wrapper.findComponent(MyPerspectiveTabStub)
+      expect(myPerspectiveTab.exists()).toBe(true)
+    })
+
+    BddTest().and('the user switches tabs to the associated elements tab', () => {
+      beforeEach(async () => {
+        const tabs = wrapper.findComponent(AvTabsStub)
+        await tabs.vm.$emit('update:modelValue', 1)
+      })
+
+      BddTest().then('it should update the active tab index', () => {
+        const tabs = wrapper.findComponent(AvTabsStub)
+        expect(tabs.props('modelValue')).toBe(1)
+      })
+
+      BddTest().then('it should not render the associated elements tab content', () => {
+        const associatedElementsTab = wrapper.findComponent(AssociatedElementsTabStub)
+        expect(associatedElementsTab.exists()).toBe(false)
       })
     })
   })

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/MyPerspectiveSection/MyPerspectiveSection.vue
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/MyPerspectiveSection/MyPerspectiveSection.vue
@@ -1,5 +1,7 @@
 <script lang="ts" setup>
 import type { DeclaredActivityDetailsDTO } from '@/api/avenir-esr'
+import Loader from '@/common/components/Loader/Loader.vue'
+import { useGetDeclaredActivityAssociationsQuery } from '@/features/student/buildProject/queries/use-activities.query/use-activities.query'
 import AssociatedElementsTab from '@/features/student/buildProject/views/ProjectActivityDetailedView/components/tabs/AssociatedElementsTab/AssociatedElementsTab.vue'
 import MyPerspectiveTab from '@/features/student/buildProject/views/ProjectActivityDetailedView/components/tabs/MyPerspectiveTab/MyPerspectiveTab.vue'
 import { ICONS } from '@/features/student/global/icons'
@@ -10,12 +12,12 @@ export interface MyPerspectiveSectionProps {
   declaredActivityDetails: DeclaredActivityDetailsDTO
 }
 
-defineProps<MyPerspectiveSectionProps>()
+const { declaredActivityDetails } = defineProps<MyPerspectiveSectionProps>()
 
 const { t } = useI18n()
+const { declaredActivityAssociations, isPending, isError } = useGetDeclaredActivityAssociationsQuery(declaredActivityDetails.id)
 
 const activeTab = ref(0)
-const dummyElementCount = 5 // TODO: #1211
 </script>
 
 <template>
@@ -30,10 +32,15 @@ const dummyElementCount = 5 // TODO: #1211
       <MyPerspectiveTab :declared-activity-details="declaredActivityDetails" />
     </AvTab>
     <AvTab
-      :title="t('student.buildProject.activities.views.ProjectActivityDetailedView.MyPerspectiveSection.AssociatedElementsTab.title', { count: dummyElementCount })"
+      :title="t('student.buildProject.activities.views.ProjectActivityDetailedView.MyPerspectiveSection.AssociatedElementsTab.title', { count: declaredActivityAssociations?.traceAssociations.length })"
       :icon="ICONS.ASSOCIATED"
     >
-      <AssociatedElementsTab />
+      <Loader :is-loading="isPending && !isError">
+        <AssociatedElementsTab
+          v-if="declaredActivityAssociations"
+          :associations="declaredActivityAssociations"
+        />
+      </Loader>
     </AvTab>
   </AvTabs>
 </template>

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/cards/AssociatedTracesCard/AssociatedTracesCard.stub.ts
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/cards/AssociatedTracesCard/AssociatedTracesCard.stub.ts
@@ -1,0 +1,16 @@
+import type { DeclaredActivityTraceAssociationDTO } from '@/api/avenir-esr'
+
+export const AssociatedTracesCardStub = defineComponent({
+  name: 'AssociatedTracesCard',
+  props: {
+    associatedTraces: {
+      type: Array as () => DeclaredActivityTraceAssociationDTO[],
+      required: true
+    }
+  },
+  template: `
+    <div v-if="associatedTraces.length > 0" data-testid="associated-trace-card">
+      <span v-for="trace in associatedTraces" :key="trace.id">{{ trace.name }}</span>
+    </div>
+  `
+})

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/cards/AssociatedTracesCard/AssociatedTracesCard.test.ts
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/cards/AssociatedTracesCard/AssociatedTracesCard.test.ts
@@ -1,0 +1,53 @@
+import { createMockedTraceAssociations } from '@/__mocks__/fixtures/student/activities.fixtures'
+import AssociatedTracesCard, { type AssociatedTracesCardProps } from '@/features/student/buildProject/views/ProjectActivityDetailedView/components/cards/AssociatedTracesCard/AssociatedTracesCard.vue'
+import { AssociatedTraceCardStub } from '@/features/student/global/components/cards/AssociatedTraceCard/AssociatedTraceCard.stub'
+import { AvCardStub, AvIconTextStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { beforeEach, expect } from 'vitest'
+
+BddTest().given('an associated traces card', () => {
+  let wrapper: VueWrapper<InstanceType<typeof AssociatedTracesCard>>
+
+  const stubs = {
+    AvCard: AvCardStub,
+    AvIconText: AvIconTextStub,
+    AssociatedTraceCard: AssociatedTraceCardStub,
+  }
+
+  BddTest().when('the component is mounted with associated traces', () => {
+    const props: AssociatedTracesCardProps = {
+      associatedTraces: createMockedTraceAssociations(3)
+    }
+
+    beforeEach(() => {
+      vi.clearAllMocks()
+      wrapper = mount(AssociatedTracesCard, { props, global: { stubs } })
+    })
+
+    BddTest().then('it should render the av card', () => {
+      const card = wrapper.findComponent(AvCardStub)
+      expect(card.exists()).toBe(true)
+    })
+
+    BddTest().then('it should render a card for each associated trace', () => {
+      const traceCards = wrapper.findAllComponents(AssociatedTraceCardStub)
+      expect(traceCards).toHaveLength(props.associatedTraces.length)
+    })
+  })
+
+  BddTest().when('the component is mounted with no associated traces', () => {
+    const props: AssociatedTracesCardProps = {
+      associatedTraces: []
+    }
+
+    beforeEach(() => {
+      vi.clearAllMocks()
+      wrapper = mount(AssociatedTracesCard, { props, global: { stubs } })
+    })
+
+    BddTest().then('it should render nothing', () => {
+      const card = wrapper.findComponent(AvCardStub)
+      expect(card.exists()).toBe(false)
+    })
+  })
+})

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/cards/AssociatedTracesCard/AssociatedTracesCard.vue
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/cards/AssociatedTracesCard/AssociatedTracesCard.vue
@@ -1,0 +1,49 @@
+<script setup lang="ts">
+import type { DeclaredActivityTraceAssociationDTO } from '@/api/avenir-esr'
+import AssociatedTraceCard from '@/features/student/global/components/cards/AssociatedTraceCard/AssociatedTraceCard.vue'
+import { ICONS } from '@/features/student/global/icons'
+import { AvCard, AvIconText } from '@avenirs-esr/avenirs-dsav'
+import { useI18n } from 'vue-i18n'
+
+export interface AssociatedTracesCardProps {
+  associatedTraces: DeclaredActivityTraceAssociationDTO[]
+}
+
+defineProps<AssociatedTracesCardProps>()
+
+const { t } = useI18n()
+</script>
+
+<template>
+  <AvCard
+    v-if="associatedTraces.length > 0"
+    background-color="var(--card2)"
+    title-background="var(--card2)"
+    border-color="var(--other-border-skill-card)"
+    collapsible
+    collapsed
+    data-testid="associated-trace-card"
+  >
+    <template #title>
+      <div class="av-row av-flex-fill av-justify-start">
+        <AvIconText
+          typography-class="n4"
+          :icon="ICONS.TRACES"
+          icon-color="var(--text2)"
+          :text="t('student.buildProject.activities.views.ProjectActivityDetailedView.AssociatedTracesCard.title', { count: associatedTraces.length })"
+          text-color="var(--text1)"
+          gap="var(--spacing-sm)"
+          data-testid="associated-trace-card-title"
+        />
+      </div>
+    </template>
+
+    <div class="av-row av-wrap av-align-center av-justify-center av-gap-md">
+      <AssociatedTraceCard
+        v-for="associatedTrace in associatedTraces"
+        :key="associatedTrace.trace.traceId"
+        :associated-trace="associatedTrace"
+      />
+    </div>
+  </AvCard>
+</template>

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/tabs/AssociatedElementsTab/AssociatedElementsTab.test.ts
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/tabs/AssociatedElementsTab/AssociatedElementsTab.test.ts
@@ -1,3 +1,5 @@
+import { mockedDeclaredActivityAssociations } from '@/__mocks__/fixtures/student/activities.fixtures'
+import { AssociatedTracesCardStub } from '@/features/student/buildProject/views/ProjectActivityDetailedView/components/cards/AssociatedTracesCard/AssociatedTracesCard.stub'
 import { ActivityAssociateElementsDropdownStub } from '@/features/student/buildProject/views/ProjectActivityDetailedView/components/overlays/dropdowns/ActivityAssociateElementsDropdown/ActivityAssociateElementsDropdown.stub'
 import { DeleteActivityAssociatedElementsDropdownStub } from '@/features/student/buildProject/views/ProjectActivityDetailedView/components/overlays/dropdowns/DeleteActivityAssociatedElementsDropdown/DeleteActivityAssociatedElementsDropdown.stub'
 import {
@@ -5,7 +7,7 @@ import {
 } from '@/features/student/buildProject/views/ProjectActivityDetailedView/components/overlays/modals/AssociateTracesModal/AssociateTracesModal.stub'
 import { DeleteActivityAssociatedSkillsModalStub } from '@/features/student/buildProject/views/ProjectActivityDetailedView/components/overlays/modals/DeleteActivityAssociatedSkillsModal/DeleteActivityAssociatedSkillsModal.stub'
 import { DeleteActivityAssociatedTracesModalStub } from '@/features/student/buildProject/views/ProjectActivityDetailedView/components/overlays/modals/DeleteActivityAssociatedTracesModal/DeleteActivityAssociatedTracesModal.stub'
-import AssociatedElementsTab from '@/features/student/buildProject/views/ProjectActivityDetailedView/components/tabs/AssociatedElementsTab/AssociatedElementsTab.vue'
+import AssociatedElementsTab, { type AssociatedElementsTabProps } from '@/features/student/buildProject/views/ProjectActivityDetailedView/components/tabs/AssociatedElementsTab/AssociatedElementsTab.vue'
 import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { mount, type VueWrapper } from '@vue/test-utils'
 import { beforeEach, expect } from 'vitest'
@@ -13,17 +15,22 @@ import { beforeEach, expect } from 'vitest'
 BddTest().given('an associated elements tab', () => {
   let wrapper: VueWrapper<InstanceType<typeof AssociatedElementsTab>>
 
+  const props: AssociatedElementsTabProps = {
+    associations: mockedDeclaredActivityAssociations,
+  }
+
   const stubs = {
     DeleteActivityAssociatedElementsDropdown: DeleteActivityAssociatedElementsDropdownStub,
     ActivityAssociateElementsDropdown: ActivityAssociateElementsDropdownStub,
     DeleteActivityAssociatedSkillsModal: DeleteActivityAssociatedSkillsModalStub,
     DeleteActivityAssociatedTracesModal: DeleteActivityAssociatedTracesModalStub,
-    AssociateTracesModal: AssociateTracesModalStub
+    AssociateTracesModal: AssociateTracesModalStub,
+    AssociatedTracesCard: AssociatedTracesCardStub
   }
 
   BddTest().when('the component is mounted', () => {
     beforeEach(() => {
-      wrapper = mount(AssociatedElementsTab, { global: { stubs } })
+      wrapper = mount(AssociatedElementsTab, { props, global: { stubs } })
     })
 
     BddTest().then('it should render the delete associated elements dropdown', () => {
@@ -34,6 +41,12 @@ BddTest().given('an associated elements tab', () => {
     BddTest().then('it should render the associate elements dropdown', () => {
       const dropdown = wrapper.findComponent(ActivityAssociateElementsDropdownStub)
       expect(dropdown.exists()).toBe(true)
+    })
+
+    BddTest().then('it should render the associated traces card', () => {
+      const associatedTracesCard = wrapper.findComponent(AssociatedTracesCardStub)
+      expect(associatedTracesCard.exists()).toBe(true)
+      expect(associatedTracesCard.findAll('span')).toHaveLength(props.associations.traceAssociations.length)
     })
 
     BddTest().then('it should render the delete associated skills modal in hidden state', () => {

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/tabs/AssociatedElementsTab/AssociatedElementsTab.vue
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/tabs/AssociatedElementsTab/AssociatedElementsTab.vue
@@ -1,5 +1,7 @@
 <script lang="ts" setup>
+import type { DeclaredActivityAssociationsDTO } from '@/api/avenir-esr'
 import { useModal } from '@/common/composables'
+import AssociatedTracesCard from '@/features/student/buildProject/views/ProjectActivityDetailedView/components/cards/AssociatedTracesCard/AssociatedTracesCard.vue'
 import ActivityAssociateElementsDropdown
   from '@/features/student/buildProject/views/ProjectActivityDetailedView/components/overlays/dropdowns/ActivityAssociateElementsDropdown/ActivityAssociateElementsDropdown.vue'
 import DeleteActivityAssociatedElementsDropdown from '@/features/student/buildProject/views/ProjectActivityDetailedView/components/overlays/dropdowns/DeleteActivityAssociatedElementsDropdown/DeleteActivityAssociatedElementsDropdown.vue'
@@ -7,6 +9,12 @@ import AssociateTracesModal
   from '@/features/student/buildProject/views/ProjectActivityDetailedView/components/overlays/modals/AssociateTracesModal/AssociateTracesModal.vue'
 import DeleteActivityAssociatedSkillsModal from '@/features/student/buildProject/views/ProjectActivityDetailedView/components/overlays/modals/DeleteActivityAssociatedSkillsModal/DeleteActivityAssociatedSkillsModal.vue'
 import DeleteActivityAssociatedTracesModal from '@/features/student/buildProject/views/ProjectActivityDetailedView/components/overlays/modals/DeleteActivityAssociatedTracesModal/DeleteActivityAssociatedTracesModal.vue'
+
+export interface AssociatedElementsTabProps {
+  associations: DeclaredActivityAssociationsDTO
+}
+
+defineProps<AssociatedElementsTabProps>()
 
 const { showModal: showSkillsModal, displayModal: displaySkillsModal, hideModal: hideSkillsModal } = useModal()
 const { showModal: showTracesModal, displayModal: displayTracesModal, hideModal: hideTracesModal } = useModal()
@@ -24,6 +32,10 @@ const { showModal: showAssociateTracesModal, displayModal: displayAssociateTrace
         @traces-selected="displayAssociateTracesModal"
       />
     </div>
+
+    <AssociatedTracesCard
+      :associated-traces="associations.traceAssociations"
+    />
   </div>
 
   <DeleteActivityAssociatedSkillsModal

--- a/src/features/student/global/components/cards/AssociatedTraceCard/AssociatedTraceCard.stub.ts
+++ b/src/features/student/global/components/cards/AssociatedTraceCard/AssociatedTraceCard.stub.ts
@@ -1,14 +1,12 @@
+import type { DeclaredActivityTraceAssociationDTO } from '@/api/avenir-esr/generated/types/declaredActivityTraceAssociationDTO'
+
 export const AssociatedTraceCardStub = defineComponent({
   name: 'AssociatedTraceCard',
   props: {
-    title: {
-      type: String,
+    associatedTrace: {
+      type: Object as () => DeclaredActivityTraceAssociationDTO,
       required: true
     },
-    to: {
-      type: [String, Object],
-      required: true
-    }
   },
   template: '<div data-testid="associated-trace-card"></div>'
 })

--- a/src/features/student/global/components/cards/AssociatedTraceCard/AssociatedTraceCard.test.ts
+++ b/src/features/student/global/components/cards/AssociatedTraceCard/AssociatedTraceCard.test.ts
@@ -1,3 +1,5 @@
+import { mockedDeclaredActivityAssociations } from '@/__mocks__/fixtures/student/activities.fixtures'
+import { ROUTES } from '@/common/constants'
 import AssociatedTraceCard, { type AssociatedTraceCardProps } from '@/features/student/global/components/cards/AssociatedTraceCard/AssociatedTraceCard.vue'
 import { AssociationCardStub } from '@/features/student/global/components/cards/AssociationCard/AssociationCard.stub'
 import { ICONS } from '@/features/student/global/icons'
@@ -16,8 +18,7 @@ BddTest().given('an associatied trace card', () => {
 
   BddTest().when('the component is mounted', () => {
     const props: AssociatedTraceCardProps = {
-      title: 'Skill',
-      to: '/test'
+      associatedTrace: mockedDeclaredActivityAssociations.traceAssociations[0],
     }
 
     beforeEach(() => {
@@ -28,13 +29,13 @@ BddTest().given('an associatied trace card', () => {
       const associationCard = wrapper.findComponent(AssociationCardStub)
       expect(associationCard.exists()).toBe(true)
       expect(associationCard.props()).toMatchObject({
-        title: props.title,
+        title: props.associatedTrace.trace.title,
         icon: ICONS.TRACES,
         color: 'var(--text1)',
         backgroundColor: 'var(--light-background-neutral)',
         hoverBorderColor: 'var(--dark-background-primary1)',
         iconBorderColor: 'var(--other-border-skill-card)',
-        to: props.to
+        to: { name: ROUTES.STUDENT.TRACE.name, params: { id: props.associatedTrace.trace.traceId } }
       })
     })
   })

--- a/src/features/student/global/components/cards/AssociatedTraceCard/AssociatedTraceCard.vue
+++ b/src/features/student/global/components/cards/AssociatedTraceCard/AssociatedTraceCard.vue
@@ -1,24 +1,24 @@
 <script lang="ts" setup>
-import type { RouteLocationRaw } from 'vue-router'
+import type { DeclaredActivityTraceAssociationDTO } from '@/api/avenir-esr'
+import { ROUTES } from '@/common/constants'
 import AssociationCard from '@/features/student/global/components/cards/AssociationCard/AssociationCard.vue'
 import { ICONS } from '@/features/student/global/icons'
 
 export interface AssociatedTraceCardProps {
-  title: string
-  to: RouteLocationRaw
+  associatedTrace: DeclaredActivityTraceAssociationDTO
 }
 
-const { title, to } = defineProps<AssociatedTraceCardProps>()
+const { associatedTrace } = defineProps<AssociatedTraceCardProps>()
 </script>
 
 <template>
   <AssociationCard
-    :title="title"
+    :title="associatedTrace.trace.title"
     :icon="ICONS.TRACES"
     color="var(--text1)"
     background-color="var(--light-background-neutral)"
     hover-border-color="var(--dark-background-primary1)"
     icon-border-color="var(--other-border-skill-card)"
-    :to="to"
+    :to="{ name: ROUTES.STUDENT.TRACE.name, params: { id: associatedTrace.trace.traceId } }"
   />
 </template>


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
Ce PR ajoute la requête "get activity associations" (US#1211) et intègre le composant AssociatedTracesCard, avec tests, stubs, mocks et internationalisation. Il améliore la couverture de tests et la robustesse des vues d'activité projet étudiant.

**Principaux changements :**
- ✨ Ajout de la requête getActivityAssociations (backend + mocks)
- ✨ Ajout du composant AssociatedTracesCard (vue, stub, test)
- ✅ Mise à jour et ajout de tests unitaires et d'intégration
- 📝 Mise à jour des fichiers de traduction (en, fr)
- 🎨 Refactor et corrections sur les composants et tests liés

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1211

---

### Documentation
- Modif : `api-specs/avenir-esr.swagger.json`
- Modif : `src/__mocks__/fixtures/student/activities.fixtures.ts`, `msw/handlers/student/activities.handlers.ts`
- Modif : `src/features/student/buildProject/locales/en.json`, `fr.json`
- Modif : `src/features/student/buildProject/queries/use-activities.query/use-activities.query.ts`, `.test.ts`
- Modif : `src/features/student/buildProject/views/ProjectActivityDetailedView/components/MyPerspectiveSection/MyPerspectiveSection.vue`, `.test.ts`
- Ajout : `src/features/student/buildProject/views/ProjectActivityDetailedView/components/cards/AssociatedTracesCard/AssociatedTracesCard.vue`, `.test.ts`, `.stub.ts`
- Modif : `src/features/student/buildProject/views/ProjectActivityDetailedView/components/tabs/AssociatedElementsTab/AssociatedElementsTab.vue`, `.test.ts`
- Modif : `src/features/student/global/components/cards/AssociatedTraceCard/AssociatedTraceCard.vue`, `.test.ts`, `.stub.ts`

---

### Target Branch
`develop`

---

### Additional Notes
- Les nouveaux composants et requêtes sont testés et prêts à être intégrés dans les vues du portfolio.
- Les stubs facilitent les tests et la documentation.
- Pas de breaking change pour les autres fonctionnalités.

---

### Known Limitations or Side Effects
Aucune limitation ou effet de bord connu à ce stade.

---

## ✅ Checklist

- [ ] a11y tested (si applicable)
- [ ] Tests fournis (unitaires et intégration)
- [ ] i18n géré (labels et textes traduits)
- [ ] Performance tests (non applicable)
- [ ] Pas de code inutile
- [ ] Respect des règles de style et conventions
- [ ] Versionnement sémantique respecté
- [ ] Ajout dans `CHANGELOG.md` si besoin
