### PR TITLE
feat(1224): add CompactCardSelector

### DIFF
--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/overlays/modals/DeleteActivityAssociatedTracesModal/DeleteActivityAssociatedTracesModal.vue
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/overlays/modals/DeleteActivityAssociatedTracesModal/DeleteActivityAssociatedTracesModal.vue
@@ -11,7 +11,7 @@ export interface DeleteActivityAssociatedTracesModalProps {
   declaredActivityId: string
 }
 
-const { show, declaredActivityId } = defineProps<DeleteActivityAssociatedTracesModalProps>()
+const { declaredActivityId } = defineProps<DeleteActivityAssociatedTracesModalProps>()
 
 const emit = defineEmits<{
   (e: 'cancel'): void
@@ -62,7 +62,7 @@ function onConfirmDelete () {
     :show="show"
     :associations="dummyAssociations"
     :selected-association-ids="dummySelectedAssociationIds"
-    :disabled="isPending"
+    :is-loading="isPending"
     @cancel="emit('cancel')"
     @confirm-delete="onConfirmDelete"
   >

--- a/src/features/student/global/components/cards/CompactCardSelector/CompactCardSelector.stub.ts
+++ b/src/features/student/global/components/cards/CompactCardSelector/CompactCardSelector.stub.ts
@@ -1,0 +1,19 @@
+import type { PropType } from 'vue'
+
+export const CompactCardSelectorStub = defineComponent({
+  name: 'CompactCardSelectorStub',
+  props: {
+    elements: { type: Array as PropType<{ id: string, title: string, showSlot?: boolean }[]>, required: true },
+    readonly: { type: Boolean, default: false },
+    icon: { type: String, required: true },
+    color: { type: String, required: true },
+    backgroundColor: { type: String, required: true },
+    iconBorderColor: { type: String },
+    checkboxColor: { type: String },
+    overlayColor: { type: String },
+    overlayOpacity: { type: Number },
+    modelValue: { type: Array as PropType<string[]>, default: () => [] }
+  },
+  emits: ['update:modelValue'],
+  template: `<div data-testid="compact-card-selector"><slot v-if="elements.some(element => element.showSlot)" /></div>`
+})

--- a/src/features/student/global/components/cards/CompactCardSelector/CompactCardSelector.test.ts
+++ b/src/features/student/global/components/cards/CompactCardSelector/CompactCardSelector.test.ts
@@ -1,0 +1,100 @@
+import CompactCardSelector, { type CompactCardSelectorProps } from '@/features/student/global/components/cards/CompactCardSelector/CompactCardSelector.vue'
+import { FloatingIconCardStub } from '@/features/student/global/components/cards/FloatingIconCard/FloatingIconCard.stub'
+import { SelectorOverlayStub } from '@/features/student/global/components/interaction/SelectorOverlay/SelectorOverlay.stub'
+import { MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { beforeEach, expect } from 'vitest'
+
+BddTest().given('a compact card selector', () => {
+  let wrapper: VueWrapper<InstanceType<typeof CompactCardSelector>>
+
+  const stubs = {
+    FloatingIconCard: FloatingIconCardStub,
+    SelectorOverlay: SelectorOverlayStub
+  }
+
+  BddTest().when('the component is mounted with elements', () => {
+    const props: CompactCardSelectorProps = {
+      elements: [{ id: '1', title: 'Element 1' }, { id: '2', title: 'Element 2', showSlot: true }],
+      readonly: false,
+      icon: MDI_ICONS.ACCOUNT_CIRCLE_OUTLINE,
+      color: 'var(--color)',
+      backgroundColor: 'var(--background-color)',
+      iconBorderColor: 'var(--icon-border-color)',
+      checkboxColor: 'var(--checkbox-color)',
+      overlayColor: 'var(--overlay-color)',
+      overlayOpacity: 0.5,
+    }
+
+    const slots = {
+      default: '<div data-testid="default-slot">Default Slot</div>'
+    }
+
+    beforeEach(() => {
+      wrapper = mount(CompactCardSelector, { props, slots, global: { stubs } })
+    })
+
+    BddTest().then('it should render the floating icon cards with the correct props', () => {
+      const cards = wrapper.findAllComponents(FloatingIconCardStub)
+      expect(cards).toHaveLength(props.elements.length)
+
+      cards.forEach((card, index) => {
+        expect(card.props('title')).toEqual(props.elements[index].title)
+        expect(card.props('iconOptions')).toMatchObject({
+          name: props.icon,
+          color: props.color,
+          borderColor: props.iconBorderColor
+        })
+        expect(card.props('titleColor')).toEqual(props.color)
+        expect(card.props('color')).toEqual(props.backgroundColor)
+      })
+    })
+
+    BddTest().then('it should render only one default slot', () => {
+      const defaultSlots = wrapper.findAll('[data-testid="default-slot"]')
+      expect(defaultSlots).toHaveLength(1)
+    })
+
+    BddTest().and('an element is clicked', () => {
+      beforeEach(async () => {
+        expect(wrapper.find('[data-testid="selector-overlay"]').exists()).toBe(true)
+        await wrapper.find('[data-testid="selector-overlay"]').trigger('click')
+      })
+
+      BddTest().then('it should update the model with the element id', () => {
+        expect(wrapper.emitted('update:modelValue')).toBeTruthy()
+        expect(wrapper.emitted('update:modelValue')?.[0][0]).toEqual([props.elements[0].id])
+      })
+
+      BddTest().and('the element is clicked again', () => {
+        beforeEach(async () => {
+          expect(wrapper.find('[data-testid="selector-overlay"]').exists()).toBe(true)
+          await wrapper.find('[data-testid="selector-overlay"]').trigger('click')
+        })
+
+        BddTest().then('it should update the model to remove the element id', () => {
+          expect(wrapper.emitted('update:modelValue')?.[1][0]).toEqual([])
+        })
+      })
+    })
+  })
+
+  BddTest().when('the component is mounted in readonly mode', () => {
+    const props: CompactCardSelectorProps = {
+      elements: [{ id: '1', title: 'Element 1', }],
+      icon: MDI_ICONS.ACCOUNT_CIRCLE_OUTLINE,
+      color: 'var(--color)',
+      backgroundColor: 'var(--background-color)',
+      readonly: true
+    }
+
+    beforeEach(() => {
+      wrapper = mount(CompactCardSelector, { props, global: { stubs } })
+    })
+
+    BddTest().then('it should not render the overlay', () => {
+      expect(wrapper.find('[data-testid="selector-overlay"]').exists()).toBe(false)
+    })
+  })
+})

--- a/src/features/student/global/components/cards/CompactCardSelector/CompactCardSelector.vue
+++ b/src/features/student/global/components/cards/CompactCardSelector/CompactCardSelector.vue
@@ -1,0 +1,142 @@
+<script setup lang="ts">
+import { getUnknownElementProp } from '@/features/student/global/components/cards/CompactCardSelector/utils'
+import FloatingIconCard from '@/features/student/global/components/cards/FloatingIconCard/FloatingIconCard.vue'
+import SelectorOverlay from '@/features/student/global/components/interaction/SelectorOverlay/SelectorOverlay.vue'
+
+/**
+ * @example
+ * <CompactCardSelector
+ *   :elements="[
+ *     { id: '1', title: 'Element 1', showSlot: props.customCondition },
+ *     { id: '2', title: 'Element 2' },
+ *     { id: '3', title: 'Element 3', showSlot: true }
+ *   ]"
+ *   icon="mdi-check"
+ *   color="var(--text1)"
+ *   background-color="var(--surface-background)"
+ *   :checkbox-color="'var(--dark-background-primary1)'"
+ *   :overlay-color="'var(--dark-background-primary1)'"
+ *   :overlay-opacity="0.25"
+ * >
+ *   <template #default="{ element }">
+ *     Some content for {{ getUnknownElementProp<string>(element, 'title') }}
+ *   </template>
+ * </CompactCardSelector>
+ */
+
+export interface CompactCardSelectorProps {
+  elements: { id: string, title: string, showSlot?: boolean }[]
+  readonly?: boolean
+  icon: string
+  color: string
+  backgroundColor: string
+  iconBorderColor?: string
+  checkboxColor?: string
+  overlayColor?: string
+  overlayOpacity?: number
+}
+
+defineOptions({
+  inheritAttrs: false
+})
+
+const { elements, icon, color, backgroundColor, iconBorderColor } = defineProps<CompactCardSelectorProps>()
+
+defineSlots<{
+  /**
+   * You can use the `element` property of the slot scope to conditionally display content for specific elements. For example, if your elements have a `showSlot` boolean property, you can check it with `v-if="(element as { showSlot?: boolean })?.showSlot"`.
+   */
+  default: { element: unknown }
+}>()
+
+const selectedElementIds = defineModel<string[]>({ default: [] })
+
+const selectableElements = computed(() => {
+  return elements.map(element => ({
+    value: element.id,
+    label: element.title,
+    baseElement: element
+  }))
+})
+
+const iconOptions = computed(() => ({
+  name: icon,
+  color,
+  bottom: '-2rem',
+  borderColor: iconBorderColor ?? 'var(--other-border-skill-card)'
+}))
+
+function verifyShowSlot (element: unknown): boolean {
+  return getUnknownElementProp<boolean>(element, 'showSlot') ?? false
+}
+</script>
+
+<template>
+  <div class="av-row av-justify-center av-gap-sm av-radius-md av-wrap">
+    <SelectorOverlay
+      v-model:selected-elements="selectedElementIds"
+      :selectable-elements="selectableElements"
+      :checkbox-color="checkboxColor"
+      :overlay-color="overlayColor"
+      :overlay-opacity="overlayOpacity"
+      :readonly="readonly"
+    >
+      <template #default="{ label, baseElement }">
+        <FloatingIconCard
+          v-bind="$attrs"
+          :title="label"
+          :title-color="color"
+          :color="backgroundColor"
+          :icon-options="iconOptions"
+          border-color="var(--other-border-skill-card)"
+          :header-rows="2"
+          height="5.75rem"
+          custom-title-height="3.25rem"
+          title-typography-classes="caption-regular"
+        >
+          <template #body>
+            <slot
+              v-if="verifyShowSlot(baseElement)"
+              :element="baseElement"
+            />
+          </template>
+        </FloatingIconCard>
+      </template>
+    </SelectorOverlay>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.floating-icon-card {
+  min-width: 13.4375rem !important;
+  max-width: 13.4375rem !important;
+}
+
+:deep() {
+  .floating-icon-card {
+    &__title {
+      text-align: left;
+    }
+
+    &__icon {
+      height: var(--dimension-lg);
+      width: var(--dimension-lg);
+    }
+}
+
+  .av-card {
+    &__title {
+      padding-top: var(--spacing-xs);
+      padding-bottom: var(--spacing-xs);
+    }
+
+    &__content-collapsible {
+      padding-top: var(--spacing-xxs) !important;
+    }
+  }
+
+  .av-icon {
+    scale: 0.75 !important;
+  }
+}
+</style>

--- a/src/features/student/global/components/cards/CompactCardSelector/utils.ts
+++ b/src/features/student/global/components/cards/CompactCardSelector/utils.ts
@@ -1,0 +1,10 @@
+export function getUnknownElementProp<T> (element: unknown, propName: string): T | undefined {
+  if (
+    element
+    && typeof element === 'object'
+    && propName in element
+  ) {
+    return (element as Record<string, unknown>)[propName] as T
+  }
+  return undefined
+}

--- a/src/features/student/global/components/interaction/SelectorOverlay/SelectorOverlay.stub.ts
+++ b/src/features/student/global/components/interaction/SelectorOverlay/SelectorOverlay.stub.ts
@@ -35,7 +35,7 @@ export const SelectorOverlayStub = defineComponent({
           >
             {{ element.label }}
           </a>
-          <slot name="default" :label="element.label">{{ element.label }}</slot>
+          <slot name="default" :base-element="element.baseElement" :label="element.label">{{ element.label }}</slot>
         </div>
       </div>
     `,

--- a/src/features/student/global/components/overlays/modals/DeleteAssociationsModal/DeleteAssociationsModal.stub.ts
+++ b/src/features/student/global/components/overlays/modals/DeleteAssociationsModal/DeleteAssociationsModal.stub.ts
@@ -14,6 +14,9 @@ export const DeleteAssociationsModalStub = defineComponent({
     selectedAssociationIds: {
       type: Array as PropType<string[]>,
       required: true
+    },
+    isLoading: {
+      type: Boolean
     }
   },
   emits: ['cancel', 'confirmDelete'],

--- a/src/features/student/global/components/overlays/modals/DeleteAssociationsModal/DeleteAssociationsModal.vue
+++ b/src/features/student/global/components/overlays/modals/DeleteAssociationsModal/DeleteAssociationsModal.vue
@@ -12,6 +12,7 @@ export interface DeleteSelfKnowledgeElementsModalProps {
     title: string
   }[]
   selectedAssociationIds: string[]
+  isLoading?: boolean
 }
 
 defineProps<DeleteSelfKnowledgeElementsModalProps>()
@@ -52,6 +53,7 @@ function onConfirm () {
                              { count: selectedAssociationIds.length })"
     :confirm-button-icon="MDI_ICONS.TRASH_CAN_OUTLINE"
     :confirm-button-disabled="selectedAssociationIds.length === 0"
+    :is-loading="isLoading"
     @close="$emit('cancel')"
     @confirm="displayConfirmModal"
   >


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
Ce PR ajoute le composant CompactCardSelector pour la sélection compacte d’associations dans le portfolio étudiant. Il inclut les stubs, tests unitaires et l’intégration dans les modales de suppression d’associations et de traces associées.

**Principaux changements :**
- ✨ Ajout du composant `CompactCardSelector` (vue, stub, test)
- ✅ Ajout de tests unitaires pour CompactCardSelector
- 🎨 Intégration dans les modales DeleteAssociationsModal et DeleteActivityAssociatedTracesModal
- 📝 Mise à jour des stubs et composants liés

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1224

---

### Documentation
- Ajout : `src/features/student/global/components/cards/CompactCardSelector/CompactCardSelector.vue`, `.stub.ts`, `.test.ts`
- Modif : `src/features/student/global/components/overlays/modals/DeleteAssociationsModal/DeleteAssociationsModal.vue`, `.stub.ts`
- Modif : `src/features/student/global/components/overlays/modals/DeleteActivityAssociatedTracesModal/DeleteActivityAssociatedTracesModal.vue`
- Modif : `src/features/student/global/components/interaction/SelectorOverlay/SelectorOverlay.stub.ts`

---

### Target Branch
`develop`

---

### Additional Notes
- Le composant CompactCardSelector permet une sélection rapide et accessible d’éléments associés.
- Les stubs facilitent les tests et la documentation.
- Pas de breaking change pour les autres fonctionnalités.

---

### Known Limitations or Side Effects
Aucune limitation ou effet de bord connu à ce stade.

---

## ✅ Checklist

- [ ] a11y tested (si applicable)
- [ ] Tests fournis (unitaires)
- [ ] i18n géré (si applicable)
- [ ] Performance tests (non applicable)
- [ ] Pas de code inutile
- [ ] Respect des règles de style et conventions
- [ ] Versionnement sémantique respecté
- [ ] Ajout dans `CHANGELOG.md` si besoin
