### PR TITLE
feat(1225): implement delete activity trace associations

### DIFF
--- a/src/features/student/buildProject/components/modals/UnsubscribeActivitiesConfirmModal/UnsubscribeActivitiesConfirmModal.vue
+++ b/src/features/student/buildProject/components/modals/UnsubscribeActivitiesConfirmModal/UnsubscribeActivitiesConfirmModal.vue
@@ -1,4 +1,5 @@
 <script lang="ts" setup>
+import type { IdTitleList } from '@/types'
 import ConfirmationModal from '@/common/components/ConfirmationModal/ConfirmationModal.vue'
 import { useUnsubscribeActivitiesMutation } from '@/features/student/buildProject/queries/use-activities.query/use-activities.query'
 import { useToasterStore } from '@/store'
@@ -6,10 +7,7 @@ import { useI18n } from 'vue-i18n'
 
 export interface UnsubscribeActivitiesConfirmModalProps {
   show: boolean
-  activities: {
-    id: string
-    title: string
-  }[]
+  activities: IdTitleList
 }
 
 const { activities } = defineProps<UnsubscribeActivitiesConfirmModalProps>()

--- a/src/features/student/buildProject/views/ProjectActivitiesCatalogView/components/overlays/SubscribeActivityModal/SubscribeActivityModal.vue
+++ b/src/features/student/buildProject/views/ProjectActivitiesCatalogView/components/overlays/SubscribeActivityModal/SubscribeActivityModal.vue
@@ -1,4 +1,5 @@
 <script lang="ts" setup>
+import type { IdTitle } from '@/types'
 import ConfirmationModal from '@/common/components/ConfirmationModal/ConfirmationModal.vue'
 import { useModal } from '@/common/composables'
 import ActivityPeriodFormField
@@ -10,10 +11,7 @@ import { useI18n } from 'vue-i18n'
 
 export interface SubscribeActivityModalProps {
   show: boolean
-  activity: {
-    id: string
-    title: string
-  }
+  activity: IdTitle
 }
 
 const { activity } = defineProps<SubscribeActivityModalProps>()

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/SelectedAssociateTracesContainer/SelectedAssociateTracesContainer.vue
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/SelectedAssociateTracesContainer/SelectedAssociateTracesContainer.vue
@@ -1,14 +1,12 @@
 <script lang="ts" setup>
+import type { IdTitleList } from '@/types'
 import DeleteTraceAssociationOverlay
   from '@/features/student/buildProject/views/ProjectActivityDetailedView/components/overlays/DeleteTraceAssociationOverlay/DeleteTraceAssociationOverlay.vue'
 import { AvCard } from '@avenirs-esr/avenirs-dsav'
 import { useI18n } from 'vue-i18n'
 
 export interface SelectedAssociateTracesContainerProps {
-  traces: {
-    id: string
-    title: string
-  }[]
+  traces: IdTitleList
 }
 
 defineProps<SelectedAssociateTracesContainerProps>()

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/cards/TraceCompactCard/TraceCompactCard.vue
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/cards/TraceCompactCard/TraceCompactCard.vue
@@ -1,12 +1,10 @@
 <script lang="ts" setup>
+import type { IdTitle } from '@/types'
 import FloatingIconCard from '@/features/student/global/components/cards/FloatingIconCard/FloatingIconCard.vue'
 import { ICONS } from '@/features/student/global/icons'
 
 export interface TraceCompactCardProps {
-  trace: {
-    id: string
-    title: string
-  }
+  trace: IdTitle
 }
 
 const { trace } = defineProps<TraceCompactCardProps>()

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/overlays/DeleteTraceAssociationOverlay/DeleteTraceAssociationOverlay.vue
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/overlays/DeleteTraceAssociationOverlay/DeleteTraceAssociationOverlay.vue
@@ -1,12 +1,10 @@
 <script setup lang="ts">
+import type { IdTitle } from '@/types'
 import TraceCompactCard from '@/features/student/buildProject/views/ProjectActivityDetailedView/components/cards/TraceCompactCard/TraceCompactCard.vue'
 import DeleteOverlay from '@/features/student/global/components/interaction/DeleteOverlay/DeleteOverlay.vue'
 
 export interface DeleteTraceAssociationOverlayProps {
-  trace: {
-    id: string
-    title: string
-  }
+  trace: IdTitle
 }
 
 const { trace } = defineProps<DeleteTraceAssociationOverlayProps>()

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/overlays/modals/ConfirmAssociateTracesModal/ConfirmAssociateTracesModal.vue
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/overlays/modals/ConfirmAssociateTracesModal/ConfirmAssociateTracesModal.vue
@@ -1,13 +1,11 @@
 <script lang="ts" setup>
+import type { IdTitleList } from '@/types'
 import ConfirmationModal from '@/common/components/ConfirmationModal/ConfirmationModal.vue'
 import { useI18n } from 'vue-i18n'
 
 export interface ConfirmAssociateTracesModalProps {
   show: boolean
-  traces: {
-    id: string
-    title: string
-  }[]
+  traces: IdTitleList
 }
 
 const { traces } = defineProps<ConfirmAssociateTracesModalProps>()

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/overlays/modals/DeleteActivityAssociatedTracesModal/DeleteActivityAssociatedTracesModal.stub.ts
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/overlays/modals/DeleteActivityAssociatedTracesModal/DeleteActivityAssociatedTracesModal.stub.ts
@@ -1,3 +1,5 @@
+import type { PropType } from 'vue'
+
 export const DeleteActivityAssociatedTracesModalStub = defineComponent({
   name: 'DeleteActivityAssociatedTracesModal',
   props: {
@@ -8,7 +10,11 @@ export const DeleteActivityAssociatedTracesModalStub = defineComponent({
     declaredActivityId: {
       type: String,
       required: true,
-    }
+    },
+    associations: {
+      type: Array as PropType<{ id: string, title: string }[]>,
+      required: true,
+    },
   },
   emits: ['cancel', 'deleted'],
   template: '<div data-testid="delete-activity-associated-traces-modal-stub" />',

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/overlays/modals/DeleteActivityAssociatedTracesModal/DeleteActivityAssociatedTracesModal.test.ts
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/overlays/modals/DeleteActivityAssociatedTracesModal/DeleteActivityAssociatedTracesModal.test.ts
@@ -4,6 +4,7 @@ import { server } from '@/__mocks__/msw/server'
 import DeleteActivityAssociatedTracesModal, {
   type DeleteActivityAssociatedTracesModalProps
 } from '@/features/student/buildProject/views/ProjectActivityDetailedView/components/overlays/modals/DeleteActivityAssociatedTracesModal/DeleteActivityAssociatedTracesModal.vue'
+import { CompactCardSelectorStub } from '@/features/student/global/components/cards/CompactCardSelector/CompactCardSelector.stub'
 import { DeleteAssociationsModalStub } from '@/features/student/global/components/overlays/modals/DeleteAssociationsModal/DeleteAssociationsModal.stub'
 import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { mountComponent } from 'tests/utils'
@@ -27,12 +28,23 @@ BddTest().given('a delete activity associated traces modal', () => {
   let wrapper: VueWrapper<InstanceType<typeof DeleteActivityAssociatedTracesModal>>
 
   const stubs = {
+    CompactCardSelector: CompactCardSelectorStub,
     DeleteAssociationsModal: DeleteAssociationsModalStub,
   }
 
   const props: DeleteActivityAssociatedTracesModalProps = {
     show: true,
     declaredActivityId: 'declared-activity-1',
+    associations: [
+      {
+        id: 'association-1',
+        title: 'Trace 1'
+      },
+      {
+        id: 'association-2',
+        title: 'Trace 2'
+      }
+    ]
   }
 
   beforeEach(() => {
@@ -60,6 +72,17 @@ BddTest().given('a delete activity associated traces modal', () => {
 
       BddTest().then('the delete activity associated traces modal should emit cancel', () => {
         expect(wrapper.emitted('cancel')).toBeTruthy()
+      })
+    })
+
+    BddTest().and('the user selects traces to delete from the selector', () => {
+      beforeEach(() => {
+        const selector = wrapper.findComponent(CompactCardSelectorStub)
+        selector.vm.$emit('update:modelValue', ['association-1', 'association-2'])
+      })
+
+      BddTest().then('the selectedIds should be updated accordingly', () => {
+        expect(wrapper.findComponent(CompactCardSelectorStub).props('modelValue')).toEqual(['association-1', 'association-2'])
       })
     })
 

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/overlays/modals/DeleteActivityAssociatedTracesModal/DeleteActivityAssociatedTracesModal.vue
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/overlays/modals/DeleteActivityAssociatedTracesModal/DeleteActivityAssociatedTracesModal.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
 import type { AssociationsDeleteRequest } from '@/api/avenir-esr'
 import type { BaseApiException } from '@/common/exceptions/base-api-exception/base-api.exception'
+import type { IdTitleList } from '@/types'
 import { useDeleteDeclaredActivityAssociationsMutation } from '@/features/student/buildProject/queries/use-activities.query/use-activities.query'
 import CompactCardSelector from '@/features/student/global/components/cards/CompactCardSelector/CompactCardSelector.vue'
 import DeleteAssociationsModal from '@/features/student/global/components/overlays/modals/DeleteAssociationsModal/DeleteAssociationsModal.vue'
@@ -11,10 +12,7 @@ import { useI18n } from 'vue-i18n'
 export interface DeleteActivityAssociatedTracesModalProps {
   show: boolean
   declaredActivityId: string
-  associations: {
-    id: string
-    title: string
-  }[]
+  associations: IdTitleList
 }
 
 const { declaredActivityId, associations } = defineProps<DeleteActivityAssociatedTracesModalProps>()

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/overlays/modals/DeleteActivityAssociatedTracesModal/DeleteActivityAssociatedTracesModal.vue
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/overlays/modals/DeleteActivityAssociatedTracesModal/DeleteActivityAssociatedTracesModal.vue
@@ -2,16 +2,22 @@
 import type { AssociationsDeleteRequest } from '@/api/avenir-esr'
 import type { BaseApiException } from '@/common/exceptions/base-api-exception/base-api.exception'
 import { useDeleteDeclaredActivityAssociationsMutation } from '@/features/student/buildProject/queries/use-activities.query/use-activities.query'
+import CompactCardSelector from '@/features/student/global/components/cards/CompactCardSelector/CompactCardSelector.vue'
 import DeleteAssociationsModal from '@/features/student/global/components/overlays/modals/DeleteAssociationsModal/DeleteAssociationsModal.vue'
+import { ICONS } from '@/features/student/global/icons'
 import { useToasterStore } from '@/store'
 import { useI18n } from 'vue-i18n'
 
 export interface DeleteActivityAssociatedTracesModalProps {
   show: boolean
   declaredActivityId: string
+  associations: {
+    id: string
+    title: string
+  }[]
 }
 
-const { declaredActivityId } = defineProps<DeleteActivityAssociatedTracesModalProps>()
+const { declaredActivityId, associations } = defineProps<DeleteActivityAssociatedTracesModalProps>()
 
 const emit = defineEmits<{
   (e: 'cancel'): void
@@ -20,6 +26,8 @@ const emit = defineEmits<{
 
 const { t } = useI18n()
 const { addErrorMessage, addSuccessMessage } = useToasterStore()
+
+const selectedIds = ref<string[]>([])
 
 const { mutate: deleteDeclaredActivityAssociations, isPending } = useDeleteDeclaredActivityAssociationsMutation({
   onError: (error: BaseApiException) => {
@@ -33,21 +41,14 @@ const { mutate: deleteDeclaredActivityAssociations, isPending } = useDeleteDecla
       timeout: 2000,
       description: t('student.buildProject.activities.views.ProjectActivityDetailedView.DeleteActivityAssociatedTracesModal.success'),
     })
+    selectedIds.value = []
     emit('deleted')
   },
 })
 
-const dummyAssociations = [
-  { id: '1', title: '(Placeholder) Trace 1' },
-  { id: '2', title: '(Placeholder) Trace 2' },
-  { id: '3', title: '(Placeholder) Trace 3' }
-]
-
-const dummySelectedAssociationIds = ['1', '2']
-
 function onConfirmDelete () {
   const associationsDeleteRequest: AssociationsDeleteRequest = {
-    idsToDelete: dummySelectedAssociationIds
+    idsToDelete: selectedIds.value
   }
 
   deleteDeclaredActivityAssociations({
@@ -55,24 +56,36 @@ function onConfirmDelete () {
     associationsDeleteRequest
   })
 }
+
+const selectableElements = associations.map(association => ({
+  id: association.id,
+  title: association.title,
+}))
+
+function onCancel () {
+  selectedIds.value = []
+  emit('cancel')
+}
 </script>
 
 <template>
   <DeleteAssociationsModal
     :show="show"
-    :associations="dummyAssociations"
-    :selected-association-ids="dummySelectedAssociationIds"
+    :associations="associations"
+    :selected-association-ids="selectedIds"
     :is-loading="isPending"
-    @cancel="emit('cancel')"
+    @cancel="onCancel"
     @confirm-delete="onConfirmDelete"
   >
-    <div class="av-col">
-      <span
-        v-for="association in dummyAssociations"
-        :key="association.id"
-      >
-        {{ association.title }}
-      </span>
-    </div>
+    <CompactCardSelector
+      v-model="selectedIds"
+      :elements="selectableElements"
+      :icon="ICONS.TRACES"
+      color="var(--text1)"
+      background-color="var(--light-background-neutral)"
+      checkbox-color="var(--dark-background-primary1)"
+      overlay-color="var(--dark-background-primary1)"
+      :overlay-opacity="0.25"
+    />
   </DeleteAssociationsModal>
 </template>

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/tabs/AssociatedElementsTab/AssociatedElementsTab.test.ts
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/tabs/AssociatedElementsTab/AssociatedElementsTab.test.ts
@@ -15,11 +15,6 @@ import { beforeEach, expect } from 'vitest'
 BddTest().given('an associated elements tab', () => {
   let wrapper: VueWrapper<InstanceType<typeof AssociatedElementsTab>>
 
-  const props: AssociatedElementsTabProps = {
-    associations: mockedDeclaredActivityAssociations,
-    declaredActivityId: 'declared-activity-1',
-  }
-
   const stubs = {
     DeleteActivityAssociatedElementsDropdown: DeleteActivityAssociatedElementsDropdownStub,
     ActivityAssociateElementsDropdown: ActivityAssociateElementsDropdownStub,
@@ -29,7 +24,12 @@ BddTest().given('an associated elements tab', () => {
     AssociatedTracesCard: AssociatedTracesCardStub
   }
 
-  BddTest().when('the component is mounted', () => {
+  BddTest().when('the component is mounted with associations', () => {
+    const props: AssociatedElementsTabProps = {
+      associations: mockedDeclaredActivityAssociations,
+      declaredActivityId: 'declared-activity-1',
+    }
+
     beforeEach(() => {
       wrapper = mount(AssociatedElementsTab, { props, global: { stubs } })
     })
@@ -60,6 +60,16 @@ BddTest().given('an associated elements tab', () => {
       const tracesModal = wrapper.findComponent(DeleteActivityAssociatedTracesModalStub)
       expect(tracesModal.exists()).toBe(true)
       expect(tracesModal.props('show')).toBe(false)
+    })
+
+    BddTest().then('it should pass an array of {id, title} to delete activity associated traces modal', () => {
+      const modal = wrapper.findComponent(DeleteActivityAssociatedTracesModalStub)
+      mockedDeclaredActivityAssociations.traceAssociations.forEach((association) => {
+        expect(modal.props('associations')).toContainEqual({
+          id: association.associationId,
+          title: association.trace.title
+        })
+      })
     })
 
     BddTest().then('it should render the associate traces modal in hidden state', () => {

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/tabs/AssociatedElementsTab/AssociatedElementsTab.vue
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/tabs/AssociatedElementsTab/AssociatedElementsTab.vue
@@ -15,11 +15,18 @@ export interface AssociatedElementsTabProps {
   declaredActivityId: string
 }
 
-defineProps<AssociatedElementsTabProps>()
+const { associations } = defineProps<AssociatedElementsTabProps>()
 
 const { showModal: showSkillsModal, displayModal: displaySkillsModal, hideModal: hideSkillsModal } = useModal()
 const { showModal: showTracesModal, displayModal: displayTracesModal, hideModal: hideTracesModal } = useModal()
 const { showModal: showAssociateTracesModal, displayModal: displayAssociateTracesModal, hideModal: hideAssociateTracesModal } = useModal()
+
+const tracesAssociations = computed(() => {
+  return associations.traceAssociations.map(traceAssociation => ({
+    id: traceAssociation.associationId,
+    title: traceAssociation.trace.title
+  }))
+})
 </script>
 
 <template>
@@ -48,6 +55,7 @@ const { showModal: showAssociateTracesModal, displayModal: displayAssociateTrace
   <DeleteActivityAssociatedTracesModal
     :show="showTracesModal"
     :declared-activity-id="declaredActivityId"
+    :associations="tracesAssociations"
     @cancel="hideTracesModal"
     @deleted="hideTracesModal"
   />

--- a/src/features/student/declaredSkills/components/overlays/AddDeclaredSkillDrawer/types.ts
+++ b/src/features/student/declaredSkills/components/overlays/AddDeclaredSkillDrawer/types.ts
@@ -1,9 +1,8 @@
 import type { EDeclaredSkillLevel, EExternalSkillType } from '@/api/avenir-esr'
+import type { IdTitle } from '@/types'
 import type { AvAutocompleteOption } from '@avenirs-esr/avenirs-dsav'
 
-export interface DeclaredSkillOption extends AvAutocompleteOption {
-  id: string
-  title: string
+export interface DeclaredSkillOption extends AvAutocompleteOption, IdTitle {
   pathSegments: string[]
   type: EExternalSkillType
 }

--- a/src/features/student/global/components/cards/CompactCardSelector/CompactCardSelector.vue
+++ b/src/features/student/global/components/cards/CompactCardSelector/CompactCardSelector.vue
@@ -5,12 +5,19 @@ import SelectorOverlay from '@/features/student/global/components/interaction/Se
 
 /**
  * @example
+ * -- SCRIPT PART --
+ * const selectedElementIds = ref<string[]>([])
+ *
+ * const selectableElements = [
+ *   { id: '1', title: 'Element 1', showSlot: props.customCondition },
+ *   { id: '2', title: 'Element 2' },
+ *   { id: '3', title: 'Element 3', showSlot: true }
+ * ]
+ *
+ * -- TEMPLATE PART --
  * <CompactCardSelector
- *   :elements="[
- *     { id: '1', title: 'Element 1', showSlot: props.customCondition },
- *     { id: '2', title: 'Element 2' },
- *     { id: '3', title: 'Element 3', showSlot: true }
- *   ]"
+ *   v-model="selectedElementIds"
+ *   :elements="selectableElements"
  *   icon="mdi-check"
  *   color="var(--text1)"
  *   background-color="var(--surface-background)"
@@ -80,6 +87,7 @@ function verifyShowSlot (element: unknown): boolean {
       :overlay-color="overlayColor"
       :overlay-opacity="overlayOpacity"
       :readonly="readonly"
+      border-radius="var(--radius-lg)"
     >
       <template #default="{ label, baseElement }">
         <FloatingIconCard
@@ -116,6 +124,7 @@ function verifyShowSlot (element: unknown): boolean {
   .floating-icon-card {
     &__title {
       text-align: left;
+      margin-right: var(--spacing-lg) !important;
     }
 
     &__icon {
@@ -125,6 +134,9 @@ function verifyShowSlot (element: unknown): boolean {
 }
 
   .av-card {
+    padding: var(--spacing-xxs) !important;
+    border-radius: var(--radius-lg) !important;
+
     &__title {
       padding-top: var(--spacing-xs);
       padding-bottom: var(--spacing-xs);
@@ -137,6 +149,10 @@ function verifyShowSlot (element: unknown): boolean {
 
   .av-icon {
     scale: 0.75 !important;
+  }
+
+  .selector-overlay__checkbox {
+    padding-top: var(--spacing-none) !important;
   }
 }
 </style>

--- a/src/features/student/global/components/interaction/SelectorOverlay/SelectorOverlay.vue
+++ b/src/features/student/global/components/interaction/SelectorOverlay/SelectorOverlay.vue
@@ -10,6 +10,7 @@ export interface SelectorOverlayProps {
   overlayColor?: string
   overlayOpacity?: number
   readonly?: boolean
+  borderRadius?: string
 }
 
 const {
@@ -19,7 +20,8 @@ const {
   checkboxColor = 'var(--dark-background-primary1)',
   overlayColor = 'var(--dark-background-primary1)',
   overlayOpacity = 0.1,
-  readonly = false
+  readonly = false,
+  borderRadius = '1.5rem'
 } = defineProps<SelectorOverlayProps>()
 
 const { t } = useI18n()
@@ -93,7 +95,7 @@ function getAriaLabel (elementValue: string, elementLabel: string) {
     left: 0;
     right: 0;
     bottom: 0;
-    border-radius: 1.5rem;
+    border-radius: v-bind('borderRadius');
 
     &::before {
       content: '';
@@ -102,7 +104,7 @@ function getAriaLabel (elementValue: string, elementLabel: string) {
       left: 0;
       right: 0;
       bottom: 0;
-      border-radius: 1.5rem;
+      border-radius: v-bind('borderRadius');
       background-color: transparent;
     }
 

--- a/src/features/student/global/components/overlays/modals/DeleteAssociationsConfirmModal/DeleteAssociationsConfirmModal.test.ts
+++ b/src/features/student/global/components/overlays/modals/DeleteAssociationsConfirmModal/DeleteAssociationsConfirmModal.test.ts
@@ -1,0 +1,66 @@
+import type { DeleteAssociationsConfirmModalProps } from '@/features/student/global/components/overlays/modals/DeleteAssociationsConfirmModal/DeleteAssociationsConfirmModal.vue'
+import { ConfirmationModalStub } from '@/common/components/ConfirmationModal/ConfirmationModal.stub'
+import DeleteAssociationsConfirmModal from '@/features/student/global/components/overlays/modals/DeleteAssociationsConfirmModal/DeleteAssociationsConfirmModal.vue'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { mount, type VueWrapper } from '@vue/test-utils'
+
+BddTest().given('a DeleteAssociationsModal component', () => {
+  let wrapper: VueWrapper<InstanceType<typeof DeleteAssociationsConfirmModal>>
+
+  const stubs = {
+    ConfirmationModal: ConfirmationModalStub,
+  }
+
+  BddTest().when('the component is mounted without associations', () => {
+    const props: DeleteAssociationsConfirmModalProps = {
+      show: true,
+      associations: []
+    }
+
+    beforeEach(() => {
+      wrapper = mount(DeleteAssociationsConfirmModal, { props, global: { stubs } })
+    })
+
+    BddTest().then('it should not render the associations list', () => {
+      expect(wrapper.find('[data-testid="delete-associations-confirm-modal__associations-list"]').exists()).toBe(false)
+    })
+  })
+
+  BddTest().when('the component is mounted with associations', () => {
+    const props: DeleteAssociationsConfirmModalProps = {
+      show: true,
+      associations: [
+        { id: '1', title: 'Association 1' },
+        { id: '2', title: 'Association 2' }
+      ]
+    }
+
+    beforeEach(() => {
+      wrapper = mount(DeleteAssociationsConfirmModal, { props, global: { stubs } })
+    })
+
+    BddTest().then('it should render the associations list', () => {
+      expect(wrapper.find('[data-testid="delete-associations-confirm-modal__associations-list"]').exists()).toBe(true)
+    })
+
+    BddTest().and('the user clicks the cancel button', () => {
+      beforeEach(() => {
+        wrapper.findComponent(ConfirmationModalStub).vm.$emit('close')
+      })
+
+      BddTest().then('it should emit "cancel"', () => {
+        expect(wrapper.emitted()).toHaveProperty('cancel')
+      })
+    })
+
+    BddTest().and('the user clicks the confirm button', () => {
+      beforeEach(() => {
+        wrapper.findComponent(ConfirmationModalStub).vm.$emit('confirm')
+      })
+
+      BddTest().then('it should emit "confirm"', () => {
+        expect(wrapper.emitted()).toHaveProperty('confirm')
+      })
+    })
+  })
+})

--- a/src/features/student/global/components/overlays/modals/DeleteAssociationsConfirmModal/DeleteAssociationsConfirmModal.vue
+++ b/src/features/student/global/components/overlays/modals/DeleteAssociationsConfirmModal/DeleteAssociationsConfirmModal.vue
@@ -1,13 +1,11 @@
 <script lang="ts" setup>
+import type { IdTitleList } from '@/types'
 import ConfirmationModal from '@/common/components/ConfirmationModal/ConfirmationModal.vue'
 import { useI18n } from 'vue-i18n'
 
 export interface DeleteAssociationsConfirmModalProps {
   show: boolean
-  associations: {
-    id: string
-    title: string
-  }[]
+  associations: IdTitleList
 }
 
 const { associations } = defineProps<DeleteAssociationsConfirmModalProps>()

--- a/src/features/student/global/components/overlays/modals/DeleteAssociationsConfirmModal/DeleteAssociationsConfirmModal.vue
+++ b/src/features/student/global/components/overlays/modals/DeleteAssociationsConfirmModal/DeleteAssociationsConfirmModal.vue
@@ -2,7 +2,7 @@
 import ConfirmationModal from '@/common/components/ConfirmationModal/ConfirmationModal.vue'
 import { useI18n } from 'vue-i18n'
 
-export interface UnsubscribeActivitiesConfirmModalProps {
+export interface DeleteAssociationsConfirmModalProps {
   show: boolean
   associations: {
     id: string
@@ -10,7 +10,7 @@ export interface UnsubscribeActivitiesConfirmModalProps {
   }[]
 }
 
-const { associations } = defineProps<UnsubscribeActivitiesConfirmModalProps>()
+const { associations } = defineProps<DeleteAssociationsConfirmModalProps>()
 
 const emit = defineEmits<{
   (e: 'cancel'): void
@@ -38,7 +38,7 @@ const { t } = useI18n()
       </div>
     </template>
     <ul
-      v-if="associations.length > 1"
+      v-if="associations.length > 0"
       data-testid="delete-associations-confirm-modal__associations-list"
     >
       <li

--- a/src/features/student/global/components/overlays/modals/DeleteAssociationsModal/DeleteAssociationsModal.test.ts
+++ b/src/features/student/global/components/overlays/modals/DeleteAssociationsModal/DeleteAssociationsModal.test.ts
@@ -1,0 +1,59 @@
+import type { DeleteAssociationsModalProps } from '@/features/student/global/components/overlays/modals/DeleteAssociationsModal/DeleteAssociationsModal.vue'
+import { DeleteAssociationsConfirmModalStub } from '@/features/student/global/components/overlays/modals/DeleteAssociationsConfirmModal/DeleteAssociationsConfirmModal.stub'
+import DeleteAssociationsModal from '@/features/student/global/components/overlays/modals/DeleteAssociationsModal/DeleteAssociationsModal.vue'
+import { AvModalStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { mount, type VueWrapper } from '@vue/test-utils'
+
+BddTest().given('a DeleteAssociationsModal component', () => {
+  let wrapper: VueWrapper<InstanceType<typeof DeleteAssociationsModal>>
+
+  const stubs = {
+    AvModal: AvModalStub,
+    DeleteAssociationsConfirmModal: DeleteAssociationsConfirmModalStub
+  }
+
+  BddTest().when('the component is mounted with props and a slot', () => {
+    const props: DeleteAssociationsModalProps = {
+      show: true,
+      associations: [
+        { id: '1', title: 'Association 1' },
+        { id: '2', title: 'Association 2' }
+      ],
+      selectedAssociationIds: ['1'],
+      isLoading: false
+    }
+
+    const slots = {
+      default: '<div data-testid="modal-content">Modal Content</div>'
+    }
+
+    beforeEach(() => {
+      wrapper = mount(DeleteAssociationsModal, { props, slots, global: { stubs } })
+    })
+
+    BddTest().then('it should render the correct label for the confirm button', () => {
+      expect(wrapper.findComponent(AvModalStub).props('confirmButtonLabel')).toBe('Supprimer l\'association sélectionnée (1)')
+    })
+
+    BddTest().then('it should render the correct content in the modal', () => {
+      expect(wrapper.find('[data-testid="modal-content"]').exists()).toBe(true)
+    })
+
+    BddTest().then('it should emit "cancel" when the cancel button is clicked', async () => {
+      await wrapper.findComponent(AvModalStub).vm.$emit('close')
+      expect(wrapper.emitted()).toHaveProperty('cancel')
+    })
+
+    BddTest().and('the user confirms the deletion in the confirm modal', () => {
+      beforeEach(() => {
+        wrapper.findComponent(DeleteAssociationsConfirmModalStub).vm.$emit('confirm')
+      })
+
+      BddTest().then('it should emit "confirmDelete"', async () => {
+        await vi.waitFor(() => {
+          expect(wrapper.emitted()).toHaveProperty('confirmDelete')
+        })
+      })
+    })
+  })
+})

--- a/src/features/student/global/components/overlays/modals/DeleteAssociationsModal/DeleteAssociationsModal.vue
+++ b/src/features/student/global/components/overlays/modals/DeleteAssociationsModal/DeleteAssociationsModal.vue
@@ -1,4 +1,5 @@
 <script lang="ts" setup>
+import type { IdTitleList } from '@/types'
 import type { Slot } from 'vue'
 import { useModal } from '@/common/composables'
 import DeleteAssociationsConfirmModal from '@/features/student/global/components/overlays/modals/DeleteAssociationsConfirmModal/DeleteAssociationsConfirmModal.vue'
@@ -7,10 +8,7 @@ import { useI18n } from 'vue-i18n'
 
 export interface DeleteAssociationsModalProps {
   show: boolean
-  associations: {
-    id: string
-    title: string
-  }[]
+  associations: IdTitleList
   selectedAssociationIds: string[]
   isLoading?: boolean
 }

--- a/src/features/student/global/components/overlays/modals/DeleteAssociationsModal/DeleteAssociationsModal.vue
+++ b/src/features/student/global/components/overlays/modals/DeleteAssociationsModal/DeleteAssociationsModal.vue
@@ -5,7 +5,7 @@ import DeleteAssociationsConfirmModal from '@/features/student/global/components
 import { AvModal, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
 import { useI18n } from 'vue-i18n'
 
-export interface DeleteSelfKnowledgeElementsModalProps {
+export interface DeleteAssociationsModalProps {
   show: boolean
   associations: {
     id: string
@@ -15,7 +15,7 @@ export interface DeleteSelfKnowledgeElementsModalProps {
   isLoading?: boolean
 }
 
-defineProps<DeleteSelfKnowledgeElementsModalProps>()
+defineProps<DeleteAssociationsModalProps>()
 
 const emit = defineEmits<{
   (e: 'cancel'): void

--- a/src/features/student/traces/views/StudentToolsTracesView/components/StudentDetailedTraceAssociateModal/components/use-associate-trace-form/use-associate-trace-form.ts
+++ b/src/features/student/traces/views/StudentToolsTracesView/components/StudentDetailedTraceAssociateModal/components/use-associate-trace-form/use-associate-trace-form.ts
@@ -1,14 +1,13 @@
 import type { TraceDetailDTO } from '@/api/avenir-esr'
 import type { BaseApiException } from '@/common/exceptions'
+import type { IdTitle } from '@/types'
 import type { AvAutocompleteOption } from '@avenirs-esr/avenirs-dsav'
 import { useCreateAssociateTraceMutation } from '@/features/student/traces/queries/use-traces.query/use-traces.query'
 import { useToasterStore } from '@/store'
 import { useForm } from '@tanstack/vue-form'
 import { useI18n } from 'vue-i18n'
 
-export interface TraceAssociationOption extends AvAutocompleteOption {
-  id: string
-  title: string
+export interface TraceAssociationOption extends AvAutocompleteOption, IdTitle {
   description: string
 }
 

--- a/src/types/common.types.ts
+++ b/src/types/common.types.ts
@@ -1,0 +1,6 @@
+export interface IdTitle {
+  id: string
+  title: string
+}
+
+export type IdTitleList = IdTitle[]

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,5 @@
 export * from './api-types'
+export * from './common.types'
 export * from './filters.types'
 export * from './i18n.types'
 export * from './queries.types'


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
This PR implements the deletion of activity trace associations. It introduces the ability to remove associations directly from the activity details, improving user control and data management.

**Main changes:**
- ✨ Implements delete functionality for activity trace associations
- ✅ Adds and updates unit tests for deletion logic
- 🎨 Refactors modal and selector components for better maintainability
- 🔥 Cleans up related stubs and test files

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1225

---

### Documentation
- Unit tests added and updated for delete associations feature
- Refactored modal and selector components for clarity
- Updated stubs for new logic

**Modified files:**
- `src/features/student/buildProject/views/ProjectActivityDetailedView/components/DeleteActivityAssociatedTracesModal.stub.ts`
- `src/features/student/buildProject/views/ProjectActivityDetailedView/components/DeleteActivityAssociatedTracesModal.test.ts`
- `src/features/student/buildProject/views/ProjectActivityDetailedView/components/DeleteActivityAssociatedTracesModal.vue`
- `src/features/student/buildProject/views/ProjectActivityDetailedView/components/tabs/AssociatedElementsTab/AssociatedElementsTab.test.ts`
- `src/features/student/buildProject/views/ProjectActivityDetailedView/components/tabs/AssociatedElementsTab.vue`
- `src/features/student/buildProject/views/ProjectActivityDetailedView/components/CompactCardSelector/CompactCardSelector.vue`
- `src/features/student/buildProject/views/ProjectActivityDetailedView/components/SelectorOverlay/SelectorOverlay.vue`
- `src/features/student/buildProject/views/ProjectActivityDetailedView/components/DeleteAssociationsConfirmModal.test.ts`
- `src/features/student/buildProject/views/ProjectActivityDetailedView/components/DeleteAssociationsConfirmModal.vue`
- `src/features/student/buildProject/views/ProjectActivityDetailedView/components/DeleteAssociationsModal.test.ts`
- `src/features/student/buildProject/views/ProjectActivityDetailedView/components/DeleteAssociationsModal.vue`

---

### Target Branch
`develop`

---

### Additional Notes
This PR enhances the user experience by allowing direct management of activity trace associations. The refactor also improves code maintainability and test coverage.

**Technical decisions:**
- Centralized deletion logic in modal components
- Improved test coverage for edge cases
- Cleaned up unused stubs and test exports

---

### Known Limitations or Side Effects
No known limitations or side effects.

---

## ✅ Checklist

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [x] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process
