### PR TITLE
feat(1213): adapt ActivityCompactCard and fix e2e flaky test

### DIFF
--- a/e2e/framework/student/lifeProject/activities/StudentProjectActivitiesPage.ts
+++ b/e2e/framework/student/lifeProject/activities/StudentProjectActivitiesPage.ts
@@ -153,8 +153,8 @@ class StudentProjectActivitiesPage extends BasePage {
 
   @When('the user opens the unsubscribe activities modal')
   async openUnsubscribeActivitiesModal () {
-    this.unsubscribedActivityId = await this.getActivityLibraryTab().getCardByIndex(0).getActivityId()
-    this.unsubscribedActivityThematic = await this.getActivityLibraryTab().getCardByIndex(0).getActivityThematic()
+    this.unsubscribedActivityId = await this.getActivityLibraryTab().getCardByIndex(1).getActivityId()
+    this.unsubscribedActivityThematic = await this.getActivityLibraryTab().getCardByIndex(1).getActivityThematic()
     await this.getActivityLibraryTab().getDropdown().clickUnsubscribe()
   }
 

--- a/src/features/student/buildProject/views/ProjectActivitiesView/components/cards/ActivityCompactCard/ActivityCompactCard.stub.ts
+++ b/src/features/student/buildProject/views/ProjectActivitiesView/components/cards/ActivityCompactCard/ActivityCompactCard.stub.ts
@@ -1,5 +1,5 @@
 export const ActivityCompactCardStub = defineComponent({
   name: 'ActivityCompactCard',
-  props: ['title'],
-  template: '<div class="activity-compact-card-stub">{{ title }}</div>'
+  props: ['activity'],
+  template: '<div class="activity-compact-card-stub">{{ activity?.title }}</div>'
 })

--- a/src/features/student/buildProject/views/ProjectActivitiesView/components/cards/ActivityCompactCard/ActivityCompactCard.test.ts
+++ b/src/features/student/buildProject/views/ProjectActivitiesView/components/cards/ActivityCompactCard/ActivityCompactCard.test.ts
@@ -1,5 +1,6 @@
 import type { VueWrapper } from '@vue/test-utils'
-import { ValorizedBadgeStub } from '@/common/components/ValorizedBadge/ValorizedBadge.stub'
+import { EActivityThematic } from '@/api/avenir-esr'
+import { ActivityThematicBadgeStub } from '@/features/student/buildProject/components/badges/ActivityThematicBadge/ActivityThematicBadge.stub'
 import ActivityCompactCard, { type ActivityCompactCardProps } from '@/features/student/buildProject/views/ProjectActivitiesView/components/cards/ActivityCompactCard/ActivityCompactCard.vue'
 import { FloatingIconCardStub } from '@/features/student/global/components/cards/FloatingIconCard/FloatingIconCard.stub'
 import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
@@ -8,20 +9,41 @@ import { mountComponent } from 'tests/utils'
 BddTest().given('an activity compact card', () => {
   let wrapper: VueWrapper<InstanceType<typeof ActivityCompactCard>>
 
-  const stubs = { FloatingIconCard: FloatingIconCardStub, ValorizedBadge: ValorizedBadgeStub }
+  const stubs = { FloatingIconCard: FloatingIconCardStub, ActivityThematicBadge: ActivityThematicBadgeStub }
 
-  const props: ActivityCompactCardProps = {
-    title: 'Element Title',
-  }
+  const activity = { id: '1', title: 'Element Title' }
 
-  BddTest().when('the component is mounted', () => {
+  BddTest().when('the component is mounted without thematic', () => {
     beforeEach(() => {
+      const props: ActivityCompactCardProps = { activity }
       wrapper = mountComponent(ActivityCompactCard, { props, global: { stubs } })
     })
 
     BddTest().then('it should render the floating icon card', () => {
       const card = wrapper.findComponent(FloatingIconCardStub)
       expect(card.exists()).toBe(true)
+    })
+
+    BddTest().then('it should not render the thematic badge', () => {
+      const badge = wrapper.findComponent(ActivityThematicBadgeStub)
+      expect(badge.exists()).toBe(false)
+    })
+  })
+
+  BddTest().when('the component is mounted with a thematic', () => {
+    beforeEach(() => {
+      const props: ActivityCompactCardProps = { activity, thematic: EActivityThematic.EXPERIENCES }
+      wrapper = mountComponent(ActivityCompactCard, { props, global: { stubs } })
+    })
+
+    BddTest().then('it should render the floating icon card', () => {
+      const card = wrapper.findComponent(FloatingIconCardStub)
+      expect(card.exists()).toBe(true)
+    })
+
+    BddTest().then('it should render the thematic badge', () => {
+      const badge = wrapper.findComponent(ActivityThematicBadgeStub)
+      expect(badge.exists()).toBe(true)
     })
   })
 })

--- a/src/features/student/buildProject/views/ProjectActivitiesView/components/cards/ActivityCompactCard/ActivityCompactCard.vue
+++ b/src/features/student/buildProject/views/ProjectActivitiesView/components/cards/ActivityCompactCard/ActivityCompactCard.vue
@@ -1,12 +1,16 @@
 <script lang="ts" setup>
+import type { EActivityThematic } from '@/api/avenir-esr'
+import type { IdTitle } from '@/types'
+import ActivityThematicBadge from '@/features/student/buildProject/components/badges/ActivityThematicBadge/ActivityThematicBadge.vue'
 import FloatingIconCard from '@/features/student/global/components/cards/FloatingIconCard/FloatingIconCard.vue'
 import { ICONS } from '@/features/student/global/icons'
 
 export interface ActivityCompactCardProps {
-  title: string
+  activity: IdTitle
+  thematic?: EActivityThematic
 }
 
-defineProps<ActivityCompactCardProps>()
+const { thematic } = defineProps<ActivityCompactCardProps>()
 
 const iconOptions = computed(() => ({
   name: ICONS.ACTIVITY,
@@ -14,19 +18,33 @@ const iconOptions = computed(() => ({
   bottom: '-2.5rem',
   borderColor: 'var(--other-border-skill-card)'
 }))
+
+const height = computed(() => thematic ? '8.5rem' : '5.75rem')
 </script>
 
 <template>
   <FloatingIconCard
-    :title="title"
+    :title="activity.title"
     title-color="var(--text1)"
     color="var(--surface-background)"
     :icon-options="iconOptions"
     border-color="var(--other-border-skill-card)"
     :header-rows="2"
-    height="5.75rem"
     title-typography-classes="caption-regular"
-  />
+    :height
+  >
+    <template
+      v-if="thematic"
+      #body
+    >
+      <div class="av-row">
+        <ActivityThematicBadge
+          :thematic="thematic"
+          small
+        />
+      </div>
+    </template>
+  </FloatingIconCard>
 </template>
 
 <style lang="scss" scoped>

--- a/src/features/student/buildProject/views/ProjectActivitiesView/components/overlays/ActivitiesSelector/ActivitiesSelector.test.ts
+++ b/src/features/student/buildProject/views/ProjectActivitiesView/components/overlays/ActivitiesSelector/ActivitiesSelector.test.ts
@@ -51,7 +51,7 @@ BddTest().given('an activities selector', () => {
       BddTest().then('it should render the activity', () => {
         const card = wrapper.findComponent(ActivityCompactCardStub)
         expect(card.exists()).toBe(true)
-        expect(card.props('title')).toEqual(props.activities[0].title)
+        expect(card.props('activity')).toEqual({ id: props.activities[0].id, title: props.activities[0].title })
       })
 
       BddTest().and('the activity is clicked', () => {
@@ -103,8 +103,8 @@ BddTest().given('an activities selector', () => {
       BddTest().then('it should render the activities', () => {
         const cards = wrapper.findAllComponents(ActivityCompactCardStub)
         expect(cards).toHaveLength(2)
-        expect(cards[0].props('title')).toEqual(props.activities[0].title)
-        expect(cards[1].props('title')).toEqual(props.activities[1].title)
+        expect(cards[0].props('activity')).toEqual({ id: props.activities[0].id, title: props.activities[0].title })
+        expect(cards[1].props('activity')).toEqual({ id: props.activities[1].id, title: props.activities[1].title })
       })
     })
   })

--- a/src/features/student/buildProject/views/ProjectActivitiesView/components/overlays/ActivitiesSelector/ActivitiesSelector.vue
+++ b/src/features/student/buildProject/views/ProjectActivitiesView/components/overlays/ActivitiesSelector/ActivitiesSelector.vue
@@ -56,7 +56,10 @@ function getActivityThematic (baseElement?: unknown) {
           data-testid="activity-selector-item"
           :data-activity-id="value"
           :data-activity-thematic="getActivityThematic(baseElement)"
-          :title="label"
+          :activity="{
+            id: value,
+            title: label,
+          }"
         />
       </template>
     </SelectorOverlay>

--- a/src/features/student/global/components/interaction/SelectorOverlay/SelectorOverlay.stub.ts
+++ b/src/features/student/global/components/interaction/SelectorOverlay/SelectorOverlay.stub.ts
@@ -35,7 +35,7 @@ export const SelectorOverlayStub = defineComponent({
           >
             {{ element.label }}
           </a>
-          <slot name="default" :base-element="element.baseElement" :label="element.label">{{ element.label }}</slot>
+          <slot name="default" :base-element="element.baseElement" :label="element.label" :value="element.value">{{ element.label }}</slot>
         </div>
       </div>
     `,


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> Adaptation du composant `ActivityCompactCard` pour accepter une prop `activity: IdTitle` (au lieu d'une prop `title: string`) et afficher optionnellement la thématique via `ActivityThematicBadge`. Correction des tests unitaires associés et correction d'un test E2E flaky sur la page des activités.

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1213

---

### Documentation
> Aucune mise à jour de documentation requise.

---

### Target Branch
> `develop`

---

### Additional Notes
> - Le composant `ActivityCompactCard` reçoit désormais une `activity: IdTitle` en prop, aligné avec `ActivityLibraryCard` et les autres composants de type carte compacte du projet.
> - Correction d'un test E2E flaky sur `StudentProjectActivitiesPage`.

---

### Known Limitations or Side Effects
> Aucune limitation connue.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and detaiils for the update process