### PR TITLE
fix(1265): UpdateProfileDrawer - prevent multiple delete picture mutation triggers

### DIFF
--- a/src/features/student/user/components/overlays/UpdateProfileDrawer/UpdateProfileDrawer.vue
+++ b/src/features/student/user/components/overlays/UpdateProfileDrawer/UpdateProfileDrawer.vue
@@ -39,46 +39,26 @@ const {
   resetForm
 } = useUpdateProfileForm(studentSummary, onUpdateProfileSuccess)
 const FormField = markRaw(form.Field)
-const { onConfirmDeleteCoverPhoto } = useDeleteCoverPhoto()
-const { onConfirmDeleteProfilePhoto } = useDeleteProfilePhoto()
 
 function onUpdateProfileSuccess () {
   addSuccessMessage(t('student.user.overlays.UpdateProfileDrawer.onUpdate.success'))
   onClose()
 }
 
-function useDeleteCoverPhoto () {
-  function onDeleteCoverPhotoError (error: BaseApiException) {
-    addErrorMessage({ title: t('student.user.overlays.UpdateProfileDrawer.onDelete.error'), description: error.message, type: 'error', })
-  }
+const { mutate: deleteCoverPicture } = useDeletePhotoMutation({
+  onError: (error: BaseApiException) => addErrorMessage({ title: t('student.user.overlays.UpdateProfileDrawer.onDelete.error'), description: error.message, type: 'error', }),
+})
 
-  const { mutate: deletePhotoMutation } = useDeletePhotoMutation({
-    onError: onDeleteCoverPhotoError,
-    onSuccess: onConfirmDeleteCoverPhoto
-  })
+const { mutate: deleteProfilePicture } = useDeletePhotoMutation({
+  onError: (error: BaseApiException) => addErrorMessage({ title: t('student.user.overlays.UpdateProfileDrawer.onDelete.error'), description: error.message, type: 'error', }),
+})
 
-  function onConfirmDeleteCoverPhoto () {
-    deletePhotoMutation({ fileId: studentSummary.coverPicture.fileId! })
-  }
-
-  return { onConfirmDeleteCoverPhoto }
+function onDeleteCoverPicture () {
+  deleteCoverPicture({ fileId: studentSummary.coverPicture.fileId! })
 }
 
-function useDeleteProfilePhoto () {
-  function onDeleteProfilePhotoError (error: BaseApiException) {
-    addErrorMessage({ title: t('student.user.overlays.UpdateProfileDrawer.onDelete.error'), description: error.message, type: 'error', })
-  }
-
-  const { mutate: deletePhotoMutation } = useDeletePhotoMutation({
-    onError: onDeleteProfilePhotoError,
-    onSuccess: onConfirmDeleteProfilePhoto
-  })
-
-  function onConfirmDeleteProfilePhoto () {
-    deletePhotoMutation({ fileId: studentSummary.profilePicture.fileId! })
-  }
-
-  return { onConfirmDeleteProfilePhoto }
+function onDeleteProfilePicture () {
+  deleteProfilePicture({ fileId: studentSummary.profilePicture.fileId! })
 }
 
 watch(() => show, (newVal) => {
@@ -167,7 +147,7 @@ watch(() => show, (newVal) => {
           >
             <ImageUpload
               v-model="coverPictureFile"
-              :on-delete-image="onConfirmDeleteCoverPhoto"
+              :on-delete-image="onDeleteCoverPicture"
               :default-image-url="studentSummary.coverPicture.fileName ? studentSummary.coverPicture.url : undefined"
               :default-image-name="studentSummary.coverPicture.fileName ?? undefined"
               :image-alt="t('student.user.overlays.UpdateProfileDrawer.pictures.banner')"
@@ -180,7 +160,7 @@ watch(() => show, (newVal) => {
           >
             <ImageUpload
               v-model="profilePictureFile"
-              :on-delete-image="onConfirmDeleteProfilePhoto"
+              :on-delete-image="onDeleteProfilePicture"
               :default-image-name="studentSummary.profilePicture.fileName ?? undefined"
               :image-alt="t('student.user.overlays.UpdateProfileDrawer.pictures.picture')"
               :on-update="onProfilePictureUpdate"


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
This PR fixes an issue in the UpdateProfileDrawer component to prevent multiple triggers of the delete profile picture mutation. This ensures that the delete action cannot be launched multiple times simultaneously, improving reliability and user experience.

**Main changes:**
- 🐛 Prevents multiple triggers of the delete profile picture mutation in UpdateProfileDrawer.vue

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1265

---

### Documentation
- Updated logic in `UpdateProfileDrawer.vue` to ensure delete mutation cannot be triggered multiple times.
- No changes to public documentation required.

**Modified files:**
- `src/features/student/user/components/overlays/UpdateProfileDrawer/UpdateProfileDrawer.vue`

---

### Target Branch
`develop`

---

### Additional Notes
This fix addresses a bug where users could accidentally trigger multiple delete requests for their profile picture, which could lead to inconsistent state or errors.

---

### Known Limitations or Side Effects
No known limitations or side effects.

---

## ✅ Checklist

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [ ] No unnecessary code (e.g., debug logs, commented code)
- [ ] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process
