### PR TITLE
fix(1266): StudentTraceCard - update Route Location the link should navigate to when clicked on

### DIFF
--- a/e2e/framework/shared/constants/routes.ts
+++ b/e2e/framework/shared/constants/routes.ts
@@ -14,6 +14,7 @@ export const STUDENT_ROUTES = {
     },
   },
   SKILL_DETAIL: '/cofolio/student/skill/',
+  TRACE_DETAIL: '/cofolio/student/trace/',
   TOOLS: {
     RESUMES: '/cofolio/student/tools/resumes',
     PAGES: '/cofolio/student/tools/pages',

--- a/e2e/framework/student/shared/steps/StudentGlobalSteps.ts
+++ b/e2e/framework/student/shared/steps/StudentGlobalSteps.ts
@@ -63,6 +63,11 @@ class StudentGlobalSteps extends BasePage {
     await expect(this.page).toHaveURL(STUDENT_ROUTES.TOOLS.TRACES)
   }
 
+  @Then('the page navigates to trace detail page')
+  async verifyNavigationToTraceDetailPage () {
+    await expect(this.page).toHaveURL(new RegExp(`${STUDENT_ROUTES.TRACE_DETAIL}.+`))
+  }
+
   @Then('the main navigation menu is visible')
   async verifyMainNavigationMenu () {
     await expect(this.layout.getMainNavigation()).toBeVisible()

--- a/e2e/tests/student/home.deferred.feature
+++ b/e2e/tests/student/home.deferred.feature
@@ -97,10 +97,10 @@ Feature: Student Home Page - out of MVP features
       And the see all traces button is visible
 
     @high @traces @dataset-full
-    Scenario: Trace cards are clickable and navigate to traces page
+    Scenario: Trace cards are clickable and navigate to detailed trace page
       When the student clicks a trace card
-      Then the page navigates to traces page
-      And the URL contains "/cofolio/student/tools/traces"
+      Then the page navigates to trace detail page
+      And the URL contains "/cofolio/student/trace"
 
     @medium @traces @dataset-full
     Scenario: See all traces button navigates to traces page

--- a/src/features/student/traces/components/cards/StudentTraceCard/StudentTraceCard.vue
+++ b/src/features/student/traces/components/cards/StudentTraceCard/StudentTraceCard.vue
@@ -1,5 +1,4 @@
 <script lang="ts" setup>
-import type { RouteLocationRaw } from 'vue-router'
 import { EPortfolioType, type TraceOverviewDTO } from '@/api/avenir-esr'
 import { ROUTES } from '@/common/constants'
 import StudentCountAmsIconText from '@/features/student/ams/components/base/StudentCountAmsIconText/StudentCountAmsIconText.vue'
@@ -9,10 +8,9 @@ import { useI18n } from 'vue-i18n'
 
 export interface StudentTraceCardProps {
   trace: TraceOverviewDTO
-  to?: RouteLocationRaw
 }
 
-const { trace, to = { name: ROUTES.STUDENT.TOOLS_TRACES.name } } = defineProps<StudentTraceCardProps>()
+const { trace } = defineProps<StudentTraceCardProps>()
 const { title, skillCount, AMSCount, isGroup, programName } = trace
 
 const { t } = useI18n()
@@ -39,7 +37,7 @@ const iconOptions = {
 <template>
   <RouterLink
     class="student-trace-card av-w-full"
-    :to="to"
+    :to="{ name: ROUTES.STUDENT.TRACE.name, params: { id: trace.traceId } }"
     data-testid="trace-card"
   >
     <FloatingIconCard


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
This PR updates the navigation route for the StudentTraceCard component. The link now navigates to the correct route location when clicked, ensuring users are directed to the intended destination.

**Main changes:**
- 🐛 Updates the route location for StudentTraceCard link navigation

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1266

---

### Documentation
- Updated logic in `StudentTraceCard.vue` to fix the navigation route.
- No changes to public documentation required.

**Modified files:**
- `src/features/student/traces/components/cards/StudentTraceCard/StudentTraceCard.vue`

---

### Target Branch
`develop`

---

### Additional Notes
This fix ensures that clicking the StudentTraceCard navigates to the correct route, improving user experience and navigation consistency.

---

### Known Limitations or Side Effects
No known limitations or side effects.

---

## ✅ Checklist

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [ ] No unnecessary code (e.g., debug logs, commented code)
- [ ] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process
