### PR TITLE
fix(1269): AddDeclaredProgramDrawer - remove placeholders from demo mode

### DIFF
--- a/src/features/student/personalCareer/components/overlays/AddDeclaredProgramDrawer/AddDeclaredProgramDrawer.vue
+++ b/src/features/student/personalCareer/components/overlays/AddDeclaredProgramDrawer/AddDeclaredProgramDrawer.vue
@@ -51,6 +51,8 @@ function confirmCancel () {
 }
 
 const activeAccordion = ref(0)
+
+const isDemo = __DEMO_MODE__
 </script>
 
 <template>
@@ -87,6 +89,7 @@ const activeAccordion = ref(0)
             </AvAccordion>
 
             <AvAccordion
+              v-if="!isDemo"
               :title="t('student.personalCareer.overlays.AddDeclaredProgramDrawer.sections.specifyProgram')"
               :icon="MDI_ICONS.INFORMATION_OUTLINE"
             >
@@ -94,6 +97,7 @@ const activeAccordion = ref(0)
             </AvAccordion>
 
             <AvAccordion
+              v-if="!isDemo"
               :title="t('student.personalCareer.overlays.AddDeclaredProgramDrawer.sections.associateProgram')"
               :icon="MDI_ICONS.ATTACH_FILE"
             >


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
This PR removes demo placeholders from the AddDeclaredProgramDrawer component. The drawer now only displays actual content, improving clarity and user experience in demo mode.

**Main changes:**
- 🐛 Removes demo placeholders from AddDeclaredProgramDrawer.vue

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1269

---

### Documentation
- Updated `AddDeclaredProgramDrawer.vue` to remove demo placeholders.
- No changes to public documentation required.

**Modified files:**
- `src/features/student/programs/components/overlays/AddDeclaredProgramDrawer/AddDeclaredProgramDrawer.vue`

---

### Target Branch
`develop`

---

### Additional Notes
This change ensures that only real content is shown in the AddDeclaredProgramDrawer, making the demo mode more representative of actual usage.

---

### Known Limitations or Side Effects
No known limitations or side effects.

---

## ✅ Checklist

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [ ] No unnecessary code (e.g., debug logs, commented code)
- [ ] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process
