### PR TITLE
fix(1272): Declared experience detail and update views - add current page to breadcrumb

### DIFF
--- a/src/features/student/personalCareer/views/DeclaredExperienceUpdateView/DeclaredExperienceUpdateView.vue
+++ b/src/features/student/personalCareer/views/DeclaredExperienceUpdateView/DeclaredExperienceUpdateView.vue
@@ -36,12 +36,15 @@ const { showModal, displayModal, hideModal } = useModal()
 const { declaredExperiences, pageInfo, loadMoreDeclaredExperiences } = usePaginatedDeclaredExperiences({})
 const { declaredExperience, isLoading, isError } = useDeclaredExperienceDetailedViewQuery({ experienceId: selectedExperienceId })
 
+const declaredExperienceTitle = computed(() => declaredExperience.value?.title ?? '')
+
 const activeTab = ref(DeclaredExperienceUpdateViewTabs.DETAILS)
 const breadcrumbLinks = computed(() => [
   { text: t('student.global.navigation.tabs.home'), to: ROUTES.STUDENT.HOME },
   { text: t('student.global.navigation.tabs.project.header') },
   { text: t('student.personalCareer.views.PersonalCareerView.MyCareerSection.title'), to: ROUTES.STUDENT.PERSONAL_CAREER },
-  { text: t('student.personalCareer.views.PersonalCareerView.ExperiencesSection.breadcrumb') }
+  { text: t('student.personalCareer.views.PersonalCareerView.ExperiencesSection.breadcrumb') },
+  { text: declaredExperienceTitle.value }
 ])
 
 const {
@@ -82,7 +85,7 @@ function onExperienceUpdated () {
     <template #title>
       <span class="n2 av-text-title">
         {{ t('global.buttons.update') }}
-        <span class="n4">{{ declaredExperience?.title }}</span>
+        <span class="n4">{{ declaredExperienceTitle }}</span>
       </span>
     </template>
   </PageTitle>

--- a/src/features/student/personalCareer/views/DeclaredExperienceView/DeclaredExperienceView.test.ts
+++ b/src/features/student/personalCareer/views/DeclaredExperienceView/DeclaredExperienceView.test.ts
@@ -94,7 +94,7 @@ BddTest().given('a declared experience view component', () => {
 
         expect(pageTitle.props('title')).toBe('Développeur Web Full Stack')
         const breadcrumbs = pageTitle.props('breadcrumbLinks')
-        expect(breadcrumbs).toHaveLength(4)
+        expect(breadcrumbs).toHaveLength(5)
       })
     })
 
@@ -104,11 +104,12 @@ BddTest().given('a declared experience view component', () => {
         expect(pageTitle.exists()).toBe(true)
 
         const breadcrumbLinks = pageTitle.props('breadcrumbLinks') as Array<{ text: string, to?: string }>
-        expect(breadcrumbLinks).toHaveLength(4)
+        expect(breadcrumbLinks).toHaveLength(5)
         expect(breadcrumbLinks[0]).toEqual({ text: 'Accueil', to: ROUTES.STUDENT.HOME })
         expect(breadcrumbLinks[1]).toEqual({ text: 'Construire mon projet de vie' })
         expect(breadcrumbLinks[2]).toEqual({ text: 'Mon parcours', to: ROUTES.STUDENT.PERSONAL_CAREER })
         expect(breadcrumbLinks[3]).toEqual({ text: 'Mes expériences', to: ROUTES.STUDENT.PERSONAL_CAREER_EXPERIENCES })
+        expect(breadcrumbLinks[4]).toEqual({ text: 'Développeur Web Full Stack' })
       })
     })
 

--- a/src/features/student/personalCareer/views/DeclaredExperienceView/DeclaredExperienceView.vue
+++ b/src/features/student/personalCareer/views/DeclaredExperienceView/DeclaredExperienceView.vue
@@ -38,7 +38,8 @@ const breadcrumbLinks = computed(() => [
   { text: t('student.global.navigation.tabs.home'), to: ROUTES.STUDENT.HOME },
   { text: t('student.global.navigation.tabs.project.header') },
   { text: t('student.personalCareer.views.PersonalCareerView.MyCareerSection.title'), to: ROUTES.STUDENT.PERSONAL_CAREER },
-  { text: t('student.personalCareer.views.PersonalCareerView.ExperiencesSection.breadcrumb'), to: ROUTES.STUDENT.PERSONAL_CAREER_EXPERIENCES }
+  { text: t('student.personalCareer.views.PersonalCareerView.ExperiencesSection.breadcrumb'), to: ROUTES.STUDENT.PERSONAL_CAREER_EXPERIENCES },
+  { text: experienceTitle.value }
 ])
 
 const {


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
This PR adds the current page to the breadcrumb in both the DeclaredExperienceView and DeclaredExperienceUpdateView. This improves navigation clarity and helps users understand their current context within the application.

**Main changes:**
- 🐛 Adds current page to breadcrumb in DeclaredExperienceView and DeclaredExperienceUpdateView
- ✅ Updates related tests for both views

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1272

---

### Documentation
- Updated `DeclaredExperienceView.vue` and `DeclaredExperienceUpdateView.vue` to include the current page in the breadcrumb.
- Updated related test files to reflect breadcrumb changes.

**Modified files:**
- `src/features/student/personalCareer/views/DeclaredExperienceView/DeclaredExperienceView.vue`
- `src/features/student/personalCareer/views/DeclaredExperienceUpdateView/DeclaredExperienceUpdateView.vue`
- `src/features/student/personalCareer/views/DeclaredExperienceView/DeclaredExperienceView.test.ts`

---

### Target Branch
`develop`

---

### Additional Notes
This change enhances user navigation by making the breadcrumb more informative and context-aware.

---

### Known Limitations or Side Effects
No known limitations or side effects.

---

## ✅ Checklist

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [ ] No unnecessary code (e.g., debug logs, commented code)
- [ ] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process
