### PR TITLE
fix(1274): AddSelfknowledgeCategoryElementDrawer - remove placeholders for demo

### DIFF
--- a/src/features/student/selfKnowledge/components/overlays/AddSelfKnowledgeCategoryElementDrawer/AddSelfKnowledgeCategoryElementDrawer.vue
+++ b/src/features/student/selfKnowledge/components/overlays/AddSelfKnowledgeCategoryElementDrawer/AddSelfKnowledgeCategoryElementDrawer.vue
@@ -69,6 +69,8 @@ const drawerTitle = computed(() => {
     category: capitalize(selectedCategoryTypeTranslation.value)
   })
 })
+
+const isDemo = __DEMO_MODE__
 </script>
 
 <template>
@@ -115,6 +117,7 @@ const drawerTitle = computed(() => {
             </AvAccordion>
 
             <AvAccordion
+              v-if="!isDemo"
               :title="t('student.selfKnowledge.overlays.AddSelfKnowledgeCategoryElementDrawer.accordions.associate', { categoryType: selectedCategoryTypeTranslation })"
               :icon="MDI_ICONS.PLUS_CIRCLE_OUTLINE"
             >


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
This PR removes demo placeholders from the AddSelfKnowledgeCategoryElementDrawer component. The drawer now only displays actual content, improving clarity and user experience in demo mode.

**Main changes:**
- 🐛 Removes demo placeholders from AddSelfKnowledgeCategoryElementDrawer.vue

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1274

---

### Documentation
- Updated `AddSelfKnowledgeCategoryElementDrawer.vue` to remove demo placeholders.
- No changes to public documentation required.

**Modified files:**
- `src/features/student/selfKnowledge/components/overlays/AddSelfKnowledgeCategoryElementDrawer/AddSelfKnowledgeCategoryElementDrawer.vue`

---

### Target Branch
`develop`

---

### Additional Notes
This change ensures that only real content is shown in the AddSelfKnowledgeCategoryElementDrawer, making the demo mode more representative of actual usage.

---

### Known Limitations or Side Effects
No known limitations or side effects.

---

## ✅ Checklist

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [ ] No unnecessary code (e.g., debug logs, commented code)
- [ ] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process
