### PR TITLE
fix(1275): SelfKnowledge - remove share actions from demo mode

### DIFF
--- a/src/features/student/selfKnowledge/components/dropdowns/SelfKnowledgeElementsDropdown/SelfKnowledgeElementsDropdown.vue
+++ b/src/features/student/selfKnowledge/components/dropdowns/SelfKnowledgeElementsDropdown/SelfKnowledgeElementsDropdown.vue
@@ -18,6 +18,8 @@ const emit = defineEmits<{
 
 const { t } = useI18n()
 
+const isDemo = __DEMO_MODE__
+
 const isCategoryDeletable = computed(() => ![
   ESelfKnowledgeCategoryType.VALUES,
   ESelfKnowledgeCategoryType.STRENGTHS,
@@ -43,12 +45,15 @@ const menuItems = computed<AvDropdownItem[]>(() => {
       icon: MDI_ICONS.TRASH_CAN_OUTLINE,
       label: t('student.selfKnowledge.SelfKnowledgeMainSection.categoryElementsPaginator.buttons.delete')
     },
-    {
+  ]
+
+  if (!isDemo) {
+    items.push({
       name: SelfKnowledgeElementsDropdownEvents.SHARE,
       icon: MDI_ICONS.SHARE_VARIANT_OUTLINE,
       label: t('student.selfKnowledge.SelfKnowledgeMainSection.categoryElementsPaginator.buttons.share')
-    }
-  ]
+    })
+  }
 
   if (isCategoryDeletable.value) {
     items.push({

--- a/src/features/student/selfKnowledge/views/SelfKnowledgeCategoryView/components/SelfKnowledgeElementDetailsDropdown/SelfKnowledgeElementDetailsDropdown.vue
+++ b/src/features/student/selfKnowledge/views/SelfKnowledgeCategoryView/components/SelfKnowledgeElementDetailsDropdown/SelfKnowledgeElementDetailsDropdown.vue
@@ -16,6 +16,8 @@ enum SelfKnowledgeElementDetailsDropdownEvents {
   SHARE = 'share',
 }
 
+const isDemo = false
+
 const menuItems = computed<AvDropdownItem[]>(() => [
   {
     name: SelfKnowledgeElementDetailsDropdownEvents.UPDATE,
@@ -27,11 +29,13 @@ const menuItems = computed<AvDropdownItem[]>(() => [
     icon: MDI_ICONS.TRASH_CAN_OUTLINE,
     label: t('global.buttons.delete')
   },
-  {
-    name: SelfKnowledgeElementDetailsDropdownEvents.SHARE,
-    icon: MDI_ICONS.SHARE_VARIANT_OUTLINE,
-    label: t('global.buttons.share')
-  }
+  ...(!isDemo
+    ? [{
+        name: SelfKnowledgeElementDetailsDropdownEvents.SHARE,
+        icon: MDI_ICONS.SHARE_VARIANT_OUTLINE,
+        label: t('global.buttons.share')
+      }]
+    : [])
 ])
 
 function handleItemSelected (itemName: string) {


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
This PR removes share actions from the SelfKnowledge feature in demo mode. This ensures that demo users do not see or interact with sharing functionality, providing a more accurate demo experience.

**Main changes:**
- 🐛 Removes share actions from SelfKnowledgeElementsDropdown.vue and SelfKnowledgeElementDetailsDropdown.vue in demo mode

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1275

---

### Documentation
- Updated `SelfKnowledgeElementsDropdown.vue` and `SelfKnowledgeElementDetailsDropdown.vue` to conditionally hide share actions in demo mode.
- No changes to public documentation required.

**Modified files:**
- `src/features/student/selfKnowledge/views/SelfKnowledgeCategoryView/components/SelfKnowledgeElementsDropdown/SelfKnowledgeElementsDropdown.vue`
- `src/features/student/selfKnowledge/views/SelfKnowledgeCategoryView/components/SelfKnowledgeElementDetailsDropdown/SelfKnowledgeElementDetailsDropdown.vue`

---

### Target Branch
`develop`

---

### Additional Notes
This change ensures that demo users only see features available in the demo, improving clarity and user experience.

---

### Known Limitations or Side Effects
No known limitations or side effects.

---

## ✅ Checklist

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [ ] No unnecessary code (e.g., debug logs, commented code)
- [ ] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process
