### PR TITLE
fix(1278): UpdateActivityDrawer - remove placeholders for demo

### DIFF
--- a/src/features/student/buildProject/components/overlays/UpdateActivityDrawer/UpdateActivityDrawer.vue
+++ b/src/features/student/buildProject/components/overlays/UpdateActivityDrawer/UpdateActivityDrawer.vue
@@ -64,6 +64,8 @@ const minStartDate = computed(() => {
   }
   return startOfDay(new Date(declaredActivity.createdAt))
 })
+
+const isDemo = __DEMO_MODE__
 </script>
 
 <template>
@@ -104,6 +106,7 @@ const minStartDate = computed(() => {
           </AvAccordion>
 
           <AvAccordion
+            v-if="!isDemo"
             :title="t('student.buildProject.activities.overlays.UpdateActivityDrawer.sections.reminder')"
             :icon="MDI_ICONS.STAR_SHOOTING_OUTLINE"
           >


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
This PR removes demo placeholders from the UpdateActivityDrawer component. The drawer now only displays actual content, improving clarity and user experience in demo mode.

**Main changes:**
- 🐛 Removes demo placeholders from UpdateActivityDrawer.vue

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1278

---

### Documentation
- Updated `UpdateActivityDrawer.vue` to remove demo placeholders.
- No changes to public documentation required.

**Modified files:**
- `src/features/student/activities/components/overlays/UpdateActivityDrawer/UpdateActivityDrawer.vue`

---

### Target Branch
`develop`

---

### Additional Notes
This change ensures that only real content is shown in the UpdateActivityDrawer, making the demo mode more representative of actual usage.

---

### Known Limitations or Side Effects
No known limitations or side effects.

---

## ✅ Checklist

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [ ] No unnecessary code (e.g., debug logs, commented code)
- [ ] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process
