### PR TITLE
fix(1282): StudentTraceView - add redirection on trace delete

### DIFF
--- a/src/common/composables/use-navigation/use-navigation.test.ts
+++ b/src/common/composables/use-navigation/use-navigation.test.ts
@@ -210,6 +210,14 @@ BddTest().given('a useNavigation composable', () => {
     })
   })
 
+  BddTest().when('trying to navigate to student traces with replace', () => {
+    BddTest().then('it should navigate to student traces with replace', () => {
+      const { navigateToStudentTraces } = navigation
+      navigateToStudentTraces({ replace: true })
+      expect(replaceMock).toHaveBeenCalledWith(ROUTES.STUDENT.TOOLS_TRACES)
+    })
+  })
+
   BddTest().when('trying to navigate to student declared programs', () => {
     BddTest().then('it should navigate to student declared programs', () => {
       const { navigateToStudentDeclaredPrograms } = navigation

--- a/src/common/composables/use-navigation/use-navigation.ts
+++ b/src/common/composables/use-navigation/use-navigation.ts
@@ -108,7 +108,11 @@ export function useNavigation () {
     return router.push(to)
   }
 
-  const navigateToStudentTraces = () => {
+  const navigateToStudentTraces = ({ replace }: { replace?: boolean } = { replace: false }) => {
+    if (replace) {
+      return router.replace(ROUTES.STUDENT.TOOLS_TRACES)
+    }
+
     return router.push(ROUTES.STUDENT.TOOLS_TRACES)
   }
 

--- a/src/features/student/traces/views/StudentTraceView/StudentTraceView.test.ts
+++ b/src/features/student/traces/views/StudentTraceView/StudentTraceView.test.ts
@@ -9,6 +9,16 @@ import { flushPromises, type VueWrapper } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import { mountComponent } from 'tests/utils'
 
+vi.mock('@/common/composables', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/common/composables')>()
+  return {
+    ...actual,
+    useNavigation: () => ({
+      navigateToStudentTraces: vi.fn(),
+    }),
+  }
+})
+
 BddTest().given('a student trace view', () => {
   let wrapper: VueWrapper<InstanceType<typeof StudentTraceView>>
 

--- a/src/features/student/traces/views/StudentTraceView/StudentTraceView.vue
+++ b/src/features/student/traces/views/StudentTraceView/StudentTraceView.vue
@@ -2,7 +2,7 @@
 import ErrorMessage from '@/common/components/feedback/ErrorMessage/ErrorMessage.vue'
 import Loader from '@/common/components/Loader/Loader.vue'
 import PageTitle from '@/common/components/PageTitle/PageTitle.vue'
-import { useModal } from '@/common/composables'
+import { useModal, useNavigation } from '@/common/composables'
 import { ROUTES } from '@/common/constants'
 import { ICONS } from '@/features/student/global/icons'
 import TraceAssociations from '@/features/student/traces/components/composites/TraceAssociations/TraceAssociations.vue'
@@ -26,6 +26,7 @@ const { traceId } = toRefs(props)
 
 const { traceDetailed, error: traceDetailsError, isLoading } = useTraceDetailedQuery(traceId)
 const { traceAssociations, error: associationsError } = useTraceAssociationsQuery(traceId)
+const { navigateToStudentTraces } = useNavigation()
 
 const countAssociations = computed(() => !traceAssociations.value ? 0 : traceAssociations.value.declaredActivityAssociations.length + traceAssociations.value.declaredSkillAssociations.length)
 
@@ -48,6 +49,7 @@ const activeTab = ref(0)
 
 function onDeleteTraceSuccess () {
   hideDeleteModal()
+  navigateToStudentTraces({ replace: true })
 }
 
 const breadcrumbLinks = computed(() => [


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
This PR adds a redirection in the StudentTraceView when a trace is deleted, improving navigation and user experience. Now, after deleting a trace, the user is redirected appropriately.

**Main changes:**
- 🐛 Adds redirection logic on trace delete in StudentTraceView.vue
- ✅ Updates and adds tests for navigation and redirection
- ➕ Updates use-navigation composable for new logic

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1282

---

### Documentation
- Updated `StudentTraceView.vue` and `use-navigation.ts` to handle redirection after trace deletion.
- Added and updated related test files.

**Modified files:**
- `src/features/student/traces/views/StudentTraceView/StudentTraceView.vue`
- `src/common/composables/use-navigation/use-navigation.ts`
- `src/common/composables/use-navigation/use-navigation.test.ts`

---

### Target Branch
`develop`

---

### Additional Notes
This change ensures users are redirected after deleting a trace, preventing confusion and improving flow.

---

### Known Limitations or Side Effects
No known limitations or side effects.

---

## ✅ Checklist

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [ ] No unnecessary code (e.g., debug logs, commented code)
- [ ] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process
