### PR TITLE
fix(1283): AddTraceDrawer - remove placeholder from demo

### DIFF
--- a/src/features/student/traces/views/StudentToolsTracesView/components/StudentToolsTracesAddTraceDrawer/StudentToolsTracesAddTraceDrawer.vue
+++ b/src/features/student/traces/views/StudentToolsTracesView/components/StudentToolsTracesAddTraceDrawer/StudentToolsTracesAddTraceDrawer.vue
@@ -55,6 +55,8 @@ function handleCancel () {
 async function onSave () {
   await form.handleSubmit()
 }
+
+const isDemo = __DEMO_MODE__
 </script>
 
 <template>
@@ -100,7 +102,10 @@ async function onSave () {
               <CreateTraceFormDeclarationItems :form="form" />
             </AvAccordion>
 
-            <AvAccordion :title="t('student.traces.views.StudentToolsTracesView.studentToolsTracesAddTraceDrawer.accordionItems.associateTrace')">
+            <AvAccordion
+              v-if="!isDemo"
+              :title="t('student.traces.views.StudentToolsTracesView.studentToolsTracesAddTraceDrawer.accordionItems.associateTrace')"
+            >
               <div class="placeholder-content av-text-text2 av-p-md">
                 <p>{{ t('student.traces.views.StudentToolsTracesView.studentToolsTracesAddTraceDrawer.accordionItems.associateTrace') }} - Contenu à implémenter</p>
               </div>


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
This PR removes the placeholder from the AddTraceDrawer component in demo mode, ensuring only real content is displayed for a more accurate demo experience.

**Main changes:**
- 🐛 Removes placeholder from StudentToolsTracesAddTraceDrawer.vue in demo mode

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1283

---

### Documentation
- Updated `StudentToolsTracesAddTraceDrawer.vue` to remove the demo placeholder.

**Modified files:**
- `src/features/student/traces/components/StudentToolsTracesAddTraceDrawer/StudentToolsTracesAddTraceDrawer.vue`

---

### Target Branch
`develop`

---

### Additional Notes
This change ensures that only actual content is shown in the AddTraceDrawer during demo mode, improving clarity and user experience.

---

### Known Limitations or Side Effects
No known limitations or side effects.

---

## ✅ Checklist

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [ ] No unnecessary code (e.g., debug logs, commented code)
- [ ] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process
