### PR TITLE
fix(1284): StudentProfilePopover - disable trigger on demo mode

### DIFF
--- a/src/features/student/user/components/overlays/StudentProfilePopover/StudentProfilePopover.vue
+++ b/src/features/student/user/components/overlays/StudentProfilePopover/StudentProfilePopover.vue
@@ -5,16 +5,20 @@ import { useI18n } from 'vue-i18n'
 const { username } = defineProps<{ username: string }>()
 
 const { t } = useI18n()
+
+const isDemo = __DEMO_MODE__
 </script>
 
 <template>
   <AvPopover padding="var(--spacing-xs)">
     <template #trigger="{ toggle }">
       <AvButton
+        class="trigger-displayed-for-demo"
         :label="username"
         :icon="MDI_ICONS.ACCOUNT_CIRCLE_OUTLINE"
         small
         no-sentence-case
+        :disabled="isDemo"
         @click="toggle"
       />
     </template>
@@ -78,5 +82,9 @@ const { t } = useI18n()
 <style lang="scss" scoped>
 li > .av-button {
   width: 100% !important;
+}
+
+:deep(.trigger-displayed-for-demo) {
+  color: var(--dark-background-primary1) !important;
 }
 </style>


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
This PR disables the trigger for the StudentProfilePopover component in demo mode, preventing users from opening the profile popover when in demo.

**Main changes:**
- 🐛 Disables StudentProfilePopover trigger in demo mode

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1284

---

### Documentation
- Updated `StudentProfilePopover.vue` to disable the trigger in demo mode.

**Modified files:**
- `src/features/student/overlays/StudentProfilePopover/StudentProfilePopover.vue`

---

### Target Branch
`develop`

---

### Additional Notes
This change ensures that the profile popover cannot be opened in demo mode, aligning the UI with expected demo restrictions.

---

### Known Limitations or Side Effects
No known limitations or side effects.

---

## ✅ Checklist

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [ ] No unnecessary code (e.g., debug logs, commented code)
- [ ] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process
