### PR TITLE
fix(1287): [MOBILE] AddSkillDrawer - display all title

### DIFF
--- a/src/features/student/declaredSkills/components/overlays/AddDeclaredSkillDrawer/AddDeclaredSkillDrawer.test.ts
+++ b/src/features/student/declaredSkills/components/overlays/AddDeclaredSkillDrawer/AddDeclaredSkillDrawer.test.ts
@@ -9,6 +9,16 @@ import { AvButtonStub, AvCancelConfirmButtonsStub, AvDrawerStub, AvIconStub, Bdd
 import { mountComponent } from 'tests/utils'
 import { beforeEach, expect, vi } from 'vitest'
 
+vi.mock('@avenirs-esr/avenirs-dsav', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@avenirs-esr/avenirs-dsav')>()
+  return {
+    ...actual,
+    useAvBreakpoints: () => ({
+      isMobile: false,
+    })
+  }
+})
+
 const stubs = {
   AvDrawer: AvDrawerStub,
   AvButton: AvButtonStub,

--- a/src/features/student/declaredSkills/components/overlays/AddDeclaredSkillDrawer/AddDeclaredSkillDrawer.vue
+++ b/src/features/student/declaredSkills/components/overlays/AddDeclaredSkillDrawer/AddDeclaredSkillDrawer.vue
@@ -8,7 +8,7 @@ import {
 } from '@/features/student/declaredSkills/components/overlays/AddDeclaredSkillDrawer/use-declared-skill-form/use-declared-skill-form'
 import { useDeclaredSkillsStore } from '@/features/student/declaredSkills/stores/declaredSkills.store'
 import { useToasterStore } from '@/store'
-import { AvDrawer, AvIconText, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
+import { AvDrawer, AvIconText, MDI_ICONS, useAvBreakpoints } from '@avenirs-esr/avenirs-dsav'
 import { useI18n } from 'vue-i18n'
 
 const { t } = useI18n()
@@ -26,6 +26,7 @@ const { form, isFormValid, isSubmitting } = useDeclaredSkillForm(() => {
 })
 
 const { showModal: showConfirmationModal, displayModal: displayConfirmationModal, hideModal: hideConfirmationModal } = useModal()
+const { isMobile } = useAvBreakpoints()
 
 const isDirty = computed(() => {
   const state = form.useStore(state => state)
@@ -66,6 +67,7 @@ function confirmCancel () {
           :text="t('student.declaredSkills.overlays.AddDeclaredSkillDrawer.title')"
           text-color="var(--text1)"
           typography-class="n6"
+          :inline="isMobile"
         />
       </div>
 


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
**Main changes:**
- :iphone: AddSkillDrawer - prevents the title from being trucated
- ✅ Updates/Adds tests for AddDeclaredSkillDrawer

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1287

---

### Documentation
- Updated `AddDeclaredSkillDrawer.vue` to prevent truncated title on mobile.
- Updated/Add tests in `AddDeclaredSkillDrawer.test.ts`.

**Modified files:**
- `src/features/student/declaredSkills/components/overlays/AddDeclaredSkillDrawer/AddDeclaredSkillDrawer.vue`
- `src/features/student/declaredSkills/components/overlays/AddDeclaredSkillDrawer/AddDeclaredSkillDrawer.test.ts`

---

### Target Branch
`develop`

---

### Additional Notes
This change improves the mobile UI by removing unnecessary titles, making the drawer more user-friendly.

---

### Known Limitations or Side Effects
No known limitations or side effects.

---

## ✅ Checklist

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [ ] No unnecessary code (e.g., debug logs, commented code)
- [ ] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process
