### PR TITLE
refactor: Header - remove service tittle

### DIFF
--- a/src/features/student/global/layouts/StudentLayout/StudentLayout.vue
+++ b/src/features/student/global/layouts/StudentLayout/StudentLayout.vue
@@ -13,11 +13,8 @@ import {
 } from '@/features/student/user'
 import { AvHeader } from '@avenirs-esr/avenirs-dsav'
 import capitalize from 'lodash-es/capitalize'
-import { useI18n } from 'vue-i18n'
 
 useInvalidateAllQueriesAfterLocaleChange()
-
-const { t } = useI18n()
 
 const { languageSelector, selectLanguage } = useStudentUserStore()
 const { data: studentSummary, error: studentSummaryError } = useStudentSummaryQuery()
@@ -43,7 +40,6 @@ defineExpose({ searchQuery })
 <template>
   <AvHeader
     v-model="searchQuery"
-    :service-title="t('student.global.layout.header.serviceTitle')"
     :home-to="{ name: ROUTES.STUDENT.HOME.name }"
     :show-search="!isDemo"
     :language-selector="languageSelector"


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
This PR refactors the header by removing the service title from the StudentLayout, simplifying the header UI.

**Main changes:**
- ♻️ Removes service title from StudentLayout.vue

---

### Reference to an Issue, Feature, Task, User Story or another PR
No related issue.

---

### Documentation
- Updated `StudentLayout.vue` to remove the service title from the header.

**Modified files:**
- `src/features/student/global/layouts/StudentLayout/StudentLayout.vue`

---

### Target Branch
`develop`

---

### Additional Notes
This change is a UI simplification and does not affect functionality.

---

### Known Limitations or Side Effects
No known limitations or side effects.

---

## ✅ Checklist

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [ ] No unnecessary code (e.g., debug logs, commented code)
- [ ] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process
