### PR TITLE
feat(1237): delete trace associations related to an activity

### DIFF
--- a/api-specs/avenir-esr.swagger.json
+++ b/api-specs/avenir-esr.swagger.json
@@ -1339,6 +1339,49 @@
             }
           }
         }
+      },
+      "delete": {
+        "tags": [
+          "trace-controller"
+        ],
+        "operationId": "deleteTraceAssociations",
+        "parameters": [
+          {
+            "name": "traceId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/me/student-progress": {

--- a/src/__mocks__/msw/handlers/student/traces.handlers.ts
+++ b/src/__mocks__/msw/handlers/student/traces.handlers.ts
@@ -16,6 +16,7 @@ import {
   EErrorCode,
   ETraceAssociationType,
   getCreateTraceUrl,
+  getDeleteTraceAssociationsUrl,
   getGetTraceAssociationsUrl,
   getGetTraceConfigUrl,
   getGetTraceOverviewUrl,
@@ -320,5 +321,35 @@ export const tracesHandlers = [
         declaredSkillAssociations: []
       } as TraceAssociationsDTO)
     }
+  ),
+
+  http.delete(
+    `*${getDeleteTraceAssociationsUrl(':traceId')}`,
+    ({ params }) => {
+      const traceId = params.traceId as string
+
+      if (!traceId) {
+        return HttpResponse.json({ error: 'Trace ID is required' }, { status: 400 })
+      }
+
+      if (traceId === invalidTraceId) {
+        return HttpResponse.json({ error: 'Trace not found' }, { status: 404 })
+      }
+
+      return HttpResponse.json<string>(createDeletedTraceIdMock(traceId), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      })
+    }
   )
 ]
+
+export const deleteTraceAssociationsErrorHandler = http.delete(
+  `*${getDeleteTraceAssociationsUrl(':traceId')}`,
+  () => {
+    return HttpResponse.json(
+      { message: 'Internal Server Error' },
+      { status: 500 }
+    )
+  }
+)

--- a/src/features/student/traces/queries/use-traces.query/use-traces.query.test.ts
+++ b/src/features/student/traces/queries/use-traces.query/use-traces.query.test.ts
@@ -15,8 +15,10 @@ import {
 } from '@/api/avenir-esr'
 import { useInvalidateQuery } from '@/common/composables'
 import {
+  type DeleteTraceAssociationsMutationVariables,
   type DeleteTraceVariables,
   type UpdateTraceVariables,
+  useDeleteTraceAssociationsMutation,
   useDeleteTraceMutation,
   useStudentTracesSummaryQuery,
   useTraceAssociationsQuery,
@@ -997,6 +999,200 @@ BddTest().given('a useTraceAssociationsQuery composable', async () => {
         await flushPromises()
         expect(queryReturn.error.value).toBeDefined()
         expect(queryReturn.isSuccess.value).toBe(false)
+      })
+    })
+  })
+})
+
+BddTest().given('a useDeleteTraceAssociationsMutation composable', async () => {
+  let deleteTraceAssociationsSpy: MockInstance<(traceId: string, deleteTraceAssociationsBody: string[], options?: RequestInit | undefined) => Promise<string>>
+  let mutationResult: ReturnType<typeof useDeleteTraceAssociationsMutation>
+
+  const mockUseInvalidateQuery = useInvalidateQuery as MockedFunction<typeof useInvalidateQuery>
+  const mockInvalidateFunction = vi.fn()
+  const mockOnSuccess = vi.fn()
+  const mockOnError = vi.fn()
+  const mutationArgs: MutationArgs<string, DeleteTraceAssociationsMutationVariables> = {
+    onSuccess: mockOnSuccess,
+    onError: mockOnError
+  }
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    vi.restoreAllMocks()
+
+    deleteTraceAssociationsSpy = vi.spyOn<typeof import('@/api/avenir-esr'), 'deleteTraceAssociations'>(
+      await import('@/api/avenir-esr'),
+    'deleteTraceAssociations'
+    )
+
+    mockUseInvalidateQuery.mockReturnValue(mockInvalidateFunction)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  BddTest().and('a valid trace ID and association IDs with success callback', () => {
+    const traceId = '123e4567-e89b-12d3-a456-426614174000'
+    const associationIds = ['assoc-1', 'assoc-2']
+    const variables: DeleteTraceAssociationsMutationVariables = { traceId, associationIds }
+
+    BddTest().when('the mutation is called with mutateAsync', () => {
+      beforeEach(async () => {
+        mutationResult = mountQueryComposable(() => useDeleteTraceAssociationsMutation(mutationArgs))
+        await mutationResult.mutateAsync(variables)
+        await flushPromises()
+      })
+
+      BddTest().then('it should call the deleteTraceAssociations API with correct parameters', () => {
+        expect(deleteTraceAssociationsSpy).toHaveBeenCalledWith(traceId, associationIds)
+        expect(deleteTraceAssociationsSpy).toHaveBeenCalledTimes(1)
+      })
+
+      BddTest().then('it should return the expected success response', () => {
+        expect(mutationResult.data.value).toBeDefined()
+      })
+
+      BddTest().then('it should mark the mutation as successful', () => {
+        expect(mutationResult.isSuccess.value).toBe(true)
+        expect(mutationResult.isError.value).toBe(false)
+        expect(mutationResult.isPending.value).toBe(false)
+      })
+
+      BddTest().then('it should call the invalidation function once for both queries', () => {
+        expect(mockUseInvalidateQuery).toHaveBeenCalledTimes(1)
+        expect(mockInvalidateFunction).toHaveBeenCalledTimes(2)
+      })
+
+      BddTest().then('it should call the custom onSuccess callback', () => {
+        expect(mockOnSuccess).toHaveBeenCalledTimes(1)
+        expect(mockOnSuccess).toHaveBeenCalledWith(
+          expect.any(String),
+          variables
+        )
+      })
+
+      BddTest().then('it should not call the onError callback', () => {
+        expect(mockOnError).not.toHaveBeenCalled()
+      })
+    })
+
+    BddTest().when('the mutation is called with mutate', () => {
+      beforeEach(async () => {
+        mutationResult = mountQueryComposable(() => useDeleteTraceAssociationsMutation(mutationArgs))
+        mutationResult.mutate(variables)
+        await flushPromises()
+      })
+
+      BddTest().then('it should call the deleteTraceAssociations API with correct parameters', () => {
+        expect(deleteTraceAssociationsSpy).toHaveBeenCalledWith(traceId, associationIds)
+        expect(deleteTraceAssociationsSpy).toHaveBeenCalledTimes(1)
+      })
+
+      BddTest().then('it should call the custom onSuccess callback', () => {
+        expect(mockOnSuccess).toHaveBeenCalledTimes(1)
+      })
+
+      BddTest().then('it should call the invalidation function for both queries', () => {
+        expect(mockInvalidateFunction).toHaveBeenCalledTimes(2)
+      })
+    })
+  })
+
+  BddTest().and('no success or error callbacks', () => {
+    const traceId = '123e4567-e89b-12d3-a456-426614174000'
+    const associationIds = ['assoc-1']
+    const variables: DeleteTraceAssociationsMutationVariables = { traceId, associationIds }
+    const emptyMutationArgs: MutationArgs<string, DeleteTraceAssociationsMutationVariables> = {}
+
+    BddTest().when('the mutation is called without callbacks', () => {
+      beforeEach(async () => {
+        mutationResult = mountQueryComposable(() => useDeleteTraceAssociationsMutation(emptyMutationArgs))
+        await mutationResult.mutateAsync(variables)
+        await flushPromises()
+      })
+
+      BddTest().then('it should call the deleteTraceAssociations API with correct parameters', () => {
+        expect(deleteTraceAssociationsSpy).toHaveBeenCalledWith(traceId, associationIds)
+        expect(deleteTraceAssociationsSpy).toHaveBeenCalledTimes(1)
+      })
+
+      BddTest().then('it should still call the invalidation function for both queries', () => {
+        expect(mockInvalidateFunction).toHaveBeenCalledTimes(2)
+      })
+
+      BddTest().then('it should mark the mutation as successful', () => {
+        expect(mutationResult.isSuccess.value).toBe(true)
+        expect(mutationResult.isError.value).toBe(false)
+      })
+
+      BddTest().then('it should return the expected response', () => {
+        expect(mutationResult.data.value).toBeDefined()
+      })
+    })
+  })
+
+  BddTest().and('an invalid trace ID with error callback', () => {
+    const variables: DeleteTraceAssociationsMutationVariables = {
+      traceId: invalidTraceId,
+      associationIds: ['assoc-1']
+    }
+
+    BddTest().when('the mutation encounters an error', () => {
+      beforeEach(async () => {
+        mutationResult = mountQueryComposable(() => useDeleteTraceAssociationsMutation(mutationArgs))
+        await mutationResult.mutateAsync(variables).catch(() => {})
+        await flushPromises()
+      })
+
+      BddTest().then('it should call the deleteTraceAssociations API with the invalid ID', () => {
+        expect(deleteTraceAssociationsSpy).toHaveBeenCalledWith(invalidTraceId, variables.associationIds)
+        expect(deleteTraceAssociationsSpy).toHaveBeenCalledTimes(1)
+      })
+
+      BddTest().then('it should mark the mutation as error', () => {
+        expect(mutationResult.isError.value).toBe(true)
+        expect(mutationResult.isSuccess.value).toBe(false)
+        expect(mutationResult.isPending.value).toBe(false)
+      })
+
+      BddTest().then('it should contain the error information', () => {
+        expect(mutationResult.error.value).toBeDefined()
+      })
+
+      BddTest().then('it should call the custom onError callback', () => {
+        expect(mockOnError).toHaveBeenCalledTimes(1)
+      })
+
+      BddTest().then('it should not call the onSuccess callback', () => {
+        expect(mockOnSuccess).not.toHaveBeenCalled()
+      })
+
+      BddTest().then('it should not call the invalidation function on error', () => {
+        expect(mockInvalidateFunction).not.toHaveBeenCalled()
+      })
+    })
+
+    BddTest().when('the mutation is called using mutate with error', () => {
+      beforeEach(async () => {
+        mutationResult = mountQueryComposable(() => useDeleteTraceAssociationsMutation(mutationArgs))
+        mutationResult.mutate(variables)
+        await flushPromises()
+      })
+
+      BddTest().then('it should call the deleteTraceAssociations API with the invalid ID', () => {
+        expect(deleteTraceAssociationsSpy).toHaveBeenCalledWith(invalidTraceId, variables.associationIds)
+        expect(deleteTraceAssociationsSpy).toHaveBeenCalledTimes(1)
+      })
+
+      BddTest().then('it should contain the error information', () => {
+        expect(mutationResult.error.value).toBeDefined()
+        expect(mutationResult.isError.value).toBe(true)
+      })
+
+      BddTest().then('it should call the custom onError callback', () => {
+        expect(mockOnError).toHaveBeenCalledTimes(1)
       })
     })
   })

--- a/src/features/student/traces/queries/use-traces.query/use-traces.query.ts
+++ b/src/features/student/traces/queries/use-traces.query/use-traces.query.ts
@@ -6,6 +6,7 @@ import {
   createTrace,
   type CreateTraceDTO,
   deleteTrace,
+  deleteTraceAssociations,
   type ETraceAssociationType,
   getAssociatedTraces,
   getTraceAssociations,
@@ -39,7 +40,7 @@ import { type MaybeRef, type Ref, toValue, type UnwrapRef } from 'vue'
 
 const tracesCommonQueryKeys = [...commonQueryKeys, 'traces']
 const traceDetailQueryKey = [...tracesCommonQueryKeys, 'trace-detailed']
-const traceAssocationsQueryKey = [...tracesCommonQueryKeys, 'associations']
+const traceAssociationsQueryKey = [...tracesCommonQueryKeys, 'associations']
 const tracesViewQueryKey = [...tracesCommonQueryKeys, 'view']
 
 export interface UseTracesViewQueryParams {
@@ -175,7 +176,7 @@ export function useTraceDetailedQuery (traceId: MaybeRef<string>) {
 }
 
 export function useTraceAssociationsQuery (traceId: MaybeRef<string>) {
-  const queryKey = computed(() => [...traceAssocationsQueryKey, toValue(traceId)])
+  const queryKey = computed(() => [...traceAssociationsQueryKey, toValue(traceId)])
 
   const queryFn = computed(() => async (): Promise<TraceAssociationsDTO> => {
     return getTraceAssociations(toValue(traceId))
@@ -305,5 +306,30 @@ export function useStudentTracesSummaryQuery (): UseQueryReturnType<TraceOvervie
     queryFn: async (): Promise<TraceOverviewDTO[]> => {
       return getTraceOverview()
     }
+  })
+}
+
+export interface DeleteTraceAssociationsMutationVariables {
+  traceId: string
+  associationIds: string[]
+}
+
+export function useDeleteTraceAssociationsMutation ({
+  onError,
+  onSuccess
+}: MutationArgs<string, DeleteTraceAssociationsMutationVariables> = {}) {
+  const invalidateQueryKey = useInvalidateQuery()
+
+  return useMutation<string, BaseApiException, DeleteTraceAssociationsMutationVariables>({
+    mutationFn: async ({ traceId, associationIds }): Promise<string> => deleteTraceAssociations(traceId, associationIds),
+    onSuccess: async (data, variables) => {
+      const { traceId } = variables
+      await Promise.all([
+        invalidateQueryKey([...traceDetailQueryKey, traceId]),
+        invalidateQueryKey([...traceAssociationsQueryKey, traceId])
+      ])
+      onSuccess?.(data, variables)
+    },
+    onError
   })
 }

--- a/src/features/student/traces/views/StudentTraceView/components/overlays/modals/DeleteTraceAssociatedActivitiesModal/DeleteTraceAssociatedActivitiesModal.test.ts
+++ b/src/features/student/traces/views/StudentTraceView/components/overlays/modals/DeleteTraceAssociatedActivitiesModal/DeleteTraceAssociatedActivitiesModal.test.ts
@@ -1,4 +1,6 @@
 import type { DeclaredActivityAssociationDTO } from '@/api/avenir-esr'
+import { deleteTraceAssociationsErrorHandler } from '@/__mocks__/msw/handlers/student/traces.handlers'
+import { server } from '@/__mocks__/msw/server'
 import { EActivityThematic, EDeclaredActivityStatus } from '@/api/avenir-esr'
 import { CompactCardSelectorStub } from '@/features/student/global/components/cards/CompactCardSelector/CompactCardSelector.stub'
 import { DeleteAssociationsModalStub } from '@/features/student/global/components/overlays/modals/DeleteAssociationsModal/DeleteAssociationsModal.stub'
@@ -6,11 +8,25 @@ import DeleteTraceAssociatedActivitiesModal, {
   type DeleteTraceAssociatedActivitiesModalProps
 } from '@/features/student/traces/views/StudentTraceView/components/overlays/modals/DeleteTraceAssociatedActivitiesModal/DeleteTraceAssociatedActivitiesModal.vue'
 import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
-import { mount, type VueWrapper } from '@vue/test-utils'
-import { beforeEach, expect } from 'vitest'
+import { mountComponent } from 'tests/utils'
+import { beforeEach, expect, vi } from 'vitest'
+
+const mockAddSuccessMessage = vi.fn()
+const mockAddErrorMessage = vi.fn()
+
+vi.mock('@/store', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/store')>()
+  return {
+    ...actual,
+    useToasterStore: () => ({
+      addSuccessMessage: mockAddSuccessMessage,
+      addErrorMessage: mockAddErrorMessage,
+    }),
+  }
+})
 
 BddTest().given('a delete trace associated activities modal', () => {
-  let wrapper: VueWrapper<InstanceType<typeof DeleteTraceAssociatedActivitiesModal>>
+  let wrapper: ReturnType<typeof mountComponent<typeof DeleteTraceAssociatedActivitiesModal>>
 
   const stubs = {
     DeleteAssociationsModal: DeleteAssociationsModalStub,
@@ -48,9 +64,13 @@ BddTest().given('a delete trace associated activities modal', () => {
     associations,
   }
 
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
   BddTest().when('the modal is shown', () => {
     beforeEach(() => {
-      wrapper = mount(DeleteTraceAssociatedActivitiesModal, { props, global: { stubs } })
+      wrapper = mountComponent(DeleteTraceAssociatedActivitiesModal, { props, global: { stubs } })
     })
 
     BddTest().then('it should render the delete associations modal', () => {
@@ -76,7 +96,7 @@ BddTest().given('a delete trace associated activities modal', () => {
       expect(selector.props('modelValue')).toEqual([])
     })
 
-    BddTest().and('the compact card selector emits update:modelValue', () => {
+    BddTest().and('the user selects associations from the compact card selector', () => {
       beforeEach(() => {
         const selector = wrapper.findComponent(CompactCardSelectorStub)
         selector.vm.$emit('update:modelValue', ['assoc-1', 'assoc-2'])
@@ -104,19 +124,77 @@ BddTest().given('a delete trace associated activities modal', () => {
       })
     })
 
+    BddTest().and('the delete associations modal emits confirmDelete successfully', () => {
+      beforeEach(() => {
+        const confirmModal = wrapper.findComponent(DeleteAssociationsModalStub)
+        confirmModal.vm.$emit('confirmDelete')
+      })
+
+      BddTest().then('the modal should emit deleted', async () => {
+        await vi.waitFor(() => {
+          expect(wrapper.emitted('deleted')).toBeTruthy()
+        })
+      })
+
+      BddTest().then('it should add a success toaster message', async () => {
+        await vi.waitFor(() => {
+          expect(mockAddSuccessMessage).toHaveBeenCalledWith({
+            timeout: 2000,
+            description: 'Les associations sélectionnées ont été supprimées avec succès',
+          })
+        })
+      })
+
+      BddTest().then('it should not add an error toaster message', async () => {
+        await vi.waitFor(() => {
+          expect(mockAddErrorMessage).not.toHaveBeenCalled()
+        })
+      })
+
+      BddTest().then('the selectedIds should be reset', async () => {
+        await vi.waitFor(() => {
+          const selector = wrapper.findComponent(CompactCardSelectorStub)
+          expect(selector.props('modelValue')).toEqual([])
+        })
+      })
+    })
+  })
+
+  BddTest().when('deleting associated activities fails', () => {
+    beforeEach(() => {
+      server.use(deleteTraceAssociationsErrorHandler)
+
+      wrapper = mountComponent(DeleteTraceAssociatedActivitiesModal, {
+        props,
+        global: { stubs }
+      })
+    })
+
     BddTest().and('the delete associations modal emits confirmDelete', () => {
       beforeEach(() => {
         const confirmModal = wrapper.findComponent(DeleteAssociationsModalStub)
         confirmModal.vm.$emit('confirmDelete')
       })
 
-      BddTest().then('the modal should emit deleted', () => {
-        expect(wrapper.emitted('deleted')).toBeTruthy()
+      BddTest().then('it should add an error toaster message', async () => {
+        await vi.waitFor(() => {
+          expect(mockAddErrorMessage).toHaveBeenCalledWith({
+            title: 'Une erreur est survenue. Veuillez réessayer ultérieurement.',
+            description: 'Internal Server Error',
+          })
+        })
       })
 
-      BddTest().then('the selectedIds should be reset', () => {
-        const selector = wrapper.findComponent(CompactCardSelectorStub)
-        expect(selector.props('modelValue')).toEqual([])
+      BddTest().then('it should not add a success toaster message', async () => {
+        await vi.waitFor(() => {
+          expect(mockAddSuccessMessage).not.toHaveBeenCalled()
+        })
+      })
+
+      BddTest().then('the modal should not emit deleted', async () => {
+        await vi.waitFor(() => {
+          expect(wrapper.emitted('deleted')).toBeFalsy()
+        })
       })
     })
   })

--- a/src/features/student/traces/views/StudentTraceView/components/overlays/modals/DeleteTraceAssociatedActivitiesModal/DeleteTraceAssociatedActivitiesModal.vue
+++ b/src/features/student/traces/views/StudentTraceView/components/overlays/modals/DeleteTraceAssociatedActivitiesModal/DeleteTraceAssociatedActivitiesModal.vue
@@ -1,8 +1,12 @@
 <script lang="ts" setup>
 import type { DeclaredActivityAssociationDTO } from '@/api/avenir-esr'
+import type { BaseApiException } from '@/common/exceptions'
 import CompactCardSelector from '@/features/student/global/components/cards/CompactCardSelector/CompactCardSelector.vue'
 import DeleteAssociationsModal from '@/features/student/global/components/overlays/modals/DeleteAssociationsModal/DeleteAssociationsModal.vue'
 import { ICONS } from '@/features/student/global/icons'
+import { useDeleteTraceAssociationsMutation } from '@/features/student/traces/queries/use-traces.query/use-traces.query'
+import { useToasterStore } from '@/store'
+import { useI18n } from 'vue-i18n'
 
 export interface DeleteTraceAssociatedActivitiesModalProps {
   show: boolean
@@ -10,12 +14,15 @@ export interface DeleteTraceAssociatedActivitiesModalProps {
   associations: DeclaredActivityAssociationDTO[]
 }
 
-const { associations } = defineProps<DeleteTraceAssociatedActivitiesModalProps>()
+const { traceId, associations } = defineProps<DeleteTraceAssociatedActivitiesModalProps>()
 
 const emit = defineEmits<{
   (e: 'cancel'): void
   (e: 'deleted'): void
 }>()
+
+const { t } = useI18n()
+const { addErrorMessage, addSuccessMessage } = useToasterStore()
 
 const selectedIds = ref<string[]>([])
 
@@ -24,10 +31,28 @@ const selectableElements = computed(() => associations.map(({ associationId, dec
   title: declaredActivity.title,
 })))
 
+const { mutate: deleteTraceAssociations } = useDeleteTraceAssociationsMutation({
+  onError: (error: BaseApiException) => {
+    addErrorMessage({
+      title: t('global.error.generic'),
+      description: error.message,
+    })
+  },
+  onSuccess: () => {
+    addSuccessMessage({
+      timeout: 2000,
+      description: t('student.global.overlays.modals.DeleteAssociationsModal.success', { count: selectedIds.value.length }),
+    })
+    selectedIds.value = []
+    emit('deleted')
+  },
+})
+
 function onConfirmDelete () {
-  // TODO: #1237
-  selectedIds.value = []
-  emit('deleted')
+  deleteTraceAssociations({
+    traceId,
+    associationIds: selectedIds.value
+  })
 }
 
 function onCancel () {


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> Adds `useDeleteTraceAssociationsMutation` TanStack Query mutation to handle deletion of trace-activity associations. Integrates the mutation into `DeleteTraceAssociatedActivitiesModal` with proper success/error toaster feedback. Adds the corresponding MSW handler and full unit test coverage for both the mutation and the component.

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1237

---

### Documentation
> No documentation changes required.

---

### Target Branch
> `develop`

---

### Additional Notes
> - `useDeleteTraceAssociationsMutation` invalidates both `traceDetail` and `traceAssociations` query caches on success.
> - MSW handler added for `DELETE /me/traces/:traceId/associations` in `traces.handlers.ts` with a dedicated `deleteTraceAssociationsErrorHandler` export for error scenario testing.
> - Component test updated from `mount` to `mountComponent` (with TanStack Query + Pinia) and now uses `vi.waitFor` for async mutation assertions.

---

### Known Limitations or Side Effects
> None.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [x] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process