### PR TITLE
feat(1243): delete traces associations of type skills

### DIFF
--- a/src/__mocks__/fixtures/student/traces.fixtures.ts
+++ b/src/__mocks__/fixtures/student/traces.fixtures.ts
@@ -1,5 +1,7 @@
 import {
   type AttachmentUploadDTO,
+  EActivityThematic,
+  EDeclaredActivityStatus,
   EDeclaredSkillLevel,
   EExternalSkillType,
   EFileType,
@@ -157,7 +159,30 @@ export function createMockedAttachmentUploadResponse (traceId: string, file: Fil
 }
 
 export const mockedTraceAssociations: TraceAssociationsDTO = {
-  declaredActivityAssociations: [],
+  declaredActivityAssociations: [
+    {
+      associationId: 'activity-assoc-1',
+      declaredActivity: {
+        id: 'declared-activity-1',
+        activityId: 'activity-1',
+        title: 'Stage en entreprise - Développement logiciel',
+        thematic: EActivityThematic.EXPERIENCES,
+        status: EDeclaredActivityStatus.IN_PROGRESS,
+        summary: 'Stage de 6 mois dans une entreprise de développement logiciel',
+      }
+    },
+    {
+      associationId: 'activity-assoc-2',
+      declaredActivity: {
+        id: 'declared-activity-2',
+        activityId: 'activity-2',
+        title: 'Projet tuteuré - Application mobile',
+        thematic: EActivityThematic.PROGRAMS,
+        status: EDeclaredActivityStatus.COMPLETED,
+        summary: 'Développement d\'une application mobile en équipe',
+      }
+    }
+  ],
   declaredSkillAssociations: [
     {
       id: 'declared-1',

--- a/src/__mocks__/msw/handlers/student/traces.handlers.ts
+++ b/src/__mocks__/msw/handlers/student/traces.handlers.ts
@@ -4,6 +4,7 @@ import {
   createMockedTraceCreationResponse,
   createMockedTracesViewResponse,
   invalidTraceId,
+  mockedTraceAssociations,
   mockedTraceDetailed,
   mockedTraceOverview,
   mockedTracesConfiguration,
@@ -316,10 +317,7 @@ export const tracesHandlers = [
         )
       }
 
-      return HttpResponse.json({
-        declaredActivityAssociations: [],
-        declaredSkillAssociations: []
-      } as TraceAssociationsDTO)
+      return HttpResponse.json<TraceAssociationsDTO>(mockedTraceAssociations)
     }
   ),
 

--- a/src/features/student/global/components/cards/CompactCardSelector/CompactCardSelector.vue
+++ b/src/features/student/global/components/cards/CompactCardSelector/CompactCardSelector.vue
@@ -78,7 +78,7 @@ const selectableElements = computed(() => {
 const iconOptions = computed(() => ({
   name: icon,
   color,
-  bottom: '-2rem',
+  bottom: '-2.5rem',
   borderColor: iconBorderColor ?? 'var(--other-border-skill-card)'
 }))
 

--- a/src/features/student/traces/components/composites/TraceAssociations/TraceAssociations.vue
+++ b/src/features/student/traces/components/composites/TraceAssociations/TraceAssociations.vue
@@ -43,6 +43,8 @@ const activityAssociations = computed(() => associations.declaredActivityAssocia
 
   <DeleteTraceAssociatedSkillsModal
     :show="showSkillsModal"
+    :trace-id="traceId"
+    :associations="declaredSkillAssociations"
     @cancel="hideSkillsModal"
     @deleted="hideSkillsModal"
   />

--- a/src/features/student/traces/views/StudentTraceView/StudentTraceView.test.ts
+++ b/src/features/student/traces/views/StudentTraceView/StudentTraceView.test.ts
@@ -135,7 +135,7 @@ BddTest().given('a student trace view', () => {
 
     BddTest().then('it should render the associations tab with correct title', () => {
       const tabs = wrapper.findAllComponents({ name: 'AvTab' })
-      expect(tabs[1].props('title')).toBe('Mes éléments associés (0)')
+      expect(tabs[1].props('title')).toBe('Mes éléments associés (5)')
     })
 
     BddTest().then('it should render StudentTraceDetails component in the first tab', () => {

--- a/src/features/student/traces/views/StudentTraceView/components/overlays/modals/DeleteTraceAssociatedSkillsModal/DeleteTraceAssociatedSkillsModal.test.ts
+++ b/src/features/student/traces/views/StudentTraceView/components/overlays/modals/DeleteTraceAssociatedSkillsModal/DeleteTraceAssociatedSkillsModal.test.ts
@@ -1,24 +1,88 @@
+import { mockedTraceAssociations } from '@/__mocks__/fixtures/student'
+import { deleteTraceAssociationsErrorHandler } from '@/__mocks__/msw/handlers/student/traces.handlers'
+import { server } from '@/__mocks__/msw/server'
+import { CompactCardSelectorStub } from '@/features/student/global/components/cards/CompactCardSelector/CompactCardSelector.stub'
 import { DeleteAssociationsModalStub } from '@/features/student/global/components/overlays/modals/DeleteAssociationsModal/DeleteAssociationsModal.stub'
-import DeleteTraceAssociatedSkillsModal from '@/features/student/traces/views/StudentTraceView/components/overlays/modals/DeleteTraceAssociatedSkillsModal/DeleteTraceAssociatedSkillsModal.vue'
+import DeleteTraceAssociatedSkillsModal, {
+  type DeleteTraceAssociatedSkillsModalProps
+} from '@/features/student/traces/views/StudentTraceView/components/overlays/modals/DeleteTraceAssociatedSkillsModal/DeleteTraceAssociatedSkillsModal.vue'
 import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
-import { mount, type VueWrapper } from '@vue/test-utils'
-import { beforeEach } from 'vitest'
+import { mountComponent } from 'tests/utils'
+import { beforeEach, expect, vi } from 'vitest'
+
+const mockAddSuccessMessage = vi.fn()
+const mockAddErrorMessage = vi.fn()
+
+vi.mock('@/store', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/store')>()
+  return {
+    ...actual,
+    useToasterStore: () => ({
+      addSuccessMessage: mockAddSuccessMessage,
+      addErrorMessage: mockAddErrorMessage,
+    }),
+  }
+})
 
 BddTest().given('a delete trace associated skills modal', () => {
-  let wrapper: VueWrapper<InstanceType<typeof DeleteTraceAssociatedSkillsModal>>
+  let wrapper: ReturnType<typeof mountComponent<typeof DeleteTraceAssociatedSkillsModal>>
 
   const stubs = {
     DeleteAssociationsModal: DeleteAssociationsModalStub,
+    CompactCardSelector: CompactCardSelectorStub,
   }
+
+  const associations = mockedTraceAssociations.declaredSkillAssociations
+
+  const props: DeleteTraceAssociatedSkillsModalProps = {
+    show: true,
+    traceId: 'trace-1',
+    associations,
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
 
   BddTest().when('the modal is shown', () => {
     beforeEach(() => {
-      wrapper = mount(DeleteTraceAssociatedSkillsModal, { props: { show: true }, global: { stubs } })
+      wrapper = mountComponent(DeleteTraceAssociatedSkillsModal, { props, global: { stubs } })
     })
 
     BddTest().then('it should render the delete associations modal', () => {
       const confirmModal = wrapper.findComponent(DeleteAssociationsModalStub)
       expect(confirmModal.exists()).toBe(true)
+    })
+
+    BddTest().then('it should render the compact card selector', () => {
+      const selector = wrapper.findComponent(CompactCardSelectorStub)
+      expect(selector.exists()).toBe(true)
+    })
+
+    BddTest().then('it should pass selectable elements derived from associations to the compact card selector', () => {
+      const selector = wrapper.findComponent(CompactCardSelectorStub)
+      expect(selector.props('elements')).toEqual(
+        associations.map(({ id, title }) => ({ id, title }))
+      )
+    })
+
+    BddTest().then('it should initialize selectedIds as empty', () => {
+      const selector = wrapper.findComponent(CompactCardSelectorStub)
+      expect(selector.props('modelValue')).toEqual([])
+    })
+
+    BddTest().and('the user selects associations from the compact card selector', () => {
+      const selectedIds = associations.slice(0, 2).map(({ id }) => id)
+
+      beforeEach(() => {
+        const selector = wrapper.findComponent(CompactCardSelectorStub)
+        selector.vm.$emit('update:modelValue', selectedIds)
+      })
+
+      BddTest().then('the selectedIds should be updated accordingly', () => {
+        const selector = wrapper.findComponent(CompactCardSelectorStub)
+        expect(selector.props('modelValue')).toEqual(selectedIds)
+      })
     })
 
     BddTest().and('the delete associations modal emits cancel', () => {
@@ -27,8 +91,59 @@ BddTest().given('a delete trace associated skills modal', () => {
         confirmModal.vm.$emit('cancel')
       })
 
-      BddTest().then('the delete trace associated skills modal should emit cancel', () => {
+      BddTest().then('the modal should emit cancel', () => {
         expect(wrapper.emitted('cancel')).toBeTruthy()
+      })
+
+      BddTest().then('the selectedIds should be reset', () => {
+        const selector = wrapper.findComponent(CompactCardSelectorStub)
+        expect(selector.props('modelValue')).toEqual([])
+      })
+    })
+
+    BddTest().and('the delete associations modal emits confirmDelete successfully', () => {
+      beforeEach(() => {
+        const confirmModal = wrapper.findComponent(DeleteAssociationsModalStub)
+        confirmModal.vm.$emit('confirmDelete')
+      })
+
+      BddTest().then('the modal should emit deleted', async () => {
+        await vi.waitFor(() => {
+          expect(wrapper.emitted('deleted')).toBeTruthy()
+        })
+      })
+
+      BddTest().then('it should add a success toaster message', async () => {
+        await vi.waitFor(() => {
+          expect(mockAddSuccessMessage).toHaveBeenCalledWith({
+            timeout: 2000,
+            description: 'Les associations sélectionnées ont été supprimées avec succès',
+          })
+        })
+      })
+
+      BddTest().then('it should not add an error toaster message', async () => {
+        await vi.waitFor(() => {
+          expect(mockAddErrorMessage).not.toHaveBeenCalled()
+        })
+      })
+
+      BddTest().then('the selectedIds should be reset', async () => {
+        await vi.waitFor(() => {
+          const selector = wrapper.findComponent(CompactCardSelectorStub)
+          expect(selector.props('modelValue')).toEqual([])
+        })
+      })
+    })
+  })
+
+  BddTest().when('deleting associated skills fails', () => {
+    beforeEach(() => {
+      server.use(deleteTraceAssociationsErrorHandler)
+
+      wrapper = mountComponent(DeleteTraceAssociatedSkillsModal, {
+        props,
+        global: { stubs }
       })
     })
 
@@ -38,8 +153,25 @@ BddTest().given('a delete trace associated skills modal', () => {
         confirmModal.vm.$emit('confirmDelete')
       })
 
-      BddTest().then('the delete trace associated skills modal should emit deleted', () => {
-        expect(wrapper.emitted('deleted')).toBeTruthy()
+      BddTest().then('it should add an error toaster message', async () => {
+        await vi.waitFor(() => {
+          expect(mockAddErrorMessage).toHaveBeenCalledWith({
+            title: 'Une erreur est survenue. Veuillez réessayer ultérieurement.',
+            description: 'Internal Server Error',
+          })
+        })
+      })
+
+      BddTest().then('it should not add a success toaster message', async () => {
+        await vi.waitFor(() => {
+          expect(mockAddSuccessMessage).not.toHaveBeenCalled()
+        })
+      })
+
+      BddTest().then('the modal should not emit deleted', async () => {
+        await vi.waitFor(() => {
+          expect(wrapper.emitted('deleted')).toBeFalsy()
+        })
       })
     })
   })

--- a/src/features/student/traces/views/StudentTraceView/components/overlays/modals/DeleteTraceAssociatedSkillsModal/DeleteTraceAssociatedSkillsModal.vue
+++ b/src/features/student/traces/views/StudentTraceView/components/overlays/modals/DeleteTraceAssociatedSkillsModal/DeleteTraceAssociatedSkillsModal.vue
@@ -1,46 +1,81 @@
 <script lang="ts" setup>
+import type { DeclaredSkillAssociationDTO } from '@/api/avenir-esr'
+import type { BaseApiException } from '@/common/exceptions'
+import CompactCardSelector from '@/features/student/global/components/cards/CompactCardSelector/CompactCardSelector.vue'
 import DeleteAssociationsModal from '@/features/student/global/components/overlays/modals/DeleteAssociationsModal/DeleteAssociationsModal.vue'
+import { ICONS } from '@/features/student/global/icons'
+import { useDeleteTraceAssociationsMutation } from '@/features/student/traces/queries/use-traces.query/use-traces.query'
+import { useToasterStore } from '@/store'
+import { useI18n } from 'vue-i18n'
 
 export interface DeleteTraceAssociatedSkillsModalProps {
   show: boolean
+  traceId: string
+  associations: DeclaredSkillAssociationDTO[]
 }
 
-defineProps<DeleteTraceAssociatedSkillsModalProps>()
+const { traceId, associations } = defineProps<DeleteTraceAssociatedSkillsModalProps>()
 
 const emit = defineEmits<{
   (e: 'cancel'): void
   (e: 'deleted'): void
 }>()
 
-const dummyAssociations = [
-  { id: '1', title: '(Placeholder) Skill 1' },
-  { id: '2', title: '(Placeholder) Skill 2' },
-  { id: '3', title: '(Placeholder) Skill 3' }
-]
+const { t } = useI18n()
+const { addErrorMessage, addSuccessMessage } = useToasterStore()
 
-const dummySelectedAssociationIds = ['1', '2']
+const selectedIds = ref<string[]>([])
+
+const selectableElements = computed(() => associations.map(({ id, title }) => ({
+  id,
+  title,
+})))
+
+const { mutate: deleteTraceAssociations } = useDeleteTraceAssociationsMutation({
+  onError: (error: BaseApiException) => {
+    addErrorMessage({
+      title: t('global.error.generic'),
+      description: error.message,
+    })
+  },
+  onSuccess: () => {
+    addSuccessMessage({
+      timeout: 2000,
+      description: t('student.global.overlays.modals.DeleteAssociationsModal.success', { count: selectedIds.value.length }),
+    })
+    selectedIds.value = []
+    emit('deleted')
+  },
+})
 
 function onConfirmDelete () {
-  // TODO: #1243
-  emit('deleted')
+  deleteTraceAssociations({
+    traceId,
+    associationIds: selectedIds.value
+  })
+}
+
+function onCancel () {
+  selectedIds.value = []
+  emit('cancel')
 }
 </script>
 
 <template>
   <DeleteAssociationsModal
     :show="show"
-    :associations="dummyAssociations"
-    :selected-association-ids="dummySelectedAssociationIds"
-    @cancel="emit('cancel')"
+    :associations="selectableElements"
+    :selected-association-ids="selectedIds"
+    @cancel="onCancel"
     @confirm-delete="onConfirmDelete"
   >
-    <div class="av-col">
-      <span
-        v-for="association in dummyAssociations"
-        :key="association.id"
-      >
-        {{ association.title }}
-      </span>
-    </div>
+    <CompactCardSelector
+      v-model="selectedIds"
+      :elements="selectableElements"
+      :icon="ICONS.SKILLS"
+      background-color="var(--dark-background-primary1)"
+      color="var(--card)"
+      checkbox-color="var(--card)"
+    />
   </DeleteAssociationsModal>
 </template>


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> Implémentation de la suppression des associations de type compétences déclarées depuis la page de détails d'une trace. La `DeleteTraceAssociatedSkillsModal` appelle désormais la mutation `useDeleteTraceAssociationsMutation`, affiche un toast de succès/erreur et réinitialise la sélection après confirmation.

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1243

---

### Documentation
> Aucune mise à jour de documentation requise.

---

### Target Branch
> `develop`

---

### Additional Notes
> - La `DeleteTraceAssociatedSkillsModal` suit le même pattern que `DeleteTraceAssociatedActivitiesModal`
> - Le `CompactCardSelector` utilise `background-color="var(--dark-background-primary1)"` et `color="var(--card)"` pour correspondre au design Figma (fond bleu marine, texte blanc)
> - Le fixture `mockedTraceAssociations` a été enrichi avec des `declaredActivityAssociations` pour le handler MSW
> - Le handler MSW `getGetTraceAssociationsUrl` retourne désormais `mockedTraceAssociations` avec des données réelles

---

### Known Limitations or Side Effects
> - Le `StudentTraceView.test.ts` a été mis à jour pour refléter le nouveau nombre d'associations retournées par le handler MSW (5 au lieu de 0)

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [x] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and detaiils for the update process