### PR TITLE
fix(1298): Side navigations and menus - force replace on navigate

### DIFF
--- a/src/features/student/buildProject/views/ProjectActivitiesCatalogView/components/ActivitiesSideNavigation/ActivitiesSideNavigation.test.ts
+++ b/src/features/student/buildProject/views/ProjectActivitiesCatalogView/components/ActivitiesSideNavigation/ActivitiesSideNavigation.test.ts
@@ -170,7 +170,7 @@ BddTest().given('a build project activities side navigation component', () => {
         expect(navigateToStudentProjectActivitiesCatalogMock).toHaveBeenCalledWith({
           thematic: EActivityThematic.SELF_KNOWLEDGE,
           id: 'some-id',
-          replace: false,
+          replace: true,
         })
       })
     })

--- a/src/features/student/buildProject/views/ProjectActivitiesCatalogView/components/ActivitiesSideNavigation/ActivitiesSideNavigation.vue
+++ b/src/features/student/buildProject/views/ProjectActivitiesCatalogView/components/ActivitiesSideNavigation/ActivitiesSideNavigation.vue
@@ -84,7 +84,7 @@ function navigateToSelectedItem (value: AvSideNavigationSelectedItem) {
   navigateToStudentProjectActivitiesCatalog({
     thematic,
     id,
-    replace: !routeThematic.value || !routeId.value,
+    replace: true,
   })
 }
 </script>

--- a/src/features/student/personalCareer/views/DeclaredExperienceUpdateView/DeclaredExperienceUpdateView.vue
+++ b/src/features/student/personalCareer/views/DeclaredExperienceUpdateView/DeclaredExperienceUpdateView.vue
@@ -59,7 +59,7 @@ const {
 
 async function onSelectExperience (experienceId: string) {
   if (await canLeave()) {
-    router.push({
+    router.replace({
       name: ROUTES.STUDENT.UPDATE_DECLARED_EXPERIENCE.name,
       params: { id: experienceId }
     })

--- a/src/features/student/personalCareer/views/DeclaredExperienceView/DeclaredExperienceView.test.ts
+++ b/src/features/student/personalCareer/views/DeclaredExperienceView/DeclaredExperienceView.test.ts
@@ -35,7 +35,7 @@ vi.mock('@/common/composables', async (importOriginal) => {
   }
 })
 
-const routerPush = vi.fn()
+const routerReplace = vi.fn()
 const mockRouteId = ref<string>('exp-123')
 
 vi.mock('vue-router', async (importOriginal) => {
@@ -51,7 +51,7 @@ vi.mock('vue-router', async (importOriginal) => {
       }
     }),
     useRouter: () => ({
-      push: routerPush
+      replace: routerReplace
     })
   }
 })
@@ -156,7 +156,7 @@ BddTest().given('a declared experience view component', () => {
       })
 
       BddTest().then('it should navigate to the declared experience route', () => {
-        expect(routerPush).toHaveBeenCalledWith({
+        expect(routerReplace).toHaveBeenCalledWith({
           name: 'student-declared-experience',
           params: { id: experienceId }
         })

--- a/src/features/student/personalCareer/views/DeclaredExperienceView/DeclaredExperienceView.vue
+++ b/src/features/student/personalCareer/views/DeclaredExperienceView/DeclaredExperienceView.vue
@@ -49,7 +49,7 @@ const {
 } = usePaginatedDeclaredExperiences()
 
 function onSelectExperience (experienceId: string) {
-  router.push({ name: ROUTES.STUDENT.DECLARED_EXPERIENCE.name, params: { id: experienceId } })
+  router.replace({ name: ROUTES.STUDENT.DECLARED_EXPERIENCE.name, params: { id: experienceId } })
 }
 
 function handleUpdateSelected () {

--- a/src/features/student/personalCareer/views/DeclaredProgramDetailedView/DeclaredProgramDetailedView.test.ts
+++ b/src/features/student/personalCareer/views/DeclaredProgramDetailedView/DeclaredProgramDetailedView.test.ts
@@ -20,7 +20,7 @@ import { mountComponent } from 'tests/utils'
 import { afterEach, beforeEach, expect, vi } from 'vitest'
 import { nextTick } from 'vue'
 
-const routerPush = vi.fn()
+const routerReplace = vi.fn()
 const mockRouteId = ref<string>('')
 const mockShowModal = ref(false)
 const mockDisplayModal = vi.fn(() => {
@@ -45,7 +45,7 @@ vi.mock('vue-router', async (importOriginal) => {
       }
     }),
     useRouter: () => ({
-      push: routerPush
+      replace: routerReplace
     })
   }
 })
@@ -251,7 +251,7 @@ BddTest().given('a declared program detailed view component', () => {
       })
 
       BddTest().then('it should navigate to the route with the selected id', () => {
-        expect(routerPush).toHaveBeenCalledWith({
+        expect(routerReplace).toHaveBeenCalledWith({
           name: ROUTES.STUDENT.PERSONAL_CAREER_DECLARED_PROGRAM_DETAILED.name,
           params: { id: secondProgramId }
         })

--- a/src/features/student/personalCareer/views/DeclaredProgramDetailedView/DeclaredProgramDetailedView.vue
+++ b/src/features/student/personalCareer/views/DeclaredProgramDetailedView/DeclaredProgramDetailedView.vue
@@ -38,7 +38,7 @@ const breadcrumbLinks = computed(() => [
 ])
 
 function onSelectProgram (programId: string) {
-  router.push({ name: ROUTES.STUDENT.PERSONAL_CAREER_DECLARED_PROGRAM_DETAILED.name, params: { id: programId } })
+  router.replace({ name: ROUTES.STUDENT.PERSONAL_CAREER_DECLARED_PROGRAM_DETAILED.name, params: { id: programId } })
 }
 
 function handleConfirmDelete () {

--- a/src/features/student/personalCareer/views/DeclaredProgramUpdateView/DeclaredProgramUpdateView.test.ts
+++ b/src/features/student/personalCareer/views/DeclaredProgramUpdateView/DeclaredProgramUpdateView.test.ts
@@ -13,7 +13,7 @@ import { mountComponent } from 'tests/utils'
 import { afterEach, beforeEach, expect, vi } from 'vitest'
 import { nextTick } from 'vue'
 
-const routerPush = vi.fn()
+const routerReplace = vi.fn()
 const mockRouteId = ref<string>('')
 
 const showConfirmationModal = ref(false)
@@ -68,7 +68,7 @@ vi.mock('vue-router', async (importOriginal) => {
       }
     }),
     useRouter: () => ({
-      push: routerPush
+      replace: routerReplace
     })
   }
 })
@@ -220,7 +220,7 @@ BddTest().given('a declared program update view component', () => {
       })
 
       BddTest().then('it should navigate immediately and not open the modal', () => {
-        expect(routerPush).toHaveBeenCalledWith({
+        expect(routerReplace).toHaveBeenCalledWith({
           name: ROUTES.STUDENT.PERSONAL_CAREER_UPDATE_DECLARED_PROGRAM.name,
           params: { id: secondProgramId }
         })
@@ -251,7 +251,7 @@ BddTest().given('a declared program update view component', () => {
 
         expect(displayConfirmationModal).toHaveBeenCalledTimes(1)
         expect(modal.props('show')).toBe(true)
-        expect(routerPush).not.toHaveBeenCalled()
+        expect(routerReplace).not.toHaveBeenCalled()
       })
 
       BddTest().and('closing the modal', () => {
@@ -267,7 +267,7 @@ BddTest().given('a declared program update view component', () => {
 
           expect(mockCancel).toHaveBeenCalledTimes(1)
           expect(modal.props('show')).toBe(true)
-          expect(routerPush).not.toHaveBeenCalled()
+          expect(routerReplace).not.toHaveBeenCalled()
         })
       })
 

--- a/src/features/student/personalCareer/views/DeclaredProgramUpdateView/DeclaredProgramUpdateView.vue
+++ b/src/features/student/personalCareer/views/DeclaredProgramUpdateView/DeclaredProgramUpdateView.vue
@@ -47,7 +47,7 @@ const {
 
 async function onSelectProgram (programId: string) {
   if (await canLeave()) {
-    router.push({
+    router.replace({
       name: ROUTES.STUDENT.PERSONAL_CAREER_UPDATE_DECLARED_PROGRAM.name,
       params: { id: programId }
     })

--- a/src/features/student/personalCareer/views/PersonalCareerView/layouts/PersonalCareerLayout/PersonalCareerLayout.test.ts
+++ b/src/features/student/personalCareer/views/PersonalCareerView/layouts/PersonalCareerLayout/PersonalCareerLayout.test.ts
@@ -6,14 +6,14 @@ import { flushPromises, type VueWrapper } from '@vue/test-utils'
 import { mountComponent } from 'tests/utils'
 import { beforeEach, expect, vi } from 'vitest'
 
-const mockPush = vi.fn()
+const mockReplace = vi.fn()
 
 vi.mock('vue-router', async () => {
   const actual = await vi.importActual<typeof import('vue-router')>('vue-router')
   return {
     ...actual,
     useRouter: () => ({
-      push: mockPush
+      replace: mockReplace
     }),
     useRoute: () => ({
       name: ROUTES.STUDENT.PERSONAL_CAREER_MY_CAREER.name
@@ -124,7 +124,7 @@ BddTest().given('a student academic career layout component', () => {
       })
 
       BddTest().then('it should navigate to the selected route', () => {
-        expect(mockPush).toHaveBeenCalledWith({
+        expect(mockReplace).toHaveBeenCalledWith({
           name: ROUTES.STUDENT.PERSONAL_CAREER_DECLARED_PROGRAMS.name
         })
       })

--- a/src/features/student/personalCareer/views/PersonalCareerView/layouts/PersonalCareerLayout/PersonalCareerLayout.vue
+++ b/src/features/student/personalCareer/views/PersonalCareerView/layouts/PersonalCareerLayout/PersonalCareerLayout.vue
@@ -34,7 +34,7 @@ const items = computed<AvSideNavigationItem[]>(() => {
 })
 
 function navigateToSelectedItem (item: { itemId: string }) {
-  router.push({ name: item.itemId })
+  router.replace({ name: item.itemId })
 }
 </script>
 


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
This PR updates side navigations and menus to force a route replace on navigation, ensuring correct navigation behavior and preventing unwanted history entries.

**Main changes:**
- 🐛 Updates ActivitiesSideNavigation, DeclaredExperienceView, DeclaredProgramDetailedView, and related components to use force replace on navigation
- ✅ Updates and adds tests for navigation behavior

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1298

---

### Documentation
- Updated navigation logic in side navigation and menu components
- Updated and added related tests

**Modified files:**
- `src/features/student/buildProject/components/sideNavigations/ActivitiesSideNavigation/ActivitiesSideNavigation.vue`
- `src/features/student/personalCareer/views/DeclaredExperienceView/DeclaredExperienceView.vue`
- `src/features/student/personalCareer/views/DeclaredProgramDetailedView/DeclaredProgramDetailedView.vue`
- `src/features/student/personalCareer/views/DeclaredProgramUpdateView/DeclaredProgramUpdateView.vue`
- `src/features/student/personalCareer/views/layouts/PersonalCareerLayout/PersonalCareerLayout.vue`
- Related test files

---

### Target Branch
`develop`

---

### Additional Notes
This change improves navigation consistency and user experience by ensuring route replaces where appropriate.

---

### Known Limitations or Side Effects
No known limitations or side effects.

---

## ✅ Checklist

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [ ] No unnecessary code (e.g., debug logs, commented code)
- [ ] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process
