### PR TITLE
fix: remove delete activity / skill association cta in dropdown

### DIFF
--- a/src/features/student/buildProject/locales/en.json
+++ b/src/features/student/buildProject/locales/en.json
@@ -113,7 +113,6 @@
               "title": "Are you sure you want to associate these items?"
             },
             "DeleteActivityAssociatedElementsDropdown": {
-              "skills": "one/many associated skill(s)",
               "traces": "one/many associated trace(s)"
             },
             "DeleteActivityAssociatedTracesModal": {

--- a/src/features/student/buildProject/locales/fr.json
+++ b/src/features/student/buildProject/locales/fr.json
@@ -112,7 +112,6 @@
               "title": "Êtes-vous certain(e) de vouloir associer ces éléments ?"
             },
             "DeleteActivityAssociatedElementsDropdown": {
-              "skills": "une/des compétence(s) associée(s)",
               "traces": "une/des trace(s) associée(s)"
             },
             "DeleteActivityAssociatedTracesModal": {

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/overlays/dropdowns/DeleteActivityAssociatedElementsDropdown/DeleteActivityAssociatedElementsDropdown.test.ts
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/overlays/dropdowns/DeleteActivityAssociatedElementsDropdown/DeleteActivityAssociatedElementsDropdown.test.ts
@@ -18,22 +18,14 @@ BddTest().given('a delete activity associated elements dropdown', () => {
     BddTest().then('it should render the dropdown with two menu items', () => {
       const dropdown = wrapper.findComponent({ name: 'AvDropdown' })
       expect(dropdown.exists()).toBe(true)
-      expect(dropdown.props('items')).toHaveLength(2)
+      expect(dropdown.props('items')).toHaveLength(1)
     })
 
     BddTest().then('it should pass correct props to dropdown', () => {
       const dropdown = wrapper.findComponent({ name: 'AvDropdown' })
-      expect(dropdown.props('items')).toHaveLength(2)
+      expect(dropdown.props('items')).toHaveLength(1)
       expect(dropdown.props('triggerAriaLabel')).toBe('Supprimer...')
       expect(dropdown.props('triggerLabel')).toBe('Supprimer...')
-    })
-  })
-
-  BddTest().when('the skills button is clicked', () => {
-    BddTest().then('it should emit the skillsSelected event', async () => {
-      const skillsButton = wrapper.find('[data-name="skills"]')
-      await skillsButton.trigger('click')
-      expect(wrapper.emitted('skillsSelected')).toHaveLength(1)
     })
   })
 

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/overlays/dropdowns/DeleteActivityAssociatedElementsDropdown/DeleteActivityAssociatedElementsDropdown.vue
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/overlays/dropdowns/DeleteActivityAssociatedElementsDropdown/DeleteActivityAssociatedElementsDropdown.vue
@@ -4,23 +4,16 @@ import { AvDropdown, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
 import { useI18n } from 'vue-i18n'
 
 const emit = defineEmits<{
-  (e: 'skillsSelected'): void
   (e: 'tracesSelected'): void
 }>()
 
 enum DeleteActivityAssociatedElementsDropdownEvents {
-  SKILLS = 'skills',
   TRACES = 'traces',
 }
 
 const { t } = useI18n()
 
 const menuItems = computed(() => [
-  {
-    name: DeleteActivityAssociatedElementsDropdownEvents.SKILLS,
-    icon: ICONS.SKILLS,
-    label: t('student.buildProject.activities.views.ProjectActivityDetailedView.DeleteActivityAssociatedElementsDropdown.skills')
-  },
   {
     name: DeleteActivityAssociatedElementsDropdownEvents.TRACES,
     icon: ICONS.TRACES,
@@ -30,9 +23,6 @@ const menuItems = computed(() => [
 
 function handleItemSelected (itemName: string) {
   switch (itemName) {
-    case DeleteActivityAssociatedElementsDropdownEvents.SKILLS:
-      emit('skillsSelected')
-      break
     case DeleteActivityAssociatedElementsDropdownEvents.TRACES:
       emit('tracesSelected')
       break


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
remove delete activity / skill association cta in dropdown

