### PR TITLE
fix(1332): display activities option in trace associations dropdown

### DIFF
--- a/src/features/student/traces/views/StudentTraceView/components/overlays/dropdowns/TraceAssociateElementsDropdown/TraceAssociateElementsDropdown.test.ts
+++ b/src/features/student/traces/views/StudentTraceView/components/overlays/dropdowns/TraceAssociateElementsDropdown/TraceAssociateElementsDropdown.test.ts
@@ -32,15 +32,15 @@ BddTest().given('a trace associate elements dropdown', () => {
     })
   })
 
-  BddTest().when('the skills button is clicked', () => {
+  BddTest().when('the activities button is clicked', () => {
     beforeEach(() => {
       wrapper = mount(TraceAssociateElementsDropdown, { global: { stubs } })
     })
 
-    BddTest().then('it should emit the skillsSelected event', async () => {
-      const skillsButton = wrapper.find('[data-name="skills"]')
-      await skillsButton.trigger('click')
-      expect(wrapper.emitted('skillsSelected')).toHaveLength(1)
+    BddTest().then('it should emit the activitiesSelected event', async () => {
+      const activitiesButton = wrapper.find('[data-name="activities"]')
+      await activitiesButton.trigger('click')
+      expect(wrapper.emitted('activitiesSelected')).toHaveLength(1)
     })
   })
 })

--- a/src/features/student/traces/views/StudentTraceView/components/overlays/dropdowns/TraceAssociateElementsDropdown/TraceAssociateElementsDropdown.vue
+++ b/src/features/student/traces/views/StudentTraceView/components/overlays/dropdowns/TraceAssociateElementsDropdown/TraceAssociateElementsDropdown.vue
@@ -4,10 +4,12 @@ import { AvDropdown } from '@avenirs-esr/avenirs-dsav'
 import { useI18n } from 'vue-i18n'
 
 const emit = defineEmits<{
+  (e: 'activitiesSelected'): void
   (e: 'skillsSelected'): void
 }>()
 
 enum TraceAssociateElementsDropdownEvents {
+  ACTIVITIES = 'activities',
   SKILLS = 'skills'
 }
 
@@ -15,14 +17,17 @@ const { t } = useI18n()
 
 const menuItems = computed(() => [
   {
-    name: TraceAssociateElementsDropdownEvents.SKILLS,
-    icon: ICONS.SKILLS,
-    label: t('student.traces.views.StudentTraceView.TraceAssociateElementsDropdown.skills')
+    name: TraceAssociateElementsDropdownEvents.ACTIVITIES,
+    icon: ICONS.ACTIVITY,
+    label: t('student.traces.views.StudentTraceView.TraceAssociateElementsDropdown.activities')
   }
 ])
 
 function handleItemSelected (itemName: string) {
   switch (itemName) {
+    case TraceAssociateElementsDropdownEvents.ACTIVITIES:
+      emit('activitiesSelected')
+      break
     case TraceAssociateElementsDropdownEvents.SKILLS:
       emit('skillsSelected')
       break


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> Correction du composant `TraceAssociateElementsDropdown` qui affichait incorrectement l'option "compétences" au lieu de l'option "activités" dans le dropdown des associations de trace. Le composant émet désormais l'événement `activitiesSelected` et affiche l'icône et le label correspondant aux activités.

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1332

---

### Documentation
> Aucune mise à jour de documentation nécessaire.

---

### Target Branch
> `develop`

---

### Additional Notes
> - L'événement émis passe de `skillsSelected` à `activitiesSelected`
> - L'enum `TraceAssociateElementsDropdownEvents` est mis à jour avec la valeur `ACTIVITIES`
> - L'icône utilisée passe de `ICONS.SKILLS` à `ICONS.ACTIVITY`
> - Les tests unitaires sont mis à jour en conséquence

---

### Known Limitations or Side Effects
> Les composants parents qui écoutaient l'événement `skillsSelected` doivent être mis à jour pour écouter `activitiesSelected` (déjà pris en charge dans les PRs précédentes de cette US).

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [x] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and detaiils for the update process