### PR TITLE
fix(1340): hide COMPLETED declared activities from association deletion modal

### DIFF
--- a/src/features/student/traces/components/composites/TraceAssociations/TraceAssociations.test.ts
+++ b/src/features/student/traces/components/composites/TraceAssociations/TraceAssociations.test.ts
@@ -4,6 +4,7 @@ import {
   mockedTraceDeclaredActivityAssociations,
   mockedTraceDeclaredSkillAssociations
 } from '@/__mocks__/fixtures/student'
+import { EActivityThematic, EDeclaredActivityStatus } from '@/api/avenir-esr'
 import { AssociatedActivityCardStub } from '@/features/student/global/components/cards/AssociatedActivityCard/AssociatedActivityCard.stub'
 import { AssociatedSkillCardStub } from '@/features/student/global/components/cards/AssociatedSkillCard/AssociatedSkillCard.stub'
 import TraceAssociations
@@ -239,7 +240,24 @@ BddTest().given('a student trace associations component', () => {
   })
 
   BddTest().when('the component is mounted with only declared activity associations', () => {
-    const declaredActivityAssociations = mockedTraceDeclaredActivityAssociations
+    const declaredActivityAssociations = [
+      ...mockedTraceDeclaredActivityAssociations,
+      {
+        associationId: '8cb6cff4-2419-4b22-8c44-a92022a2423a',
+        declaredActivity: {
+          id: 'c1c9f6d2-6c2b-4a5e-9c4f-8e2a6b1d3f01',
+          activityId: '2a9f6c4d-8b1e-4d33-9c7a-5e2b8f1c6d77',
+          title: 'Renforcer sa capacité d’adaptation',
+          thematic: EActivityThematic.RESUMES,
+          summary: 'Activité visant à analyser sa capacité à s’adapter à des contextes variés et à gérer les changements. L’étudiant.e identifie des situations concrètes illustrant sa flexibilité et sa résilience.',
+          executionPeriodInfoSummary: 'Avant entretien professionnel',
+          status: EDeclaredActivityStatus.COMPLETED,
+          startDate: '2027-01-10',
+          endDate: '2027-01-20',
+          updatedAt: '2026-03-30T15:43:46.438115Z'
+        }
+      }
+    ]
     const associationsProps = { declaredActivityAssociations, declaredSkillAssociations: [] }
 
     beforeEach(() => {
@@ -254,9 +272,9 @@ BddTest().given('a student trace associations component', () => {
       })
     })
 
-    BddTest().then('it should render 2 declared activity association cards', () => {
+    BddTest().then('it should render 3 declared activity association cards', () => {
       const declaredActivityCards = wrapper.findAllComponents(AssociatedActivityCardStub)
-      expect(declaredActivityCards).toHaveLength(2)
+      expect(declaredActivityCards).toHaveLength(3)
     })
 
     BddTest().then('it should render only the declared activity associations container', () => {
@@ -286,7 +304,8 @@ BddTest().given('a student trace associations component', () => {
 
     BddTest().then('it should pass declared activity associations to the delete activities modal', () => {
       const activitiesModal = wrapper.findComponent(DeleteTraceAssociatedActivitiesModalStub)
-      expect(activitiesModal.props('associations')).toEqual(declaredActivityAssociations)
+      const expectedAssociations = declaredActivityAssociations.filter(association => association.declaredActivity.status !== EDeclaredActivityStatus.COMPLETED)
+      expect(activitiesModal.props('associations')).toEqual(expectedAssociations)
       expect(activitiesModal.props('traceId')).toBe(traceId)
     })
   })

--- a/src/features/student/traces/components/composites/TraceAssociations/TraceAssociations.vue
+++ b/src/features/student/traces/components/composites/TraceAssociations/TraceAssociations.vue
@@ -1,16 +1,21 @@
 <script setup lang="ts">
-import type { TraceAssociationsDTO } from '@/api/avenir-esr'
+import { EDeclaredActivityStatus, type TraceAssociationsDTO } from '@/api/avenir-esr'
 import { useModal } from '@/common/composables'
 import AssociatedActivityCard from '@/features/student/global/components/cards/AssociatedActivityCard/AssociatedActivityCard.vue'
 import AssociatedSkillCard from '@/features/student/global/components/cards/AssociatedSkillCard/AssociatedSkillCard.vue'
 import { ICONS } from '@/features/student/global/icons'
-import DeleteTraceAssociatedElementsDropdown from '@/features/student/traces/views/StudentTraceView/components/overlays/dropdowns/DeleteTraceAssociatedElementsDropdown/DeleteTraceAssociatedElementsDropdown.vue'
-import TraceAssociateElementsDropdown from '@/features/student/traces/views/StudentTraceView/components/overlays/dropdowns/TraceAssociateElementsDropdown/TraceAssociateElementsDropdown.vue'
-import AssociateActivitiesModal from '@/features/student/traces/views/StudentTraceView/components/overlays/modals/AssociateActivitiesModal/AssociateActivitiesModal.vue'
+import DeleteTraceAssociatedElementsDropdown
+  from '@/features/student/traces/views/StudentTraceView/components/overlays/dropdowns/DeleteTraceAssociatedElementsDropdown/DeleteTraceAssociatedElementsDropdown.vue'
+import TraceAssociateElementsDropdown
+  from '@/features/student/traces/views/StudentTraceView/components/overlays/dropdowns/TraceAssociateElementsDropdown/TraceAssociateElementsDropdown.vue'
+import AssociateActivitiesModal
+  from '@/features/student/traces/views/StudentTraceView/components/overlays/modals/AssociateActivitiesModal/AssociateActivitiesModal.vue'
 import AssociateDeclaredSkillsModal
   from '@/features/student/traces/views/StudentTraceView/components/overlays/modals/AssociateDeclaredSkillsModal/AssociateDeclaredSkillsModal.vue'
-import DeleteTraceAssociatedActivitiesModal from '@/features/student/traces/views/StudentTraceView/components/overlays/modals/DeleteTraceAssociatedActivitiesModal/DeleteTraceAssociatedActivitiesModal.vue'
-import DeleteTraceAssociatedSkillsModal from '@/features/student/traces/views/StudentTraceView/components/overlays/modals/DeleteTraceAssociatedSkillsModal/DeleteTraceAssociatedSkillsModal.vue'
+import DeleteTraceAssociatedActivitiesModal
+  from '@/features/student/traces/views/StudentTraceView/components/overlays/modals/DeleteTraceAssociatedActivitiesModal/DeleteTraceAssociatedActivitiesModal.vue'
+import DeleteTraceAssociatedSkillsModal
+  from '@/features/student/traces/views/StudentTraceView/components/overlays/modals/DeleteTraceAssociatedSkillsModal/DeleteTraceAssociatedSkillsModal.vue'
 import { AvCard, AvIconText } from '@avenirs-esr/avenirs-dsav'
 import isEmpty from 'lodash-es/isEmpty'
 import { useI18n } from 'vue-i18n'
@@ -31,13 +36,15 @@ const { showModal: showAssociationModal, displayModal: displayAssociationModal, 
 
 const declaredSkillAssociations = computed(() => associations.declaredSkillAssociations ?? [])
 const declaredActivityAssociations = computed(() => associations.declaredActivityAssociations ?? [])
+
+const deletableDeclaredActivityAssociations = computed(() => declaredActivityAssociations.value.filter(({ declaredActivity }) => declaredActivity.status !== EDeclaredActivityStatus.COMPLETED))
 </script>
 
 <template>
   <div class="av-col av-gap-xl av-pt-xl">
     <div class="av-row av-flex-fill av-justify-end av-gap-md">
       <DeleteTraceAssociatedElementsDropdown
-        :activities-disabled="isEmpty(declaredActivityAssociations)"
+        :activities-disabled="isEmpty(deletableDeclaredActivityAssociations)"
         :skills-disabled="isEmpty(declaredSkillAssociations)"
         @activities-selected="displayActivitiesModal"
         @skills-selected="displaySkillsModal"
@@ -131,7 +138,7 @@ const declaredActivityAssociations = computed(() => associations.declaredActivit
   <DeleteTraceAssociatedActivitiesModal
     :show="showActivitiesModal"
     :trace-id="traceId"
-    :associations="declaredActivityAssociations"
+    :associations="deletableDeclaredActivityAssociations"
     @cancel="hideActivitiesModal"
     @deleted="hideActivitiesModal"
   />


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> Correction du composant `TraceAssociations` pour exclure les activités déclarées au statut `COMPLETED` de la liste transmise au modal de suppression d'associations. Les activités terminées ne doivent pas pouvoir être désassociées d'une trace.

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1340

---

### Documentation
> Aucune mise à jour de documentation nécessaire.

---

### Target Branch
> `develop`

---

### Additional Notes
> - Le filtrage est appliqué dans `TraceAssociations.vue` via un `computed` qui exclut les associations dont `declaredActivity.status === EDeclaredActivityStatus.COMPLETED`
> - Les tests unitaires de `TraceAssociations.test.ts` sont mis à jour : un troisième élément d'activité avec le statut `COMPLETED` est ajouté aux fixtures, et l'assertion vérifie que seules les activités non terminées sont transmises au modal

---

### Known Limitations or Side Effects
> Aucune limitation connue.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [x] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and detaiils for the update process