### PR TITLE
feat(1398): add footer in staff layout

### DIFF
--- a/src/common/components/Footer/Footer.stub.ts
+++ b/src/common/components/Footer/Footer.stub.ts
@@ -1,0 +1,4 @@
+export const FooterStub = defineComponent({
+  name: 'FooterStub',
+  template: '<div data-testid="footer-stub" />'
+})

--- a/src/features/staff/global/layouts/StaffLayout/StaffLayout.test.ts
+++ b/src/features/staff/global/layouts/StaffLayout/StaffLayout.test.ts
@@ -1,24 +1,28 @@
 import type { VueWrapper } from '@vue/test-utils'
+import { FooterStub } from '@/common/components/Footer/Footer.stub'
 import { ROUTES } from '@/common/constants'
 import StaffLayout from '@/features/staff/global/layouts/StaffLayout/StaffLayout.vue'
 import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { mountWithRouter } from 'tests/utils'
 import { beforeEach, expect, vi } from 'vitest'
 
+const AvHeaderStub = defineComponent({
+  name: 'AvHeader',
+  props: ['modelValue', 'serviceTitle', 'homeTo', 'quickLinks', 'languageSelector'],
+  emits: ['update:modelValue', 'language-select'],
+  template: `
+    <div>
+      <button @click="quickLinks[0].onClick($event)" data-testid="home-btn">Home</button>
+    </div>
+  `
+})
+
 BddTest().given('a staff layout component', () => {
   let wrapper: VueWrapper<InstanceType<typeof StaffLayout>>
 
   const stubs = {
-    AvHeader: {
-      name: 'AvHeader',
-      props: ['modelValue', 'serviceTitle', 'homeTo', 'quickLinks', 'languageSelector'],
-      emits: ['update:modelValue', 'language-select'],
-      template: `
-      <div>
-        <button @click="quickLinks[0].onClick($event)" data-testid="home-btn">Home</button>
-      </div>
-    `
-    }
+    AvHeader: AvHeaderStub,
+    Footer: FooterStub
   }
 
   beforeEach(async () => {
@@ -30,11 +34,15 @@ BddTest().given('a staff layout component', () => {
 
   BddTest().when('the component is mounted', () => {
     BddTest().then('it should render the AvHeader component', () => {
-      expect(wrapper.findComponent({ name: 'AvHeader' }).exists()).toBe(true)
+      expect(wrapper.findComponent(AvHeaderStub).exists()).toBe(true)
+    })
+
+    BddTest().then('it should render the Footer component', () => {
+      expect(wrapper.findComponent(FooterStub).exists()).toBe(true)
     })
 
     BddTest().then('it should pass correct quickLinks to AvHeader', () => {
-      const header = wrapper.findComponent({ name: 'AvHeader' })
+      const header = wrapper.findComponent(AvHeaderStub)
       const quickLinks = header.props('quickLinks')
 
       expect(quickLinks).toEqual([
@@ -46,25 +54,31 @@ BddTest().given('a staff layout component', () => {
         },
       ])
     })
-  })
 
-  BddTest().when('AvHeader emits update:modelValue', () => {
-    BddTest().then('it should update the searchQuery property', async () => {
-      const avHeader = wrapper.findComponent({ name: 'AvHeader' })
-      avHeader.vm.$emit('update:modelValue', 'test')
-      await wrapper.vm.$nextTick()
+    BddTest().and('AvHeader emits update:modelValue', () => {
+      beforeEach(async () => {
+        const avHeader = wrapper.findComponent(AvHeaderStub)
+        avHeader.vm.$emit('update:modelValue', 'test')
+        await wrapper.vm.$nextTick()
+      })
 
-      expect(wrapper.vm.searchQuery).toBe('test')
+      BddTest().then('it should update the searchQuery property', () => {
+        expect(wrapper.vm.searchQuery).toBe('test')
+      })
     })
-  })
 
-  BddTest().when('searchQuery is updated', () => {
-    BddTest().then('it should pass searchQuery as modelValue to AvHeader', async () => {
-      const avHeader = wrapper.findComponent({ name: 'AvHeader' })
-      wrapper.vm.searchQuery = 'test'
-      await wrapper.vm.$nextTick()
+    BddTest().and('searchQuery is updated', () => {
+      let avHeader: VueWrapper<InstanceType<typeof AvHeaderStub>>
 
-      expect(avHeader.props('modelValue')).toBe('test')
+      beforeEach(async () => {
+        avHeader = wrapper.findComponent(AvHeaderStub)
+        wrapper.vm.searchQuery = 'test'
+        await wrapper.vm.$nextTick()
+      })
+
+      BddTest().then('it should pass searchQuery as modelValue to AvHeader', async () => {
+        expect(avHeader.props('modelValue')).toBe('test')
+      })
     })
   })
 })

--- a/src/features/staff/global/layouts/StaffLayout/StaffLayout.vue
+++ b/src/features/staff/global/layouts/StaffLayout/StaffLayout.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import Footer from '@/common/components/Footer/Footer.vue'
 import SwitchUniverse from '@/common/components/SwitchUniverse/SwitchUniverse.vue'
 import { useLanguageSwitcher } from '@/common/composables'
 import { ROUTES } from '@/common/constants'
@@ -40,7 +41,6 @@ defineExpose({ searchQuery })
       <router-view />
     </div>
   </main>
-</template>
 
-<style lang="scss" scoped>
-</style>
+  <Footer />
+</template>


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
This PR adds the global `Footer` component to the `StaffLayout`, making the footer available to staff users, consistent with its presence in the student layout.

**Main changes:**
- ✨ Integrates `Footer` component into `StaffLayout.vue`
- 🎨 Adds a `FooterStub` for testing (`Footer.stub.ts`)
- ✅ Updates `StaffLayout` unit tests to cover the Footer and refactors them to use proper BDD nesting and typed stubs

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1398

---

### Documentation
- `FooterStub` created for consistent testing across components that use `Footer`
- `StaffLayout` tests refactored: `AvHeaderStub` extracted as a typed component, `Footer` assertion added, BDD test nesting improved (`when → and` for related sub-scenarios)

**Modified files:**
- `src/common/components/Footer/Footer.stub.ts` — new Footer stub for tests
- `src/features/staff/global/layouts/StaffLayout/StaffLayout.vue` — add `<Footer />` and import
- `src/features/staff/global/layouts/StaffLayout/StaffLayout.test.ts` — update tests with FooterStub, typed AvHeaderStub, and BDD refactor

---

### Target Branch
`develop`

---

### Additional Notes
The `Footer` component was already present in `StudentLayout`. This PR ensures parity by also including it in `StaffLayout`, so both user universes benefit from the global footer.

The empty `<style scoped>` block was also removed from `StaffLayout.vue` as part of minor cleanup.

---

### Demo

<img width="1915" height="924" alt="image" src="https://github.com/user-attachments/assets/397dae26-25d4-4d06-acd5-baf6851b5aad" />


---

### Known Limitations or Side Effects
No known limitations or side effects.

---

## ✅ Checklist

- [ ] a11y tested (Footer already tested for accessibility in its own a11y test suite)
- [x] Tests provided (unit tests updated for StaffLayout with Footer assertion)
- [x] i18n handled (Footer already uses existing translations)
- [ ] Performance tests (no performance impact)
- [x] No unnecessary code (empty style block removed)
- [x] Code style and formatting rules respected (linting passes)
- [x] Semantic Versioning respected (conventional commit used)
- [x] Add to `CHANGELOG.md` file all properties and database change and details for the update process (no database or property changes)