### PR TITLE
feat(1378): add StaffNavigation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "avenirs-cofolio-client",
       "version": "0.0.0",
       "dependencies": {
-        "@avenirs-esr/avenirs-dsav": "^0.1.181",
+        "@avenirs-esr/avenirs-dsav": "^0.1.182",
         "@tanstack/vue-form": "^1.15.0",
         "@tanstack/vue-query": "^5.74.9",
         "@vue-flow/core": "^1.48.0",
@@ -392,9 +392,9 @@
       }
     },
     "node_modules/@avenirs-esr/avenirs-dsav": {
-      "version": "0.1.181",
-      "resolved": "https://registry.npmjs.org/@avenirs-esr/avenirs-dsav/-/avenirs-dsav-0.1.181.tgz",
-      "integrity": "sha512-l6tn99801FfTjn1LGnASfhvJhj0czWYQ6jhsH6Xg59Oj93CmfWB0mIFgTqXAQMwGvmziLjUpsAYHLoka7Pp2bg==",
+      "version": "0.1.182",
+      "resolved": "https://registry.npmjs.org/@avenirs-esr/avenirs-dsav/-/avenirs-dsav-0.1.182.tgz",
+      "integrity": "sha512-oON/tFWYhxntE/P3okQMvdgIZYonOmk/7nlimy1BTnRQoyUgFBqTan3z+ALtf6my4eXS/qDWnWKGr9oYPU/gfA==",
       "dependencies": {
         "@tiptap/extension-character-count": "^3.20.2",
         "@tiptap/extension-image": "^3.20.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
-    "@avenirs-esr/avenirs-dsav": "^0.1.181",
+    "@avenirs-esr/avenirs-dsav": "^0.1.182",
     "@tanstack/vue-form": "^1.15.0",
     "@tanstack/vue-query": "^5.74.9",
     "@vue-flow/core": "^1.48.0",

--- a/src/common/components/SwitchUniverse/SwitchUniverse.stub.ts
+++ b/src/common/components/SwitchUniverse/SwitchUniverse.stub.ts
@@ -1,0 +1,4 @@
+export const SwitchUniverseStub = defineComponent({
+  name: 'SwitchUniverse',
+  template: '<div data-testid="switch-universe">Switch Universe</div>'
+})

--- a/src/common/constants/route-names.ts
+++ b/src/common/constants/route-names.ts
@@ -1,4 +1,11 @@
 export const ROUTES = {
+  STAFF: {
+    HOME: { name: 'staff-home', path: '' },
+    ACCESSIBILITY: { name: 'staff-accessibility', path: 'accessibility' },
+    COOKIES: { name: 'staff-cookies', path: 'cookies' },
+    LEGAL: { name: 'staff-legal', path: 'legal' },
+    PERSONAL_DATA: { name: 'staff-personal-data', path: 'personal-data' },
+  },
   STUDENT: {
     HOME: { name: 'student-home', path: '' },
     ACCESSIBILITY: { name: 'student-accessibility', path: 'accessibility' },
@@ -36,12 +43,5 @@ export const ROUTES = {
     SKILL: { name: 'student-skill', path: 'skill/:id' },
     TOOLS_TRACES: { name: 'student-tools-traces', path: 'tools/traces' },
     TRACE: { name: 'student-trace', path: 'trace/:id' },
-  },
-  STAFF: {
-    HOME: { name: 'staff-home', path: '' },
-    ACCESSIBILITY: { name: 'staff-accessibility', path: 'accessibility' },
-    COOKIES: { name: 'staff-cookies', path: 'cookies' },
-    LEGAL: { name: 'staff-legal', path: 'legal' },
-    PERSONAL_DATA: { name: 'staff-personal-data', path: 'personal-data' },
   },
 } as const

--- a/src/features/staff/global/components/navigation/StaffNavigation/StaffNavigation.stub.ts
+++ b/src/features/staff/global/components/navigation/StaffNavigation/StaffNavigation.stub.ts
@@ -1,0 +1,4 @@
+export const StaffNavigationStub = defineComponent({
+  name: 'StaffNavigation',
+  template: '<nav data-testid="staff-navigation">Navigation</nav>'
+})

--- a/src/features/staff/global/components/navigation/StaffNavigation/StaffNavigation.test.ts
+++ b/src/features/staff/global/components/navigation/StaffNavigation/StaffNavigation.test.ts
@@ -1,0 +1,34 @@
+import type { VueWrapper } from '@vue/test-utils'
+import StaffNavigation from '@/features/staff/global/components/navigation/StaffNavigation/StaffNavigation.vue'
+import { MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
+import { AvNavigationStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { mountWithRouter } from 'tests/utils'
+import { beforeEach, expect } from 'vitest'
+
+BddTest().given('a staff navigation', () => {
+  let wrapper: VueWrapper<InstanceType<typeof StaffNavigation>>
+
+  const stubs = { AvNavigation: AvNavigationStub }
+
+  BddTest().when('the component is mounted', () => {
+    beforeEach(async () => {
+      wrapper = await mountWithRouter<typeof StaffNavigation>(StaffNavigation, { global: { stubs } })
+    })
+
+    BddTest().then('it should render AvNavigation component', () => {
+      const avNavigation = wrapper.findComponent(AvNavigationStub)
+      expect(avNavigation.exists()).toBe(true)
+    })
+
+    BddTest().then('it should pass correct navigation items to AvNavigation', () => {
+      const avNavigation = wrapper.findComponent(AvNavigationStub)
+      const navItems = avNavigation.props('navItems')
+      expect(navItems).toHaveLength(1)
+      expect(navItems[0]).toMatchObject({
+        text: 'ACCUEIL',
+        to: expect.objectContaining({ name: 'staff-home' }),
+        icon: MDI_ICONS.HOME_VARIANT_OUTLINE,
+      })
+    })
+  })
+})

--- a/src/features/staff/global/components/navigation/StaffNavigation/StaffNavigation.vue
+++ b/src/features/staff/global/components/navigation/StaffNavigation/StaffNavigation.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+import { ROUTES } from '@/common/constants'
+import { AvNavigation, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
+import { useId } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
+
+const homeItemId = useId()
+const navItems = computed(() => [
+  {
+    id: homeItemId,
+    to: ROUTES.STAFF.HOME,
+    text: t('student.global.navigation.tabs.home').toUpperCase(),
+    icon: MDI_ICONS.HOME_VARIANT_OUTLINE,
+  },
+])
+</script>
+
+<template>
+  <AvNavigation
+    :nav-items="navItems"
+    data-testid="main-navigation"
+  />
+</template>

--- a/src/features/staff/global/layouts/StaffLayout/StaffLayout.test.ts
+++ b/src/features/staff/global/layouts/StaffLayout/StaffLayout.test.ts
@@ -1,20 +1,22 @@
 import type { VueWrapper } from '@vue/test-utils'
 import { FooterStub } from '@/common/components/Footer/Footer.stub'
-import { ROUTES } from '@/common/constants'
+import { SwitchUniverseStub } from '@/common/components/SwitchUniverse/SwitchUniverse.stub'
+import { StaffNavigationStub } from '@/features/staff/global/components/navigation/StaffNavigation/StaffNavigation.stub'
 import StaffLayout from '@/features/staff/global/layouts/StaffLayout/StaffLayout.vue'
-import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { AvHeaderStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { mountWithRouter } from 'tests/utils'
 import { beforeEach, expect, vi } from 'vitest'
 
-const AvHeaderStub = defineComponent({
-  name: 'AvHeader',
-  props: ['modelValue', 'serviceTitle', 'homeTo', 'quickLinks', 'languageSelector'],
-  emits: ['update:modelValue', 'language-select'],
-  template: `
-    <div>
-      <button @click="quickLinks[0].onClick($event)" data-testid="home-btn">Home</button>
-    </div>
-  `
+const selectLanguageMock = vi.fn()
+
+vi.mock('@/common/composables', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/common/composables')>()
+  return {
+    ...actual,
+    useLanguageSwitcher: () => ({
+      selectLanguage: selectLanguageMock
+    }),
+  }
 })
 
 BddTest().given('a staff layout component', () => {
@@ -22,7 +24,9 @@ BddTest().given('a staff layout component', () => {
 
   const stubs = {
     AvHeader: AvHeaderStub,
-    Footer: FooterStub
+    Footer: FooterStub,
+    StaffNavigation: StaffNavigationStub,
+    SwitchUniverse: SwitchUniverseStub
   }
 
   beforeEach(async () => {
@@ -41,18 +45,8 @@ BddTest().given('a staff layout component', () => {
       expect(wrapper.findComponent(FooterStub).exists()).toBe(true)
     })
 
-    BddTest().then('it should pass correct quickLinks to AvHeader', () => {
-      const header = wrapper.findComponent(AvHeaderStub)
-      const quickLinks = header.props('quickLinks')
-
-      expect(quickLinks).toEqual([
-        {
-          label: 'Home',
-          to: ROUTES.STAFF.HOME,
-          icon: 'ri-home-4-line',
-          iconAttrs: { color: 'var(--red-marianne-425-625)' },
-        },
-      ])
+    BddTest().then('it should render the StaffNavigation component', () => {
+      expect(wrapper.findComponent(StaffNavigationStub).exists()).toBe(true)
     })
 
     BddTest().and('AvHeader emits update:modelValue', () => {
@@ -78,6 +72,18 @@ BddTest().given('a staff layout component', () => {
 
       BddTest().then('it should pass searchQuery as modelValue to AvHeader', async () => {
         expect(avHeader.props('modelValue')).toBe('test')
+      })
+    })
+
+    BddTest().and('AvHeader emits language-select', () => {
+      beforeEach(async () => {
+        const avHeader = wrapper.findComponent(AvHeaderStub)
+        avHeader.vm.$emit('language-select', 'en')
+        await wrapper.vm.$nextTick()
+      })
+
+      BddTest().then('it should call selectLanguage from useLanguageSwitcher', () => {
+        expect(selectLanguageMock).toHaveBeenCalledWith('en')
       })
     })
   })

--- a/src/features/staff/global/layouts/StaffLayout/StaffLayout.vue
+++ b/src/features/staff/global/layouts/StaffLayout/StaffLayout.vue
@@ -3,18 +3,12 @@ import Footer from '@/common/components/Footer/Footer.vue'
 import SwitchUniverse from '@/common/components/SwitchUniverse/SwitchUniverse.vue'
 import { useLanguageSwitcher } from '@/common/composables'
 import { ROUTES } from '@/common/constants'
-import { AvHeader, type AvHeaderProps } from '@avenirs-esr/avenirs-dsav'
+import StaffNavigation from '@/features/staff/global/components/navigation/StaffNavigation/StaffNavigation.vue'
+import { AvHeader } from '@avenirs-esr/avenirs-dsav'
+import { useI18n } from 'vue-i18n'
 
+const { t } = useI18n()
 const { languageSelector, selectLanguage } = useLanguageSwitcher()
-
-const quickLinks: AvHeaderProps['quickLinks'] = [
-  {
-    label: 'Home',
-    to: ROUTES.STAFF.HOME,
-    icon: 'ri-home-4-line',
-    iconAttrs: { color: 'var(--red-marianne-425-625)' },
-  },
-]
 
 const searchQuery = ref('')
 
@@ -24,14 +18,15 @@ defineExpose({ searchQuery })
 <template>
   <AvHeader
     v-model="searchQuery"
-    service-title=" "
+    :home-label="t('staff.global.layout.header.home')"
     :home-to="ROUTES.STAFF.HOME"
-    show-search
-    :quick-links="quickLinks"
     :language-selector="languageSelector"
     @language-select="selectLanguage($event)"
   >
-    <template #serviceDescription>
+    <template #mainnav>
+      <StaffNavigation />
+    </template>
+    <template #roleContext>
       <SwitchUniverse />
     </template>
   </AvHeader>

--- a/src/features/staff/global/locales/en.json
+++ b/src/features/staff/global/locales/en.json
@@ -1,3 +1,11 @@
 {
-  "staff": {}
+  "staff": {
+    "global": {
+      "layout": {
+        "header": {
+          "home": "Home - Staff CoFolio"
+        }
+      }
+    }
+  }
 }

--- a/src/features/staff/global/locales/fr.json
+++ b/src/features/staff/global/locales/fr.json
@@ -1,3 +1,11 @@
 {
-  "staff": {}
+  "staff": {
+    "global": {
+      "layout": {
+        "header": {
+          "home": "Accueil - Cofolio Staff"
+        }
+      }
+    }
+  }
 }

--- a/src/features/student/global/components/navigation/StudentNavigation/StudentNavigation.test.ts
+++ b/src/features/student/global/components/navigation/StudentNavigation/StudentNavigation.test.ts
@@ -3,51 +3,13 @@ import StudentNavigation from '@/features/student/global/components/navigation/S
 import { useStudentApcAccess } from '@/features/student/global/composables/use-student-apc-access/use-student-apc-access'
 import router from '@/router'
 import { registerNavigationLinkKey } from '@avenirs-esr/avenirs-dsav'
-import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { AvNavigationStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { mount, type VueWrapper } from '@vue/test-utils'
 import { beforeEach, vi } from 'vitest'
 
 vi.mock('@/features/student/global/composables/use-student-apc-access/use-student-apc-access', () => ({
   useStudentApcAccess: vi.fn(),
 }))
-
-const AvNavigationStub = defineComponent({
-  name: 'AvNavigation',
-  props: {
-    id: { type: String, default: 'nav-stub' },
-    label: { type: String, default: 'Menu principal' },
-    navItems: { type: Array, required: true },
-  },
-  emits: ['toggle-id'],
-  template: `
-    <nav :id="id" :aria-label="label" class="av-nav">
-      <ul class="av-nav__list">
-        <li
-          v-for="(item, index) in navItems"
-          :key="index"
-          class="av-nav__item"
-          @click="$emit('toggle-id', item.id)"
-        >
-          <span class="nav-item-text">{{ item.text || item.title }}</span>
-          <ul v-if="item.links" class="av-nav__submenu">
-            <li
-              v-for="(link, linkIndex) in item.links"
-              :key="linkIndex"
-              class="av-nav__subitem"
-            >
-              <RouterLink
-                :to="link.to"
-                class="nav-link"
-              >
-                {{ link.text }}
-              </RouterLink>
-            </li>
-          </ul>
-        </li>
-      </ul>
-    </nav>
-  `,
-})
 
 BddTest().given('a student navigation', () => {
   let wrapper: VueWrapper<InstanceType<typeof StudentNavigation>>

--- a/src/features/student/global/layouts/StudentLayout/StudentLayout.test.ts
+++ b/src/features/student/global/layouts/StudentLayout/StudentLayout.test.ts
@@ -4,12 +4,25 @@ import type { VueWrapper } from '@vue/test-utils'
 import type { Ref } from 'vue'
 import profile_banner_placeholder from '@/assets/profile_banner_placeholder.png'
 import profile_picture_placeholder from '@/assets/profile_picture_placeholder.png'
+import { SwitchUniverseStub } from '@/common/components/SwitchUniverse/SwitchUniverse.stub'
 import StudentLayout from '@/features/student/global/layouts/StudentLayout/StudentLayout.vue'
 import { useStudentSummaryQuery } from '@/features/student/user'
-import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { AvHeaderStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { QueryClient, type UseQueryDefinedReturnType, VueQueryPlugin } from '@tanstack/vue-query'
 import { mountWithRouter } from 'tests/utils'
 import { beforeEach, expect, vi } from 'vitest'
+
+const selectLanguageMock = vi.fn()
+
+vi.mock('@/common/composables', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/common/composables')>()
+  return {
+    ...actual,
+    useLanguageSwitcher: () => ({
+      selectLanguage: selectLanguageMock
+    }),
+  }
+})
 
 vi.mock(import('@/features/student/user'), async (importOriginal) => {
   const actual = await importOriginal()
@@ -46,17 +59,8 @@ BddTest().given('a student layout', () => {
   let wrapper: VueWrapper<InstanceType<typeof StudentLayout>>
 
   const stubs = {
-    AvHeader: {
-      name: 'AvHeader',
-      props: ['modelValue', 'serviceTitle', 'homeTo', 'showSearch', 'languageSelector'],
-      emits: ['update:modelValue', 'language-select'],
-      template: `
-        <div>
-          <slot name="before-quick-links" />
-          <slot name="mainnav" />
-        </div>
-      `
-    },
+    AvHeader: AvHeaderStub,
+    SwitchUniverse: SwitchUniverseStub,
     StudentMailboxPopover: {
       name: 'StudentMailboxPopover',
       props: ['messagesCount'],
@@ -131,6 +135,18 @@ BddTest().given('a student layout', () => {
         await wrapper.vm.$nextTick()
 
         expect(wrapper.vm.searchQuery).toBe('test search')
+      })
+    })
+
+    BddTest().when('AvHeader emits language-select', () => {
+      beforeEach(async () => {
+        const avHeader = wrapper.findComponent(AvHeaderStub)
+        avHeader.vm.$emit('language-select', 'en')
+        await wrapper.vm.$nextTick()
+      })
+
+      BddTest().then('it should call selectLanguage from useLanguageSwitcher', () => {
+        expect(selectLanguageMock).toHaveBeenCalledWith('en')
       })
     })
 

--- a/src/features/student/global/layouts/StudentLayout/StudentLayout.vue
+++ b/src/features/student/global/layouts/StudentLayout/StudentLayout.vue
@@ -13,6 +13,9 @@ import {
 } from '@/features/student/user'
 import { AvHeader } from '@avenirs-esr/avenirs-dsav'
 import capitalize from 'lodash-es/capitalize'
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
 
 useInvalidateAllQueriesAfterLocaleChange()
 
@@ -40,10 +43,10 @@ defineExpose({ searchQuery })
 <template>
   <AvHeader
     v-model="searchQuery"
+    :home-label="t('student.global.layout.header.home')"
     :home-to="{ name: ROUTES.STUDENT.HOME.name }"
     :show-search="!isDemo"
     :language-selector="languageSelector"
-    service-title=" "
     @language-select="selectLanguage($event)"
   >
     <template #before-quick-links>
@@ -70,7 +73,7 @@ defineExpose({ searchQuery })
     <template #mainnav>
       <StudentNavigation />
     </template>
-    <template #serviceDescription>
+    <template #roleContext>
       <SwitchUniverse />
     </template>
   </AvHeader>
@@ -83,5 +86,3 @@ defineExpose({ searchQuery })
 
   <Footer />
 </template>
-
-<style lang="scss" scoped></style>

--- a/src/features/student/global/locales/en.json
+++ b/src/features/student/global/locales/en.json
@@ -11,11 +11,11 @@
       },
       "layout": {
         "header": {
+          "home": "Home - Student CoFolio",
           "quicklinks": {
             "mailbox": "Mailbox",
             "notifications": "Notifications"
-          },
-          "serviceTitle": "Cofolio Student"
+          }
         }
       },
       "myAssociatedTracesWithCount": "My associated trace ({count}) | My associated traces ({count})",

--- a/src/features/student/global/locales/fr.json
+++ b/src/features/student/global/locales/fr.json
@@ -11,11 +11,11 @@
       },
       "layout": {
         "header": {
+          "home": "Accueil - Cofolio Étudiant",
           "quicklinks": {
             "mailbox": "Messagerie",
             "notifications": "Notifications"
-          },
-          "serviceTitle": "Cofolio Étudiant"
+          }
         }
       },
       "myAssociatedTracesWithCount": "Ma trace associée ({count}) | Mes traces associées ({count})",


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
This PR adds the `StaffNavigation` component to the staff universe and integrates it into `StaffLayout`. The navigation is now rendered via the `#mainnav` slot of `AvHeader`, replacing the previous `quickLinks` prop approach. The DSAV dependency is bumped to `0.1.182` to match the new slot API.

**Main changes:**
- ✨ New `StaffNavigation` component using `AvNavigation` from DSAV
- 🎨 Refactor `StaffLayout` to use `StaffNavigation` in `#mainnav` slot instead of `quickLinks` prop
- 🔥 Remove `.gitkeep` placeholder in staff components folder
- ✅ Add unit tests for `StaffNavigation`
- ✅ Update `StaffLayout` and `StudentLayout` tests (use shared `AvHeaderStub` from DSAV test-utils, add `SwitchUniverseStub`, mock `useLanguageSwitcher`)
- ➕ Add `StaffNavigation.stub.ts` and `SwitchUniverse.stub.ts` for testing
- 🌐 Add i18n translations for staff layout header (`home` key) in `en.json` and `fr.json`
- 🏷️ Move `STAFF` routes block before `STUDENT` in `route-names.ts`
- ⬆️ Bump `@avenirs-esr/avenirs-dsav` from `0.1.181` to `0.1.182`

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1378

---

### Documentation
- Unit tests added for `StaffNavigation` verifying `AvNavigation` is rendered and receives correct nav items
- `StaffLayout` tests updated: replaced local `AvHeaderStub` with shared one from DSAV test-utils; added assertion for `StaffNavigation` rendering; added test for `language-select` event handling
- `StudentLayout` tests updated: replaced inline `AvHeader` stub with shared `AvHeaderStub`; added `SwitchUniverseStub`; added mock for `useLanguageSwitcher`

**Modified files:**
- `src/common/components/SwitchUniverse/SwitchUniverse.stub.ts` — New stub for SwitchUniverse
- `src/common/constants/route-names.ts` — Move STAFF block before STUDENT
- `src/features/staff/global/components/navigation/StaffNavigation/StaffNavigation.vue` — New component
- `src/features/staff/global/components/navigation/StaffNavigation/StaffNavigation.stub.ts` — New stub
- `src/features/staff/global/components/navigation/StaffNavigation/StaffNavigation.test.ts` — New tests
- `src/features/staff/global/layouts/StaffLayout/StaffLayout.vue` — Integrate StaffNavigation, use `#mainnav` slot
- `src/features/staff/global/layouts/StaffLayout/StaffLayout.test.ts` — Updated tests
- `src/features/staff/global/locales/en.json` — Add staff layout header i18n key
- `src/features/staff/global/locales/fr.json` — Add staff layout header i18n key
- `src/features/student/global/layouts/StudentLayout/StudentLayout.test.ts` — Updated tests
- `package.json` — Bump `@avenirs-esr/avenirs-dsav` to `^0.1.182`

---

### Target Branch
`develop`

---

### Additional Notes
The `StaffNavigation` component follows the same pattern as `StudentNavigation`, using `AvNavigation` from DSAV and `useI18n` for labels. The staff home nav item currently uses the student i18n key `student.global.navigation.tabs.home` as a placeholder — this can be updated once dedicated staff navigation keys are defined.

---

### Known Limitations or Side Effects
No known limitations or side effects.

---

## ✅ Checklist

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (unit tests added for StaffNavigation, StaffLayout and StudentLayout tests updated)
- [x] i18n handled (staff layout header translations added in en.json and fr.json)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [x] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process
