### PR TITLE
test(1382): add E2E tests for US #1250

### DIFF
--- a/e2e/framework/staff/shared/componentObjects/StaffLayout.ts
+++ b/e2e/framework/staff/shared/componentObjects/StaffLayout.ts
@@ -1,0 +1,17 @@
+import type { Page } from '@playwright/test'
+import { BaseObject } from '@e2e/framework/shared/base/BaseObject'
+import { STAFF_ROUTES } from '@e2e/framework/shared/constants/routes'
+
+export class StaffLayout extends BaseObject {
+  constructor (protected page: Page) {
+    super(page.locator('header'), page)
+  }
+
+  getMainNavigation () {
+    return this.root.getByTestId('main-navigation').locator('nav')
+  }
+
+  getHomeNavLink () {
+    return this.getMainNavigation().locator(`[data-testid="nav-router-link"][href="${STAFF_ROUTES.HOME}"]`)
+  }
+}

--- a/e2e/framework/staff/shared/steps/StaffGlobalSteps.ts
+++ b/e2e/framework/staff/shared/steps/StaffGlobalSteps.ts
@@ -2,14 +2,18 @@ import type { test } from '@e2e/framework/shared/fixtures/fixtures'
 import { BasePage } from '@e2e/framework/shared/base/BasePage'
 import { STAFF_ROUTES } from '@e2e/framework/shared/constants/routes'
 import { waitForPageLoad } from '@e2e/framework/shared/utils/waits'
+import { StaffLayout } from '@e2e/framework/staff/shared/componentObjects/StaffLayout'
 import { expect, type Page } from '@playwright/test'
 import { Fixture, Given, Then } from 'playwright-bdd/decorators'
 
 export
 @Fixture<typeof test>('staffGlobalSteps')
 class StaffGlobalSteps extends BasePage {
+  private layout: StaffLayout
+
   constructor (page: Page) {
     super(page)
+    this.layout = new StaffLayout(page)
   }
 
   @Given('the staff opens the home page')
@@ -21,5 +25,15 @@ class StaffGlobalSteps extends BasePage {
   @Then('the staff home page is displayed')
   async verifyPageLoaded () {
     await expect(this.page).toHaveURL(STAFF_ROUTES.HOME)
+  }
+
+  @Then('the staff HOME link is visible')
+  async verifyHomeLink () {
+    await expect(this.layout.getHomeNavLink()).toBeVisible()
+  }
+
+  @Then('the staff main navigation menu is visible')
+  async verifyMainNavigationMenuVisible () {
+    await expect(this.layout.getMainNavigation()).toBeVisible()
   }
 }

--- a/e2e/tests/staff/home.feature
+++ b/e2e/tests/staff/home.feature
@@ -17,3 +17,10 @@ Feature: Staff Home Page
     @high @footer
     Scenario: Staff can see the footer
       Then the footer is visible
+      
+  Rule: Navigation
+
+    @high @navigation @desktop
+    Scenario: Main navigation is fully visible on desktop
+      Then the staff main navigation menu is visible
+      And the staff HOME link is visible

--- a/src/features/staff/global/components/navigation/StaffNavigation/StaffNavigation.vue
+++ b/src/features/staff/global/components/navigation/StaffNavigation/StaffNavigation.vue
@@ -11,7 +11,7 @@ const navItems = computed(() => [
   {
     id: homeItemId,
     to: ROUTES.STAFF.HOME,
-    text: t('student.global.navigation.tabs.home').toUpperCase(),
+    text: t('staff.global.navigation.tabs.home').toUpperCase(),
     icon: MDI_ICONS.HOME_VARIANT_OUTLINE,
   },
 ])

--- a/src/features/staff/global/locales/en.json
+++ b/src/features/staff/global/locales/en.json
@@ -5,6 +5,11 @@
         "header": {
           "home": "Home - Staff CoFolio"
         }
+      },
+      "navigation": {
+        "tabs": {
+          "home": "Home"
+        }
       }
     }
   }

--- a/src/features/staff/global/locales/fr.json
+++ b/src/features/staff/global/locales/fr.json
@@ -5,6 +5,11 @@
         "header": {
           "home": "Accueil - Cofolio Staff"
         }
+      },
+      "navigation": {
+        "tabs": {
+          "home": "Accueil"
+        }
       }
     }
   }

--- a/vitest-setup.ts
+++ b/vitest-setup.ts
@@ -56,6 +56,7 @@ beforeAll(async () => {
   vi.stubGlobal('__DEMO_MODE__', false)
   i18n.global.locale.value = 'fr'
   await registerFeatureLocales('student')
+  await registerFeatureLocales('staff')
   config.global.plugins = config.global.plugins || []
   config.global.plugins.push(i18n)
 })


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
This PR adds E2E tests for the staff navigation (US #1250) and fixes the i18n key used in the StaffNavigation component.

**Main changes:**
- ✅ Adds E2E scenario for staff main navigation visibility on desktop in `home.feature`
- ✅ Creates `StaffLayout` component object with `getMainNavigation()` and `getHomeNavLink()` helpers
- ✅ Adds `verifyHomeLink()` and `verifyMainNavigationMenuVisible()` step definitions in `StaffGlobalSteps`
- 🐛 Fixes wrong i18n key in `StaffNavigation.vue` (was using `student.global.navigation.tabs.home`, now correctly uses `staff.global.navigation.tabs.home`)
- 🌐 Adds missing staff navigation i18n keys (`home`) in `en.json` and `fr.json`
- 🔥 Removes `.gitkeep` placeholder in `componentObjects/` folder now that real files exist

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1382

---

### Documentation
- New E2E component object `StaffLayout` documented through its typed methods
- New step definitions added to `StaffGlobalSteps` for navigation assertions

**Modified files:**
- `e2e/framework/staff/shared/componentObjects/StaffLayout.ts` — New component object for staff layout (header/navigation)
- `e2e/framework/staff/shared/steps/StaffGlobalSteps.ts` — Added two new step definitions for navigation checks
- `e2e/tests/staff/home.feature` — Added Navigation rule with desktop scenario
- `src/features/staff/global/components/navigation/StaffNavigation/StaffNavigation.vue` — Fix i18n key
- `src/features/staff/global/locales/en.json` — Add navigation.tabs.home key
- `src/features/staff/global/locales/fr.json` — Add navigation.tabs.home key

---

### Target Branch
`develop`

---

### Additional Notes
The E2E tests follow existing patterns from the student feature (e.g., `StudentLayout` component object). The i18n fix was a prerequisite to make the navigation label render correctly in E2E tests.

---

### Known Limitations or Side Effects
No known limitations or side effects.

---

## ✅ Checklist

- [ ] a11y tested (E2E navigation tests cover basic visibility)
- [x] Tests provided (E2E tests added for staff navigation)
- [x] i18n handled (en.json and fr.json updated with missing staff navigation keys)
- [ ] Performance tests (no performance impact)
- [x] No unnecessary code (removed .gitkeep placeholder)
- [x] Code style and formatting rules respected
- [x] Semantic Versioning respected (conventional commits)
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process (no database or property changes)