### PR TITLE
feat(1359): create AssociatedDeclaredActivitiesCard component

### DIFF
--- a/api-specs/avenir-esr.swagger.json
+++ b/api-specs/avenir-esr.swagger.json
@@ -996,6 +996,47 @@
         }
       }
     },
+    "/me/declared/skill-progress/{declaredSkillProgressId}/associate/declared-activities": {
+      "post": {
+        "tags": [
+          "declared-skill-progress-controller"
+        ],
+        "operationId": "associateDeclaredSkillWithDeclaredActivities",
+        "parameters": [
+          {
+            "name": "declaredSkillProgressId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AssociationsCreationRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeclaredSkillAssociationsDTO"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/me/declared/skill-progress/{declaredSkillProgressId}/unassociate/traces": {
       "post": {
         "tags": [
@@ -3187,6 +3228,27 @@
           "declaredSkill"
         ]
       },
+      "DeclaredSkillAssociationsDTO": {
+        "type": "object",
+        "properties": {
+          "traceAssociations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TraceAssociationDTO"
+            }
+          },
+          "declaredActivityAssociations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DeclaredActivityAssociationDTO"
+            }
+          }
+        },
+        "required": [
+          "declaredActivityAssociations",
+          "traceAssociations"
+        ]
+      },
       "Activity": {
         "type": "object",
         "properties": {
@@ -4341,6 +4403,22 @@
           "title",
           "traceId",
           "updatedAt"
+        ]
+      },
+      "TraceAssociationDTO": {
+        "type": "object",
+        "properties": {
+          "associationId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "trace": {
+            "$ref": "#/components/schemas/TraceOverviewDTO"
+          }
+        },
+        "required": [
+          "associationId",
+          "trace"
         ]
       },
       "StudentProgressDTO": {

--- a/e2e/framework/student/tools/traceDetails/componentObjects/TraceAssociationsObject.ts
+++ b/e2e/framework/student/tools/traceDetails/componentObjects/TraceAssociationsObject.ts
@@ -19,11 +19,11 @@ export class TraceAssociationsObject extends BaseObject {
   }
 
   getDeclaredActivityAssociationsContainer () {
-    return this.root.getByTestId('declared-activity-associations-container')
+    return this.root.getByTestId('associated-declared-activities-card')
   }
 
   getAssociatedActivityCards () {
-    return this.root.getByTestId('associated-activity-card')
+    return this.root.getByTestId('associated-declared-activity-card')
   }
 
   async getAssociatedActivityCardsCount () {

--- a/src/features/student/buildProject/components/cards/AssociatedDeclaredActivitiesCard/AssociatedDeclaredActivitiesCard.test.ts
+++ b/src/features/student/buildProject/components/cards/AssociatedDeclaredActivitiesCard/AssociatedDeclaredActivitiesCard.test.ts
@@ -1,0 +1,70 @@
+import { mockedTraceDeclaredActivityAssociations } from '@/__mocks__/fixtures/student/traces.fixtures'
+import AssociatedDeclaredActivitiesCard, { type AssociatedDeclaredActivitiesCardProps } from '@/features/student/buildProject/components/cards/AssociatedDeclaredActivitiesCard/AssociatedDeclaredActivitiesCard.vue'
+import { AssociatedActivityCardStub } from '@/features/student/global/components/cards/AssociatedActivityCard/AssociatedActivityCard.stub'
+import { AvCardStub, AvIconTextStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { beforeEach, expect } from 'vitest'
+
+BddTest().given('an associated declared activities card', () => {
+  let wrapper: VueWrapper
+
+  const stubs = {
+    AvCard: AvCardStub,
+    AvIconText: AvIconTextStub,
+    AssociatedActivityCard: AssociatedActivityCardStub,
+  }
+
+  BddTest().when('the component is mounted with associated activities', () => {
+    const props: AssociatedDeclaredActivitiesCardProps = {
+      associatedActivities: mockedTraceDeclaredActivityAssociations
+    }
+
+    beforeEach(() => {
+      vi.clearAllMocks()
+      wrapper = mount(AssociatedDeclaredActivitiesCard, { props, global: { stubs } })
+    })
+
+    BddTest().then('it should render the av card', () => {
+      expect(wrapper.findComponent(AvCardStub).exists()).toBe(true)
+    })
+
+    BddTest().then('it should render a card for each associated activity', () => {
+      const activityCards = wrapper.findAllComponents(AssociatedActivityCardStub)
+      expect(activityCards).toHaveLength(props.associatedActivities.length)
+    })
+
+    BddTest().then('it should display the plural title with count', () => {
+      expect(wrapper.findComponent(AvIconTextStub).props('text')).toBe(`Mes activités déclarées associées (${props.associatedActivities.length})`)
+    })
+  })
+
+  BddTest().when('the component is mounted with a single associated activity', () => {
+    const props: AssociatedDeclaredActivitiesCardProps = {
+      associatedActivities: [mockedTraceDeclaredActivityAssociations[0]]
+    }
+
+    beforeEach(() => {
+      vi.clearAllMocks()
+      wrapper = mount(AssociatedDeclaredActivitiesCard, { props, global: { stubs } })
+    })
+
+    BddTest().then('it should display the singular title with count', () => {
+      expect(wrapper.findComponent(AvIconTextStub).props('text')).toBe('Mon activité déclarée associée (1)')
+    })
+  })
+
+  BddTest().when('the component is mounted with no associated activities', () => {
+    const props: AssociatedDeclaredActivitiesCardProps = {
+      associatedActivities: []
+    }
+
+    beforeEach(() => {
+      vi.clearAllMocks()
+      wrapper = mount(AssociatedDeclaredActivitiesCard, { props, global: { stubs } })
+    })
+
+    BddTest().then('it should render nothing', () => {
+      expect(wrapper.findComponent(AvCardStub).exists()).toBe(false)
+    })
+  })
+})

--- a/src/features/student/buildProject/components/cards/AssociatedDeclaredActivitiesCard/AssociatedDeclaredActivitiesCard.test.ts
+++ b/src/features/student/buildProject/components/cards/AssociatedDeclaredActivitiesCard/AssociatedDeclaredActivitiesCard.test.ts
@@ -1,7 +1,8 @@
 import { mockedTraceDeclaredActivityAssociations } from '@/__mocks__/fixtures/student/traces.fixtures'
 import AssociatedDeclaredActivitiesCard, { type AssociatedDeclaredActivitiesCardProps } from '@/features/student/buildProject/components/cards/AssociatedDeclaredActivitiesCard/AssociatedDeclaredActivitiesCard.vue'
 import { AssociatedActivityCardStub } from '@/features/student/global/components/cards/AssociatedActivityCard/AssociatedActivityCard.stub'
-import { AvCardStub, AvIconTextStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { AssociationsCardStub } from '@/features/student/global/components/cards/AssociationsCard/AssociationsCard.stub'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { mount, type VueWrapper } from '@vue/test-utils'
 import { beforeEach, expect } from 'vitest'
 
@@ -9,8 +10,7 @@ BddTest().given('an associated declared activities card', () => {
   let wrapper: VueWrapper
 
   const stubs = {
-    AvCard: AvCardStub,
-    AvIconText: AvIconTextStub,
+    AssociationsCard: AssociationsCardStub,
     AssociatedActivityCard: AssociatedActivityCardStub,
   }
 
@@ -24,17 +24,13 @@ BddTest().given('an associated declared activities card', () => {
       wrapper = mount(AssociatedDeclaredActivitiesCard, { props, global: { stubs } })
     })
 
-    BddTest().then('it should render the av card', () => {
-      expect(wrapper.findComponent(AvCardStub).exists()).toBe(true)
-    })
-
     BddTest().then('it should render a card for each associated activity', () => {
       const activityCards = wrapper.findAllComponents(AssociatedActivityCardStub)
       expect(activityCards).toHaveLength(props.associatedActivities.length)
     })
 
-    BddTest().then('it should display the plural title with count', () => {
-      expect(wrapper.findComponent(AvIconTextStub).props('text')).toBe(`Mes activités déclarées associées (${props.associatedActivities.length})`)
+    BddTest().then('it should pass the plural title with count', () => {
+      expect(wrapper.findComponent(AssociationsCardStub).props('title')).toBe(`Mes activités déclarées associées (${props.associatedActivities.length})`)
     })
   })
 
@@ -48,8 +44,8 @@ BddTest().given('an associated declared activities card', () => {
       wrapper = mount(AssociatedDeclaredActivitiesCard, { props, global: { stubs } })
     })
 
-    BddTest().then('it should display the singular title with count', () => {
-      expect(wrapper.findComponent(AvIconTextStub).props('text')).toBe('Mon activité déclarée associée (1)')
+    BddTest().then('it should pass the singular title with count', () => {
+      expect(wrapper.findComponent(AssociationsCardStub).props('title')).toBe('Mon activité déclarée associée (1)')
     })
   })
 
@@ -64,7 +60,7 @@ BddTest().given('an associated declared activities card', () => {
     })
 
     BddTest().then('it should render nothing', () => {
-      expect(wrapper.findComponent(AvCardStub).exists()).toBe(false)
+      expect(wrapper.findComponent(AssociationsCardStub).exists()).toBe(false)
     })
   })
 })

--- a/src/features/student/buildProject/components/cards/AssociatedDeclaredActivitiesCard/AssociatedDeclaredActivitiesCard.vue
+++ b/src/features/student/buildProject/components/cards/AssociatedDeclaredActivitiesCard/AssociatedDeclaredActivitiesCard.vue
@@ -1,53 +1,32 @@
 <script setup lang="ts">
 import type { DeclaredActivityAssociationDTO } from '@/api/avenir-esr'
 import AssociatedActivityCard from '@/features/student/global/components/cards/AssociatedActivityCard/AssociatedActivityCard.vue'
+import AssociationsCard from '@/features/student/global/components/cards/AssociationsCard/AssociationsCard.vue'
 import { ICONS } from '@/features/student/global/icons'
-import { AvCard, AvIconText } from '@avenirs-esr/avenirs-dsav'
 import { useI18n } from 'vue-i18n'
 
 export interface AssociatedDeclaredActivitiesCardProps {
   associatedActivities: DeclaredActivityAssociationDTO[]
 }
 
-defineProps<AssociatedDeclaredActivitiesCardProps>()
+const { associatedActivities } = defineProps<AssociatedDeclaredActivitiesCardProps>()
 
 const { t } = useI18n()
+
+const title = computed(() => t('student.buildProject.activities.cards.AssociatedDeclaredActivitiesCard.title', { count: associatedActivities.length }))
 </script>
 
 <template>
-  <AvCard
+  <AssociationsCard
     v-if="associatedActivities.length > 0"
-    background-color="var(--card2)"
-    title-background="var(--card2)"
-    border-color="var(--other-border-skill-card)"
-    collapsible
-    collapsed
+    :title
+    :icon="ICONS.ACTIVITY"
     data-testid="associated-declared-activities-card"
   >
-    <template #title>
-      <div class="av-row av-flex-fill av-justify-start">
-        <AvIconText
-          typography-class="n4"
-          :icon="ICONS.ACTIVITY"
-          icon-color="var(--text2)"
-          :text="t('student.buildProject.activities.cards.AssociatedDeclaredActivitiesCard.title', { count: associatedActivities.length })"
-          text-color="var(--text1)"
-          gap="var(--spacing-sm)"
-          data-testid="associated-declared-activities-card-title"
-          inline
-        />
-      </div>
-    </template>
-
-    <div
-      class="av-row av-wrap av-align-center av-gap-md"
-      data-testid="associated-declared-activities-cards-container"
-    >
-      <AssociatedActivityCard
-        v-for="associatedActivity in associatedActivities"
-        :key="associatedActivity.associationId"
-        :declared-activity="associatedActivity.declaredActivity"
-      />
-    </div>
-  </AvCard>
+    <AssociatedActivityCard
+      v-for="associatedActivity in associatedActivities"
+      :key="associatedActivity.associationId"
+      :declared-activity="associatedActivity.declaredActivity"
+    />
+  </AssociationsCard>
 </template>

--- a/src/features/student/buildProject/components/cards/AssociatedDeclaredActivitiesCard/AssociatedDeclaredActivitiesCard.vue
+++ b/src/features/student/buildProject/components/cards/AssociatedDeclaredActivitiesCard/AssociatedDeclaredActivitiesCard.vue
@@ -1,0 +1,53 @@
+<script setup lang="ts">
+import type { DeclaredActivityAssociationDTO } from '@/api/avenir-esr'
+import AssociatedActivityCard from '@/features/student/global/components/cards/AssociatedActivityCard/AssociatedActivityCard.vue'
+import { ICONS } from '@/features/student/global/icons'
+import { AvCard, AvIconText } from '@avenirs-esr/avenirs-dsav'
+import { useI18n } from 'vue-i18n'
+
+export interface AssociatedDeclaredActivitiesCardProps {
+  associatedActivities: DeclaredActivityAssociationDTO[]
+}
+
+defineProps<AssociatedDeclaredActivitiesCardProps>()
+
+const { t } = useI18n()
+</script>
+
+<template>
+  <AvCard
+    v-if="associatedActivities.length > 0"
+    background-color="var(--card2)"
+    title-background="var(--card2)"
+    border-color="var(--other-border-skill-card)"
+    collapsible
+    collapsed
+    data-testid="associated-declared-activities-card"
+  >
+    <template #title>
+      <div class="av-row av-flex-fill av-justify-start">
+        <AvIconText
+          typography-class="n4"
+          :icon="ICONS.ACTIVITY"
+          icon-color="var(--text2)"
+          :text="t('student.buildProject.activities.cards.AssociatedDeclaredActivitiesCard.title', { count: associatedActivities.length })"
+          text-color="var(--text1)"
+          gap="var(--spacing-sm)"
+          data-testid="associated-declared-activities-card-title"
+          inline
+        />
+      </div>
+    </template>
+
+    <div
+      class="av-row av-wrap av-align-center av-gap-md"
+      data-testid="associated-declared-activities-cards-container"
+    >
+      <AssociatedActivityCard
+        v-for="associatedActivity in associatedActivities"
+        :key="associatedActivity.associationId"
+        :declared-activity="associatedActivity.declaredActivity"
+      />
+    </div>
+  </AvCard>
+</template>

--- a/src/features/student/buildProject/index.ts
+++ b/src/features/student/buildProject/index.ts
@@ -1,4 +1,5 @@
 export { default as ActivityThematicBadge } from '@/features/student/buildProject/components/badges/ActivityThematicBadge/ActivityThematicBadge.vue'
+export { default as AssociatedDeclaredActivitiesCard, type AssociatedDeclaredActivitiesCardProps } from '@/features/student/buildProject/components/cards/AssociatedDeclaredActivitiesCard/AssociatedDeclaredActivitiesCard.vue'
 export { DeclaredActivityCompactCardStub } from '@/features/student/buildProject/components/cards/DeclaredActivityCompactCard/DeclaredActivityCompactCard.stub'
 export { default as DeclaredActivityCompactCard } from '@/features/student/buildProject/components/cards/DeclaredActivityCompactCard/DeclaredActivityCompactCard.vue'
 export type { DeclaredActivityCompactCardProps } from '@/features/student/buildProject/components/cards/DeclaredActivityCompactCard/DeclaredActivityCompactCard.vue'

--- a/src/features/student/buildProject/locales/en.json
+++ b/src/features/student/buildProject/locales/en.json
@@ -17,6 +17,11 @@
           "subscribe": "Subscribe to the activity",
           "unsubscribe": "Unsubscribe"
         },
+        "cards": {
+          "AssociatedDeclaredActivitiesCard": {
+            "title": "My associated declared activity ({count}) | My associated declared activities ({count})"
+          }
+        },
         "declaredActivityStatus": {
           "COMPLETED": "Completed",
           "IN_PROGRESS": "In progress",

--- a/src/features/student/buildProject/locales/fr.json
+++ b/src/features/student/buildProject/locales/fr.json
@@ -17,6 +17,11 @@
           "subscribe": "M'inscrire à l'activité",
           "unsubscribe": "Me désinscrire"
         },
+        "cards": {
+          "AssociatedDeclaredActivitiesCard": {
+            "title": "Mon activité déclarée associée ({count}) | Mes activités déclarées associées ({count})"
+          }
+        },
         "declaredActivityStatus": {
           "COMPLETED": "Terminée",
           "IN_PROGRESS": "En cours",

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/cards/AssociatedTracesCard/AssociatedTracesCard.test.ts
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/cards/AssociatedTracesCard/AssociatedTracesCard.test.ts
@@ -1,16 +1,16 @@
 import { createMockedTraceAssociations } from '@/__mocks__/fixtures/student/activities.fixtures'
 import AssociatedTracesCard, { type AssociatedTracesCardProps } from '@/features/student/buildProject/views/ProjectActivityDetailedView/components/cards/AssociatedTracesCard/AssociatedTracesCard.vue'
 import { AssociatedTraceCardStub } from '@/features/student/global/components/cards/AssociatedTraceCard/AssociatedTraceCard.stub'
-import { AvCardStub, AvIconTextStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { AssociationsCardStub } from '@/features/student/global/components/cards/AssociationsCard/AssociationsCard.stub'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { mount, type VueWrapper } from '@vue/test-utils'
 import { beforeEach, expect } from 'vitest'
 
 BddTest().given('an associated traces card', () => {
-  let wrapper: VueWrapper<InstanceType<typeof AssociatedTracesCard>>
+  let wrapper: VueWrapper
 
   const stubs = {
-    AvCard: AvCardStub,
-    AvIconText: AvIconTextStub,
+    AssociationsCard: AssociationsCardStub,
     AssociatedTraceCard: AssociatedTraceCardStub,
   }
 
@@ -24,14 +24,13 @@ BddTest().given('an associated traces card', () => {
       wrapper = mount(AssociatedTracesCard, { props, global: { stubs } })
     })
 
-    BddTest().then('it should render the av card', () => {
-      const card = wrapper.findComponent(AvCardStub)
-      expect(card.exists()).toBe(true)
-    })
-
     BddTest().then('it should render a card for each associated trace', () => {
       const traceCards = wrapper.findAllComponents(AssociatedTraceCardStub)
       expect(traceCards).toHaveLength(props.associatedTraces.length)
+    })
+
+    BddTest().then('it should pass the plural title with count', () => {
+      expect(wrapper.findComponent(AssociationsCardStub).props('title')).toBe(`Mes traces associées (${props.associatedTraces.length})`)
     })
   })
 
@@ -46,8 +45,7 @@ BddTest().given('an associated traces card', () => {
     })
 
     BddTest().then('it should render nothing', () => {
-      const card = wrapper.findComponent(AvCardStub)
-      expect(card.exists()).toBe(false)
+      expect(wrapper.findComponent(AssociationsCardStub).exists()).toBe(false)
     })
   })
 })

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/cards/AssociatedTracesCard/AssociatedTracesCard.vue
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/cards/AssociatedTracesCard/AssociatedTracesCard.vue
@@ -1,53 +1,32 @@
 <script setup lang="ts">
 import type { DeclaredActivityTraceAssociationDTO } from '@/api/avenir-esr'
 import AssociatedTraceCard from '@/features/student/global/components/cards/AssociatedTraceCard/AssociatedTraceCard.vue'
+import AssociationsCard from '@/features/student/global/components/cards/AssociationsCard/AssociationsCard.vue'
 import { ICONS } from '@/features/student/global/icons'
-import { AvCard, AvIconText } from '@avenirs-esr/avenirs-dsav'
 import { useI18n } from 'vue-i18n'
 
 export interface AssociatedTracesCardProps {
   associatedTraces: DeclaredActivityTraceAssociationDTO[]
 }
 
-defineProps<AssociatedTracesCardProps>()
+const { associatedTraces } = defineProps<AssociatedTracesCardProps>()
 
 const { t } = useI18n()
+
+const title = computed(() => t('student.buildProject.activities.views.ProjectActivityDetailedView.AssociatedTracesCard.title', { count: associatedTraces.length }))
 </script>
 
 <template>
-  <AvCard
+  <AssociationsCard
     v-if="associatedTraces.length > 0"
-    background-color="var(--card2)"
-    title-background="var(--card2)"
-    border-color="var(--other-border-skill-card)"
-    collapsible
-    collapsed
+    :title
+    :icon="ICONS.TRACES"
     data-testid="associated-traces-card"
   >
-    <template #title>
-      <div class="av-row av-flex-fill av-justify-start">
-        <AvIconText
-          typography-class="n4"
-          :icon="ICONS.TRACES"
-          icon-color="var(--text2)"
-          :text="t('student.buildProject.activities.views.ProjectActivityDetailedView.AssociatedTracesCard.title', { count: associatedTraces.length })"
-          text-color="var(--text1)"
-          gap="var(--spacing-sm)"
-          data-testid="associated-traces-card-title"
-          inline
-        />
-      </div>
-    </template>
-
-    <div
-      class="av-row av-wrap av-align-center av-gap-md"
-      data-testid="associated-traces-cards-container"
-    >
-      <AssociatedTraceCard
-        v-for="associatedTrace in associatedTraces"
-        :key="associatedTrace.trace.traceId"
-        :associated-trace="associatedTrace"
-      />
-    </div>
-  </AvCard>
+    <AssociatedTraceCard
+      v-for="associatedTrace in associatedTraces"
+      :key="associatedTrace.trace.traceId"
+      :associated-trace="associatedTrace"
+    />
+  </AssociationsCard>
 </template>

--- a/src/features/student/declaredSkills/components/cards/AssociatedDeclaredSkillsCard/AssociatedDeclaredSkillsCard.test.ts
+++ b/src/features/student/declaredSkills/components/cards/AssociatedDeclaredSkillsCard/AssociatedDeclaredSkillsCard.test.ts
@@ -4,7 +4,8 @@ import type {
 import { createMockedDeclaredActivityAssociations } from '@/__mocks__/fixtures/student'
 import { AssociatedDeclaredSkillsCard } from '@/features/student/declaredSkills'
 import { AssociatedSkillCardStub } from '@/features/student/global/components/cards/AssociatedSkillCard/AssociatedSkillCard.stub'
-import { AvCardStub, AvIconTextStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { AssociationsCardStub } from '@/features/student/global/components/cards/AssociationsCard/AssociationsCard.stub'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { mount, type VueWrapper } from '@vue/test-utils'
 import { beforeEach, expect } from 'vitest'
 
@@ -12,8 +13,7 @@ BddTest().given('an associated declared skills card', () => {
   let wrapper: VueWrapper<InstanceType<typeof AssociatedDeclaredSkillsCard>>
 
   const stubs = {
-    AvCard: AvCardStub,
-    AvIconText: AvIconTextStub,
+    AssociationsCard: AssociationsCardStub,
     AssociatedSkillCard: AssociatedSkillCardStub,
   }
 
@@ -23,20 +23,17 @@ BddTest().given('an associated declared skills card', () => {
     }
 
     beforeEach(() => {
-      wrapper = mount(AssociatedDeclaredSkillsCard, {
-        props,
-        global: { stubs }
-      })
-    })
-
-    BddTest().then('it should render the av card', () => {
-      const card = wrapper.findComponent(AvCardStub)
-      expect(card.exists()).toBe(true)
+      vi.clearAllMocks()
+      wrapper = mount(AssociatedDeclaredSkillsCard, { props, global: { stubs } })
     })
 
     BddTest().then('it should render a card for each associated declared skill', () => {
       const skillCards = wrapper.findAllComponents(AssociatedSkillCardStub)
       expect(skillCards).toHaveLength(props.associatedDeclaredSkills.length)
+    })
+
+    BddTest().then('it should pass the plural title with count', () => {
+      expect(wrapper.findComponent(AssociationsCardStub).props('title')).toBe(`Mes compétences associées (${props.associatedDeclaredSkills.length})`)
     })
   })
 
@@ -46,15 +43,12 @@ BddTest().given('an associated declared skills card', () => {
     }
 
     beforeEach(() => {
-      wrapper = mount(AssociatedDeclaredSkillsCard, {
-        props,
-        global: { stubs }
-      })
+      vi.clearAllMocks()
+      wrapper = mount(AssociatedDeclaredSkillsCard, { props, global: { stubs } })
     })
 
     BddTest().then('it should render nothing', () => {
-      const card = wrapper.findComponent(AvCardStub)
-      expect(card.exists()).toBe(false)
+      expect(wrapper.findComponent(AssociationsCardStub).exists()).toBe(false)
     })
   })
 })

--- a/src/features/student/declaredSkills/components/cards/AssociatedDeclaredSkillsCard/AssociatedDeclaredSkillsCard.vue
+++ b/src/features/student/declaredSkills/components/cards/AssociatedDeclaredSkillsCard/AssociatedDeclaredSkillsCard.vue
@@ -1,54 +1,32 @@
 <script setup lang="ts">
 import type { DeclaredSkillAssociationDTO } from '@/api/avenir-esr'
 import AssociatedSkillCard from '@/features/student/global/components/cards/AssociatedSkillCard/AssociatedSkillCard.vue'
+import AssociationsCard from '@/features/student/global/components/cards/AssociationsCard/AssociationsCard.vue'
 import { ICONS } from '@/features/student/global/icons'
-import { AvCard, AvIconText } from '@avenirs-esr/avenirs-dsav'
 import { useI18n } from 'vue-i18n'
 
 export interface AssociatedDeclaredSkillsCardProps {
   associatedDeclaredSkills: DeclaredSkillAssociationDTO[]
 }
 
-defineProps<AssociatedDeclaredSkillsCardProps>()
+const { associatedDeclaredSkills } = defineProps<AssociatedDeclaredSkillsCardProps>()
 
 const { t } = useI18n()
+
+const title = computed(() => t('student.declaredSkills.cards.AssociatedDeclaredSkillsCard.title', { count: associatedDeclaredSkills.length }))
 </script>
 
 <template>
-  <AvCard
+  <AssociationsCard
     v-if="associatedDeclaredSkills.length > 0"
-    background-color="var(--card2)"
-    title-background="var(--card2)"
-    border-color="var(--other-border-skill-card)"
-    collapsible
-    collapsed
+    :title
+    :icon="ICONS.SKILLS"
     data-testid="associated-declared-skills-card"
   >
-    <template #title>
-      <div class="av-row av-flex-fill av-justify-start">
-        <AvIconText
-          typography-class="n4"
-          :icon="ICONS.SKILLS"
-          icon-color="var(--text2)"
-          :text="t('student.declaredSkills.cards.AssociatedDeclaredSkillsCard.title', { count: associatedDeclaredSkills.length })"
-          text-color="var(--text1)"
-          gap="var(--spacing-sm)"
-          inline
-          data-testid="associated-declared-skills-card-title"
-        />
-      </div>
-    </template>
-
-    <div
-      class="av-row av-wrap av-align-center av-gap-md"
-      data-testid="associated-declared-skills-cards-container"
-    >
-      <AssociatedSkillCard
-        v-for="associatedDeclaredSkill in associatedDeclaredSkills"
-        :key="associatedDeclaredSkill.associationId"
-        :declared-skill="associatedDeclaredSkill.declaredSkill"
-        data-testid="associated-declared-skill-card"
-      />
-    </div>
-  </AvCard>
+    <AssociatedSkillCard
+      v-for="associatedDeclaredSkill in associatedDeclaredSkills"
+      :key="associatedDeclaredSkill.associationId"
+      :declared-skill="associatedDeclaredSkill.declaredSkill"
+    />
+  </AssociationsCard>
 </template>

--- a/src/features/student/global/components/cards/AssociatedActivityCard/AssociatedActivityCard.stub.ts
+++ b/src/features/student/global/components/cards/AssociatedActivityCard/AssociatedActivityCard.stub.ts
@@ -9,5 +9,5 @@ export const AssociatedActivityCardStub = defineComponent({
       required: true
     }
   },
-  template: '<div data-testid="associated-activity-card"></div>'
+  template: '<div data-testid="associated-declared-activity-card"></div>'
 })

--- a/src/features/student/global/components/cards/AssociatedActivityCard/AssociatedActivityCard.vue
+++ b/src/features/student/global/components/cards/AssociatedActivityCard/AssociatedActivityCard.vue
@@ -21,6 +21,7 @@ const { declaredActivity } = defineProps<AssociatedActivityCardProps>()
     icon-border-color="var(--other-border-skill-card)"
     background-color="var(--surface-background)"
     :to="{ name: ROUTES.STUDENT.PROJECT_ACTIVITIES_DETAILED.name, params: { id: declaredActivity.id, thematic: declaredActivity.thematic } }"
+    data-testid="associated-declared-activity-card"
   >
     <template #body>
       <ActivityThematicBadge

--- a/src/features/student/global/components/cards/AssociatedSkillCard/AssociatedSkillCard.vue
+++ b/src/features/student/global/components/cards/AssociatedSkillCard/AssociatedSkillCard.vue
@@ -37,6 +37,7 @@ const pathBadge = computed<AvBadgeProps>(() => ({
     color="var(--card)"
     background-color="var(--dark-background-primary1)"
     :to="{ name: ROUTES.STUDENT.DECLARED_SKILL.name, params: { id: declaredSkill.id } }"
+    data-testid="associated-declared-skill-card"
   >
     <template #body>
       <AvBadge

--- a/src/features/student/global/components/cards/AssociationsCard/AssociationsCard.stub.ts
+++ b/src/features/student/global/components/cards/AssociationsCard/AssociationsCard.stub.ts
@@ -1,0 +1,14 @@
+export const AssociationsCardStub = defineComponent({
+  name: 'AssociationsCard',
+  props: {
+    title: {
+      type: String,
+      required: true,
+    },
+    icon: {
+      type: String,
+      required: true,
+    },
+  },
+  template: '<div data-testid="associations-card-stub"><slot /></div>',
+})

--- a/src/features/student/global/components/cards/AssociationsCard/AssociationsCard.test.ts
+++ b/src/features/student/global/components/cards/AssociationsCard/AssociationsCard.test.ts
@@ -1,0 +1,55 @@
+import AssociationsCard from '@/features/student/global/components/cards/AssociationsCard/AssociationsCard.vue'
+import { AvCardStub, AvIconTextStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { beforeEach, expect } from 'vitest'
+
+BddTest().given('an association cards', () => {
+  let wrapper: VueWrapper
+
+  const stubs = {
+    AvCard: AvCardStub,
+    AvIconText: AvIconTextStub,
+  }
+
+  const props = {
+    title: 'Mon titre test (3)',
+    icon: 'test-icon',
+  }
+
+  BddTest().when('the component is mounted', () => {
+    let avIconText: VueWrapper<InstanceType<typeof AvIconTextStub>>
+
+    beforeEach(() => {
+      vi.clearAllMocks()
+      wrapper = mount(AssociationsCard, { props, global: { stubs } })
+      avIconText = wrapper.findComponent(AvIconTextStub)
+    })
+
+    BddTest().then('it should render the av card', () => {
+      expect(wrapper.findComponent(AvCardStub).exists()).toBe(true)
+    })
+
+    BddTest().then('it should pass the title to av icon text', () => {
+      expect(avIconText.props('text')).toBe(props.title)
+    })
+
+    BddTest().then('it should pass the icon to av icon text', () => {
+      expect(avIconText.props('icon')).toBe(props.icon)
+    })
+  })
+
+  BddTest().when('the component is mounted with slot content', () => {
+    beforeEach(() => {
+      vi.clearAllMocks()
+      wrapper = mount(AssociationsCard, {
+        props,
+        global: { stubs },
+        slots: { default: '<div data-testid="slot-content">Content</div>' },
+      })
+    })
+
+    BddTest().then('it should render the slot content', () => {
+      expect(wrapper.find('[data-testid="slot-content"]').exists()).toBe(true)
+    })
+  })
+})

--- a/src/features/student/global/components/cards/AssociationsCard/AssociationsCard.vue
+++ b/src/features/student/global/components/cards/AssociationsCard/AssociationsCard.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+import { AvCard, AvIconText } from '@avenirs-esr/avenirs-dsav'
+
+export interface AssociatedDeclaredActivitiesCardProps {
+  title: string
+  icon: string
+}
+
+defineProps<AssociatedDeclaredActivitiesCardProps>()
+</script>
+
+<template>
+  <AvCard
+    background-color="var(--card2)"
+    title-background="var(--card2)"
+    border-color="var(--other-border-skill-card)"
+    collapsible
+    collapsed
+  >
+    <template #title>
+      <div class="av-row av-flex-fill av-justify-start">
+        <AvIconText
+          typography-class="n4"
+          :icon="icon"
+          icon-color="var(--text2)"
+          :text="title"
+          text-color="var(--text1)"
+          gap="var(--spacing-sm)"
+          data-testid="associations-card-title"
+          inline
+        />
+      </div>
+    </template>
+    <div
+      v-if="$slots.default"
+      data-testid="associations-card-container"
+      class="av-row av-wrap av-align-center av-gap-md"
+    >
+      <slot />
+    </div>
+  </AvCard>
+</template>

--- a/src/features/student/traces/components/composites/TraceAssociations/TraceAssociations.test.ts
+++ b/src/features/student/traces/components/composites/TraceAssociations/TraceAssociations.test.ts
@@ -5,6 +5,7 @@ import {
   mockedTraceDeclaredSkillAssociations
 } from '@/__mocks__/fixtures/student'
 import { EActivityThematic, EDeclaredActivityStatus } from '@/api/avenir-esr'
+import { AssociatedDeclaredActivitiesCard } from '@/features/student/buildProject'
 import { AssociatedDeclaredSkillsCardStub } from '@/features/student/declaredSkills/components/cards/AssociatedDeclaredSkillsCard/AssociatedDeclaredSkillsCard.stub'
 import { AssociatedActivityCardStub } from '@/features/student/global/components/cards/AssociatedActivityCard/AssociatedActivityCard.stub'
 import TraceAssociations
@@ -305,7 +306,7 @@ BddTest().given('a student trace associations component', () => {
     })
 
     BddTest().then('it should render only the declared activity associations container', () => {
-      const activityContainer = wrapper.find('[data-testid="declared-activity-associations-container"]')
+      const activityContainer = wrapper.findComponent(AssociatedDeclaredActivitiesCard)
       expect(activityContainer.exists()).toBe(true)
     })
 

--- a/src/features/student/traces/components/composites/TraceAssociations/TraceAssociations.vue
+++ b/src/features/student/traces/components/composites/TraceAssociations/TraceAssociations.vue
@@ -1,9 +1,8 @@
 <script setup lang="ts">
 import { EDeclaredActivityStatus, type TraceAssociationsDTO } from '@/api/avenir-esr'
 import { useModal } from '@/common/composables'
+import { AssociatedDeclaredActivitiesCard } from '@/features/student/buildProject'
 import { AssociatedDeclaredSkillsCard } from '@/features/student/declaredSkills'
-import AssociatedActivityCard from '@/features/student/global/components/cards/AssociatedActivityCard/AssociatedActivityCard.vue'
-import { ICONS } from '@/features/student/global/icons'
 import DeleteTraceAssociatedElementsDropdown
   from '@/features/student/traces/views/StudentTraceView/components/overlays/dropdowns/DeleteTraceAssociatedElementsDropdown/DeleteTraceAssociatedElementsDropdown.vue'
 import TraceAssociateElementsDropdown
@@ -16,8 +15,6 @@ import DeleteTraceAssociatedActivitiesModal
   from '@/features/student/traces/views/StudentTraceView/components/overlays/modals/DeleteTraceAssociatedActivitiesModal/DeleteTraceAssociatedActivitiesModal.vue'
 import DeleteTraceAssociatedSkillsModal
   from '@/features/student/traces/views/StudentTraceView/components/overlays/modals/DeleteTraceAssociatedSkillsModal/DeleteTraceAssociatedSkillsModal.vue'
-import { AvCard, AvIconText } from '@avenirs-esr/avenirs-dsav'
-import { useI18n } from 'vue-i18n'
 
 export interface TraceAssociationsProps {
   associations: TraceAssociationsDTO
@@ -25,8 +22,6 @@ export interface TraceAssociationsProps {
 }
 
 const { associations, traceId } = defineProps<TraceAssociationsProps>()
-
-const { t } = useI18n()
 
 const { showModal: showSkillsModal, displayModal: displaySkillsModal, hideModal: hideSkillsModal } = useModal()
 const { showModal: showActivitiesModal, displayModal: displayActivitiesModal, hideModal: hideActivitiesModal } = useModal()
@@ -63,37 +58,7 @@ const deletableDeclaredActivityAssociations = computed(() => declaredActivityAss
       :associated-declared-skills="declaredSkillAssociations"
     />
 
-    <AvCard
-      v-if="declaredActivityAssociations.length > 0"
-      data-testid="declared-activity-associations-container"
-      background-color="var(--surface-background)"
-      title-background="var(--surface-background)"
-      border-color="var(--stroke)"
-      collapsible
-      collapsed
-    >
-      <template #title>
-        <div class="av-row av-align-center av-justify-between av-w-full av-gap-md av-px-md">
-          <AvIconText
-            typography-class="n5"
-            :icon="ICONS.ACTIVITY"
-            icon-color="var(--icon)"
-            :text="t('student.global.myDeclaredActivityCount', { count: declaredActivityAssociations.length })"
-            text-color="var(--title)"
-            gap="var(--spacing-sm)"
-          />
-        </div>
-      </template>
-
-      <div class="av-row av-justify-start av-gap-md av-wrap">
-        <AssociatedActivityCard
-          v-for="activityAssociation in declaredActivityAssociations"
-          :key="activityAssociation.associationId"
-          :declared-activity="activityAssociation.declaredActivity"
-          data-testid="associated-activity-card"
-        />
-      </div>
-    </AvCard>
+    <AssociatedDeclaredActivitiesCard :associated-activities="declaredActivityAssociations" />
   </div>
 
   <AssociateActivitiesModal


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> Création du composant `AssociatedDeclaredActivitiesCard` dans la feature `buildProject`. Ce composant affiche la liste des activités déclarées associées à un élément (compétence déclarée, trace, etc.) en utilisant une `AvCard` repliable avec titre, icône et nombre d'éléments. Il réutilise le composant `AssociatedActivityCard` existant et utilise le type générique `DeclaredActivityAssociationDTO[]` (au lieu du type spécifique aux traces).

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1359

---

### Documentation
> Aucune mise à jour de documentation requise.

---

### Target Branch
> `develop`

---

### Additional Notes
> Le type de prop `DeclaredActivityAssociationDTO[]` a été préféré à `DeclaredActivityTraceAssociationDTO[]` pour rendre le composant plus générique et réutilisable indépendamment du contexte (trace, compétence, etc.).

---

### Known Limitations or Side Effects
> Aucune.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [x] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and detaiils for the update process