### PR TITLE
fix(1413): remove PDF from ImageUpload and prevent submit form on updateProfileDrawer picture delete

### DIFF
--- a/src/common/components/ImageUpload/ImageUpload.test.ts
+++ b/src/common/components/ImageUpload/ImageUpload.test.ts
@@ -1,3 +1,4 @@
+import { ConfirmationModalStub } from '@/common/components/ConfirmationModal/ConfirmationModal.stub'
 import ImageUpload from '@/common/components/ImageUpload/ImageUpload.vue'
 import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { mount, type VueWrapper } from '@vue/test-utils'
@@ -6,15 +7,29 @@ import { expect, type Mock, vi } from 'vitest'
 const error = ref('')
 const valid = ref(true)
 
-vi.mock('@/common/composables', () => ({
-  useImageUpload: () => ({
-    update: vi.fn(),
-    error,
-    valid,
-    name: { value: 'test.jpg' },
-    previewUrl: { value: 'exemple.com/image.png' }
-  })
-}))
+const mockShowModal = ref(false)
+const mockDisplayModal = vi.fn()
+const mockHideModal = vi.fn()
+const mockOnDeleteImage = vi.fn()
+
+vi.mock('@/common/composables', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/common/composables')>()
+  return {
+    ...actual,
+    useModal: () => ({
+      showModal: mockShowModal,
+      displayModal: mockDisplayModal,
+      hideModal: mockHideModal
+    }),
+    useImageUpload: () => ({
+      update: vi.fn(),
+      error,
+      valid,
+      name: { value: 'test.jpg' },
+      previewUrl: { value: 'exemple.com/image.png' }
+    })
+  }
+})
 
 function createWrapper (props = {}) {
   return mount<typeof ImageUpload>(ImageUpload, {
@@ -44,10 +59,12 @@ function createWrapper (props = {}) {
               >
                 Trigger Error
               </button>
+              <button data-testid="delete-file-button" @click="onDeleteFile && onDeleteFile()">Delete File</button>
             </div>
           `
-        }
-      }
+        },
+        ConfirmationModal: ConfirmationModalStub
+      },
     },
   })
 }
@@ -66,7 +83,7 @@ BddTest().given('and image upload with valid props', () => {
 
   beforeEach(() => {
     onUpdateMock = vi.fn()
-    wrapper = createWrapper({ onUpdate: onUpdateMock })
+    wrapper = createWrapper({ onUpdate: onUpdateMock, onDeleteImage: mockOnDeleteImage })
   })
 
   afterEach(() => {
@@ -121,25 +138,6 @@ BddTest().given('and image upload with valid props', () => {
     })
   })
 
-  BddTest().when('onDeleteImage prop is provided', () => {
-    BddTest().then('it should pass onDeleteImage to AvFileUpload', () => {
-      const onDeleteImageMock = vi.fn()
-      const wrapperWithDelete = createWrapper({ onDeleteImage: onDeleteImageMock })
-
-      const avFileUpload = wrapperWithDelete.findComponent({ name: 'AvFileUpload' })
-      expect(avFileUpload.props('onDeleteFile')).toBe(onDeleteImageMock)
-    })
-  })
-
-  BddTest().when('onDeleteImage prop is not provided', () => {
-    BddTest().then('it should render without onDeleteFile prop', () => {
-      const wrapperWithoutDelete = createWrapper()
-
-      const avFileUpload = wrapperWithoutDelete.findComponent({ name: 'AvFileUpload' })
-      expect(avFileUpload.props('onDeleteFile')).toBeUndefined()
-    })
-  })
-
   BddTest().when('defaultImageUrl is provided', () => {
     BddTest().then('it should use defaultImageUrl for image src', () => {
       const wrapperWithUrl = createWrapper({ defaultImageUrl: 'https://example.com/custom.jpg' })
@@ -188,6 +186,31 @@ BddTest().given('and image upload with valid props', () => {
 
       const errorSpan = wrapper.find('#image-upload-error')
       expect(errorSpan.exists()).toBe(false)
+    })
+  })
+
+  BddTest().when('delete file button is clicked', () => {
+    beforeEach(async () => {
+      const deleteButton = wrapper.find('[data-testid="delete-file-button"]')
+      await deleteButton.trigger('click')
+    })
+
+    BddTest().then('it should display the confirmation modal', () => {
+      expect(mockDisplayModal).toHaveBeenCalled()
+    })
+  })
+
+  BddTest().when('confirming file deletion in modal', () => {
+    beforeEach(() => {
+      wrapper.findComponent(ConfirmationModalStub).vm.$emit('confirm')
+    })
+
+    BddTest().then('it should hide the modal', () => {
+      expect(mockHideModal).toHaveBeenCalled()
+    })
+
+    BddTest().then('it should call delete image function', () => {
+      expect(mockOnDeleteImage).toHaveBeenCalled()
     })
   })
 })

--- a/src/common/components/ImageUpload/ImageUpload.vue
+++ b/src/common/components/ImageUpload/ImageUpload.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { useImageUpload } from '@/common/composables'
+import ConfirmationModal from '@/common/components/ConfirmationModal/ConfirmationModal.vue'
+import { useImageUpload, useModal } from '@/common/composables'
 import { AvFileUpload } from '@avenirs-esr/avenirs-dsav'
 import { useI18n } from 'vue-i18n'
 
@@ -35,12 +36,12 @@ interface ImageUploadProps {
   onDeleteImage?: () => void
 }
 
-const { defaultImageName, imageAlt, onUpdate } = defineProps<ImageUploadProps>()
+const { defaultImageName, imageAlt, onUpdate, onDeleteImage } = defineProps<ImageUploadProps>()
 
 const { t } = useI18n()
 const imageUpload = useImageUpload()
 
-const ACCEPTED_FILE_TYPES = ['image/jpg', 'image/jpeg', 'image/png', 'application/pdf']
+const ACCEPTED_FILE_TYPES = ['image/jpg', 'image/jpeg', 'image/png']
 
 const errorId = 'image-upload-error'
 const hintId = 'image-upload-hint'
@@ -63,6 +64,16 @@ async function onUpdateImage (files: FileList | File[]) {
   }
 }
 const modelValue = defineModel<File | null>()
+
+const { showModal, displayModal, hideModal } = useModal()
+
+function onConfirmDeleteImage () {
+  hideModal()
+
+  if (onDeleteImage) {
+    onDeleteImage()
+  }
+}
 </script>
 
 <template>
@@ -76,7 +87,7 @@ const modelValue = defineModel<File | null>()
     :file-name="defaultImageName"
     :aria-describedby="describedBy"
     :accept="ACCEPTED_FILE_TYPES"
-    :on-delete-file="onDeleteImage"
+    :on-delete-file="displayModal"
     @update:model-value="(value) => modelValue = value"
     @change="onUpdateImage"
     @on-drop-accept-type-error="() => { imageUpload.error.value = t('global.error.file.acceptType') }"
@@ -110,6 +121,12 @@ const modelValue = defineModel<File | null>()
       {{ imageUpload.error.value }}
     </span>
   </template>
+
+  <ConfirmationModal
+    :show="showModal"
+    @confirm="onConfirmDeleteImage"
+    @close="hideModal"
+  />
 </template>
 
 <style lang="scss" scoped>

--- a/src/common/components/overlay/drawers/UpdateProfileDrawer/UpdateProfileDrawer.vue
+++ b/src/common/components/overlay/drawers/UpdateProfileDrawer/UpdateProfileDrawer.vue
@@ -67,10 +67,12 @@ function onUpdateProfileSuccess () {
 
 const { mutate: deleteCoverPicture } = useDeletePhotoMutation(userCategory.value, {
   onError: (error: BaseApiException) => addErrorMessage({ title: t('global.overlay.drawers.UpdateProfileDrawer.onDelete.error'), description: error.message, type: 'error', }),
+  onSuccess: () => addSuccessMessage(t('global.overlay.drawers.UpdateProfileDrawer.onDelete.success'))
 })
 
 const { mutate: deleteProfilePicture } = useDeletePhotoMutation(userCategory.value, {
   onError: (error: BaseApiException) => addErrorMessage({ title: t('global.overlay.drawers.UpdateProfileDrawer.onDelete.error'), description: error.message, type: 'error', }),
+  onSuccess: () => addSuccessMessage(t('global.overlay.drawers.UpdateProfileDrawer.onDelete.success'))
 })
 
 function onDeleteCoverPicture () {
@@ -79,6 +81,16 @@ function onDeleteCoverPicture () {
 
 function onDeleteProfilePicture () {
   deleteProfilePicture({ fileId: profilePicture.fileId! })
+}
+
+function onSubmitForm (event: Event) {
+  const submitter = (event as SubmitEvent).submitter as HTMLElement | null
+
+  if (submitter?.closest('[data-image-upload-delete-zone]')) {
+    return
+  }
+
+  form.handleSubmit()
 }
 
 watch(() => show, (newVal) => {
@@ -106,7 +118,7 @@ watch(() => show, (newVal) => {
       <form
         id="profile-form"
         novalidate
-        @submit.prevent.stop="form.handleSubmit"
+        @submit.prevent.stop="onSubmitForm"
       >
         <AvAccordionsGroup>
           <AvAccordion
@@ -165,27 +177,31 @@ watch(() => show, (newVal) => {
             :title="t('global.overlay.drawers.UpdateProfileDrawer.pictures.banner')"
             :icon="MDI_ICONS.IMAGE_OUTLINE"
           >
-            <ImageUpload
-              v-model="coverPictureFile"
-              :on-delete-image="onDeleteCoverPicture"
-              :default-image-url="coverPicture.fileName ? coverPicture.url : undefined"
-              :default-image-name="coverPicture.fileName ?? undefined"
-              :image-alt="t('global.overlay.drawers.UpdateProfileDrawer.pictures.banner')"
-              :on-update="onCoverPictureUpdate"
-            />
+            <div data-image-upload-delete-zone>
+              <ImageUpload
+                v-model="coverPictureFile"
+                :on-delete-image="onDeleteCoverPicture"
+                :default-image-url="coverPicture.fileName ? coverPicture.url : undefined"
+                :default-image-name="coverPicture.fileName ?? undefined"
+                :image-alt="t('global.overlay.drawers.UpdateProfileDrawer.pictures.banner')"
+                :on-update="onCoverPictureUpdate"
+              />
+            </div>
           </AvAccordion>
           <AvAccordion
             :title="t('global.overlay.drawers.UpdateProfileDrawer.pictures.picture')"
             :icon="MDI_ICONS.IMAGE_OUTLINE"
           >
-            <ImageUpload
-              v-model="profilePictureFile"
-              :on-delete-image="onDeleteProfilePicture"
-              :default-image-url="profilePicture.fileName ? profilePicture.url : undefined"
-              :default-image-name="profilePicture.fileName ?? undefined"
-              :image-alt="t('global.overlay.drawers.UpdateProfileDrawer.pictures.picture')"
-              :on-update="onProfilePictureUpdate"
-            />
+            <div data-image-upload-delete-zone>
+              <ImageUpload
+                v-model="profilePictureFile"
+                :on-delete-image="onDeleteProfilePicture"
+                :default-image-url="profilePicture.fileName ? profilePicture.url : undefined"
+                :default-image-name="profilePicture.fileName ?? undefined"
+                :image-alt="t('global.overlay.drawers.UpdateProfileDrawer.pictures.picture')"
+                :on-update="onProfilePictureUpdate"
+              />
+            </div>
           </AvAccordion>
         </AvAccordionsGroup>
       </form>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -154,7 +154,7 @@
       "fileUpload": {
         "dragAndDrop": "or drag and drop here",
         "filesIndication": "Format: ",
-        "filesTypes": "PDF, JPG, JPEG, PNG •",
+        "filesTypes": "JPG, JPEG, PNG •",
         "size": "10 Mo max",
         "sizeIndication": "Size : ",
         "title": "Add a file"

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -154,7 +154,7 @@
       "fileUpload": {
         "dragAndDrop": "ou glisser et déposer ici",
         "filesIndication": "Format : ",
-        "filesTypes": "PDF, JPG, JPEG, PNG •",
+        "filesTypes": "JPG, JPEG, PNG •",
         "size": "10 Mo max",
         "sizeIndication": "Poids : ",
         "title": "Ajouter un fichier"


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
This PR fixes profile image upload behavior in the update profile drawer by preventing PDF uploads and by avoiding unintended form submission when deleting profile or cover images.

**Main changes:**
- 🐛 Restricts accepted upload formats in ImageUpload to JPG/JPEG/PNG (PDF removed)
- 🐛 Adds a confirmation modal before image deletion in ImageUpload
- 🐛 Prevents update profile form submission when clicking image delete actions
- 💬 Updates i18n file format labels in EN/FR to match allowed image types
- ✅ Adds success feedback on picture deletion requests

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1413

---

### Documentation
- Updated upload format labels in translations (, )
- Behavior changes implemented in profile-related UI components:
  -  (accepted file types, delete confirmation)
  -  (submit guard + delete success notifications)

---

### Target Branch


---

### Additional Notes
The implementation aligns UI messaging with actual accepted file types and makes delete interactions safer by requiring confirmation and preventing accidental profile form submission side effects.

---

### Known Limitations or Side Effects
No known limitations or side effects identified.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [ ] No unnecessary code (e.g., debug logs, commented code)
- [ ] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to  file all properties and database change and details for the update process
