### PR TITLE
fix(1419): display declared activity thematic in the dropdown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "avenirs-cofolio-client",
       "version": "0.0.0",
       "dependencies": {
-        "@avenirs-esr/avenirs-dsav": "^0.1.185",
+        "@avenirs-esr/avenirs-dsav": "^0.1.187",
         "@tanstack/vue-form": "^1.15.0",
         "@tanstack/vue-query": "^5.74.9",
         "@vue-flow/core": "^1.48.0",
@@ -393,9 +393,9 @@
       }
     },
     "node_modules/@avenirs-esr/avenirs-dsav": {
-      "version": "0.1.185",
-      "resolved": "https://registry.npmjs.org/@avenirs-esr/avenirs-dsav/-/avenirs-dsav-0.1.185.tgz",
-      "integrity": "sha512-yfT/wMcPvn7/Q4WEyAOAkRZAl/qwsQBN7EyB05LibmMlT7EywoMApKvNA4ZLblFZFweM18YPFUMTmBYen4f/vw==",
+      "version": "0.1.187",
+      "resolved": "https://registry.npmjs.org/@avenirs-esr/avenirs-dsav/-/avenirs-dsav-0.1.187.tgz",
+      "integrity": "sha512-ZzoJIH44BP45+K9qBSkRoNLTkG5sIEGE/8vT5Q3FCRS1nwsz6ak9jPR+A0vnqloJ1DpGgbfr7UacbAjYyPbb/A==",
       "dependencies": {
         "@tiptap/extension-character-count": "^3.20.2",
         "@tiptap/extension-image": "^3.20.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
-    "@avenirs-esr/avenirs-dsav": "^0.1.185",
+    "@avenirs-esr/avenirs-dsav": "^0.1.187",
     "@tanstack/vue-form": "^1.15.0",
     "@tanstack/vue-query": "^5.74.9",
     "@vue-flow/core": "^1.48.0",

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/overlays/modals/AssociateTracesModal/AssociateTracesModal.vue
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/overlays/modals/AssociateTracesModal/AssociateTracesModal.vue
@@ -3,6 +3,7 @@ import type {
   AssociationsCreationRequest,
 } from '@/api/avenir-esr'
 import type { BaseApiException } from '@/common/exceptions'
+import type { AvAutocompleteOption } from '@avenirs-esr/avenirs-dsav'
 import {
   useAssociateActivityWithTracesMutation,
   useSearchTracesForAssociationQuery
@@ -68,7 +69,7 @@ const {
 
 listenAndDisplayToastOnSearchError(isSearchError, searchError)
 
-const traceOptions = computed(() =>
+const traceOptions = computed<AvAutocompleteOption[]>(() =>
   traces.value
     .filter(trace => !trace.disabled)
     .map(trace => ({

--- a/src/features/student/global/components/interaction/SearchAssociationLayout/SearchAssociationLayout.stub.ts
+++ b/src/features/student/global/components/interaction/SearchAssociationLayout/SearchAssociationLayout.stub.ts
@@ -6,12 +6,13 @@ export const SearchAssociationLayoutStub = defineComponent({
     'items',
     'inputOptions',
     'getOptionKey',
-    'getOptionLabel'
+    'getOptionLabel',
+    'loading'
   ],
   emits: ['update:modelValue', 'search', 'clear', 'loadMore', 'delete'],
   template: `
     <div data-testid="search-association-layout-stub">
-      
+
       <div data-testid="search-association-layout-before-search-stub">
         <slot name="beforeSearch" />
       </div>

--- a/src/features/student/global/composables/use-association-modal/use-association-modal.test.ts
+++ b/src/features/student/global/composables/use-association-modal/use-association-modal.test.ts
@@ -92,6 +92,24 @@ BddTest().given('the useAssociationModal composable', () => {
       })
     })
 
+    BddTest().and('options include description', () => {
+      const optionsWithDescription: AvAutocompleteOption[] = [
+        { label: 'Item C', value: 'id-c', description: 'Description C' },
+        { label: 'Item D', value: 'id-d', description: 'Description D' }
+      ]
+
+      beforeEach(() => {
+        composable.selectedOptions.value = optionsWithDescription
+      })
+
+      BddTest().then('it should include description in selectedAssociations', () => {
+        expect(composable.selectedAssociations.value).toEqual([
+          { id: 'id-c', title: 'Item C', description: 'Description C' },
+          { id: 'id-d', title: 'Item D', description: 'Description D' }
+        ])
+      })
+    })
+
     BddTest().and('onDeleteItem is called with a non-existing id', () => {
       beforeEach(() => {
         composable.onDeleteItem('id-unknown')

--- a/src/features/student/global/composables/use-association-modal/use-association-modal.ts
+++ b/src/features/student/global/composables/use-association-modal/use-association-modal.ts
@@ -20,7 +20,8 @@ export function useAssociationModal<T extends AvAutocompleteOption = AvAutocompl
   const selectedAssociations = computed(() =>
     selectedOptions.value.map(option => ({
       id: option.value.toString(),
-      title: option.label
+      title: option.label,
+      description: option.description
     }))
   )
 

--- a/src/features/student/traces/views/StudentTraceView/components/overlays/modals/AssociateActivitiesModal/AssociateActivitiesModal.test.ts
+++ b/src/features/student/traces/views/StudentTraceView/components/overlays/modals/AssociateActivitiesModal/AssociateActivitiesModal.test.ts
@@ -51,13 +51,11 @@ BddTest().given('an associate activities modal', () => {
   const selectedActivityOptions = [
     {
       label: 'Définir ses valeurs',
-      value: 'activity-search-1',
-      thematic: EActivityThematic.SELF_KNOWLEDGE
+      value: 'activity-search-1'
     },
     {
       label: 'Explorer ses pistes d’orientation',
-      value: 'activity-search-2',
-      thematic: EActivityThematic.FUTURE_PLANS
+      value: 'activity-search-2'
     }
   ]
 
@@ -65,12 +63,14 @@ BddTest().given('an associate activities modal', () => {
     {
       id: 'activity-search-1',
       title: 'Définir ses valeurs',
-      thematic: EActivityThematic.SELF_KNOWLEDGE
+      thematic: EActivityThematic.SELF_KNOWLEDGE,
+      disabled: false
     },
     {
       id: 'activity-search-2',
       title: 'Explorer ses pistes d’orientation',
-      thematic: EActivityThematic.FUTURE_PLANS
+      thematic: EActivityThematic.FUTURE_PLANS,
+      disabled: false
     }
   ]
 
@@ -107,18 +107,26 @@ BddTest().given('an associate activities modal', () => {
       expect(confirmModal.props('items')).toEqual([])
     })
 
-    BddTest().then('it should pass only enabled activities to the layout options', () => {
+    BddTest().then('it should pass all activities to the layout options with description and disabled fields', () => {
       const layout = wrapper.findComponent(SearchAssociationLayoutStub)
       expect(layout.props('options')).toEqual([
         {
           label: 'Définir ses valeurs',
           value: 'activity-search-1',
-          thematic: EActivityThematic.SELF_KNOWLEDGE
+          description: 'Me connaître',
+          disabled: false
         },
         {
           label: 'Explorer ses pistes d’orientation',
           value: 'activity-search-2',
-          thematic: EActivityThematic.FUTURE_PLANS
+          description: 'Explorer mes futures',
+          disabled: false
+        },
+        {
+          label: 'Activité désactivée',
+          value: 'activity-search-3',
+          description: 'CV',
+          disabled: true
         }
       ])
     })
@@ -186,7 +194,8 @@ BddTest().given('an associate activities modal', () => {
             {
               id: 'activity-search-1',
               title: 'Définir ses valeurs',
-              thematic: EActivityThematic.SELF_KNOWLEDGE
+              thematic: EActivityThematic.SELF_KNOWLEDGE,
+              disabled: false
             }
           ])
         })
@@ -197,7 +206,8 @@ BddTest().given('an associate activities modal', () => {
             {
               id: 'activity-search-1',
               title: 'Définir ses valeurs',
-              thematic: EActivityThematic.SELF_KNOWLEDGE
+              thematic: EActivityThematic.SELF_KNOWLEDGE,
+              disabled: false
             }
           ])
         })
@@ -327,35 +337,6 @@ BddTest().given('an associate activities modal', () => {
     BddTest().then('it should pass loading state to modal', () => {
       const modal = wrapper.findComponent(AvModalStub)
       expect(modal.props('isLoading')).toBe(true)
-    })
-  })
-
-  BddTest().when('getOptionLabel is called', () => {
-    beforeEach(async () => {
-      wrapper = mountComponent(AssociateActivitiesModal, {
-        props,
-        global: { stubs }
-      })
-      await flushPromises()
-    })
-
-    BddTest().then('it should return label and thematic when thematic exists', () => {
-      const layout = wrapper.findComponent(SearchAssociationLayoutStub)
-      const getOptionLabel = layout.props('getOptionLabel') as (option: { label: string, thematic?: EActivityThematic }) => string
-
-      expect(getOptionLabel({
-        label: 'Définir ses valeurs',
-        thematic: EActivityThematic.SELF_KNOWLEDGE
-      })).toBe('Définir ses valeurs - SELF_KNOWLEDGE')
-    })
-
-    BddTest().then('it should return only label when thematic is undefined', () => {
-      const layout = wrapper.findComponent(SearchAssociationLayoutStub)
-      const getOptionLabel = layout.props('getOptionLabel') as (option: { label: string, thematic?: EActivityThematic }) => string
-
-      expect(getOptionLabel({
-        label: 'Définir ses valeurs'
-      })).toBe('Définir ses valeurs')
     })
   })
 })

--- a/src/features/student/traces/views/StudentTraceView/components/overlays/modals/AssociateActivitiesModal/AssociateActivitiesModal.vue
+++ b/src/features/student/traces/views/StudentTraceView/components/overlays/modals/AssociateActivitiesModal/AssociateActivitiesModal.vue
@@ -11,13 +11,7 @@ import { useI18n } from 'vue-i18n'
 
 export type AssociationActivity = IdTitle & {
   disabled: boolean
-  thematic?: EActivityThematic
-}
-
-export type SelectedActivity = Omit<AssociationActivity, 'disabled'>
-
-export type ActivityAvAutocompleteOption = AvAutocompleteOption & {
-  thematic?: EActivityThematic
+  thematic: EActivityThematic
 }
 
 export interface AssociateActivitiesModalProps {
@@ -46,24 +40,20 @@ const {
   displayConfirmModal,
   hideConfirmModal,
   onDeleteItem: onDeleteActivity,
-} = useAssociationModal<ActivityAvAutocompleteOption>()
+} = useAssociationModal<AvAutocompleteOption>()
 
-const activityAutocompleteOptions = computed<ActivityAvAutocompleteOption[]>(() =>
+const activityAutocompleteOptions = computed<AvAutocompleteOption[]>(() =>
   activities
-    .filter(({ disabled }) => !disabled)
     .map(activity => ({
       label: activity.title,
       value: activity.id,
-      thematic: activity.thematic
+      description: t(`student.buildProject.activities.thematics.${activity.thematic}`),
+      disabled: activity.disabled
     }))
 )
 
-const selectedAssociations = computed<SelectedActivity[]>(() =>
-  selectedActivityOptions.value.map(option => ({
-    id: option.value.toString(),
-    title: option.label,
-    thematic: option.thematic
-  }))
+const selectedAssociations = computed<AssociationActivity[]>(() =>
+  activities.filter(activity => selectedActivityOptions.value.some(option => option.value === activity.id))
 )
 
 watch(() => show, (newVal) => {
@@ -84,12 +74,6 @@ function onCancel () {
 
 function onConfirm () {
   emit('associate', selectedAssociations.value.map(activity => activity.id))
-}
-
-function getOptionLabel (option: ActivityAvAutocompleteOption): string {
-  return option.thematic
-    ? `${option.label} - ${option.thematic}`
-    : option.label
 }
 </script>
 
@@ -124,7 +108,7 @@ function getOptionLabel (option: ActivityAvAutocompleteOption): string {
         placeholder: t('student.traces.views.StudentTraceView.AssociateActivitiesModal.searchPlaceholder'),
       }"
       :get-option-key="option => option.value"
-      :get-option-label="getOptionLabel"
+      :get-option-label="(option) => option.label"
       :loading="isLoading"
       @search="onSearch"
       @delete="onDeleteActivity"


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> Fixes the display of activity thematic in the association search dropdown. Previously, the title and thematic were displayed on the same line separated by a dash. Now, the thematic is displayed as a subtitle (description) below the activity title using the `AvAutocompleteOption.description` field natively rendered by `AvAutocompleteDropdown`. Also implements the `disabled` prop in `AvAutocompleteOption` to prevent selection of disabled options.

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1419

---

### Documentation
> No documentation changes required. The `description` and `disabled` fields are part of the existing `AvAutocompleteOption` interface in `@avenirs-esr/avenirs-dsav`.

---

### Target Branch
> `develop`

---

### Additional Notes
> - Uses the existing `description` field in `AvAutocompleteOption` instead of a custom slot, which is cleaner and more consistent with the design system
> - The `disabled` option guard was added in `AvAutocompleteDropdown.toggleOption` to prevent selection of disabled items
> - `AssociateActivitiesModal` now maps activity thematic to a translated `description` label, and `selectedAssociations` is computed from full activity objects (no longer passes thematic through the option chain)

---

### Known Limitations or Side Effects
> None.

---

## ✅ Checklist

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [x] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process