### PR TITLE
fix(1295): DeclaredProgramDetailedView - use QuerySuspense

### DIFF
--- a/src/common/components/QuerySuspense/QuerySuspense.md
+++ b/src/common/components/QuerySuspense/QuerySuspense.md
@@ -32,6 +32,7 @@ const isEmpty = computed(() => !data.value?.length)
 | `isLoading` | `boolean` | `false` | Affiche le spinner pendant le chargement |
 | `error` | `BaseApiException \| null` | `null` | Erreur retournée par la query |
 | `errorTitle` | `string` | `"Une erreur est survenue lors du chargement des données"` | Titre du message d'erreur |
+| `errorDescription` | `string` | `"Veuillez réessayer plus tard."` | Description du message d'erreur |
 | `emptyStateMessage` | `string` | `"Aucune donnée à afficher"` | Message de l'état vide |
 
 ## Slots

--- a/src/common/components/QuerySuspense/QuerySuspense.stub.ts
+++ b/src/common/components/QuerySuspense/QuerySuspense.stub.ts
@@ -1,6 +1,13 @@
 export const QuerySuspenseStub = defineComponent({
   name: 'QuerySuspense',
-  template: '<div data-testid="query-suspense-stub"><slot /><slot name="error" /><slot name="empty" /></div>',
+  template: `
+    <div data-testid="query-suspense-stub">
+      <div v-if="isLoading" data-testid="query-suspense-loading" />
+      <slot />
+      <slot name="error"><div v-if="error" data-testid="query-suspense-error" /></slot>
+      <slot name="empty"><div v-if="isEmpty" data-testid="query-suspense-empty" /></slot>
+    </div>
+  `,
   props: {
     error: {
       type: Object,
@@ -9,10 +16,16 @@ export const QuerySuspenseStub = defineComponent({
     errorTitle: {
       type: String,
     },
+    errorDescription: {
+      type: String,
+    },
     emptyStateMessage: {
       type: String,
     },
     isEmpty: {
+      type: Boolean,
+    },
+    isLoading: {
       type: Boolean,
     },
   }

--- a/src/common/components/QuerySuspense/QuerySuspense.vue
+++ b/src/common/components/QuerySuspense/QuerySuspense.vue
@@ -9,6 +9,7 @@ import { useI18n } from 'vue-i18n'
 export interface QuerySuspenseProps {
   error?: BaseApiException | null
   errorTitle?: string
+  errorDescription?: string
   emptyStateMessage?: string
   isEmpty?: boolean
   isLoading?: boolean
@@ -16,6 +17,7 @@ export interface QuerySuspenseProps {
 
 const {
   errorTitle,
+  errorDescription,
   emptyStateMessage,
   isEmpty,
   error = null,
@@ -30,6 +32,7 @@ defineSlots<{
 
 const { t } = useI18n()
 const computedErrorTitle = computed(() => errorTitle ?? t('global.components.QuerySuspense.defaultErrorTitle'))
+const computedErrorDescription = computed(() => errorDescription ?? error?.message)
 const computedEmptyStateMessage = computed(() => emptyStateMessage ?? t('global.components.QuerySuspense.defaultEmptyStateMessage'))
 </script>
 
@@ -42,7 +45,7 @@ const computedEmptyStateMessage = computed(() => emptyStateMessage ?? t('global.
       <slot name="error">
         <ErrorMessage
           :title="computedErrorTitle"
-          :description="error.message"
+          :description="computedErrorDescription"
         />
       </slot>
     </div>

--- a/src/features/student/personalCareer/views/DeclaredProgramDetailedView/DeclaredProgramDetailedView.test.ts
+++ b/src/features/student/personalCareer/views/DeclaredProgramDetailedView/DeclaredProgramDetailedView.test.ts
@@ -7,8 +7,7 @@ import {
 } from '@/__mocks__/msw/handlers/student/declaredPrograms.handlers'
 import { server } from '@/__mocks__/msw/server'
 import { DetailedPageTitleStub } from '@/common/components/DetailedPageTitle/DetailedPageTitle.stub'
-import { ErrorMessageStub } from '@/common/components/feedback/ErrorMessage/ErrorMessage.stub'
-import { LoaderStub } from '@/common/components/Loader/Loader.stub'
+import { QuerySuspenseStub } from '@/common/components/QuerySuspense/QuerySuspense.stub'
 import { ROUTES } from '@/common/constants'
 import { DeclaredProgramSideMenuStub } from '@/features/student/personalCareer/components/navigation/DeclaredProgramSideMenu/DeclaredProgramSideMenu.stub'
 import { DeleteDeclaredProgramConfirmModalStub } from '@/features/student/personalCareer/components/overlays/DeleteDeclaredProgramConfirmModal/DeleteDeclaredProgramConfirmModal.stub'
@@ -74,12 +73,11 @@ const DeclaredProgramDetailedStub = defineComponent({
 
 const stubs = {
   DetailedPageTitle: DetailedPageTitleStub,
-  ErrorMessage: ErrorMessageStub,
   DeclaredProgramSideMenu: DeclaredProgramSideMenuStub,
   DeclaredProgramDetailed: DeclaredProgramDetailedStub,
-  Loader: LoaderStub,
   ManageDeclaredProgramDropdown: ManageDeclaredProgramDropdownStub,
-  DeleteDeclaredProgramConfirmModal: DeleteDeclaredProgramConfirmModalStub
+  DeleteDeclaredProgramConfirmModal: DeleteDeclaredProgramConfirmModalStub,
+  QuerySuspense: QuerySuspenseStub
 }
 
 BddTest().given('a declared program detailed view component', () => {
@@ -142,9 +140,9 @@ BddTest().given('a declared program detailed view component', () => {
       })
     })
 
-    BddTest().then('it should not render ErrorMessage', async () => {
+    BddTest().then('it should not render the query suspense error', async () => {
       await vi.waitFor(() => {
-        expect(wrapper.find('[data-testid="error-message"]').exists()).toBe(false)
+        expect(wrapper.find('[data-testid="query-suspense-error"]').exists()).toBe(false)
       })
     })
 
@@ -356,7 +354,7 @@ BddTest().given('a declared program detailed view component', () => {
 
     BddTest().then('it should show the loader', async () => {
       await vi.waitFor(() => {
-        const loader = wrapper.find('[data-testid="loader-stub"]')
+        const loader = wrapper.find('[data-testid="query-suspense-loading"]')
         expect(loader.exists()).toBe(true)
       })
     })
@@ -392,13 +390,13 @@ BddTest().given('a declared program detailed view component', () => {
       await flushPromises()
     })
 
-    BddTest().then('it should render ErrorMessage', async () => {
+    BddTest().then('it should render the query suspense error', async () => {
       await vi.waitFor(() => {
-        expect(wrapper.find('[data-testid="error-message"]').exists()).toBe(true)
+        expect(wrapper.find('[data-testid="query-suspense-error"]').exists()).toBe(true)
 
-        const errorMessage = wrapper.findComponent({ name: 'ErrorMessage' })
-        expect(errorMessage.props('title')).toBe('Programme déclaré introuvable')
-        expect(errorMessage.props('description')).toBe('Le programme déclaré que vous recherchez n\'existe pas ou n\'est pas accessible.')
+        const errorMessage = wrapper.findComponent(QuerySuspenseStub)
+        expect(errorMessage.props('errorTitle')).toBe('Programme déclaré introuvable')
+        expect(errorMessage.props('errorDescription')).toBe('Le programme déclaré que vous recherchez n\'existe pas ou n\'est pas accessible.')
       })
     })
 

--- a/src/features/student/personalCareer/views/DeclaredProgramDetailedView/DeclaredProgramDetailedView.vue
+++ b/src/features/student/personalCareer/views/DeclaredProgramDetailedView/DeclaredProgramDetailedView.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import DetailedPageTitle from '@/common/components/DetailedPageTitle/DetailedPageTitle.vue'
-import ErrorMessage from '@/common/components/feedback/ErrorMessage/ErrorMessage.vue'
-import Loader from '@/common/components/Loader/Loader.vue'
+import QuerySuspense from '@/common/components/QuerySuspense/QuerySuspense.vue'
 import { useModal, useNavigation } from '@/common/composables'
 import { useApiErrors } from '@/common/composables/use-api-errors/use-api-errors'
 import { ErrorCodes, ROUTES } from '@/common/constants'
@@ -64,20 +63,12 @@ function handleConfirmDelete () {
         @load-more-programs="loadMoreDeclaredPrograms"
       />
     </div>
-    <Loader
+    <QuerySuspense
+      :error="error"
       :is-loading="isLoading && !isError"
-      size="2xl"
+      :error-title="isDeclaredProgramNotFound ? t('student.personalCareer.views.DeclaredProgramDetailedView.errors.notFound.title') : t('global.error.generic')"
+      :error-description="isDeclaredProgramNotFound ? t('student.personalCareer.views.DeclaredProgramDetailedView.errors.notFound.description') : error?.message"
     >
-      <div
-        v-if="error"
-        class="av-col av-gap-md av-flex-fill"
-      >
-        <ErrorMessage
-          v-if="error"
-          :title="isDeclaredProgramNotFound ? t('student.personalCareer.views.DeclaredProgramDetailedView.errors.notFound.title') : t('global.error.generic')"
-          :description="isDeclaredProgramNotFound ? t('student.personalCareer.views.DeclaredProgramDetailedView.errors.notFound.description') : error.message"
-        />
-      </div>
       <div
         v-if="declaredProgramDetailed"
         class="av-col av-gap-md av-flex-fill"
@@ -91,7 +82,7 @@ function handleConfirmDelete () {
           :declared-program-detailed="declaredProgramDetailed"
         />
       </div>
-    </Loader>
+    </QuerySuspense>
   </div>
 
   <DeleteDeclaredProgramConfirmModal


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
This PR refactors the declared program detail loading/error handling by replacing direct  +  usage with the shared  component, and adds support for custom error descriptions in .

**Main changes:**
- ♻️ Refactors  to use 
- ✨ Adds  prop support to 
- ✅ Updates stubs and unit tests to align with  behavior
- 📝 Updates  documentation with the new prop
- 🐛 Improves control of error message wording/position in declared program detail view

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1295

---

### Documentation
Updated files include:
- 
- 
- 
- 
- 

---

### Target Branch


---

### Additional Notes
For not-found business errors, the view now passes explicit localized title and description through  props. For generic API errors, it still falls back to API-provided message content.

---

### Known Limitations or Side Effects
No known side effects identified.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [ ] No unnecessary code (e.g., debug logs, commented code)
- [ ] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to  file all properties and database change and details for the update process
