### PR TITLE
fix(1430): invalidate declared skill associations

### DIFF
--- a/src/features/student/declaredSkills/queries/use-declared-skills.query/use-declared-skills.query.ts
+++ b/src/features/student/declaredSkills/queries/use-declared-skills.query/use-declared-skills.query.ts
@@ -245,7 +245,8 @@ export function useAssociateDeclaredSkillWithActivitiesMutation ({ onError, onSu
         invalidateQueryKey([
           ...declaredSkillSearchForAssociationQueryKey,
           variables.declaredSkillProgressId
-        ])
+        ]),
+        invalidateQueryKey([...declaredSkillDetailsQueryKey, 'associations', variables.declaredSkillProgressId])
       ])
 
       onSuccess?.(data, variables)


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> Correction d'un bug où la liste des associations de compétences déclarées n'était pas actualisée après une mutation. La clé de requête `declaredSkillDetailsQueryKey` (avec suffixe `associations`) est désormais invalidée en plus de la clé de recherche existante, garantissant le rechargement des données après association.

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1430

---

### Documentation
> Aucune mise à jour de documentation nécessaire.

---

### Target Branch
> `develop`

---

### Additional Notes
> L'invalidation de `declaredSkillSearchForAssociationQueryKey` était déjà présente mais insuffisante : la liste des associations affichée dans le panneau de détail dépendait d'une clé différente (`declaredSkillDetailsQueryKey + 'associations' + id`). L'ajout de cette deuxième invalidation dans le `Promise.all` résout le problème.

---

### Known Limitations or Side Effects
> Aucune.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [x] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and detaiils for the update process