### PR TITLE
feat(1390): add link field to trace form data

### DIFF
--- a/src/common/composables/use-form-validators/use-form-validators.test.ts
+++ b/src/common/composables/use-form-validators/use-form-validators.test.ts
@@ -18,7 +18,7 @@ BddTest().given('a form validators composable', () => {
       expect(composableResult.validateRequired).toBeDefined()
       expect(composableResult.validateMaxLength).toBeDefined()
       expect(composableResult.validateDateInterval).toBeDefined()
-      expect(composableResult.validateLinkFormat).toBeDefined()
+      expect(composableResult.validateLink).toBeDefined()
     })
   })
 
@@ -158,35 +158,35 @@ BddTest().given('a form validators composable', () => {
   BddTest().when('validating link format', () => {
     BddTest().and('the link is valid', () => {
       BddTest().then('it should return undefined', () => {
-        const error = composableResult.validateLinkFormat('https://example.com')
+        const error = composableResult.validateLink('https://example.com', true)
         expect(error).toBeUndefined()
       })
     })
 
     BddTest().and('the link is invalid', () => {
       BddTest().then('it should return invalid link error', () => {
-        const error = composableResult.validateLinkFormat('invalid-link')
+        const error = composableResult.validateLink('invalid-link', true)
         expect(error).toBe('Veuillez renseigner une URL valide (ex. : http://www.exemple.com)')
       })
     })
 
     BddTest().and('the link is empty', () => {
       BddTest().then('it should return undefined', () => {
-        const error = composableResult.validateLinkFormat('')
+        const error = composableResult.validateLink('')
         expect(error).toBeUndefined()
       })
     })
 
     BddTest().and('the link is undefined', () => {
       BddTest().then('it should return undefined', () => {
-        const error = composableResult.validateLinkFormat(undefined)
+        const error = composableResult.validateLink(undefined)
         expect(error).toBeUndefined()
       })
     })
 
     BddTest().and('the link is null', () => {
       BddTest().then('it should return undefined', () => {
-        const error = composableResult.validateLinkFormat(null)
+        const error = composableResult.validateLink(null)
         expect(error).toBeUndefined()
       })
     })

--- a/src/common/composables/use-form-validators/use-form-validators.ts
+++ b/src/common/composables/use-form-validators/use-form-validators.ts
@@ -21,7 +21,7 @@ export interface UseFormValidatorsReturn {
   /** Validates an interval where endDate can be null (ongoing). If endDate provided, it must be after startDate. */
   validateDateInterval: (args: validateDateIntervalArgs) => string | undefined
   /** Validates that a link is in a valid format */
-  validateLinkFormat: (link: string | undefined | null) => string | undefined
+  validateLink: (link: string | undefined | null, required?: boolean) => string | undefined
 }
 
 export interface ValidationOptions {
@@ -39,7 +39,7 @@ export interface ValidationOptions {
  *  - `validateRequired` (function) : returns an error message if the value is empty, undefined otherwise,
  *  - `validateMaxLength` (function) : returns an error message if the value exceeds the max length, undefined otherwise.
  *  - `validateDateInterval` (function) : returns an error message if the end date is before the start date in an ongoing interval, undefined otherwise.
- *  - `validateLinkFormat` (function) : returns an error message if the link is not in a valid format, undefined otherwise.
+ *  - `validateLink` (function) : returns an error message if the link is not in a valid format, undefined otherwise ; it also returns an error if the link is required and undefined or empty.
  */
 export function useFormValidators (): UseFormValidatorsReturn {
   const { t } = useI18n()
@@ -81,7 +81,12 @@ export function useFormValidators (): UseFormValidatorsReturn {
     }
   }
 
-  function validateLinkFormat (link: string | undefined | null): string | undefined {
+  function validateLink (link: string | undefined | null, required?: boolean): string | undefined {
+    if (required) {
+      if (!link?.trim()) {
+        return t('global.error.form.requiredField')
+      }
+    }
     if (link && !isValidLink(link)) {
       return t('global.error.form.invalidLink')
     }
@@ -91,7 +96,6 @@ export function useFormValidators (): UseFormValidatorsReturn {
     validateMaxLength,
     validateRequired,
     validateDateInterval,
-    validateLinkFormat
-
+    validateLink
   }
 }

--- a/src/features/student/personalCareer/composables/use-declared-experience-form-validators/use-declared-experience-form-validators.ts
+++ b/src/features/student/personalCareer/composables/use-declared-experience-form-validators/use-declared-experience-form-validators.ts
@@ -12,7 +12,7 @@ import {
 } from '@/features/student/personalCareer/config'
 
 export function useDeclaredExperienceFormValidators () {
-  const { validateRequired, validateMaxLength, validateDateInterval, validateLinkFormat } = useFormValidators()
+  const { validateRequired, validateMaxLength, validateDateInterval, validateLink } = useFormValidators()
 
   function validateTitle (title: DeclaredExperienceFormData['title']) {
     return validateRequired(title) ?? validateMaxLength(title, DECLARED_EXPERIENCE_TITLE_MAX_LENGTH)
@@ -47,7 +47,7 @@ export function useDeclaredExperienceFormValidators () {
   }
 
   function validateExternalLink (externalLink: DeclaredExperienceFormData['externalLink']) {
-    return validateMaxLength(externalLink, DECLARED_EXPERIENCE_EXTERNAL_LINK_MAX_LENGTH) ?? validateLinkFormat(externalLink)
+    return validateMaxLength(externalLink, DECLARED_EXPERIENCE_EXTERNAL_LINK_MAX_LENGTH) ?? validateLink(externalLink)
   }
 
   function validateStartDate (startDate: DeclaredExperienceFormData['startDate']) {

--- a/src/features/student/traces/components/interactions/formFields/TraceAiUsageToggleFormField/TraceAiUsageToggleFormField.vue
+++ b/src/features/student/traces/components/interactions/formFields/TraceAiUsageToggleFormField/TraceAiUsageToggleFormField.vue
@@ -35,7 +35,3 @@ function handleChange (value: boolean, fieldChange: (value: boolean) => void) {
     </template>
   </FormField>
 </template>
-
-<style scoped lang="scss">
-
-</style>

--- a/src/features/student/traces/components/interactions/formFields/TraceFileUploadFormField/TraceFileUploadFormField.vue
+++ b/src/features/student/traces/components/interactions/formFields/TraceFileUploadFormField/TraceFileUploadFormField.vue
@@ -42,7 +42,3 @@ function handleFilesChange (files: FileList) {
     </template>
   </FormField>
 </template>
-
-<style scoped lang="scss">
-
-</style>

--- a/src/features/student/traces/components/interactions/formFields/TraceGroupProductionToggleFormField/TraceGroupProductionToggleFormField.vue
+++ b/src/features/student/traces/components/interactions/formFields/TraceGroupProductionToggleFormField/TraceGroupProductionToggleFormField.vue
@@ -24,7 +24,3 @@ const FormField = markRaw(form.Field)
     </template>
   </FormField>
 </template>
-
-<style scoped lang="scss">
-
-</style>

--- a/src/features/student/traces/components/interactions/formFields/TraceLinkInputFormField/TraceLinkInputFormField.stub.ts
+++ b/src/features/student/traces/components/interactions/formFields/TraceLinkInputFormField/TraceLinkInputFormField.stub.ts
@@ -1,0 +1,6 @@
+export const TraceLinkInputFormFieldStub = defineComponent({
+  name: 'TraceLinkInputFormField',
+  template: `<div class="trace-link-input-form-field"/>`,
+  props: ['form'],
+  emits: ['update:modelValue', 'blur']
+})

--- a/src/features/student/traces/components/interactions/formFields/TraceLinkInputFormField/TraceLinkInputFormField.test.ts
+++ b/src/features/student/traces/components/interactions/formFields/TraceLinkInputFormField/TraceLinkInputFormField.test.ts
@@ -1,0 +1,209 @@
+import type { CreateTraceForm } from '@/features/student/traces'
+import TraceLinkInputFormField from '@/features/student/traces/components/interactions/formFields/TraceLinkInputFormField/TraceLinkInputFormField.vue'
+import { TraceLinkInputStub } from '@/features/student/traces/components/interactions/inputs/TraceLinkInput/TraceLinkInput.stub'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { useForm } from '@tanstack/vue-form'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { beforeEach, expect, vi } from 'vitest'
+
+const TestWrapper = {
+  components: {
+    TraceLinkInputFormField
+  },
+  setup () {
+    const form = useForm({
+      defaultValues: {
+        link: ''
+      },
+      validators: {
+        onSubmit () {
+          return {
+            fields: {
+              link: undefined
+            }
+          }
+        }
+      }
+    }) as unknown as CreateTraceForm
+
+    return { form }
+  },
+  template: `
+    <form @submit.prevent="form.handleSubmit">
+      <TraceLinkInputFormField :form="form" />
+    </form>
+  `
+}
+
+BddTest().given('a trace link input form field component', () => {
+  let wrapper: VueWrapper
+
+  const stubs = { TraceLinkInput: TraceLinkInputStub }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    wrapper = mount(TestWrapper, {
+      global: {
+        stubs
+      }
+    })
+  })
+
+  BddTest().when('the component is mounted', () => {
+    BddTest().then('it should render the trace link input', () => {
+      const input = wrapper.findComponent({ name: 'TraceLinkInput' })
+      expect(input.exists()).toBe(true)
+    })
+
+    BddTest().then('it should have the correct id', () => {
+      const input = wrapper.findComponent({ name: 'TraceLinkInput' })
+      expect(input.props('id')).toBe('trace-link')
+    })
+
+    BddTest().then('it should have required attribute', () => {
+      const input = wrapper.findComponent({ name: 'TraceLinkInput' })
+      const inputElement = input.find('input[type="text"]')
+      expect(inputElement.attributes('required')).toBeDefined()
+    })
+
+    BddTest().then('it should have empty initial value', () => {
+      const input = wrapper.findComponent({ name: 'TraceLinkInput' })
+      expect(input.props('modelValue')).toBe('')
+    })
+  })
+
+  BddTest().when('the user types in the input', () => {
+    BddTest().then('it should update the form field value', async () => {
+      const input = wrapper.findComponent({ name: 'TraceLinkInput' })
+      const inputElement = input.find('input[type="text"]')
+
+      await inputElement.setValue('My trace name')
+      await wrapper.vm.$nextTick()
+
+      await vi.waitFor(() => {
+        const updatedInput = wrapper.findComponent({ name: 'TraceLinkInput' })
+        expect(updatedInput.props('modelValue')).toBe('My trace name')
+      })
+    })
+  })
+
+  BddTest().when('the user blurs the input', () => {
+    BddTest().then('it should trigger blur handler', async () => {
+      const input = wrapper.findComponent({ name: 'TraceLinkInput' })
+      const inputElement = input.find('input[type="text"]')
+
+      await inputElement.trigger('blur')
+      await wrapper.vm.$nextTick()
+
+      expect(input.emitted('blur')).toBeTruthy()
+    })
+  })
+
+  BddTest().when('the form is submitted with empty value', () => {
+    BddTest().then('it should not show validation error', async () => {
+      await wrapper.find('form').trigger('submit')
+      await wrapper.vm.$nextTick()
+
+      await vi.waitFor(() => {
+        const input = wrapper.findComponent({ name: 'TraceLinkInput' })
+        expect(input.props('errorMessage')).toBeFalsy()
+      })
+    })
+
+    BddTest().then('it should display error message in the DOM', async () => {
+      await wrapper.find('form').trigger('submit')
+      await wrapper.vm.$nextTick()
+
+      await vi.waitFor(() => {
+        const errorElement = wrapper.find('.error')
+        expect(errorElement.exists()).toBe(false)
+      })
+    })
+  })
+
+  BddTest().when('the user enters only whitespace', () => {
+    BddTest().then('it should show validation error on submit', async () => {
+      const input = wrapper.findComponent({ name: 'TraceLinkInput' })
+      const inputElement = input.find('input[type="text"]')
+
+      await inputElement.setValue('   ')
+      await inputElement.trigger('blur')
+      await wrapper.vm.$nextTick()
+
+      await wrapper.find('form').trigger('submit')
+      await wrapper.vm.$nextTick()
+
+      await vi.waitFor(() => {
+        const updatedInput = wrapper.findComponent({ name: 'TraceLinkInput' })
+        expect(updatedInput.props('errorMessage')).toBeTruthy()
+      })
+    })
+  })
+
+  BddTest().when('the user enters an empty URL', () => {
+    BddTest().then('it should not show validation error', async () => {
+      const input = wrapper.findComponent({ name: 'TraceLinkInput' })
+      const inputElement = input.find('input[type="text"]')
+
+      await inputElement.setValue('')
+      await inputElement.trigger('blur')
+      await wrapper.vm.$nextTick()
+
+      await vi.waitFor(() => {
+        const updatedInput = wrapper.findComponent({ name: 'TraceLinkInput' })
+        expect(updatedInput.props('errorMessage')).toBeFalsy()
+      })
+    })
+  })
+
+  BddTest().when('the user types a non-string value', () => {
+    BddTest().then('it should not update the form field value', async () => {
+      const input = wrapper.findComponent({ name: 'TraceLinkInput' })
+
+      await input.vm.$emit('update:modelValue', 123)
+      await wrapper.vm.$nextTick()
+
+      const updatedInput = wrapper.findComponent({ name: 'TraceLinkInput' })
+      expect(updatedInput.props('modelValue')).toBe('')
+    })
+  })
+
+  BddTest().when('the user enters an invalid URL', () => {
+    BddTest().then('it should show validation error', async () => {
+      const input = wrapper.findComponent({ name: 'TraceLinkInput' })
+      const inputElement = input.find('input[type="text"]')
+
+      await inputElement.setValue('pas-une-url')
+      await inputElement.trigger('blur')
+      await wrapper.vm.$nextTick()
+
+      await wrapper.find('form').trigger('submit')
+      await wrapper.vm.$nextTick()
+
+      await vi.waitFor(() => {
+        const updatedInput = wrapper.findComponent({ name: 'TraceLinkInput' })
+        expect(updatedInput.props('errorMessage')).toBeTruthy()
+      })
+    })
+  })
+
+  BddTest().when('the user enters a valid URL', () => {
+    BddTest().then('it should not show validation error', async () => {
+      const input = wrapper.findComponent({ name: 'TraceLinkInput' })
+      const inputElement = input.find('input[type="text"]')
+
+      await inputElement.setValue('https://www.google.com')
+      await inputElement.trigger('blur')
+      await wrapper.vm.$nextTick()
+
+      await wrapper.find('form').trigger('submit')
+      await wrapper.vm.$nextTick()
+
+      await vi.waitFor(() => {
+        const updatedInput = wrapper.findComponent({ name: 'TraceLinkInput' })
+        expect(updatedInput.props('errorMessage')).toBeFalsy()
+      })
+    })
+  })
+})

--- a/src/features/student/traces/components/interactions/formFields/TraceLinkInputFormField/TraceLinkInputFormField.vue
+++ b/src/features/student/traces/components/interactions/formFields/TraceLinkInputFormField/TraceLinkInputFormField.vue
@@ -1,22 +1,29 @@
 <script setup lang="ts">
 import type { CreateTraceForm, UpdateTraceForm } from '@/features/student/traces/types/forms.types'
-import TraceNameInput from '@/features/student/traces/components/interactions/inputs/TraceNameInput/TraceNameInput.vue'
+import { useFormValidators } from '@/common/composables/use-form-validators/use-form-validators'
+import TraceLinkInput from '@/features/student/traces/components/interactions/inputs/TraceLinkInput/TraceLinkInput.vue'
 import { markRaw } from 'vue'
 
-interface TraceNameInputFormFieldProps {
+interface TraceLinkInputFormFieldProps {
   form: CreateTraceForm | UpdateTraceForm
 }
 
-const { form } = defineProps<TraceNameInputFormFieldProps>()
+const { form } = defineProps<TraceLinkInputFormFieldProps>()
+const { validateLink } = useFormValidators()
 const FormField = markRaw(form.Field)
 </script>
 
 <template>
-  <FormField name="traceName">
+  <FormField
+    name="link"
+    :validators="{
+      onBlur: ({ value }) => validateLink(value),
+    }"
+  >
     <template #default="{ field }">
-      <TraceNameInput
+      <TraceLinkInput
         v-bind="$attrs"
-        id="trace-name"
+        id="trace-link"
         v-model="field.state.value"
         :error-message="field.state.meta.errors?.join(', ')"
         required

--- a/src/features/student/traces/components/interactions/inputs/TraceLinkInput/TraceLinkInput.stub.ts
+++ b/src/features/student/traces/components/interactions/inputs/TraceLinkInput/TraceLinkInput.stub.ts
@@ -1,0 +1,6 @@
+export const TraceLinkInputStub = defineComponent({
+  name: 'TraceLinkInput',
+  props: ['id', 'modelValue', 'errorMessage', 'required'],
+  emits: ['update:modelValue', 'blur'],
+  template: '<div><input type="text" :id="id" :value="modelValue" :required="required" @input="$emit(\'update:modelValue\', $event.target.value)" @blur="$emit(\'blur\')" /><span v-if="errorMessage" class="error">{{ errorMessage }}</span></div>'
+})

--- a/src/features/student/traces/components/interactions/inputs/TraceLinkInput/TraceLinkInput.test.ts
+++ b/src/features/student/traces/components/interactions/inputs/TraceLinkInput/TraceLinkInput.test.ts
@@ -1,0 +1,196 @@
+import TraceLinkInput from '@/features/student/traces/components/interactions/inputs/TraceLinkInput/TraceLinkInput.vue'
+import { MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
+import { AvInputStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { beforeEach, expect } from 'vitest'
+
+const stubs = {
+  AvInput: AvInputStub
+}
+
+BddTest().given('a trace link input component', () => {
+  let wrapper: VueWrapper<InstanceType<typeof TraceLinkInput>>
+
+  beforeEach(() => {
+    wrapper = mount(TraceLinkInput, {
+      global: { stubs }
+    })
+  })
+
+  BddTest().when('the component is mounted', () => {
+    BddTest().then('it should render AvInput with default props', () => {
+      const input = wrapper.findComponent({ name: 'AvInput' })
+
+      expect(input.exists()).toBe(true)
+      expect(input.props('label')).toBe('Ajouter un lien')
+      expect(input.props('placeholder')).toBe('Ajouter un lien...')
+      expect(input.props('prefixIcon')).toBe(MDI_ICONS.LINK)
+      expect(input.props('isTextarea')).toBe(false)
+      expect(input.props('labelVisible')).toBe(true)
+      expect(input.props('disabled')).toBe(false)
+      expect(input.props('required')).toBe(true)
+    })
+  })
+
+  BddTest().when('custom label is provided', () => {
+    BddTest().then('it should use the custom label', () => {
+      wrapper = mount(TraceLinkInput, {
+        props: {
+          label: 'Custom Label'
+        },
+        global: { stubs }
+      })
+
+      const input = wrapper.findComponent({ name: 'AvInput' })
+
+      expect(input.props('label')).toBe('Custom Label')
+    })
+  })
+
+  BddTest().when('custom placeholder is provided', () => {
+    BddTest().then('it should use the custom placeholder', () => {
+      wrapper = mount(TraceLinkInput, {
+        props: {
+          placeholder: 'Custom placeholder text'
+        },
+        global: { stubs }
+      })
+
+      const input = wrapper.findComponent({ name: 'AvInput' })
+
+      expect(input.props('placeholder')).toBe('Custom placeholder text')
+    })
+  })
+
+  BddTest().when('custom prefixIcon is provided', () => {
+    BddTest().then('it should use the custom prefixIcon', () => {
+      wrapper = mount(TraceLinkInput, {
+        props: {
+          prefixIcon: MDI_ICONS.ACCOUNT_CIRCLE_OUTLINE
+        },
+        global: { stubs }
+      })
+
+      const input = wrapper.findComponent({ name: 'AvInput' })
+
+      expect(input.props('prefixIcon')).toBe(MDI_ICONS.ACCOUNT_CIRCLE_OUTLINE)
+    })
+  })
+
+  BddTest().when('the component is disabled', () => {
+    BddTest().then('it should pass disabled state to AvInput', () => {
+      wrapper = mount(TraceLinkInput, {
+        props: {
+          disabled: true
+        },
+        global: { stubs }
+      })
+
+      const input = wrapper.findComponent({ name: 'AvInput' })
+
+      expect(input.props('disabled')).toBe(true)
+    })
+  })
+
+  BddTest().when('required is true', () => {
+    BddTest().then('it should pass required state to AvInput', () => {
+      wrapper = mount(TraceLinkInput, {
+        props: {
+          required: false
+        },
+        global: { stubs }
+      })
+
+      const input = wrapper.findComponent({ name: 'AvInput' })
+
+      expect(input.props('required')).toBe(false)
+    })
+  })
+
+  BddTest().when('labelVisible is false', () => {
+    BddTest().then('it should hide the label', () => {
+      wrapper = mount(TraceLinkInput, {
+        props: {
+          labelVisible: false
+        },
+        global: { stubs }
+      })
+
+      const input = wrapper.findComponent({ name: 'AvInput' })
+
+      expect(input.props('labelVisible')).toBe(false)
+    })
+  })
+
+  BddTest().when('isValid is true', () => {
+    BddTest().then('it should pass valid state to AvInput', () => {
+      wrapper = mount(TraceLinkInput, {
+        props: {
+          isValid: true
+        },
+        global: { stubs }
+      })
+
+      const input = wrapper.findComponent({ name: 'AvInput' })
+
+      expect(input.props('isValid')).toBe(true)
+    })
+  })
+
+  BddTest().when('text is entered', () => {
+    BddTest().then('it should update the model value', async () => {
+      const input = wrapper.findComponent({ name: 'AvInput' })
+      await input.vm.$emit('update:modelValue', 'My trace name')
+      await wrapper.vm.$nextTick()
+
+      expect(wrapper.emitted('update:modelValue')?.[0]).toEqual(['My trace name'])
+    })
+  })
+
+  BddTest().when('a value is provided via v-model', () => {
+    BddTest().then('it should pass the value to AvInput', () => {
+      const testValue = 'Test trace name'
+
+      wrapper = mount(TraceLinkInput, {
+        props: {
+          modelValue: testValue
+        },
+        global: { stubs }
+      })
+
+      const input = wrapper.findComponent({ name: 'AvInput' })
+
+      expect(input.props('modelValue')).toBe(testValue)
+    })
+  })
+
+  BddTest().when('errorMessage is provided', () => {
+    BddTest().then('it should pass the error message to AvInput', () => {
+      wrapper = mount(TraceLinkInput, {
+        props: {
+          errorMessage: 'Lien invalide'
+        },
+        global: { stubs }
+      })
+
+      const input = wrapper.findComponent({ name: 'AvInput' })
+
+      expect(input.props('errorMessage')).toBe('Lien invalide')
+    })
+  })
+
+  BddTest().when('isTextarea is true', () => {
+    BddTest().then('it should pass textarea state to AvInput', () => {
+      wrapper = mount(TraceLinkInput, {
+        props: {
+          isTextarea: true
+        },
+        global: { stubs }
+      })
+
+      const input = wrapper.findComponent({ name: 'AvInput' })
+
+      expect(input.props('isTextarea')).toBe(true)
+    })
+  })
+})

--- a/src/features/student/traces/components/interactions/inputs/TraceLinkInput/TraceLinkInput.vue
+++ b/src/features/student/traces/components/interactions/inputs/TraceLinkInput/TraceLinkInput.vue
@@ -1,0 +1,47 @@
+<script setup lang="ts">
+import { AvInput, type AvInputProps, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
+import { useAttrs } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+interface TraceLinkInputProps extends Omit<AvInputProps, 'label' | 'prefixIcon' | 'placeholder' | 'modelValue'> {
+  label?: string
+  prefixIcon?: string
+  placeholder?: string
+}
+
+const {
+  isValid = false,
+  isTextarea = false,
+  labelVisible = true,
+  disabled = false,
+  required = true,
+  label,
+  prefixIcon,
+  placeholder,
+  errorMessage,
+} = defineProps<TraceLinkInputProps>()
+
+const modelValue = defineModel<string>()
+const { t } = useI18n()
+const attr = useAttrs()
+
+const avInputProps = computed(() => ({
+  ...attr,
+  isValid,
+  isTextarea,
+  labelVisible,
+  disabled,
+  required,
+  errorMessage,
+  label: label ?? t('student.traces.interactions.inputs.TraceLinkInput.label'),
+  prefixIcon: prefixIcon ?? MDI_ICONS.LINK,
+  placeholder: placeholder ?? t('student.traces.interactions.inputs.TraceLinkInput.placeholder')
+}))
+</script>
+
+<template>
+  <AvInput
+    v-bind="avInputProps"
+    v-model="modelValue"
+  />
+</template>

--- a/src/features/student/traces/locales/en.json
+++ b/src/features/student/traces/locales/en.json
@@ -38,6 +38,10 @@
             "label": "AI usage justification",
             "placeholder": "Describe how and why you used AI..."
           },
+          "TraceLinkInput": {
+            "label": "Add a link",
+            "placeholder": "Add a link..."
+          },
           "TraceNameInput": {
             "label": "My trace name",
             "placeholder": "My-trace-name-01"

--- a/src/features/student/traces/locales/fr.json
+++ b/src/features/student/traces/locales/fr.json
@@ -38,6 +38,10 @@
             "label": "Justification de l'usage de l'IA",
             "placeholder": "Décrivez comment et pourquoi vous avez utilisé l'IA..."
           },
+          "TraceLinkInput": {
+            "label": "Ajouter un lien",
+            "placeholder": "Ajouter un lien..."
+          },
           "TraceNameInput": {
             "label": "Nom de ma trace",
             "placeholder": "Nom-de-ma-trace-01"

--- a/src/features/student/traces/types/traces.types.ts
+++ b/src/features/student/traces/types/traces.types.ts
@@ -1,5 +1,10 @@
 import type { IdTitle } from '@/types'
 
+export enum TraceType {
+  FILE = 'FILE',
+  LINK = 'LINK'
+}
+
 export enum EAssociationTypeKey {
   DECLARED_SKILLS = 'declaredSkills',
   ACTIVITIES = 'activities'
@@ -15,8 +20,8 @@ export interface AssociateElementTypeConfig {
   searchPlaceholder: string
 }
 
-export interface TraceFormData {
-  file: File | null
+interface TraceFormDataBase {
+  traceType: TraceType
   traceName: string
   personalNote?: string
   isAuthentic: boolean
@@ -25,3 +30,15 @@ export interface TraceFormData {
   iaJustification?: string
   associationSelections?: Record<string, IdTitle[]>
 }
+
+export interface TraceFormDataFile extends TraceFormDataBase {
+  traceType: TraceType.FILE
+  file: File | null
+}
+
+export interface TraceFormDataLink extends TraceFormDataBase {
+  traceType: TraceType.LINK
+  link: string
+}
+
+export type TraceFormData = TraceFormDataFile | TraceFormDataLink

--- a/src/features/student/traces/utils/trace.types-guard.test.ts
+++ b/src/features/student/traces/utils/trace.types-guard.test.ts
@@ -1,0 +1,43 @@
+import { type TraceFormDataFile, type TraceFormDataLink, TraceType } from '@/features/student/traces/types/traces.types'
+import { isTraceFileType, isTraceLinkType } from '@/features/student/traces/utils/trace.types-guard'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+
+BddTest().given('trace form data type guards', () => {
+  BddTest().when('the trace type is FILE', () => {
+    const fileTrace: TraceFormDataFile = {
+      traceType: TraceType.FILE,
+      file: null,
+      traceName: 'my-trace',
+      isAuthentic: true,
+      isGroup: false,
+      useIA: false,
+    }
+
+    BddTest().then('isTraceFileType should return true', () => {
+      expect(isTraceFileType(fileTrace)).toBe(true)
+    })
+
+    BddTest().then('isTraceLinkType should return false', () => {
+      expect(isTraceLinkType(fileTrace)).toBe(false)
+    })
+  })
+
+  BddTest().when('the trace type is LINK', () => {
+    const linkTrace: TraceFormDataLink = {
+      traceType: TraceType.LINK,
+      link: 'https://www.google.com',
+      traceName: 'my-trace',
+      isAuthentic: true,
+      isGroup: false,
+      useIA: false,
+    }
+
+    BddTest().then('isTraceFileType should return false', () => {
+      expect(isTraceFileType(linkTrace)).toBe(false)
+    })
+
+    BddTest().then('isTraceLinkType should return true', () => {
+      expect(isTraceLinkType(linkTrace)).toBe(true)
+    })
+  })
+})

--- a/src/features/student/traces/utils/trace.types-guard.ts
+++ b/src/features/student/traces/utils/trace.types-guard.ts
@@ -1,0 +1,10 @@
+import type { TraceFormData, TraceFormDataFile, TraceFormDataLink } from '@/features/student/traces/types/traces.types'
+import { TraceType } from '@/features/student/traces/types/traces.types'
+
+export function isTraceFileType (trace: TraceFormData): trace is TraceFormDataFile {
+  return trace.traceType === TraceType.FILE
+}
+
+export function isTraceLinkType (trace: TraceFormData): trace is TraceFormDataLink {
+  return trace.traceType === TraceType.LINK
+}

--- a/src/features/student/traces/views/StudentToolsTracesView/components/StudentToolsTracesAddTraceDrawer/components/CreateTraceFormDeclarationItems/CreateTraceFormDeclarationItems.test.ts
+++ b/src/features/student/traces/views/StudentToolsTracesView/components/StudentToolsTracesAddTraceDrawer/components/CreateTraceFormDeclarationItems/CreateTraceFormDeclarationItems.test.ts
@@ -1,5 +1,6 @@
 import type { TraceFormData } from '@/features/student/traces'
 import { ToggleStub } from '@/common/components/Toggle/Toggle.stub'
+import { isTraceFileType } from '@/features/student/traces/utils/trace.types-guard'
 import CreateTraceFormDeclarationItems from '@/features/student/traces/views/StudentToolsTracesView/components/StudentToolsTracesAddTraceDrawer/components/CreateTraceFormDeclarationItems/CreateTraceFormDeclarationItems.vue'
 import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { useForm } from '@tanstack/vue-form'
@@ -25,7 +26,7 @@ const TestWrapper = {
         onSubmit ({ value }) {
           return {
             fields: {
-              file: !value.file ? 'Required field' : undefined,
+              file: isTraceFileType(value) && !value.file ? 'Required field' : undefined,
               traceName: !value.traceName.trim() ? 'Required field' : undefined,
               isAuthentic: !value.isAuthentic ? 'Required field' : undefined,
               iaJustification: value.useIA && (!value.iaJustification || !value.iaJustification.trim()) ? 'Required field' : undefined,

--- a/src/features/student/traces/views/StudentToolsTracesView/components/StudentToolsTracesAddTraceDrawer/components/CreateTraceFormTraceDefinitionItems/CreateTraceFormTraceDefinitionItems.test.ts
+++ b/src/features/student/traces/views/StudentToolsTracesView/components/StudentToolsTracesAddTraceDrawer/components/CreateTraceFormTraceDefinitionItems/CreateTraceFormTraceDefinitionItems.test.ts
@@ -1,5 +1,9 @@
 import type { TraceFormData } from '@/features/student/traces'
+import { TraceLinkInputFormFieldStub } from '@/features/student/traces/components/interactions/formFields/TraceLinkInputFormField/TraceLinkInputFormField.stub'
+import { TraceType } from '@/features/student/traces/types/traces.types'
+import { isTraceFileType, isTraceLinkType } from '@/features/student/traces/utils/trace.types-guard'
 import CreateTraceFormTraceDefinitionItems from '@/features/student/traces/views/StudentToolsTracesView/components/StudentToolsTracesAddTraceDrawer/components/CreateTraceFormTraceDefinitionItems/CreateTraceFormTraceDefinitionItems.vue'
+import { TraceTypeSelectStub } from '@/features/student/traces/views/StudentToolsTracesView/components/StudentToolsTracesAddTraceDrawer/components/TraceTypeSelect/TraceTypeSelect.stub'
 import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { useForm } from '@tanstack/vue-form'
 import { mount, type VueWrapper } from '@vue/test-utils'
@@ -12,6 +16,7 @@ const TestWrapper = {
     const form = useForm({
       defaultValues: {
         file: null,
+        traceType: TraceType.FILE,
         traceName: '',
         personalNote: ''
       } as TraceFormData,
@@ -19,7 +24,8 @@ const TestWrapper = {
         onSubmit ({ value }) {
           return {
             fields: {
-              file: !value.file ? 'Required field' : undefined,
+              file: isTraceFileType(value) && !value.file ? 'Required field' : undefined,
+              link: isTraceLinkType(value) && !value.link ? 'Required field' : undefined,
               traceName: !value.traceName.trim() ? 'Required field' : undefined,
             }
           }
@@ -36,6 +42,8 @@ const TestWrapper = {
 }
 
 const stubs = {
+  TraceTypeSelect: TraceTypeSelectStub,
+  TraceLinkInputFormField: TraceLinkInputFormFieldStub,
   TraceFileUpload: {
     name: 'TraceFileUpload',
     props: ['id', 'modelValue', 'accept', 'ariaLabel', 'error', 'validMessage'],
@@ -70,6 +78,18 @@ BddTest().given('a create trace form trace definition items component', () => {
   })
 
   BddTest().when('the component is mounted', () => {
+    BddTest().then('it should render TraceTypeSelect', () => {
+      const traceTypeSelect = wrapper.findComponent({ name: 'TraceTypeSelect' })
+      expect(traceTypeSelect.exists()).toBe(true)
+    })
+
+    BddTest().then('it should render TraceFileUpload by default and not TraceLinkInputFormField', () => {
+      const fileUpload = wrapper.findComponent({ name: 'TraceFileUpload' })
+      const linkInput = wrapper.findComponent({ name: 'TraceLinkInputFormField' })
+      expect(fileUpload.exists()).toBe(true)
+      expect(linkInput.exists()).toBe(false)
+    })
+
     BddTest().then('it should render the form fields container', () => {
       const container = wrapper.find('[data-testid="form-fields-container"]')
       expect(container.exists()).toBe(true)
@@ -95,6 +115,23 @@ BddTest().given('a create trace form trace definition items component', () => {
 
       expect(personalNoteInput.exists()).toBe(true)
       expect(personalNoteInput.props('id')).toBe('personal-note')
+    })
+  })
+
+  BddTest().when('the trace type is LINK', () => {
+    BddTest().then('it should render TraceLinkInputFormField and not render TraceFileUpload', async () => {
+      const linkInputBefore = wrapper.findComponent({ name: 'TraceLinkInputFormField' })
+      expect(linkInputBefore.exists()).toBe(false)
+
+      const traceTypeSelect = wrapper.findComponent({ name: 'TraceTypeSelect' })
+      await traceTypeSelect.vm.$emit('update:traceType', { itemId: 'link' })
+      await wrapper.vm.$nextTick()
+
+      const linkInputAfter = wrapper.findComponent({ name: 'TraceLinkInputFormField' })
+      expect(linkInputAfter.exists()).toBe(true)
+
+      const fileUpload = wrapper.findComponent({ name: 'TraceFileUpload' })
+      expect(fileUpload.exists()).toBe(false)
     })
   })
 

--- a/src/features/student/traces/views/StudentToolsTracesView/components/StudentToolsTracesAddTraceDrawer/components/CreateTraceFormTraceDefinitionItems/CreateTraceFormTraceDefinitionItems.vue
+++ b/src/features/student/traces/views/StudentToolsTracesView/components/StudentToolsTracesAddTraceDrawer/components/CreateTraceFormTraceDefinitionItems/CreateTraceFormTraceDefinitionItems.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
 import type { CreateTraceForm } from '@/features/student/traces/types/forms.types'
 import TraceFileUploadFormField from '@/features/student/traces/components/interactions/formFields/TraceFileUploadFormField/TraceFileUploadFormField.vue'
+import TraceLinkInputFormField from '@/features/student/traces/components/interactions/formFields/TraceLinkInputFormField/TraceLinkInputFormField.vue'
 import TraceNameInputFormField from '@/features/student/traces/components/interactions/formFields/TraceNameInputFormField/TraceNameInputFormField.vue'
 import TracePersonalNoteTextareaFormField from '@/features/student/traces/components/interactions/formFields/TracePersonalNoteTextareaFormField/TracePersonalNoteTextareaFormField.vue'
+import { TraceType } from '@/features/student/traces/types/traces.types'
 import TraceTypeSelect from '@/features/student/traces/views/StudentToolsTracesView/components/StudentToolsTracesAddTraceDrawer/components/TraceTypeSelect/TraceTypeSelect.vue'
-import { TraceType } from '@/features/student/traces/views/StudentToolsTracesView/components/StudentToolsTracesAddTraceDrawer/types/trace-type.types'
 
 interface CreateTraceFormTraceDefinitionItemsProps {
   form: CreateTraceForm
@@ -13,6 +14,10 @@ interface CreateTraceFormTraceDefinitionItemsProps {
 const { form } = defineProps<CreateTraceFormTraceDefinitionItemsProps>()
 
 const selectedTraceType = ref({ itemId: TraceType.FILE })
+
+watch(selectedTraceType, (newType) => {
+  form.setFieldValue('traceType', newType.itemId)
+})
 </script>
 
 <template>
@@ -34,7 +39,7 @@ const selectedTraceType = ref({ itemId: TraceType.FILE })
         v-else
         class="av-col"
       >
-        <h5>Link Trace Task #1390</h5>
+        <TraceLinkInputFormField :form="form" />
       </div>
 
       <div class="av-col">

--- a/src/features/student/traces/views/StudentToolsTracesView/components/StudentToolsTracesAddTraceDrawer/components/TraceTypeSelect/TraceTypeSelect.test.ts
+++ b/src/features/student/traces/views/StudentToolsTracesView/components/StudentToolsTracesAddTraceDrawer/components/TraceTypeSelect/TraceTypeSelect.test.ts
@@ -1,5 +1,5 @@
+import { TraceType } from '@/features/student/traces/types/traces.types'
 import TraceTypeSelect from '@/features/student/traces/views/StudentToolsTracesView/components/StudentToolsTracesAddTraceDrawer/components/TraceTypeSelect/TraceTypeSelect.vue'
-import { TraceType } from '@/features/student/traces/views/StudentToolsTracesView/components/StudentToolsTracesAddTraceDrawer/types'
 import { AvSelectStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { mount, type VueWrapper } from '@vue/test-utils'
 import { beforeEach, expect } from 'vitest'

--- a/src/features/student/traces/views/StudentToolsTracesView/components/StudentToolsTracesAddTraceDrawer/components/TraceTypeSelect/TraceTypeSelect.vue
+++ b/src/features/student/traces/views/StudentToolsTracesView/components/StudentToolsTracesAddTraceDrawer/components/TraceTypeSelect/TraceTypeSelect.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { TraceType } from '@/features/student/traces/views/StudentToolsTracesView/components/StudentToolsTracesAddTraceDrawer/types'
+import { TraceType } from '@/features/student/traces/types/traces.types'
 import { AvSelect } from '@avenirs-esr/avenirs-dsav'
 import { useI18n } from 'vue-i18n'
 

--- a/src/features/student/traces/views/StudentToolsTracesView/components/StudentToolsTracesAddTraceDrawer/types/index.ts
+++ b/src/features/student/traces/views/StudentToolsTracesView/components/StudentToolsTracesAddTraceDrawer/types/index.ts
@@ -1,1 +1,0 @@
-export * from './trace-type.types'

--- a/src/features/student/traces/views/StudentToolsTracesView/components/StudentToolsTracesAddTraceDrawer/types/trace-type.types.ts
+++ b/src/features/student/traces/views/StudentToolsTracesView/components/StudentToolsTracesAddTraceDrawer/types/trace-type.types.ts
@@ -1,4 +1,0 @@
-export enum TraceType {
-  FILE = 'file',
-  LINK = 'link'
-}

--- a/src/features/student/traces/views/StudentToolsTracesView/components/StudentToolsTracesAddTraceDrawer/use-create-tarce-form/use-create-trace-form.test.ts
+++ b/src/features/student/traces/views/StudentToolsTracesView/components/StudentToolsTracesAddTraceDrawer/use-create-tarce-form/use-create-trace-form.test.ts
@@ -6,7 +6,7 @@ import {
   type UploadAttachmentBody
 } from '@/api/avenir-esr'
 import * as avenirEsrApi from '@/api/avenir-esr'
-import { EAssociationTypeKey, type TraceFormData } from '@/features/student/traces/types/traces.types'
+import { EAssociationTypeKey, type TraceFormData, TraceType } from '@/features/student/traces/types/traces.types'
 import { useCreateTraceForm } from '@/features/student/traces/views/StudentToolsTracesView/components/StudentToolsTracesAddTraceDrawer/use-create-tarce-form/use-create-trace-form'
 import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { waitFor } from 'storybook/test'
@@ -52,8 +52,9 @@ BddTest().given('the useCreateTraceForm composable', () => {
 
   BddTest().when('form is validated with invalid data', () => {
     BddTest().then('it should return validation errors', () => {
-      const invalidData = {
+      const invalidData: TraceFormData = {
         file: null as unknown as File,
+        traceType: TraceType.FILE,
         traceName: '',
         personalNote: '',
         isAuthentic: false,
@@ -76,8 +77,9 @@ BddTest().given('the useCreateTraceForm composable', () => {
   BddTest().when('form is validated with valid data', () => {
     BddTest().then('it should return no validation errors', () => {
       const mockFile = new File(['test content'], 'test.pdf', { type: 'application/pdf' })
-      const validData = {
+      const validData: TraceFormData = {
         file: mockFile,
+        traceType: TraceType.FILE,
         traceName: 'My Trace Name',
         personalNote: 'Optional note',
         isAuthentic: true,
@@ -103,8 +105,9 @@ BddTest().given('the useCreateTraceForm composable', () => {
     })
 
     BddTest().then('it should validate form before submission', () => {
-      const validFormData = {
+      const validFormData: TraceFormData = {
         file: new File(['test'], 'test.pdf', { type: 'application/pdf' }),
+        traceType: TraceType.FILE,
         traceName: 'My Trace Name',
         personalNote: 'Optional note',
         isAuthentic: true,
@@ -120,8 +123,9 @@ BddTest().given('the useCreateTraceForm composable', () => {
     })
 
     BddTest().then('it should validate required fields before submission', () => {
-      const invalidFormData = {
+      const invalidFormData: TraceFormData = {
         file: null,
+        traceType: TraceType.FILE,
         traceName: '',
         personalNote: 'Optional note',
         isAuthentic: false,
@@ -141,8 +145,9 @@ BddTest().given('the useCreateTraceForm composable', () => {
 
     BddTest().then('it should call both createTrace and uploadAttachment APIs when file is provided', async () => {
       const mockFile = new File(['text content'], 'test.txt', { type: 'text/plain' })
-      const formData = {
+      const formData: TraceFormData = {
         file: mockFile,
+        traceType: TraceType.FILE,
         traceName: 'my-trace-name',
         personalNote: 'Optional note',
         isAuthentic: true,
@@ -171,8 +176,9 @@ BddTest().given('the useCreateTraceForm composable', () => {
     })
 
     BddTest().then('it should handle form submission without personalNote', async () => {
-      const formData = {
+      const formData: TraceFormData = {
         file: null,
+        traceType: TraceType.FILE,
         traceName: 'my-trace-name',
         personalNote: '',
         isAuthentic: true,
@@ -195,8 +201,9 @@ BddTest().given('the useCreateTraceForm composable', () => {
     })
 
     BddTest().then('it should handle form submission with IA usage and justification', async () => {
-      const formData = {
+      const formData: TraceFormData = {
         file: null,
+        traceType: TraceType.FILE,
         traceName: 'my-trace-name',
         personalNote: '',
         isAuthentic: true,
@@ -219,8 +226,9 @@ BddTest().given('the useCreateTraceForm composable', () => {
     })
 
     BddTest().then('it should validate IA justification when IA is enabled', () => {
-      const formDataWithoutJustification = {
+      const formDataWithoutJustification: TraceFormData = {
         file: new File(['test'], 'test.pdf', { type: 'application/pdf' }),
+        traceType: TraceType.FILE,
         traceName: 'my-trace-name',
         personalNote: '',
         isAuthentic: true,
@@ -235,12 +243,76 @@ BddTest().given('the useCreateTraceForm composable', () => {
       const validationResult = onSubmitValidator!({ value: formDataWithoutJustification })
       expect(validationResult?.fields?.iaJustification).toEqual('Ce champ est requis.')
     })
+
+    BddTest().then('it should require link when traceType is LINK and link is empty', () => {
+      const formData: TraceFormData = {
+        link: '',
+        traceType: TraceType.LINK,
+        traceName: 'my-trace-name',
+        personalNote: '',
+        isAuthentic: true,
+        isGroup: false,
+        useIA: false,
+        iaJustification: ''
+      }
+
+      const onSubmitValidator = composableResult.form.options.validators?.onSubmit
+      const validationResult = onSubmitValidator!({ value: formData })
+
+      expect(validationResult?.fields?.link).toEqual('Ce champ est requis.')
+    })
+
+    BddTest().then('it should not require link when traceType is FILE', () => {
+      const formData: TraceFormData = {
+        file: null,
+        traceType: TraceType.FILE,
+        traceName: 'my-trace-name',
+        personalNote: '',
+        isAuthentic: true,
+        isGroup: false,
+        useIA: false,
+        iaJustification: ''
+      }
+
+      const onSubmitValidator = composableResult.form.options.validators?.onSubmit
+      const validationResult = onSubmitValidator!({ value: formData })
+
+      expect(validationResult?.fields?.link).toBeUndefined()
+    })
+
+    BddTest().then('it should not call uploadAttachment when no file is provided', async () => {
+      const onTraceCreated = vi.fn()
+      const result = mountComposable(() => useCreateTraceForm(onTraceCreated), {
+        useI18n: true,
+        useTanstack: true,
+        usePinia: true
+      })
+
+      const formData: TraceFormData = {
+        file: null,
+        traceType: TraceType.FILE,
+        traceName: 'my-trace-name',
+        personalNote: '',
+        isAuthentic: true,
+        isGroup: false,
+        useIA: false,
+        iaJustification: ''
+      }
+
+      result.result.form.options.onSubmit?.({ value: formData, formApi: result.result.form, meta: {} })
+      await waitFor(() => {
+        expect(createTraceSpy).toHaveBeenCalled()
+        expect(uploadAttachmentSpy).not.toHaveBeenCalled()
+        expect(onTraceCreated).toHaveBeenCalled()
+      })
+    })
   })
 
   BddTest().when('form is submitted with association selections', () => {
     BddTest().then('it should call associateTraceWithActivities when activities are selected', async () => {
       const formData: TraceFormData = {
         file: null,
+        traceType: TraceType.FILE,
         traceName: 'my-trace-name',
         personalNote: '',
         isAuthentic: true,
@@ -266,6 +338,7 @@ BddTest().given('the useCreateTraceForm composable', () => {
     BddTest().then('it should call associateTraceWithDeclaredSkill when declared skills are selected', async () => {
       const formData: TraceFormData = {
         file: null,
+        traceType: TraceType.FILE,
         traceName: 'my-trace-name',
         personalNote: '',
         isAuthentic: true,
@@ -291,6 +364,7 @@ BddTest().given('the useCreateTraceForm composable', () => {
     BddTest().then('it should call both association APIs when both types are selected', async () => {
       const formData: TraceFormData = {
         file: null,
+        traceType: TraceType.FILE,
         traceName: 'my-trace-name',
         personalNote: '',
         isAuthentic: true,
@@ -320,6 +394,7 @@ BddTest().given('the useCreateTraceForm composable', () => {
     BddTest().then('it should not call association APIs when selections are empty', async () => {
       const formData: TraceFormData = {
         file: null,
+        traceType: TraceType.FILE,
         traceName: 'my-trace-name',
         personalNote: '',
         isAuthentic: true,
@@ -350,6 +425,7 @@ BddTest().given('the useCreateTraceForm composable', () => {
 
       const formData: TraceFormData = {
         file: null,
+        traceType: TraceType.FILE,
         traceName: 'my-trace-name',
         personalNote: '',
         isAuthentic: true,

--- a/src/features/student/traces/views/StudentToolsTracesView/components/StudentToolsTracesAddTraceDrawer/use-create-tarce-form/use-create-trace-form.ts
+++ b/src/features/student/traces/views/StudentToolsTracesView/components/StudentToolsTracesAddTraceDrawer/use-create-tarce-form/use-create-trace-form.ts
@@ -1,8 +1,8 @@
 import type { BaseApiException } from '@/common/exceptions'
-import type { TraceFormData } from '@/features/student/traces/types/traces.types'
 import type { IdTitle } from '@/types'
 import type { ComputedRef } from 'vue'
 import { ELanguage } from '@/api/avenir-esr'
+import { useFormValidators } from '@/common/composables/use-form-validators/use-form-validators'
 import { useTraceFileValidation } from '@/features/student/traces/composables/use-trace-file/use-trace-file'
 import {
   useAssociateTraceWithActivitiesMutation,
@@ -10,7 +10,8 @@ import {
   useCreateTraceMutation,
   useUploadAttachmentMutation
 } from '@/features/student/traces/queries/use-traces.query/use-traces.query'
-import { EAssociationTypeKey } from '@/features/student/traces/types/traces.types'
+import { EAssociationTypeKey, type TraceFormData, TraceType } from '@/features/student/traces/types/traces.types'
+import { isTraceFileType, isTraceLinkType } from '@/features/student/traces/utils/trace.types-guard'
 import { useToasterStore } from '@/store'
 import { useForm } from '@tanstack/vue-form'
 import { useI18n } from 'vue-i18n'
@@ -18,11 +19,11 @@ import { useI18n } from 'vue-i18n'
 function getIdsForType (associationSelections: Record<string, IdTitle[]>, typeKey: string): string[] {
   return (associationSelections[typeKey] ?? []).map(item => item.id)
 }
-
 export function useCreateTraceForm (onTraceCreated?: () => void) {
   const { t } = useI18n()
 
   const { addErrorMessage } = useToasterStore()
+  const { validateLink } = useFormValidators()
 
   function onCreateTraceError (error: BaseApiException) {
     addErrorMessage({
@@ -76,22 +77,18 @@ export function useCreateTraceForm (onTraceCreated?: () => void) {
 
     const activityIds = getIdsForType(associationSelections, EAssociationTypeKey.ACTIVITIES)
     if (activityIds.length > 0) {
-      pendingAssociations.push(
-        makeAssociationPromise(associateWithActivities, {
-          traceId,
-          associationsCreationRequest: { idsToAssociate: activityIds }
-        })
-      )
+      pendingAssociations.push(makeAssociationPromise(associateWithActivities, {
+        traceId,
+        associationsCreationRequest: { idsToAssociate: activityIds }
+      }))
     }
 
     const skillIds = getIdsForType(associationSelections, EAssociationTypeKey.DECLARED_SKILLS)
     if (skillIds.length > 0) {
-      pendingAssociations.push(
-        makeAssociationPromise(associateWithDeclaredSkills, {
-          traceId,
-          associationsCreationRequest: { idsToAssociate: skillIds }
-        })
-      )
+      pendingAssociations.push(makeAssociationPromise(associateWithDeclaredSkills, {
+        traceId,
+        associationsCreationRequest: { idsToAssociate: skillIds }
+      }))
     }
 
     return pendingAssociations
@@ -99,14 +96,16 @@ export function useCreateTraceForm (onTraceCreated?: () => void) {
 
   function finalizeTraceCreation (traceId: string, traceFormData: TraceFormData) {
     const selections = traceFormData.associationSelections ?? {}
+    const pendingOperations: Promise<void>[] = associateElements(traceId, selections)
 
-    const pendingOperations: Promise<void>[] = [
-      ...associateElements(traceId, selections),
-      makeAssociationPromise(uploadAttachmentMutation.mutate, {
-        traceId,
-        file: traceFormData.file!
-      })
-    ]
+    if (isTraceFileType(traceFormData) && traceFormData.file) {
+      pendingOperations.push(
+        makeAssociationPromise(uploadAttachmentMutation.mutate, {
+          traceId,
+          file: traceFormData.file
+        })
+      )
+    }
 
     Promise.allSettled(pendingOperations).then(() => {
       onTraceCreated?.()
@@ -119,7 +118,8 @@ export function useCreateTraceForm (onTraceCreated?: () => void) {
       personalNote: traceFormData.personalNote || undefined,
       isGroup: traceFormData.isGroup,
       iaJustification: traceFormData.useIA ? traceFormData.iaJustification : undefined,
-      language: ELanguage.FRENCH
+      language: ELanguage.FRENCH,
+      link: isTraceLinkType(traceFormData) ? traceFormData.link : undefined,
     }, {
       onSuccess: (traceResult) => {
         finalizeTraceCreation(traceResult.traceId, traceFormData)
@@ -130,6 +130,7 @@ export function useCreateTraceForm (onTraceCreated?: () => void) {
   const form = useForm({
     defaultValues: {
       file: null,
+      traceType: TraceType.FILE,
       traceName: '',
       personalNote: '',
       isAuthentic: false,
@@ -142,7 +143,8 @@ export function useCreateTraceForm (onTraceCreated?: () => void) {
       onSubmit ({ value }: { value: TraceFormData }) {
         return {
           fields: {
-            file: validateFile(value.file),
+            file: isTraceFileType(value) ? validateFile(value.file) : undefined,
+            link: isTraceLinkType(value) ? validateLink(value.link, true) : undefined,
             traceName: !value.traceName.trim() ? t('global.error.form.requiredField') : undefined,
             isAuthentic: !value.isAuthentic ? t('student.traces.interactions.toggles.TraceAuthenticDeclarationToggle.requiredMessage') : undefined,
             iaJustification: value.useIA && (!value.iaJustification || !value.iaJustification.trim()) ? t('global.error.form.requiredField') : undefined,
@@ -152,7 +154,7 @@ export function useCreateTraceForm (onTraceCreated?: () => void) {
       onChange ({ value }: { value: TraceFormData }) {
         return {
           fields: {
-            file: validateFile(value.file),
+            file: isTraceFileType(value) ? validateFile(value.file) : undefined,
           }
         }
       }

--- a/src/features/student/traces/views/StudentTraceView/components/UpdateTraceForm/use-update-trace-form/use-update-trace-form.test.ts
+++ b/src/features/student/traces/views/StudentTraceView/components/UpdateTraceForm/use-update-trace-form/use-update-trace-form.test.ts
@@ -1,6 +1,7 @@
 import { mockedTraceDetailed } from '@/__mocks__/fixtures/student/traces.fixtures'
 import { ELanguage, type TraceDetailDTO } from '@/api/avenir-esr'
 import * as avenirEsrApi from '@/api/avenir-esr'
+import { type TraceFormData, TraceType } from '@/features/student/traces/types/traces.types'
 import { useUpdateTraceForm } from '@/features/student/traces/views/StudentTraceView/components/UpdateTraceForm/use-update-trace-form/use-update-trace-form'
 import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { mountComposable } from 'tests/utils'
@@ -71,8 +72,9 @@ BddTest().given('the useUpdateTraceForm composable', () => {
 
   BddTest().when('form is validated with invalid data', () => {
     BddTest().then('it should return validation errors for empty title', () => {
-      const invalidData = {
+      const invalidData: TraceFormData = {
         file: null,
+        traceType: TraceType.FILE,
         traceName: '',
         personalNote: '',
         isAuthentic: false,
@@ -92,8 +94,9 @@ BddTest().given('the useUpdateTraceForm composable', () => {
 
     BddTest().then('it should return validation error when useIA is true but justification is empty', () => {
       const mockFile = new File(['test content'], 'test.pdf', { type: 'application/pdf' })
-      const invalidData = {
+      const invalidData: TraceFormData = {
         file: mockFile,
+        traceType: TraceType.FILE,
         traceName: 'Valid Title',
         personalNote: 'Note',
         isAuthentic: true,
@@ -112,8 +115,9 @@ BddTest().given('the useUpdateTraceForm composable', () => {
   BddTest().when('form is validated with valid data', () => {
     BddTest().then('it should return no validation errors', () => {
       const mockFile = new File(['test content'], 'test.pdf', { type: 'application/pdf' })
-      const validData = {
+      const validData: TraceFormData = {
         file: mockFile,
+        traceType: TraceType.FILE,
         traceName: 'Updated Title',
         personalNote: 'Updated note',
         isAuthentic: true,
@@ -140,8 +144,9 @@ BddTest().given('the useUpdateTraceForm composable', () => {
     })
 
     BddTest().then('it should call updateTrace API with correct data', async () => {
-      const formData = {
+      const formData: TraceFormData = {
         file: null,
+        traceType: TraceType.FILE,
         traceName: 'Updated Title',
         personalNote: 'Updated note',
         isAuthentic: true,
@@ -166,8 +171,9 @@ BddTest().given('the useUpdateTraceForm composable', () => {
     })
 
     BddTest().then('it should call updateTrace without personalNote when empty', async () => {
-      const formData = {
+      const formData: TraceFormData = {
         file: null,
+        traceType: TraceType.FILE,
         traceName: 'Updated Title',
         personalNote: '',
         isAuthentic: true,
@@ -190,8 +196,9 @@ BddTest().given('the useUpdateTraceForm composable', () => {
     })
 
     BddTest().then('it should handle form submission with AI usage and justification', async () => {
-      const formData = {
+      const formData: TraceFormData = {
         file: null,
+        traceType: TraceType.FILE,
         traceName: 'Updated Title',
         personalNote: 'Note',
         isAuthentic: true,
@@ -228,8 +235,9 @@ BddTest().given('the useUpdateTraceForm composable', () => {
     })
 
     BddTest().then('it should not upload file when file field is not dirty', async () => {
-      const formData = {
+      const formData: TraceFormData = {
         file: new File(['original'], 'test.pdf', { type: 'application/pdf' }),
+        traceType: TraceType.FILE,
         traceName: 'Updated Title',
         personalNote: 'Note',
         isAuthentic: true,
@@ -258,8 +266,9 @@ BddTest().given('the useUpdateTraceForm composable', () => {
         usePinia: true
       })
 
-      const formData = {
+      const formData: TraceFormData = {
         file: null,
+        traceType: TraceType.FILE,
         traceName: 'Updated Title',
         personalNote: 'Note',
         isAuthentic: true,
@@ -285,8 +294,9 @@ BddTest().given('the useUpdateTraceForm composable', () => {
       const onChangeValidator = composableResult.form.options.validators?.onChange
       expect(onChangeValidator).toBeDefined()
 
-      const invalidData = {
+      const invalidData: TraceFormData = {
         file: null,
+        traceType: TraceType.FILE,
         traceName: 'Title',
         personalNote: 'Note',
         isAuthentic: true,
@@ -309,8 +319,9 @@ BddTest().given('the useUpdateTraceForm composable', () => {
 
       updateTraceSpy.mockRejectedValueOnce(mockError)
 
-      const formData = {
+      const formData: TraceFormData = {
         file: null,
+        traceType: TraceType.FILE,
         traceName: 'Updated Title',
         personalNote: 'Note',
         isAuthentic: true,
@@ -336,8 +347,9 @@ BddTest().given('the useUpdateTraceForm composable', () => {
 
       uploadAttachmentSpy.mockRejectedValueOnce(mockError)
 
-      const formData = {
+      const formData: TraceFormData = {
         file: null,
+        traceType: TraceType.FILE,
         traceName: 'Updated Title',
         personalNote: 'Note',
         isAuthentic: true,

--- a/src/features/student/traces/views/StudentTraceView/components/UpdateTraceForm/use-update-trace-form/use-update-trace-form.ts
+++ b/src/features/student/traces/views/StudentTraceView/components/UpdateTraceForm/use-update-trace-form/use-update-trace-form.ts
@@ -4,6 +4,8 @@ import { ELanguage, type TraceDetailDTO } from '@/api/avenir-esr'
 import { useTraceAttachmentFile, useTraceFileValidation } from '@/features/student/traces/composables/use-trace-file/use-trace-file'
 import { useUpdateTraceMutation, useUploadAttachmentMutation } from '@/features/student/traces/queries/use-traces.query/use-traces.query'
 import { useTracesStore } from '@/features/student/traces/stores/traces.store'
+import { TraceType } from '@/features/student/traces/types/traces.types'
+import { isTraceFileType } from '@/features/student/traces/utils/trace.types-guard'
 import { useToasterStore } from '@/store'
 import { useForm } from '@tanstack/vue-form'
 import { useI18n } from 'vue-i18n'
@@ -41,6 +43,7 @@ export function useUpdateTraceForm (trace: TraceDetailDTO, onTraceUpdated?: () =
   const form = useForm({
     defaultValues: {
       file: attachmentFile.value,
+      traceType: TraceType.FILE,
       traceName: trace.title,
       personalNote: trace.personalNote || '',
       isAuthentic: true,
@@ -52,7 +55,7 @@ export function useUpdateTraceForm (trace: TraceDetailDTO, onTraceUpdated?: () =
       onSubmit ({ value }: { value: TraceFormData }) {
         return {
           fields: {
-            file: validateFile(value.file),
+            file: isTraceFileType(value) ? validateFile(value.file) : undefined,
             isAuthentic: !value.isAuthentic ? t('student.traces.interactions.toggles.TraceAuthenticDeclarationToggle.requiredMessage') : undefined,
             traceName: !value.traceName.trim() ? t('global.error.form.requiredField') : undefined,
             iaJustification: value.useIA && (!value.iaJustification || !value.iaJustification.trim()) ? t('global.error.form.requiredField') : undefined,
@@ -62,7 +65,7 @@ export function useUpdateTraceForm (trace: TraceDetailDTO, onTraceUpdated?: () =
       onChange ({ value }: { value: TraceFormData }) {
         return {
           fields: {
-            file: validateFile(value.file),
+            file: isTraceFileType(value) ? validateFile(value.file) : undefined,
           }
         }
       }
@@ -98,7 +101,14 @@ export function useUpdateTraceForm (trace: TraceDetailDTO, onTraceUpdated?: () =
         language: ELanguage.FRENCH
       }
     }, {
-      onSuccess: () => mutateFile(traceFormData.file, trace.id)
+      onSuccess: () => {
+        if (isTraceFileType(traceFormData)) {
+          mutateFile(traceFormData.file, trace.id)
+        }
+        else {
+          onTraceUpdated?.()
+        }
+      }
     })
   }
 


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
Add a link input field to the trace form data, allowing the user to
add a trace of type link with URL validation.
 
### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1390
 
### Target Branch
develop
 
### Additional Notes
- Added traceLink field to TraceFormData
- Added TraceLinkInput component
- Added TraceLinkInputFormField component with URL validation on blur
- Added fr/en translations for new components
- Added unit tests for all new components
 
### Known Limitations or Side Effects
The link field is not yet sent to the API (pending task #1346 backend).
 
## ✅ Checklist
- [x] a11y tested
- [x] Tests provided
- [x] i18n handled
- [ ] Performance tests
- [x] No unnecessary code
- [x] Code style and formatting rules respected
- [ ] Semantic Versioning respected
- [ ] Add to CHANGELOG.md