### PR TITLE
feat(1344): declared skill associations e2e tests

### DIFF
--- a/e2e/framework/shared/constants/routes.ts
+++ b/e2e/framework/shared/constants/routes.ts
@@ -13,10 +13,12 @@ export const STUDENT_ROUTES = {
     ACTIVITIES: '/cofolio/student/project/activities',
     ACTIVITIES_CATALOG: '/cofolio/student/project/activities/catalog/:thematic/:id',
     ACTIVITY_DETAIL: '/cofolio/student/project/activities/:id',
+    SKILLS: '/cofolio/student/project/skills',
     TRAJECTORIES: {
       SELF_KNOWLEDGE: '/cofolio/student/project/trajectories?section=SELF_KNOWLEDGE',
     },
   },
+  DECLARED_SKILL: '/cofolio/student/declared-skill/',
   SKILL_DETAIL: '/cofolio/student/skill/',
   TRACE_DETAIL: '/cofolio/student/trace/',
   TOOLS: {

--- a/e2e/framework/shared/fixtures/fixtures.ts
+++ b/e2e/framework/shared/fixtures/fixtures.ts
@@ -8,6 +8,7 @@ import { StudentHomePage } from '@e2e/framework/student/home/StudentHomePage'
 import { StudentProjectActivitiesPage } from '@e2e/framework/student/lifeProject/activities/StudentProjectActivitiesPage'
 import { StudentProjectActivitiesCatalogPage } from '@e2e/framework/student/lifeProject/activitiesCatalog/StudentProjectActivitiesCatalog'
 import { StudentProjectActivityDetails } from '@e2e/framework/student/lifeProject/activityDetails/StudentProjectActivityDetails'
+import { StudentDeclaredSkillDetailPage } from '@e2e/framework/student/lifeProject/declaredSkillDetails/StudentDeclaredSkillDetailPage'
 import { StudentTrajectoriesSelfKnowledgePage } from '@e2e/framework/student/lifeProject/selfKnowledge/StudentTrajectoriesSelfKnowledgePage'
 import { StudentGlobalSteps } from '@e2e/framework/student/shared/steps/StudentGlobalSteps'
 import { StudentTracePage } from '@e2e/framework/student/tools/traceDetails/StudentTracePage'
@@ -22,6 +23,7 @@ interface Fixtures {
   staffHomePage: StaffHomePage
   studentGlobalSteps: StudentGlobalSteps
   studentHomePage: StudentHomePage
+  studentDeclaredSkillDetailPage: StudentDeclaredSkillDetailPage
   studentProjectActivitiesPage: StudentProjectActivitiesPage
   studentProjectActivityDetails: StudentProjectActivityDetails
   studentTrajectoriesSelfKnowledgePage: StudentTrajectoriesSelfKnowledgePage
@@ -57,6 +59,10 @@ export const test = base.extend<Fixtures>({
   studentHomePage: async ({ page }, use) => {
     await setLocaleFromPage(page)
     await use(new StudentHomePage(page))
+  },
+  studentDeclaredSkillDetailPage: async ({ page }, use) => {
+    await setLocaleFromPage(page)
+    await use(new StudentDeclaredSkillDetailPage(page))
   },
   studentProjectActivitiesPage: async ({ page }, use) => {
     await setLocaleFromPage(page)

--- a/e2e/framework/student/lifeProject/declaredSkillDetails/StudentDeclaredSkillDetailPage.ts
+++ b/e2e/framework/student/lifeProject/declaredSkillDetails/StudentDeclaredSkillDetailPage.ts
@@ -1,0 +1,107 @@
+import type { test } from '@e2e/framework/shared/fixtures/fixtures'
+import type { Page } from '@playwright/test'
+import { BasePage } from '@e2e/framework/shared/base/BasePage'
+import { waitForPageLoad } from '@e2e/framework/shared/utils/waits'
+import { DeclaredSkillAssociationsObject } from '@e2e/framework/student/lifeProject/declaredSkillDetails/componentObjects/DeclaredSkillAssociationsObject'
+import { Fixture, Then, When } from 'playwright-bdd/decorators'
+
+export
+@Fixture<typeof test>('studentDeclaredSkillDetailPage')
+class StudentDeclaredSkillDetailPage extends BasePage {
+  constructor (public page: Page) {
+    super(page)
+  }
+
+  getDeclaredSkillsContainer () {
+    return this.page.getByTestId('skills-container')
+  }
+
+  getDeclaredSkillCards () {
+    return this.getDeclaredSkillsContainer().getByTestId('student-detailed-skill-card')
+  }
+
+  getDeclaredSkillsTabItem () {
+    return this.page.getByTestId('declared-skills-tab-item')
+  }
+
+  getSkillAssociationsTabItem () {
+    return this.page.getByTestId('skill-associations-tab-item')
+  }
+
+  getDeclaredSkillAssociations () {
+    return new DeclaredSkillAssociationsObject(this.page.getByTestId('declared-skill-associations'))
+  }
+
+  @When('the student opens the declared skills tab')
+  async clickDeclaredSkillsTab () {
+    await this.getDeclaredSkillsTabItem().click()
+    await waitForPageLoad(this.page)
+  }
+
+  @When('the student clicks the first declared skill')
+  async clickFirstDeclaredSkill () {
+    await this.getDeclaredSkillCards().first().click()
+    await waitForPageLoad(this.page)
+  }
+
+  @When('the student opens the declared skill associations tab')
+  async clickAssociationsTab () {
+    await this.getSkillAssociationsTabItem().click()
+    await waitForPageLoad(this.page)
+  }
+
+  @Then('the declared skill associations are loaded')
+  async verifyAssociationsLoaded () {
+    await this.getDeclaredSkillAssociations().verifyVisible()
+  }
+
+  @Then('the trace associations card is visible')
+  async verifyTracesCardVisible () {
+    await this.getDeclaredSkillAssociations().verifyTracesCardVisible()
+  }
+
+  @Then('the trace associations title is defined')
+  async verifyTracesCardTitleDefined () {
+    await this.getDeclaredSkillAssociations().verifyTracesCardTitleDefined()
+  }
+
+  @When('the student expands the trace associations card')
+  async expandTracesCard () {
+    await this.getDeclaredSkillAssociations().expandTracesCard()
+  }
+
+  @Then('the trace association items are not empty')
+  async verifyTraceItemsNotEmpty () {
+    await this.getDeclaredSkillAssociations().verifyTraceItemsNotEmpty()
+  }
+
+  @Then('each trace association item has a defined title')
+  async verifyAllTraceItemsHaveTitles () {
+    await this.getDeclaredSkillAssociations().verifyAllTraceItemsHaveTitles()
+  }
+
+  @Then('the activity associations card is visible')
+  async verifyActivitiesCardVisible () {
+    await this.getDeclaredSkillAssociations().verifyActivitiesCardVisible()
+  }
+
+  @Then('the activity associations title is defined')
+  async verifyActivitiesCardTitleDefined () {
+    await this.getDeclaredSkillAssociations().verifyActivitiesCardTitleDefined()
+  }
+
+  @When('the student expands the activity associations card')
+  async expandActivitiesCard () {
+    await this.getDeclaredSkillAssociations().expandActivitiesCard()
+  }
+
+  @Then('the activity association items are not empty')
+  async verifyActivityItemsNotEmpty () {
+    await this.getDeclaredSkillAssociations().verifyActivityItemsNotEmpty()
+  }
+
+  @Then('each activity association item has a defined title')
+  async verifyAllActivityItemsHaveTitles () {
+    await this.getDeclaredSkillAssociations().verifyAllActivityItemsHaveTitles()
+  }
+}

--- a/e2e/framework/student/lifeProject/declaredSkillDetails/componentObjects/DeclaredSkillAssociationsObject.ts
+++ b/e2e/framework/student/lifeProject/declaredSkillDetails/componentObjects/DeclaredSkillAssociationsObject.ts
@@ -1,0 +1,98 @@
+import { BaseObject } from '@e2e/framework/shared/base/BaseObject'
+import { expect, type Locator } from '@playwright/test'
+
+export class DeclaredSkillAssociationsObject extends BaseObject {
+  constructor (protected root: Locator) {
+    super(root)
+  }
+
+  getAssociatedTracesCard () {
+    return this.root.getByTestId('associated-traces-card')
+  }
+
+  getAssociatedActivitiesCard () {
+    return this.root.getByTestId('associated-declared-activities-card')
+  }
+
+  getTracesCardTitle () {
+    return this.getAssociatedTracesCard().getByTestId('associations-card-title')
+  }
+
+  getActivitiesCardTitle () {
+    return this.getAssociatedActivitiesCard().getByTestId('associations-card-title')
+  }
+
+  getTracesCardContainer () {
+    return this.getAssociatedTracesCard().getByTestId('associations-card-container')
+  }
+
+  getActivitiesCardContainer () {
+    return this.getAssociatedActivitiesCard().getByTestId('associations-card-container')
+  }
+
+  getTraceAssociationItems () {
+    return this.getTracesCardContainer().getByTestId('association-card')
+  }
+
+  getActivityAssociationItems () {
+    return this.getActivitiesCardContainer().getByTestId('association-card')
+  }
+
+  async verifyVisible () {
+    await expect(this.root).toBeVisible()
+  }
+
+  async verifyTracesCardVisible () {
+    await expect(this.getAssociatedTracesCard()).toBeVisible()
+  }
+
+  async verifyActivitiesCardVisible () {
+    await expect(this.getAssociatedActivitiesCard()).toBeVisible()
+  }
+
+  async verifyTracesCardTitleDefined () {
+    const title = await this.getTracesCardTitle().textContent()
+    expect(title?.trim()).toBeTruthy()
+  }
+
+  async verifyActivitiesCardTitleDefined () {
+    const title = await this.getActivitiesCardTitle().textContent()
+    expect(title?.trim()).toBeTruthy()
+  }
+
+  async expandTracesCard () {
+    await this.getTracesCardTitle().click()
+  }
+
+  async expandActivitiesCard () {
+    await this.getActivitiesCardTitle().click()
+  }
+
+  async verifyTraceItemsNotEmpty () {
+    const count = await this.getTraceAssociationItems().count()
+    expect(count).toBeGreaterThan(0)
+  }
+
+  async verifyActivityItemsNotEmpty () {
+    const count = await this.getActivityAssociationItems().count()
+    expect(count).toBeGreaterThan(0)
+  }
+
+  async verifyAllTraceItemsHaveTitles () {
+    const items = this.getTraceAssociationItems()
+    const count = await items.count()
+    for (let i = 0; i < count; i++) {
+      const title = await items.nth(i).getByTestId('floating-icon-card-title').textContent()
+      expect(title?.trim()).toBeTruthy()
+    }
+  }
+
+  async verifyAllActivityItemsHaveTitles () {
+    const items = this.getActivityAssociationItems()
+    const count = await items.count()
+    for (let i = 0; i < count; i++) {
+      const title = await items.nth(i).getByTestId('floating-icon-card-title').textContent()
+      expect(title?.trim()).toBeTruthy()
+    }
+  }
+}

--- a/e2e/framework/student/shared/steps/StudentGlobalSteps.ts
+++ b/e2e/framework/student/shared/steps/StudentGlobalSteps.ts
@@ -182,4 +182,10 @@ class StudentGlobalSteps extends BasePage {
   async verifyNavigationToToolsTracesPage () {
     await expect(this.page).toHaveURL(STUDENT_ROUTES.TOOLS.TRACES)
   }
+
+  @Given('the student opens the skills page')
+  async goToSkillsPage () {
+    await this.page.goto(STUDENT_ROUTES.PROJECT.SKILLS)
+    await waitForPageLoad(this.page)
+  }
 }

--- a/e2e/tests/student/lifeProject/declaredSkillDetails/declaredSkillDetails.feature
+++ b/e2e/tests/student/lifeProject/declaredSkillDetails/declaredSkillDetails.feature
@@ -1,0 +1,35 @@
+@declared-skill-details @dataset-full
+Feature: Student Life Project Declared Skill Detail Page
+
+  Background:
+    Given the student opens the skills page
+    When the student opens the declared skills tab
+    And the student clicks the first declared skill
+
+  Rule: Declared skill associations
+
+    Background:
+      When the student opens the declared skill associations tab
+      Then the declared skill associations are loaded
+
+    @high @declared-skill-details @declared-skill-associations @dataset-full
+    Scenario: Student can see the trace associations card
+      And the trace associations card is visible
+      And the trace associations title is defined
+
+    @high @declared-skill-details @declared-skill-associations @dataset-full
+    Scenario: Student can see trace association items
+      When the student expands the trace associations card
+      Then the trace association items are not empty
+      And each trace association item has a defined title
+
+    @high @declared-skill-details @declared-skill-associations @dataset-full
+    Scenario: Student can see the activity associations card
+      And the activity associations card is visible
+      And the activity associations title is defined
+
+    @high @declared-skill-details @declared-skill-associations @dataset-full
+    Scenario: Student can see activity association items
+      When the student expands the activity associations card
+      Then the activity association items are not empty
+      And each activity association item has a defined title

--- a/src/features/student/declaredSkills/views/StudentDeclaredSkillView/StudentDeclaredSkillView.vue
+++ b/src/features/student/declaredSkills/views/StudentDeclaredSkillView/StudentDeclaredSkillView.vue
@@ -93,6 +93,7 @@ function handleSkillDeleted () {
     <AvTab
       :title="t('student.global.myAssociationsWithCount', { count: countAssociations })"
       :icon="ICONS.ASSOCIATIONS"
+      data-testid="skill-associations-tab-item"
     >
       <QuerySuspense
         :error="associationsError"

--- a/src/features/student/skills/components/cards/StudentDetailedSkillCard/StudentDetailedSkillCard.vue
+++ b/src/features/student/skills/components/cards/StudentDetailedSkillCard/StudentDetailedSkillCard.vue
@@ -26,6 +26,7 @@ const iconOptions = {
   <RouterLink
     class="student-detailed-skill-card"
     :to="{ name: to ?? ROUTES.STUDENT.SKILL.name, params: { id } }"
+    data-testid="student-detailed-skill-card"
   >
     <FloatingIconCard
       :title="name"

--- a/src/features/student/skills/views/StudentProjectSkillsView/components/SkillsViewTabs/SkillsViewTabs.vue
+++ b/src/features/student/skills/views/StudentProjectSkillsView/components/SkillsViewTabs/SkillsViewTabs.vue
@@ -14,12 +14,14 @@ const activeTab = ref(0)
     <AvTab
       :title="t('student.skills.views.StudentProjectSkillsView.skillsViewTabs.education')"
       :icon="MDI_ICONS.STARS"
+      data-testid="education-skills-tab-item"
     >
       <SkillsViewEducationTab />
     </AvTab>
     <AvTab
       :title="t('student.skills.views.StudentProjectSkillsView.skillsViewTabs.other')"
       :icon="MDI_ICONS.STARS"
+      data-testid="declared-skills-tab-item"
     >
       <SkillsViewOtherTab />
     </AvTab>


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> Implémentation des tests E2E pour la page de détail d'une compétence déclarée, couvrant l'onglet associations (traces et activités).

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1344

---

### Documentation
> Aucune mise à jour de documentation requise.

---

### Target Branch
> `develop`

---

### Additional Notes
> - Ajout d'un `PageObject` (`StudentDeclaredSkillDetailPage`) avec les étapes de navigation : page compétences → onglet compétences déclarées → première compétence → onglet associations
> - Ajout d'un `ComponentObject` (`DeclaredSkillAssociationsObject`) pour encapsuler les assertions sur les cartes d'associations (traces et activités)
> - Ajout du step `Given the student opens the skills page` dans `StudentGlobalSteps`
> - Ajout des routes `PROJECT.SKILLS` et `DECLARED_SKILL` dans les constantes partagées
> - Ajout des attributs `data-testid` sur les onglets dans `SkillsViewTabs` et `StudentDeclaredSkillView`
> - 4 scénarios `@dataset-full` couvrant : visibilité des cartes, titre défini, items non vides, titre de chaque item défini

---

### Known Limitations or Side Effects
> Aucune.

---

## ✅ Checklist

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [x] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and detaiils for the update process