### PR TITLE
feat(1387): add staff home profile section e2e tests

### DIFF
--- a/e2e/framework/shared/componentObjects/ProfileCard.ts
+++ b/e2e/framework/shared/componentObjects/ProfileCard.ts
@@ -1,4 +1,5 @@
 import { BaseObject } from '@e2e/framework/shared/base/BaseObject'
+import { verifyTextLocator } from '@e2e/framework/shared/utils/text'
 import { expect, type Locator } from '@playwright/test'
 
 export class ProfileCard extends BaseObject {
@@ -14,11 +15,11 @@ export class ProfileCard extends BaseObject {
     return this.root.getByTestId('profile-picture')
   }
 
-  getStudentName () {
+  getFullName () {
     return this.root.getByTestId('profile-full-name')
   }
 
-  getStudentBio () {
+  getBio () {
     return this.root.getByTestId('profile-bio')
   }
 
@@ -30,18 +31,18 @@ export class ProfileCard extends BaseObject {
     await expect(this.getProfilePicture()).toBeVisible()
   }
 
-  async verifyStudentName () {
-    await expect(this.getStudentName()).toBeVisible()
+  async verifyFullName () {
+    await verifyTextLocator(this.getFullName())
   }
 
-  async verifyStudentBio () {
-    await expect(this.getStudentBio()).toBeVisible()
+  async verifyBio () {
+    await verifyTextLocator(this.getBio())
   }
 
   async verifyCardContent () {
     await this.verifyProfileBanner()
     await this.verifyProfilePicture()
-    await this.verifyStudentName()
-    await this.verifyStudentBio()
+    await this.verifyFullName()
+    await this.verifyBio()
   }
 }

--- a/e2e/framework/shared/utils/text.ts
+++ b/e2e/framework/shared/utils/text.ts
@@ -1,6 +1,12 @@
-import type { Locator } from '@playwright/test'
+import { expect, type Locator } from '@playwright/test'
 
 export async function extractNumberFromText (locator: Locator): Promise<number> {
   const text = await locator.textContent()
   return Number.parseInt(text?.match(/\d+/)?.[0] ?? '0')
+}
+
+export async function verifyTextLocator (locator: Locator) {
+  await expect(locator).toBeVisible()
+  const text = await locator.textContent()
+  expect(text?.trim()).toBeTruthy()
 }

--- a/e2e/framework/staff/home/StaffHomePage.ts
+++ b/e2e/framework/staff/home/StaffHomePage.ts
@@ -1,11 +1,36 @@
 import type { test } from '@e2e/framework/shared/fixtures/fixtures'
 import type { Page } from '@playwright/test'
 import { BasePage } from '@e2e/framework/shared/base/BasePage'
-import { Fixture } from 'playwright-bdd/decorators'
+import { StaffOverviewWidget } from '@e2e/framework/staff/home/componentObjects/StaffOverviewWidget'
+import { Fixture, Given, Then } from 'playwright-bdd/decorators'
 
 @Fixture<typeof test>('staffHomePage')
 export class StaffHomePage extends BasePage {
   constructor (public page: Page) {
     super(page)
+  }
+
+  getStaffOverviewWidget () {
+    return new StaffOverviewWidget(this.page)
+  }
+
+  @Given('the staff profile overview widget is visible')
+  async verifyStaffProfileOverviewWidgetVisible () {
+    await this.getStaffOverviewWidget().isVisible()
+  }
+
+  @Then('the staff profile banner is visible')
+  async verifyStaffProfileBanner () {
+    await this.getStaffOverviewWidget().verifyProfileBanner()
+  }
+
+  @Then('the staff profile picture is visible')
+  async verifyStaffProfilePicture () {
+    await this.getStaffOverviewWidget().verifyProfilePicture()
+  }
+
+  @Then('the staff name is visible')
+  async verifyStaffName () {
+    await this.getStaffOverviewWidget().verifyStaffName()
   }
 }

--- a/e2e/framework/staff/home/componentObjects/StaffOverviewWidget.ts
+++ b/e2e/framework/staff/home/componentObjects/StaffOverviewWidget.ts
@@ -1,0 +1,37 @@
+import type { Page } from '@playwright/test'
+import { BaseObject } from '@e2e/framework/shared/base/BaseObject'
+import { ProfileCard } from '@e2e/framework/shared/componentObjects/ProfileCard'
+
+export class StaffOverviewWidget extends BaseObject {
+  constructor (protected page: Page) {
+    super(page.getByTestId('staff-overview-widget'))
+  }
+
+  getProfileCard () {
+    return new ProfileCard(this.root.getByTestId('profile-card'))
+  }
+
+  getProfileBanner () {
+    return this.getProfileCard().getProfileBanner()
+  }
+
+  getProfilePicture () {
+    return this.getProfileCard().getProfilePicture()
+  }
+
+  getStaffName () {
+    return this.getProfileCard().getFullName()
+  }
+
+  async verifyProfileBanner () {
+    await this.getProfileCard().verifyProfileBanner()
+  }
+
+  async verifyProfilePicture () {
+    await this.getProfileCard().verifyProfilePicture()
+  }
+
+  async verifyStaffName () {
+    await this.getProfileCard().verifyFullName()
+  }
+}

--- a/e2e/framework/student/home/componentObjects/StudentOverviewWidget.ts
+++ b/e2e/framework/student/home/componentObjects/StudentOverviewWidget.ts
@@ -1,6 +1,6 @@
 import { BaseObject } from '@e2e/framework/shared/base/BaseObject'
+import { ProfileCard } from '@e2e/framework/shared/componentObjects/ProfileCard'
 import { t } from '@e2e/framework/shared/utils/i18n'
-import { ProfileCard } from '@e2e/framework/student/user/componentObjects/ProfileCard'
 import { expect, type Page } from '@playwright/test'
 
 export class StudentOverviewWidget extends BaseObject {
@@ -21,11 +21,11 @@ export class StudentOverviewWidget extends BaseObject {
   }
 
   getStudentName () {
-    return this.getProfileCard().getStudentName()
+    return this.getProfileCard().getFullName()
   }
 
   getStudentBio () {
-    return this.getProfileCard().getStudentBio()
+    return this.getProfileCard().getBio()
   }
 
   getEditProfileButton () {
@@ -57,11 +57,11 @@ export class StudentOverviewWidget extends BaseObject {
   }
 
   async verifyStudentName () {
-    await this.getProfileCard().verifyStudentName()
+    await this.getProfileCard().verifyFullName()
   }
 
   async verifyStudentBio () {
-    await this.getProfileCard().verifyStudentBio()
+    await this.getProfileCard().verifyBio()
   }
 
   async verifyActionButtons () {

--- a/e2e/framework/student/lifeProject/declaredSkillDetails/componentObjects/DeclaredSkillAssociationsObject.ts
+++ b/e2e/framework/student/lifeProject/declaredSkillDetails/componentObjects/DeclaredSkillAssociationsObject.ts
@@ -1,4 +1,5 @@
 import { BaseObject } from '@e2e/framework/shared/base/BaseObject'
+import { verifyTextLocator } from '@e2e/framework/shared/utils/text'
 import { expect, type Locator } from '@playwright/test'
 
 export class DeclaredSkillAssociationsObject extends BaseObject {
@@ -51,13 +52,11 @@ export class DeclaredSkillAssociationsObject extends BaseObject {
   }
 
   async verifyTracesCardTitleDefined () {
-    const title = await this.getTracesCardTitle().textContent()
-    expect(title?.trim()).toBeTruthy()
+    await verifyTextLocator(this.getTracesCardTitle())
   }
 
   async verifyActivitiesCardTitleDefined () {
-    const title = await this.getActivitiesCardTitle().textContent()
-    expect(title?.trim()).toBeTruthy()
+    await verifyTextLocator(this.getActivitiesCardTitle())
   }
 
   async expandTracesCard () {
@@ -82,8 +81,8 @@ export class DeclaredSkillAssociationsObject extends BaseObject {
     const items = this.getTraceAssociationItems()
     const count = await items.count()
     for (let i = 0; i < count; i++) {
-      const title = await items.nth(i).getByTestId('floating-icon-card-title').textContent()
-      expect(title?.trim()).toBeTruthy()
+      const titleLocator = items.nth(i).getByTestId('floating-icon-card-title')
+      await verifyTextLocator(titleLocator)
     }
   }
 
@@ -91,8 +90,8 @@ export class DeclaredSkillAssociationsObject extends BaseObject {
     const items = this.getActivityAssociationItems()
     const count = await items.count()
     for (let i = 0; i < count; i++) {
-      const title = await items.nth(i).getByTestId('floating-icon-card-title').textContent()
-      expect(title?.trim()).toBeTruthy()
+      const titleLocator = items.nth(i).getByTestId('floating-icon-card-title')
+      await verifyTextLocator(titleLocator)
     }
   }
 }

--- a/e2e/framework/student/lifeProject/selfKnowledge/StudentTrajectoriesSelfKnowledgePage.ts
+++ b/e2e/framework/student/lifeProject/selfKnowledge/StudentTrajectoriesSelfKnowledgePage.ts
@@ -1,9 +1,9 @@
 import type { test } from '@e2e/framework/shared/fixtures/fixtures'
 import { BasePage } from '@e2e/framework/shared/base/BasePage'
+import { ProfileCard } from '@e2e/framework/shared/componentObjects/ProfileCard'
 import { STUDENT_ROUTES } from '@e2e/framework/shared/constants/routes'
 import { t } from '@e2e/framework/shared/utils/i18n'
 import { waitForPageLoad } from '@e2e/framework/shared/utils/waits'
-import { ProfileCard } from '@e2e/framework/student/user/componentObjects/ProfileCard'
 import { expect, type Page } from '@playwright/test'
 import { Fixture, Given, Then, When } from 'playwright-bdd/decorators'
 
@@ -123,12 +123,12 @@ class StudentTrajectoriesSelfKnowledgePage extends BasePage {
 
   @Then('the self-knowledge profile card name is visible')
   async verifyProfileCardNameVisible () {
-    await this.getProfileCard().verifyStudentName()
+    await this.getProfileCard().verifyFullName()
   }
 
   @Then('the self-knowledge profile card bio is visible')
   async verifyProfileCardBioVisible () {
-    await this.getProfileCard().verifyStudentBio()
+    await this.getProfileCard().verifyBio()
   }
 
   @Then('the profile card spans full width')

--- a/e2e/tests/staff/home.feature
+++ b/e2e/tests/staff/home.feature
@@ -18,6 +18,17 @@ Feature: Staff Home Page
     Scenario: Staff can see the footer
       Then the footer is visible
       
+  Rule: Profile Section
+
+    Background:
+      Given the staff profile overview widget is visible
+
+    @high @profile
+    Scenario: Staff can see profile section
+      Then the staff profile banner is visible
+      And the staff profile picture is visible
+      And the staff name is visible
+
   Rule: Navigation
 
     @high @navigation @desktop

--- a/src/features/staff/global/views/StaffHomeView/StaffHomeView.vue
+++ b/src/features/staff/global/views/StaffHomeView/StaffHomeView.vue
@@ -19,32 +19,36 @@ const { data: staffSummary } = useUserSummaryQuery(EUserCategory.STAFF)
     {{ t('staff.global.layout.header.home') }}
   </h1>
   <div class="layout-home av-row av-wrap av-nowrap--md av-justify-center--md av-gap-xl av-align-start">
-    <div class="layout-home__sidebar av-col av-gap-xl">
-      <ProfileCard
-        v-if="staffSummary"
-        :first-name="staffSummary.firstname"
-        :last-name="staffSummary.lastname"
-        :profile-picture-url="staffSummary.profilePicture.url"
-        :cover-picture-url="staffSummary.coverPicture.url"
-      >
-        <div
-          class="av-pt-sm"
-          data-testid="staff-overview-widget-actions"
+    <div
+      class="layout-home__sidebar av-col av-gap-xl"
+    >
+      <div data-testid="staff-overview-widget">
+        <ProfileCard
+          v-if="staffSummary"
+          :first-name="staffSummary.firstname"
+          :last-name="staffSummary.lastname"
+          :profile-picture-url="staffSummary.profilePicture.url"
+          :cover-picture-url="staffSummary.coverPicture.url"
         >
-          <ul class="av-col av-gap-sm av-list-reset">
-            <li>
-              <AvRichButton
-                :label="t('staff.global.views.StaffHomeView.buttons.editProfile')"
-                :icon-right="MDI_ICONS.PENCIL_OUTLINE"
-                data-testid="edit-profile-button"
-                @click="displayDrawer"
-              >
-                <span class="b1-regular">{{ t('staff.global.views.StaffHomeView.buttons.editProfile') }}</span>
-              </AvRichButton>
-            </li>
-          </ul>
-        </div>
-      </ProfileCard>
+          <div
+            class="av-pt-sm"
+            data-testid="staff-overview-widget-actions"
+          >
+            <ul class="av-col av-gap-sm av-list-reset">
+              <li>
+                <AvRichButton
+                  :label="t('staff.global.views.StaffHomeView.buttons.editProfile')"
+                  :icon-right="MDI_ICONS.PENCIL_OUTLINE"
+                  data-testid="edit-profile-button"
+                  @click="displayDrawer"
+                >
+                  <span class="b1-regular">{{ t('staff.global.views.StaffHomeView.buttons.editProfile') }}</span>
+                </AvRichButton>
+              </li>
+            </ul>
+          </div>
+        </ProfileCard>
+      </div>
     </div>
     <div class="layout-home__main av-col av-gap-xl">
       Placeholder main categories


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> Ajout des tests E2E pour la section profil de la page d'accueil staff (`/cofolio/staff`). Les tests vérifient que la bannière de profil, la photo de profil et le nom du staff s'affichent correctement.
>
> Le composant objet `ProfileCard` a été déplacé de `student/user/componentObjects` vers `shared/componentObjects` afin d'être partagé entre les contextes student et staff.

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1387

---

### Documentation
> Aucune mise à jour de documentation nécessaire.

---

### Target Branch
> `develop`

---

### Additional Notes
> - `ProfileCard` (component object E2E) renommé avec des méthodes génériques (`getFullName`, `getBio`, `verifyFullName`, `verifyBio`) pour être agnostique du rôle
> - `data-testid="staff-overview-widget"` ajouté sur le sidebar de `StaffHomeView.vue` pour ancrer le widget
> - `StudentTrajectoriesSelfKnowledgePage` mis à jour pour utiliser le nouveau `ProfileCard` partagé

---

### Known Limitations or Side Effects
> Aucune.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and detaiils for the update process