### PR TITLE
fix(1432): enforce max length constraint on trace name input

### DIFF
--- a/src/features/student/traces/components/interactions/inputs/TraceNameInput/TraceNameInput.test.ts
+++ b/src/features/student/traces/components/interactions/inputs/TraceNameInput/TraceNameInput.test.ts
@@ -6,7 +6,7 @@ import { beforeEach, expect } from 'vitest'
 
 const AvInputStub = {
   name: 'AvInput',
-  props: ['modelValue', 'label', 'placeholder', 'prefixIcon', 'isValid', 'isTextarea', 'labelVisible', 'disabled', 'required', 'errorMessage'],
+  props: ['modelValue', 'label', 'placeholder', 'maxlength', 'prefixIcon', 'isValid', 'isTextarea', 'labelVisible', 'disabled', 'required', 'errorMessage'],
   emits: ['update:modelValue'],
   template: `
     <div>
@@ -14,10 +14,12 @@ const AvInputStub = {
       <input
         :value="modelValue"
         :placeholder="placeholder"
+        :maxlength="maxlength"
         :disabled="disabled"
         :required="required"
         @input="$emit('update:modelValue', $event.target.value)"
       />
+      <slot name="maxLengthCaption" :current-value="modelValue" :maxlength="maxlength" />
     </div>
   `
 }
@@ -44,11 +46,19 @@ BddTest().given('a trace name input component', () => {
       expect(input.exists()).toBe(true)
       expect(input.props('label')).toBe('Nom de ma trace')
       expect(input.props('placeholder')).toBe('Nom-de-ma-trace-01')
+      expect(input.props('maxlength')).toBe(80)
       expect(input.props('prefixIcon')).toBe(MDI_ICONS.ATTACH_FILE)
       expect(input.props('isTextarea')).toBe(false)
       expect(input.props('labelVisible')).toBe(true)
       expect(input.props('disabled')).toBe(false)
       expect(input.props('required')).toBe(true)
+    })
+
+    BddTest().then('it should render character count hint', () => {
+      const hint = wrapper.find('.caption-light')
+
+      expect(hint.exists()).toBe(true)
+      expect(hint.text()).toBe('0 / 80 caractères (espaces compris)')
     })
   })
 
@@ -83,6 +93,23 @@ BddTest().given('a trace name input component', () => {
       const input = wrapper.findComponent({ name: 'AvInput' })
 
       expect(input.props('placeholder')).toBe('Custom placeholder text')
+    })
+  })
+
+  BddTest().when('custom maxlength is provided', () => {
+    BddTest().then('it should use the custom maxlength', () => {
+      wrapper = mount(TraceNameInput, {
+        props: {
+          maxlength: 200
+        },
+        global: {
+          stubs
+        }
+      })
+
+      const input = wrapper.findComponent({ name: 'AvInput' })
+
+      expect(input.props('maxlength')).toBe(200)
     })
   })
 
@@ -179,6 +206,21 @@ BddTest().given('a trace name input component', () => {
 
       expect(wrapper.emitted('update:modelValue')?.[0]).toEqual(['My trace name'])
     })
+
+    BddTest().then('it should update the character count hint', async () => {
+      wrapper = mount(TraceNameInput, {
+        props: {
+          modelValue: 'Du texte ici'
+        },
+        global: {
+          stubs
+        }
+      })
+
+      const hint = wrapper.find('.caption-light')
+
+      expect(hint.text()).toBe('12 / 80 caractères (espaces compris)')
+    })
   })
 
   BddTest().when('a value is provided via v-model', () => {
@@ -231,6 +273,25 @@ BddTest().given('a trace name input component', () => {
       const input = wrapper.findComponent({ name: 'AvInput' })
 
       expect(input.props('isTextarea')).toBe(true)
+    })
+  })
+
+  BddTest().when('the character count reaches maximum', () => {
+    BddTest().then('it should display the correct count in hint', () => {
+      const maxText = 'a'.repeat(80)
+
+      wrapper = mount(TraceNameInput, {
+        props: {
+          modelValue: maxText
+        },
+        global: {
+          stubs
+        }
+      })
+
+      const hint = wrapper.find('.caption-light')
+
+      expect(hint.text()).toBe('80 / 80 caractères (espaces compris)')
     })
   })
 })

--- a/src/features/student/traces/components/interactions/inputs/TraceNameInput/TraceNameInput.vue
+++ b/src/features/student/traces/components/interactions/inputs/TraceNameInput/TraceNameInput.vue
@@ -3,10 +3,11 @@ import { AvInput, type AvInputProps, MDI_ICONS } from '@avenirs-esr/avenirs-dsav
 import { useAttrs } from 'vue'
 import { useI18n } from 'vue-i18n'
 
-interface TraceNameInputProps extends Omit<AvInputProps, 'label' | 'prefixIcon' | 'placeholder' | 'modelValue'> {
+interface TraceNameInputProps extends Omit<AvInputProps, 'label' | 'prefixIcon' | 'placeholder' | 'modelValue' | 'maxlength' > {
   label?: string
   prefixIcon?: string
   placeholder?: string
+  maxlength?: number
 }
 
 const {
@@ -15,6 +16,7 @@ const {
   labelVisible = true,
   disabled = false,
   required = true,
+  maxlength = 80,
   label,
   prefixIcon,
   placeholder,
@@ -32,6 +34,7 @@ const avInputProps = computed(() => ({
   labelVisible,
   disabled,
   required,
+  maxlength,
   errorMessage,
   label: label ?? t('student.traces.interactions.inputs.TraceNameInput.label'),
   prefixIcon: prefixIcon ?? MDI_ICONS.ATTACH_FILE,
@@ -40,8 +43,22 @@ const avInputProps = computed(() => ({
 </script>
 
 <template>
-  <AvInput
-    v-bind="avInputProps"
-    v-model="modelValue"
-  />
+  <div class="av-col av-flex-fill">
+    <AvInput
+      v-bind="avInputProps"
+      v-model="modelValue"
+    >
+      <template
+        v-if="!$slots.maxLengthCaption"
+        #maxLengthCaption="{ currentValue }"
+      >
+        <span class="caption-light">
+          {{ t('global.inputs.textarea.limit', {
+            count: currentValue?.toString().length || 0,
+            maxlength,
+          }) }}
+        </span>
+      </template>
+    </AvInput>
+  </div>
 </template>


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
- Enforce an 80-character limit on the `Name` field in the trace form, aligning with the API's maximum accepted input length

---

### Reference to an Issue, Feature, Task, User Story or another PR
- Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1432

---

**Modified areas:**
- `src/features/student/traces/components/interactions/inputs/TraceNameInput/TraceNameInput.vue`
- `src/features/student/traces/components/interactions/inputs/TraceNameInput/TraceNameInput.test.ts`

---

**Screenshots**
<img width="762" height="927" alt="image" src="https://github.com/user-attachments/assets/a97fe2d5-0681-46d7-ba60-e5da40849d48" />

---

### Target Branch
`develop`

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [x] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process