### PR TITLE
feat(1456): implement download trace attachment

### DIFF
--- a/api-specs/avenir-esr.swagger.json
+++ b/api-specs/avenir-esr.swagger.json
@@ -2052,6 +2052,51 @@
         }
       }
     },
+    "/me/storage/traces/attachments/{attachmentId}": {
+      "get": {
+        "tags": [
+          "trace-attachment-controller"
+        ],
+        "summary": "Download an attachment",
+        "description": "Retrieves the binary content of a specific attachment associated with a trace.",
+        "operationId": "downloadAttachment",
+        "parameters": [
+          {
+            "name": "attachmentId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "File downloaded successfully",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Attachment not found",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string",
+                  "format": "byte"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/me/skill-level-progress": {
       "get": {
         "tags": [
@@ -3430,6 +3475,9 @@
           "personalNote": {
             "type": "string"
           },
+          "link": {
+            "type": "string"
+          },
           "attachment": {
             "$ref": "#/components/schemas/AttachmentUploadDTO"
           },
@@ -3448,6 +3496,7 @@
           "createdAt",
           "id",
           "isGroup",
+          "link",
           "personalNote",
           "programName",
           "status",
@@ -4052,6 +4101,9 @@
             "type": "string"
           },
           "iaJustification": {
+            "type": "string"
+          },
+          "link": {
             "type": "string"
           }
         },
@@ -5854,6 +5906,7 @@
           "SKILL_NOT_FOUND",
           "SKILL_LEVEL_NOT_FOUND",
           "TRACE_NOT_FOUND",
+          "INVALID_TRACE_TYPE",
           "AMS_NOT_FOUND",
           "USER_IS_NOT_STUDENT_EXCEPTION",
           "USER_IS_NOT_STAFF_EXCEPTION",
@@ -5865,6 +5918,7 @@
           "STUDENT_DECLARED_ALREADY_EXIST",
           "STUDENT_PROGRESS_NOT_FOUND",
           "FILE_NOT_FOUND",
+          "ATTACHMENT_NOT_FOUND",
           "CONFIGURATION_ERROR",
           "TITLE_TOO_LONG",
           "DESCRIPTION_TOO_LONG",

--- a/orval.config.ts
+++ b/orval.config.ts
@@ -13,6 +13,13 @@ export default defineConfig({
       mode: 'tags',
       clean: true,
       override: {
+        operations: {
+          downloadAttachment: {
+            query: {
+              useMutation: true,
+            }
+          }
+        },
         fetch: {
           includeHttpResponseReturnType: false,
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "avenirs-cofolio-client",
       "version": "0.0.0",
       "dependencies": {
-        "@avenirs-esr/avenirs-dsav": "^0.1.189",
+        "@avenirs-esr/avenirs-dsav": "^0.1.190",
         "@tanstack/vue-form": "^1.15.0",
         "@tanstack/vue-query": "^5.74.9",
         "@vue-flow/core": "^1.48.0",
@@ -348,9 +348,9 @@
       "license": "ISC"
     },
     "node_modules/@avenirs-esr/avenirs-dsav": {
-      "version": "0.1.189",
-      "resolved": "https://registry.npmjs.org/@avenirs-esr/avenirs-dsav/-/avenirs-dsav-0.1.189.tgz",
-      "integrity": "sha512-4ntzf5oE1uDytTHH8n+iXBOw9jEoLDhCuPPArHFY7uW4r/Q2z7xhaB8BrM6tzzxqegV04S0qN0KtfR41ItVD9w==",
+      "version": "0.1.190",
+      "resolved": "https://registry.npmjs.org/@avenirs-esr/avenirs-dsav/-/avenirs-dsav-0.1.190.tgz",
+      "integrity": "sha512-liWSeNKhn2seSl3hzt0e3syiEH9nAdOT6clJpdZv7fKZNKN6ZjL3AAYe99oE0f3yKOj+0IXOpE6gMlb6crlniw==",
       "dependencies": {
         "@tiptap/extension-character-count": "^3.20.2",
         "@tiptap/extension-image": "^3.20.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
-    "@avenirs-esr/avenirs-dsav": "^0.1.189",
+    "@avenirs-esr/avenirs-dsav": "^0.1.190",
     "@tanstack/vue-form": "^1.15.0",
     "@tanstack/vue-query": "^5.74.9",
     "@vue-flow/core": "^1.48.0",

--- a/src/__mocks__/fixtures/student/traces.fixtures.ts
+++ b/src/__mocks__/fixtures/student/traces.fixtures.ts
@@ -244,6 +244,7 @@ export const mockedTraceDetailed = {
   id: 'trace1',
   title: 'Développement d\'un ePortfolio',
   isAssociated: false,
+  link: 'https://example.com/trace/trace1',
   createdAt: '2025-06-16T10:42:00.000Z',
   updatedAt: '2025-06-17T15:18:00.000Z',
   programName: 'An awesome program',

--- a/src/__mocks__/msw/handlers/student/traces.handlers.ts
+++ b/src/__mocks__/msw/handlers/student/traces.handlers.ts
@@ -21,6 +21,7 @@ import {
   getCreateTraceUrl,
   getDeleteTraceAssociationsUrl,
   getDeleteTraceUrl,
+  getDownloadAttachmentUrl,
   getGetTraceAssociationsUrl,
   getGetTraceConfigUrl,
   getGetTraceDetailUrl,
@@ -232,6 +233,26 @@ export const tracesHandlers = [
     })
   }),
 
+  http.get(`*${getDownloadAttachmentUrl(':attachmentId')}`, ({ params }) => {
+    const attachmentId: string | undefined = params.attachmentId as string | undefined
+
+    if (!attachmentId) {
+      return HttpResponse.json({ error: 'Attachment ID is required' }, { status: 400 })
+    }
+
+    if (attachmentId === 'INVALID_ATTACHMENT_ID') {
+      return HttpResponse.json({ error: 'Attachment not found' }, { status: 404 })
+    }
+
+    return new HttpResponse('trace attachment content', {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/octet-stream',
+        'Content-Disposition': 'attachment; filename="An awesome attachment"'
+      }
+    })
+  }),
+
   http.get<PathParams, TraceDetailDTO>(`*${getGetTraceDetailUrl(':traceId')}`, async () => {
     await delay(100)
     return HttpResponse.json(mockedTraceDetailed, {
@@ -410,6 +431,16 @@ export const tracesHandlers = [
 
 export const deleteTraceAssociationsErrorHandler = http.delete(
   `*${getDeleteTraceAssociationsUrl(':traceId')}`,
+  () => {
+    return HttpResponse.json(
+      { message: 'Internal Server Error' },
+      { status: 500 }
+    )
+  }
+)
+
+export const downloadTraceAttachmentErrorHandler = http.get(
+  `*${getDownloadAttachmentUrl(':attachmentId')}`,
   () => {
     return HttpResponse.json(
       { message: 'Internal Server Error' },

--- a/src/api/fetch/fetch-factory/fetch-factory.test.ts
+++ b/src/api/fetch/fetch-factory/fetch-factory.test.ts
@@ -91,6 +91,19 @@ BddTest().given('a custom fetch creator', () => {
     })
   })
 
+  BddTest().when('creating a custom fetch for image content', () => {
+    BddTest().then('it should return a blob', async () => {
+      const imageContent = 'PNG content'
+      vi.mocked(mockFetch).mockResolvedValueOnce(
+        new Response(imageContent, { status: 200, headers: { 'content-type': 'image/png' } })
+      )
+      const fetcher = createCustomFetch({ baseUrl }, interceptorManager)
+      const result = await fetcher<Blob>('/me/traces/attachment')
+      const responseText = await result.text()
+      expect(responseText).toBe(imageContent)
+    })
+  })
+
   BddTest().when('creating a custom fetch for application/octet-stream', () => {
     BddTest().then('it should return body', async () => {
       const content = 'Binary content'
@@ -98,9 +111,8 @@ BddTest().given('a custom fetch creator', () => {
         new Response(content, { status: 200, headers: { 'content-type': 'application/octet-stream' } })
       )
       const fetcher = createCustomFetch({ baseUrl }, interceptorManager)
-      const result = await fetcher<ArrayBuffer>('/me/resumes')
-      const decoder = new TextDecoder()
-      const responseText = decoder.decode(result)
+      const result = await fetcher<Blob>('/me/resumes')
+      const responseText = await result.text()
       expect(responseText).toBe(content)
     })
   })

--- a/src/api/fetch/fetch-factory/fetch-factory.ts
+++ b/src/api/fetch/fetch-factory/fetch-factory.ts
@@ -14,20 +14,31 @@ function buildUrl (url: string, baseUrl: string): string {
 }
 
 async function getBody<T> (response: Response): Promise<T> {
-  const contentType = response.headers.get('content-type') || ''
+  const contentType = (response.headers.get('content-type') || '').toLowerCase()
   const contentLength = response.headers.get('content-length')
+  const contentDisposition = (response.headers.get('content-disposition') || '').toLowerCase()
 
   if (contentLength === '0' || response.status === 204) {
     return undefined as T
   }
 
-  if (contentType.includes('application/pdf')) {
+  const isJsonResponse = contentType.includes('application/json') || contentType.includes('+json')
+  const isTextResponse = contentType.startsWith('text/')
+  const isBinaryResponse = contentDisposition.includes('attachment')
+    || contentType.startsWith('image/')
+    || contentType.startsWith('audio/')
+    || contentType.startsWith('video/')
+    || (contentType.startsWith('application/') && !isJsonResponse && !contentType.includes('xml'))
+
+  if (isJsonResponse) {
+    return await response.json() as T
+  }
+
+  if (isBinaryResponse) {
     return await response.blob() as T
   }
-  if (contentType.includes('application/octet-stream')) {
-    return await response.arrayBuffer() as T
-  }
-  if (contentType.includes('text')) {
+
+  if (isTextResponse) {
     return await response.text() as T
   }
 

--- a/src/common/utils/download/download.test.ts
+++ b/src/common/utils/download/download.test.ts
@@ -1,0 +1,55 @@
+import { downloadBlob } from '@/common/utils/download/download'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+
+BddTest().given('the download blob helper', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+
+    if (!window.URL.createObjectURL) {
+      Object.defineProperty(window.URL, 'createObjectURL', {
+        writable: true,
+        value: vi.fn(() => 'blob:download-url')
+      })
+    }
+    else {
+      vi.spyOn(window.URL, 'createObjectURL').mockReturnValue('blob:download-url')
+    }
+
+    if (!window.URL.revokeObjectURL) {
+      Object.defineProperty(window.URL, 'revokeObjectURL', {
+        writable: true,
+        value: vi.fn()
+      })
+    }
+    else {
+      vi.spyOn(window.URL, 'revokeObjectURL').mockImplementation(() => undefined)
+    }
+
+    vi.spyOn(document.body, 'append').mockImplementation(() => undefined)
+    vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => undefined)
+    vi.spyOn(HTMLAnchorElement.prototype, 'remove').mockImplementation(() => undefined)
+  })
+
+  BddTest().when('a filename is provided', () => {
+    BddTest().then('it should create and trigger a download link with that filename', () => {
+      const blob = new Blob(['trace content'], { type: 'text/plain' })
+      const link = {
+        href: '',
+        download: '',
+        click: vi.fn(),
+        remove: vi.fn()
+      } as unknown as HTMLAnchorElement
+      vi.spyOn(document, 'createElement').mockReturnValue(link)
+
+      downloadBlob(blob, 'trace.txt')
+
+      expect(URL.createObjectURL).toHaveBeenCalledWith(blob)
+      expect(document.body.append).toHaveBeenCalledWith(link)
+      expect(link.href).toBe('blob:download-url')
+      expect(link.download).toBe('trace.txt')
+      expect(link.click).toHaveBeenCalledTimes(1)
+      expect(link.remove).toHaveBeenCalledTimes(1)
+      expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:download-url')
+    })
+  })
+})

--- a/src/common/utils/download/download.ts
+++ b/src/common/utils/download/download.ts
@@ -1,0 +1,16 @@
+/**
+ * Downloads a Blob as a file.
+ * @param blob The Blob to download.
+ * @param fileName The name of the file to save as. If not provided, defaults to "file".
+ */
+export function downloadBlob (blob: Blob, fileName?: string): void {
+  const objectUrl = URL.createObjectURL(blob)
+  const link = document.createElement('a')
+
+  link.href = objectUrl
+  link.download = fileName ?? 'file'
+  document.body.append(link)
+  link.click()
+  link.remove()
+  URL.revokeObjectURL(objectUrl)
+}

--- a/src/features/student/traces/locales/en.json
+++ b/src/features/student/traces/locales/en.json
@@ -247,12 +247,14 @@
           },
           "errors": {
             "delete": "An error occurred while deleting the trace",
+            "download": "An error occurred while downloading the trace",
             "fetchAssociations": "An error occurred while fetching the trace associations",
             "fetchTrace": "An error occurred while fetching the trace details"
           },
           "settings": {
             "associate": "Associate my trace",
             "delete": "Delete my trace",
+            "download": "Download my trace",
             "update": "Update my trace"
           },
           "subtitle": "Detail of my trace",

--- a/src/features/student/traces/locales/fr.json
+++ b/src/features/student/traces/locales/fr.json
@@ -246,12 +246,14 @@
           },
           "errors": {
             "delete": "Une erreur est survenue lors de la suppression de la trace.",
+            "download": "Une erreur est survenue lors du téléchargement de la trace.",
             "fetchAssociations": "Une erreur est survenue lors de la récupération des éléments associés à la trace.",
             "fetchTrace": "Une erreur est survenue lors de la récupération de la trace."
           },
           "settings": {
             "associate": "Associer ma trace",
             "delete": "Supprimer ma trace",
+            "download": "Télécharger ma trace",
             "update": "Modifier ma trace"
           },
           "subtitle": "Détail de ma trace",

--- a/src/features/student/traces/views/StudentToolsTracesView/components/StudentTraceDetails/StudentTraceDetails.test.ts
+++ b/src/features/student/traces/views/StudentToolsTracesView/components/StudentTraceDetails/StudentTraceDetails.test.ts
@@ -53,6 +53,7 @@ BddTest().given('a student detailed trace information component', () => {
     title: 'Test Trace Title',
     isAssociated: true,
     programName: 'Test Program',
+    link: 'https://example.com/trace/1',
     isGroup: false,
     aiUseJustification: '',
     personalNote: 'Test personal note content',

--- a/src/features/student/traces/views/StudentTraceView/StudentTraceView.test.ts
+++ b/src/features/student/traces/views/StudentTraceView/StudentTraceView.test.ts
@@ -1,15 +1,38 @@
 import { mockedTraceDetailed } from '@/__mocks__/fixtures/student/traces.fixtures'
-import { createTraceDetailedHandler } from '@/__mocks__/msw/handlers/student/traces.handlers'
+import {
+  createTraceDetailedHandler,
+  downloadTraceAttachmentErrorHandler
+} from '@/__mocks__/msw/handlers/student/traces.handlers'
 import { server } from '@/__mocks__/msw/server'
 import { PageTitleStub } from '@/common/components/PageTitle/PageTitle.stub'
 import { ROUTES } from '@/common/constants'
+import { downloadBlob } from '@/common/utils/download/download'
 import { TraceAssociationsStub } from '@/features/student/traces/components/composites/TraceAssociations/TraceAssociations.stub'
 import { AssociateDeclaredSkillsToTracesModalStub } from '@/features/student/traces/views/StudentTraceView/components/overlays/modals/AssociateDeclaredSkillsToTracesModal/AssociateDeclaredSkillsToTracesModal.stub'
 import StudentTraceView from '@/features/student/traces/views/StudentTraceView/StudentTraceView.vue'
 import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { flushPromises, type VueWrapper } from '@vue/test-utils'
-import { createPinia, setActivePinia } from 'pinia'
 import { mountComponent } from 'tests/utils'
+
+vi.mock('@/common/utils/download/download', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/common/utils/download/download')>()
+  return {
+    ...actual,
+    downloadBlob: vi.fn()
+  }
+})
+
+const mockAddErrorMessage = vi.fn()
+
+vi.mock('@/store', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/store')>()
+  return {
+    ...actual,
+    useToasterStore: () => ({
+      addErrorMessage: mockAddErrorMessage,
+    }),
+  }
+})
 
 vi.mock('@/common/composables', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/common/composables')>()
@@ -66,7 +89,7 @@ BddTest().given('a student trace view', () => {
 
   beforeEach(async () => {
     vi.clearAllMocks()
-    setActivePinia(createPinia())
+
     const handler = createTraceDetailedHandler(mockedTraceDetailed)
     server.use(handler)
     wrapper = mountComponent(StudentTraceView, {
@@ -185,6 +208,46 @@ BddTest().given('a student trace view', () => {
       const { useTracesStore } = await import('@/features/student/traces')
       const tracesStore = useTracesStore()
       expect(tracesStore.showUpdateTraceModal).toBe(true)
+    })
+  })
+
+  BddTest().when('TraceSettingsDropdown emits download-selected', () => {
+    BddTest().then('it should download the trace attachment', async () => {
+      const popover = wrapper.findComponent({ name: 'TraceSettingsDropdown' })
+
+      await popover.vm.$emit('download-selected')
+      await flushPromises()
+
+      expect(downloadBlob).toHaveBeenCalledTimes(1)
+      const [blob, fileName] = vi.mocked(downloadBlob).mock.calls[0]
+      expect(blob).toMatchObject({
+        size: expect.any(Number),
+        type: 'application/octet-stream'
+      })
+      expect(fileName).toBe(mockedTraceDetailed.attachment.fileName)
+      expect(mockAddErrorMessage).not.toHaveBeenCalled()
+    })
+  })
+
+  BddTest().when('TraceSettingsDropdown emits download-selected and download fails', () => {
+    beforeEach(() => {
+      server.use(downloadTraceAttachmentErrorHandler)
+    })
+
+    BddTest().then('it should add an error toaster message', async () => {
+      const popover = wrapper.findComponent({ name: 'TraceSettingsDropdown' })
+
+      await popover.vm.$emit('download-selected')
+      await flushPromises()
+
+      await vi.waitFor(() => {
+        expect(mockAddErrorMessage).toHaveBeenCalledWith({
+          title: 'Une erreur est survenue lors du téléchargement de la trace.',
+          description: 'Internal Server Error',
+        })
+      })
+
+      expect(downloadBlob).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/features/student/traces/views/StudentTraceView/StudentTraceView.vue
+++ b/src/features/student/traces/views/StudentTraceView/StudentTraceView.vue
@@ -1,10 +1,13 @@
 <script setup lang="ts">
+import { useDownloadAttachment } from '@/api/avenir-esr'
 import { QuerySuspense } from '@/common/components'
 import ErrorMessage from '@/common/components/feedback/ErrorMessage/ErrorMessage.vue'
 import Loader from '@/common/components/Loader/Loader.vue'
 import PageTitle from '@/common/components/PageTitle/PageTitle.vue'
 import { useModal, useNavigation } from '@/common/composables'
 import { ROUTES } from '@/common/constants'
+import { BaseApiException } from '@/common/exceptions'
+import { downloadBlob } from '@/common/utils/download/download'
 import { ICONS } from '@/features/student/global/icons'
 import TraceAssociations from '@/features/student/traces/components/composites/TraceAssociations/TraceAssociations.vue'
 import { useTraceAssociationsQuery, useTraceDetailedQuery } from '@/features/student/traces/queries/use-traces.query/use-traces.query'
@@ -14,6 +17,7 @@ import AssociateDeclaredSkillsToTracesModal from '@/features/student/traces/view
 import TraceDeletionConfirmationModal from '@/features/student/traces/views/StudentTraceView/components/TraceDeletionConfirmationModal/TraceDeletionConfirmationModal.vue'
 import TraceSettingsDropdown from '@/features/student/traces/views/StudentTraceView/components/TraceSettingsDropdown/TraceSettingsDropdown.vue'
 import UpdateTraceModal from '@/features/student/traces/views/StudentTraceView/components/UpdateTraceModal/UpdateTraceModal.vue'
+import { useToasterStore } from '@/store'
 import { AvTab, AvTabs, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
 import { useI18n } from 'vue-i18n'
 
@@ -23,6 +27,7 @@ export interface StudentTraceDetailedProps {
 
 const props = defineProps<StudentTraceDetailedProps>()
 const { traceId } = toRefs(props)
+const { addErrorMessage } = useToasterStore()
 
 const { traceDetailed, error: traceDetailsError, isLoading } = useTraceDetailedQuery(traceId)
 const { traceAssociations, error: associationsError } = useTraceAssociationsQuery(traceId)
@@ -38,6 +43,19 @@ const {
 } = useModal()
 
 const { displayUpdateTraceModal } = useTracesStore()
+const { mutate: mutateDownloadAttachment } = useDownloadAttachment()
+
+function downloadAttachment (attachmentId: string) {
+  mutateDownloadAttachment({ attachmentId }, {
+    onError: (error: BaseApiException) => {
+      addErrorMessage({
+        title: t('student.traces.views.StudentTraceView.errors.download'),
+        description: error instanceof BaseApiException ? error.message : t('global.error.generic')
+      })
+    },
+    onSuccess: data => downloadBlob(data, traceDetailed.value?.attachment.fileName)
+  })
+}
 
 const {
   showModal: showAssociateModal,
@@ -81,6 +99,7 @@ const breadcrumbLinks = computed(() => [
           @delete-selected="displayDeleteModal"
           @associate-selected="displayAssociateModal"
           @update-selected="displayUpdateTraceModal"
+          @download-selected="downloadAttachment(traceDetailed.attachment.id)"
         />
       </div>
 

--- a/src/features/student/traces/views/StudentTraceView/components/TraceDeletionConfirmationModal/TraceDeletionConfirmationModal.test.ts
+++ b/src/features/student/traces/views/StudentTraceView/components/TraceDeletionConfirmationModal/TraceDeletionConfirmationModal.test.ts
@@ -35,6 +35,7 @@ BddTest().given('a trace deletion confirmation modal', () => {
   const mockedTrace: TraceDetailDTO = {
     id: 'trace1',
     title: 'Développement d\'un ePortfolio',
+    link: 'https://example.com/trace1',
     isAssociated: false,
     createdAt: '2025-06-16T10:42:00.000Z',
     updatedAt: '2025-06-17T15:18:00.000Z',

--- a/src/features/student/traces/views/StudentTraceView/components/TraceSettingsDropdown/TraceSettingsDropdown.test.ts
+++ b/src/features/student/traces/views/StudentTraceView/components/TraceSettingsDropdown/TraceSettingsDropdown.test.ts
@@ -18,12 +18,12 @@ BddTest().given('a setting popover', () => {
     BddTest().then('it should render the dropdown with three menu items', () => {
       const dropdown = wrapper.findComponent({ name: 'AvDropdown' })
       expect(dropdown.exists()).toBe(true)
-      expect(dropdown.props('items')).toHaveLength(3)
+      expect(dropdown.props('items')).toHaveLength(4)
     })
 
     BddTest().then('it should pass correct props to dropdown', () => {
       const dropdown = wrapper.findComponent({ name: 'AvDropdown' })
-      expect(dropdown.props('items')).toHaveLength(3)
+      expect(dropdown.props('items')).toHaveLength(4)
       expect(dropdown.props('triggerAriaLabel')).toBe('Plus d\'actions')
       expect(dropdown.props('triggerLabel')).toBe('Plus d\'actions')
     })
@@ -50,6 +50,14 @@ BddTest().given('a setting popover', () => {
       const updateButton = wrapper.find('[data-name="update"]')
       await updateButton.trigger('click')
       expect(wrapper.emitted('updateSelected')).toHaveLength(1)
+    })
+  })
+
+  BddTest().when('the download button is clicked', () => {
+    BddTest().then('it should emit the downloadSelected event', async () => {
+      const downloadButton = wrapper.find('[data-name="download"]')
+      await downloadButton.trigger('click')
+      expect(wrapper.emitted('downloadSelected')).toHaveLength(1)
     })
   })
 })

--- a/src/features/student/traces/views/StudentTraceView/components/TraceSettingsDropdown/TraceSettingsDropdown.vue
+++ b/src/features/student/traces/views/StudentTraceView/components/TraceSettingsDropdown/TraceSettingsDropdown.vue
@@ -6,12 +6,14 @@ const emit = defineEmits<{
   (e: 'associateSelected'): void
   (e: 'deleteSelected'): void
   (e: 'updateSelected'): void
+  (e: 'downloadSelected'): void
 }>()
 
 enum TraceSettingsPopoverEvents {
   ASSOCIATE = 'associate',
   DELETE = 'delete',
-  UPDATE = 'update'
+  UPDATE = 'update',
+  DOWNLOAD = 'download'
 }
 
 const { t } = useI18n()
@@ -31,6 +33,11 @@ const menuItems = computed(() => [
     name: TraceSettingsPopoverEvents.UPDATE,
     icon: MDI_ICONS.PENCIL_OUTLINE,
     label: t('student.traces.views.StudentTraceView.settings.update')
+  },
+  {
+    name: TraceSettingsPopoverEvents.DOWNLOAD,
+    icon: MDI_ICONS.DOWNLOAD_OUTLINE,
+    label: t('student.traces.views.StudentTraceView.settings.download')
   }
 ])
 
@@ -44,6 +51,9 @@ function handleItemSelected (itemName: string) {
       break
     case TraceSettingsPopoverEvents.UPDATE:
       emit('updateSelected')
+      break
+    case TraceSettingsPopoverEvents.DOWNLOAD:
+      emit('downloadSelected')
       break
   }
 }

--- a/src/features/student/traces/views/StudentTraceView/components/UpdateTraceForm/UpdateTraceForm.test.ts
+++ b/src/features/student/traces/views/StudentTraceView/components/UpdateTraceForm/UpdateTraceForm.test.ts
@@ -68,6 +68,7 @@ BddTest().given('an update trace form component', () => {
     mockTrace = {
       id: 'trace-123',
       title: 'Existing Trace',
+      link: 'https://example.com/existing-trace',
       programName: 'Test Program',
       isGroup: false,
       aiUseJustification: '',

--- a/src/features/student/traces/views/StudentTraceView/components/UpdateTraceModal/TermsStep.test.ts
+++ b/src/features/student/traces/views/StudentTraceView/components/UpdateTraceModal/TermsStep.test.ts
@@ -11,6 +11,7 @@ BddTest().given('a terms step', () => {
   const mockedTrace: TraceDetailDTO = {
     id: 'mock-trace',
     title: 'An awesome trace',
+    link: 'https://example.com',
     isAssociated: true,
     createdAt: '2025-06-01T10:42:00.000Z',
     updatedAt: '2025-06-02T11:42:00.000Z',

--- a/src/features/student/traces/views/StudentTraceView/components/UpdateTraceModal/UpdateStep.test.ts
+++ b/src/features/student/traces/views/StudentTraceView/components/UpdateTraceModal/UpdateStep.test.ts
@@ -23,6 +23,7 @@ BddTest().given('an update step', () => {
   const mockedTrace: TraceDetailDTO = {
     id: 'mock-trace',
     title: 'An awesome trace',
+    link: 'https://example.com',
     isAssociated: true,
     createdAt: '2025-06-01T10:42:00.000Z',
     updatedAt: '2025-06-02T11:42:00.000Z',

--- a/src/features/student/traces/views/StudentTraceView/components/UpdateTraceModal/UpdateTraceModal.test.ts
+++ b/src/features/student/traces/views/StudentTraceView/components/UpdateTraceModal/UpdateTraceModal.test.ts
@@ -16,6 +16,7 @@ BddTest().given('an update trace modal', () => {
   const mockedTrace: TraceDetailDTO = {
     id: 'mock-trace',
     title: 'An awesome trace',
+    link: 'https://example.com',
     isAssociated: true,
     createdAt: '2025-06-01T10:42:00.000Z',
     updatedAt: '2025-06-02T11:42:00.000Z',


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
This PR adds trace attachment download support in the student trace view.

**Main changes:**
- ✨ Adds a download action in the trace settings menu and triggers the attachment download from the trace details view
- ♻️ Extends the fetch factory so binary attachment responses are handled as `Blob` values instead of being limited to PDFs or raw array buffers
- 🔧 Updates the generated API contract and Orval configuration to expose the new `downloadAttachment` operation as a mutation
- ✅ Covers the new success and error flows with view, dropdown, mock handler, and fetch factory tests
- 💬 Adds the related UI labels and error message translations

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1456

---

### Documentation
- OpenAPI specification updated with the trace attachment download endpoint and related schema changes
- Orval generation updated so the attachment download endpoint is available through the typed client
- Frontend translations updated in both English and French for the new download action and error feedback
- Automated tests updated for the fetch layer and trace view download flow

**Modified files:**
- `api-specs/avenir-esr.swagger.json` - adds the download endpoint and related schema updates
- `orval.config.ts` - configures `downloadAttachment` as a mutation
- `src/api/fetch/fetch-factory/fetch-factory.ts` - improves binary response handling
- `src/features/student/traces/views/StudentTraceView/StudentTraceView.vue` - downloads the attachment and reports API errors to the toaster
- `src/features/student/traces/views/StudentTraceView/components/TraceSettingsDropdown/TraceSettingsDropdown.vue` - adds the download action to the trace settings menu
- Test files and MSW fixtures - cover the new download behavior

---

### Target Branch
`develop`

---

### Additional Notes
The implementation relies on the generated API client for the actual download request and uses a browser object URL to save the returned blob with the attachment filename. The fetch factory change is intentionally broader than this single screen so other binary endpoints can also be consumed as `Blob` responses without extra per-endpoint handling.

---

### Known Limitations or Side Effects
The download is still browser-driven, so there is no progress feedback during the transfer. When the backend does not provide a usable filename, the client falls back to `attachment`.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [x] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [ ] Code style and formatting rules respected (linting, conventions, etc.)
- [x] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process
