### PR TITLE
feat(993): add useUnsavedChangesGuard in StudentToolsTracesAddTraceDr…

### DIFF
--- a/src/common/components/overlay/drawers/UpdateProfileDrawer/UpdateProfileDrawer.test.ts
+++ b/src/common/components/overlay/drawers/UpdateProfileDrawer/UpdateProfileDrawer.test.ts
@@ -34,6 +34,24 @@ vi.mock('./use-update-profile-form', () => ({
   useUpdateProfileForm: vi.fn(),
 }))
 
+const mockCanLeave = vi.fn<() => Promise<boolean>>()
+const mockConfirm = vi.fn()
+const mockCancel = vi.fn()
+
+vi.mock('@/common/composables/use-unsaved-changes-guard/use-unsaved-changes-guard', async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import('@/common/composables/use-unsaved-changes-guard/use-unsaved-changes-guard')
+  >()
+  return {
+    ...actual,
+    useUnsavedChangesGuard: () => ({
+      canLeave: mockCanLeave,
+      confirm: mockConfirm,
+      cancel: mockCancel
+    })
+  }
+})
+
 BddTest().given('given an update profile drawer', () => {
   let wrapper: VueWrapper
 
@@ -215,6 +233,8 @@ BddTest().given('given an update profile drawer', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    mockCanLeave.mockResolvedValue(true)
+
     vi.mocked(useRoute).mockReturnValue({
       path: '/student/home'
     } as any)
@@ -396,13 +416,115 @@ BddTest().given('given an update profile drawer', () => {
       })
     })
 
-    BddTest().when('the confirmation modal emits confirm', () => {
-      BddTest().then('it should call hideModal and onClose', async () => {
-        const modal = wrapper.findComponent({ name: 'ConfirmationModal' })
-        await modal.vm.$emit('confirm')
-        await wrapper.vm.$nextTick()
+    BddTest().when('escape is pressed on drawer', () => {
+      BddTest().and('canLeave is true', () => {
+        beforeEach(async () => {
+          const drawer = wrapper.findComponent({ name: 'AvDrawer' })
+          await drawer.vm.$emit('escape-pressed')
+          await wrapper.vm.$nextTick()
+        })
 
-        expect(defaultProps.onClose).toHaveBeenCalled()
+        BddTest().then('it should call onClose', () => {
+          expect(mockOnClose).toHaveBeenCalledTimes(1)
+        })
+      })
+
+      BddTest().and('canLeave is false', () => {
+        beforeEach(async () => {
+          mockCanLeave.mockResolvedValue(false)
+          mockedUseUpdateProfileForm.mockImplementation(() => ({
+            form: mockedForm as any,
+            isPending: computed(() => false),
+            isModified: computed(() => true),
+            resetForm: mockedResetForm,
+            onCoverPictureUpdate: vi.fn(),
+            onProfilePictureUpdate: vi.fn(),
+            onUpdateProfileCoverSuccess: vi.fn(),
+            onUpdateProfilePhotoSuccess: vi.fn(),
+            coverPictureFile: ref<File | null>(null),
+            profilePictureFile: ref<File | null>(null),
+          }))
+          wrapper = mountComponent(UpdateProfileDrawer, {
+            props: defaultProps,
+            global: { stubs }
+          })
+          const drawer = wrapper.findComponent({ name: 'AvDrawer' })
+          await drawer.vm.$emit('escape-pressed')
+          await wrapper.vm.$nextTick()
+        })
+
+        BddTest().then('it should not call onClose', () => {
+          expect(mockOnClose).not.toHaveBeenCalled()
+        })
+      })
+    })
+
+    BddTest().when('cancel button is clicked', () => {
+      BddTest().and('canLeave is true', () => {
+        beforeEach(async () => {
+          const cancelButton = wrapper.findAllComponents({ name: 'AvButton' })
+            .find(b => b.props('label') === 'Quitter')
+          await cancelButton?.trigger('click')
+          await wrapper.vm.$nextTick()
+        })
+
+        BddTest().then('it should call onClose', () => {
+          expect(mockOnClose).toHaveBeenCalledTimes(1)
+        })
+      })
+
+      BddTest().and('canLeave is false', () => {
+        beforeEach(async () => {
+          mockCanLeave.mockResolvedValue(false)
+          mockedUseUpdateProfileForm.mockImplementation(() => ({
+            form: mockedForm as any,
+            isPending: computed(() => false),
+            isModified: computed(() => true),
+            resetForm: mockedResetForm,
+            onCoverPictureUpdate: vi.fn(),
+            onProfilePictureUpdate: vi.fn(),
+            onUpdateProfileCoverSuccess: vi.fn(),
+            onUpdateProfilePhotoSuccess: vi.fn(),
+            coverPictureFile: ref<File | null>(null),
+            profilePictureFile: ref<File | null>(null),
+          }))
+          wrapper = mountComponent(UpdateProfileDrawer, {
+            props: defaultProps,
+            global: { stubs }
+          })
+          const cancelButton = wrapper.findAllComponents({ name: 'AvButton' })
+            .find(b => b.props('label') === 'Quitter')
+          await cancelButton?.trigger('click')
+          await wrapper.vm.$nextTick()
+        })
+
+        BddTest().then('it should not call onClose', () => {
+          expect(mockOnClose).not.toHaveBeenCalled()
+        })
+
+        BddTest().and('confirming the modal', () => {
+          beforeEach(async () => {
+            const confirmationModal = wrapper.findComponent({ name: 'ConfirmationModal' })
+            await confirmationModal.vm.$emit('confirm')
+            await wrapper.vm.$nextTick()
+          })
+
+          BddTest().then('it should call guard confirm', () => {
+            expect(mockConfirm).toHaveBeenCalledTimes(1)
+          })
+        })
+
+        BddTest().and('closing the modal', () => {
+          beforeEach(async () => {
+            const confirmationModal = wrapper.findComponent({ name: 'ConfirmationModal' })
+            await confirmationModal.vm.$emit('close')
+            await wrapper.vm.$nextTick()
+          })
+
+          BddTest().then('it should call guard cancel', () => {
+            expect(mockCancel).toHaveBeenCalledTimes(1)
+          })
+        })
       })
     })
 

--- a/src/common/components/overlay/drawers/UpdateProfileDrawer/UpdateProfileDrawer.vue
+++ b/src/common/components/overlay/drawers/UpdateProfileDrawer/UpdateProfileDrawer.vue
@@ -5,6 +5,7 @@ import { ConfirmationModal, ImageUpload } from '@/common/components'
 import { BIOGRAPHY_MAX_LENGTH } from '@/common/components/overlay/drawers/UpdateProfileDrawer/config'
 import { useUpdateProfileForm } from '@/common/components/overlay/drawers/UpdateProfileDrawer/use-update-profile-form'
 import { useModal } from '@/common/composables'
+import { useUnsavedChangesGuard } from '@/common/composables/use-unsaved-changes-guard/use-unsaved-changes-guard'
 import { useToasterStore } from '@/store'
 import {
   AvAccordion,
@@ -66,6 +67,16 @@ function onUpdateProfileSuccess () {
   onClose()
 }
 
+const {
+  canLeave,
+  confirm,
+  cancel
+} = useUnsavedChangesGuard({
+  isDirty: isModified,
+  openModal: displayModal,
+  closeModal: hideModal
+})
+
 const { mutate: deleteCoverPictureMutation } = useDeleteUserPhoto()
 
 function deleteCoverPicture ({ fileId }: { fileId: string }) {
@@ -108,6 +119,12 @@ function onSubmitForm (event: Event) {
   form.handleSubmit()
 }
 
+async function handleCancel () {
+  if (await canLeave()) {
+    onClose()
+  }
+}
+
 watch(() => show, (newVal) => {
   if (newVal) {
     resetForm()
@@ -119,7 +136,7 @@ watch(() => show, (newVal) => {
   <AvDrawer
     :show="show"
     data-testid="update-profile-drawer"
-    @escape-pressed="isModified ? displayModal() : onClose()"
+    @escape-pressed="handleCancel"
   >
     <div class="av-col av-gap-xl">
       <AvIconText
@@ -232,8 +249,8 @@ watch(() => show, (newVal) => {
           :confirm-is-loading="isPending"
           :confirm-disabled="!isModified"
           form="profile-form"
-          @cancel="() => isModified ? displayModal() : onClose()"
-          @confirm="form.handleSubmit"
+          @cancel="handleCancel"
+          @confirm="confirm"
         />
       </div>
     </template>
@@ -241,10 +258,7 @@ watch(() => show, (newVal) => {
   <ConfirmationModal
     :show="showModal"
     :is-loading="isPending"
-    @confirm="() => {
-      hideModal()
-      onClose()
-    }"
-    @close="hideModal"
+    @confirm="confirm"
+    @close="cancel"
   />
 </template>

--- a/src/features/student/buildProject/components/overlays/UpdateActivityDrawer/UpdateActivityDrawer.test.ts
+++ b/src/features/student/buildProject/components/overlays/UpdateActivityDrawer/UpdateActivityDrawer.test.ts
@@ -8,6 +8,24 @@ import { AvAccordionStub, AvDrawerStub, AvIconTextStub, BddTest } from '@avenirs
 import { mountComponent } from 'tests/utils'
 import { beforeEach, expect, vi } from 'vitest'
 
+const mockCanLeave = vi.fn<() => Promise<boolean>>()
+const mockConfirm = vi.fn()
+const mockCancel = vi.fn()
+
+vi.mock('@/common/composables/use-unsaved-changes-guard/use-unsaved-changes-guard', async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import('@/common/composables/use-unsaved-changes-guard/use-unsaved-changes-guard')
+  >()
+  return {
+    ...actual,
+    useUnsavedChangesGuard: () => ({
+      canLeave: mockCanLeave,
+      confirm: mockConfirm,
+      cancel: mockCancel
+    })
+  }
+})
+
 BddTest().given('the UpdateActivityDrawer component', () => {
   let wrapper: VueWrapper<InstanceType<typeof UpdateActivityDrawer>>
 
@@ -22,6 +40,8 @@ BddTest().given('the UpdateActivityDrawer component', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    mockCanLeave.mockResolvedValue(true)
+
     wrapper = mountComponent(UpdateActivityDrawer, {
       props: {
         show: true,
@@ -61,6 +81,8 @@ BddTest().given('the UpdateActivityDrawer component', () => {
   BddTest().when('the drawer is mounted with show=false', () => {
     beforeEach(() => {
       vi.clearAllMocks()
+      mockCanLeave.mockResolvedValue(true)
+
       wrapper = mountComponent(UpdateActivityDrawer, {
         props: {
           show: false,
@@ -76,32 +98,86 @@ BddTest().given('the UpdateActivityDrawer component', () => {
     })
   })
 
-  BddTest().when('the cancel action is triggered without dirty form', () => {
-    beforeEach(async () => {
-      const formCancelConfirmButtons = wrapper.findComponent({ name: 'FormCancelConfirmButtons' })
-      await formCancelConfirmButtons.vm.$emit('cancel')
-      await wrapper.vm.$nextTick()
+  BddTest().when('cancel button is clicked', () => {
+    BddTest().and('canLeave is true', () => {
+      beforeEach(async () => {
+        const formCancelConfirmButtons = wrapper.findComponent({ name: 'FormCancelConfirmButtons' })
+        await formCancelConfirmButtons.vm.$emit('cancel')
+        await wrapper.vm.$nextTick()
+      })
+
+      BddTest().then('it should emit close', () => {
+        expect(wrapper.emitted('close')).toBeTruthy()
+      })
+
+      BddTest().then('it should not show the confirmation modal', () => {
+        const modal = wrapper.findComponent({ name: 'ConfirmationModal' }) as VueWrapper<InstanceType<typeof ConfirmationModalStub>>
+        expect(modal.props('show')).toBe(false)
+      })
     })
 
-    BddTest().then('it should emit close', () => {
-      expect(wrapper.emitted('close')).toBeTruthy()
-    })
+    BddTest().and('canLeave is false', () => {
+      beforeEach(async () => {
+        mockCanLeave.mockResolvedValue(false)
+        const formCancelConfirmButtons = wrapper.findComponent({ name: 'FormCancelConfirmButtons' })
+        await formCancelConfirmButtons.vm.$emit('cancel')
+        await wrapper.vm.$nextTick()
+      })
 
-    BddTest().then('it should not show the confirmation modal', () => {
-      const modal = wrapper.findComponent({ name: 'ConfirmationModal' }) as VueWrapper<InstanceType<typeof ConfirmationModalStub>>
-      expect(modal.props('show')).toBe(false)
+      BddTest().then('it should not emit close', () => {
+        expect(wrapper.emitted('close')).toBeFalsy()
+      })
+
+      BddTest().and('confirming the modal', () => {
+        beforeEach(async () => {
+          const confirmationModal = wrapper.findComponent({ name: 'ConfirmationModal' })
+          await confirmationModal.vm.$emit('confirm')
+          await wrapper.vm.$nextTick()
+        })
+
+        BddTest().then('it should call guard confirm', () => {
+          expect(mockConfirm).toHaveBeenCalledTimes(1)
+        })
+      })
+
+      BddTest().and('closing the modal', () => {
+        beforeEach(async () => {
+          const confirmationModal = wrapper.findComponent({ name: 'ConfirmationModal' })
+          await confirmationModal.vm.$emit('close')
+          await wrapper.vm.$nextTick()
+        })
+
+        BddTest().then('it should call guard cancel', () => {
+          expect(mockCancel).toHaveBeenCalledTimes(1)
+        })
+      })
     })
   })
 
-  BddTest().when('escape is pressed without dirty form', () => {
-    beforeEach(async () => {
-      const avDrawer = wrapper.findComponent({ name: 'AvDrawer' })
-      await avDrawer.vm.$emit('escape-pressed')
-      await wrapper.vm.$nextTick()
+  BddTest().when('escape is pressed on drawer', () => {
+    BddTest().and('canLeave is true', () => {
+      beforeEach(async () => {
+        const avDrawer = wrapper.findComponent({ name: 'AvDrawer' })
+        await avDrawer.vm.$emit('escape-pressed')
+        await wrapper.vm.$nextTick()
+      })
+
+      BddTest().then('it should emit close', () => {
+        expect(wrapper.emitted('close')).toBeTruthy()
+      })
     })
 
-    BddTest().then('it should emit close', () => {
-      expect(wrapper.emitted('close')).toBeTruthy()
+    BddTest().and('canLeave is false', () => {
+      beforeEach(async () => {
+        mockCanLeave.mockResolvedValue(false)
+        const avDrawer = wrapper.findComponent({ name: 'AvDrawer' })
+        await avDrawer.vm.$emit('escape-pressed')
+        await wrapper.vm.$nextTick()
+      })
+
+      BddTest().then('it should not emit close', () => {
+        expect(wrapper.emitted('close')).toBeFalsy()
+      })
     })
   })
 
@@ -112,8 +188,8 @@ BddTest().given('the UpdateActivityDrawer component', () => {
       await wrapper.vm.$nextTick()
     })
 
-    BddTest().then('it should not emit close', () => {
-      expect(wrapper.emitted('close')).toBeFalsy()
+    BddTest().then('it should call guard cancel', () => {
+      expect(mockCancel).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/src/features/student/buildProject/components/overlays/UpdateActivityDrawer/UpdateActivityDrawer.vue
+++ b/src/features/student/buildProject/components/overlays/UpdateActivityDrawer/UpdateActivityDrawer.vue
@@ -3,6 +3,7 @@ import type { DeclaredActivityDetailsDTO } from '@/api/avenir-esr'
 import ConfirmationModal from '@/common/components/ConfirmationModal/ConfirmationModal.vue'
 import FormCancelConfirmButtons from '@/common/components/FormCancelConfirmButtons/FormCancelConfirmButtons.vue'
 import { useModal } from '@/common/composables'
+import { useUnsavedChangesGuard } from '@/common/composables/use-unsaved-changes-guard/use-unsaved-changes-guard'
 import ActivityPeriodFormField
   from '@/features/student/buildProject/components/interactions/formFields/ActivityPeriodFormField/ActivityPeriodFormField.vue'
 import { useUpdateActivityForm } from '@/features/student/buildProject/components/overlays/UpdateActivityDrawer/use-update-activity-form/use-update-activity-form'
@@ -43,19 +44,21 @@ const isDirty = computed(() => {
   return state.value.isDirty
 })
 
-function handleCancel () {
-  if (isDirty.value) {
-    displayConfirmationModal()
-  }
-  else {
-    confirmCancel()
-  }
-}
+const {
+  canLeave,
+  confirm,
+  cancel
+} = useUnsavedChangesGuard({
+  isDirty,
+  openModal: displayConfirmationModal,
+  closeModal: hideConfirmationModal
+})
 
-function confirmCancel () {
-  form.reset()
-  hideConfirmationModal()
-  emit('close')
+async function handleCancel () {
+  if (await canLeave()) {
+    form.reset()
+    emit('close')
+  }
 }
 
 const minStartDate = computed(() => {
@@ -134,7 +137,7 @@ const isDemo = __DEMO_MODE__
   <ConfirmationModal
     :show="showConfirmationModal"
     :description="t('student.buildProject.activities.overlays.UpdateActivityDrawer.confirmationModal.description')"
-    @close="hideConfirmationModal"
-    @confirm="confirmCancel"
+    @close="cancel"
+    @confirm="confirm"
   />
 </template>

--- a/src/features/student/declaredSkills/components/overlays/AddDeclaredSkillDrawer/AddDeclaredSkillDrawer.test.ts
+++ b/src/features/student/declaredSkills/components/overlays/AddDeclaredSkillDrawer/AddDeclaredSkillDrawer.test.ts
@@ -19,6 +19,24 @@ vi.mock('@avenirs-esr/avenirs-dsav', async (importOriginal) => {
   }
 })
 
+const mockCanLeave = vi.fn<() => Promise<boolean>>()
+const mockConfirm = vi.fn()
+const mockCancel = vi.fn()
+
+vi.mock('@/common/composables/use-unsaved-changes-guard/use-unsaved-changes-guard', async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import('@/common/composables/use-unsaved-changes-guard/use-unsaved-changes-guard')
+  >()
+  return {
+    ...actual,
+    useUnsavedChangesGuard: () => ({
+      canLeave: mockCanLeave,
+      confirm: mockConfirm,
+      cancel: mockCancel
+    })
+  }
+})
+
 const stubs = {
   AvDrawer: AvDrawerStub,
   AvButton: AvButtonStub,
@@ -42,6 +60,7 @@ BddTest().given('an add declared skill drawer component', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    mockCanLeave.mockResolvedValue(true)
 
     wrapper = mountComponent(AddDeclaredSkillDrawer, {
       global: {
@@ -119,27 +138,85 @@ BddTest().given('an add declared skill drawer component', () => {
     })
   })
 
-  BddTest().when('the escape key is pressed on drawer', () => {
-    BddTest().then('it should hide the declared skill drawer', async () => {
-      const store = useDeclaredSkillsStore()
-      const hideDrawerSpy = vi.spyOn(store, 'hideCreateDeclaredSkillDrawer')
-      const drawer = wrapper.findComponent({ name: 'AvDrawer' })
+  BddTest().when('escape is pressed on drawer', () => {
+    BddTest().and('canLeave is true', () => {
+      beforeEach(async () => {
+        const drawer = wrapper.findComponent({ name: 'AvDrawer' })
+        await drawer.vm.$emit('escape-pressed')
+        await wrapper.vm.$nextTick()
+      })
 
-      await drawer.vm.$emit('escape-pressed')
+      BddTest().then('it should hide the declared skill drawer', () => {
+        const store = useDeclaredSkillsStore()
+        expect(store.showCreateDeclaredSkillDrawer).toBe(false)
+      })
+    })
 
-      expect(hideDrawerSpy).toHaveBeenCalled()
+    BddTest().and('canLeave is false', () => {
+      beforeEach(async () => {
+        mockCanLeave.mockResolvedValue(false)
+        const drawer = wrapper.findComponent({ name: 'AvDrawer' })
+        await drawer.vm.$emit('escape-pressed')
+        await wrapper.vm.$nextTick()
+      })
+
+      BddTest().then('it should not hide the declared skill drawer', () => {
+        const store = useDeclaredSkillsStore()
+        expect(store.showCreateDeclaredSkillDrawer).toBe(true)
+      })
     })
   })
 
-  BddTest().when('the cancel button is clicked', () => {
-    BddTest().then('it should hide the drawer and reset form', async () => {
-      const store = useDeclaredSkillsStore()
-      const hideDrawerSpy = vi.spyOn(store, 'hideCreateDeclaredSkillDrawer')
-      const cancelButton = getCancelButton()
+  BddTest().when('cancel button is clicked', () => {
+    BddTest().and('canLeave is true', () => {
+      beforeEach(async () => {
+        const cancelButton = getCancelButton()
+        await cancelButton?.trigger('click')
+        await wrapper.vm.$nextTick()
+      })
 
-      await cancelButton?.trigger('click')
+      BddTest().then('it should hide the declared skill drawer', () => {
+        const store = useDeclaredSkillsStore()
+        expect(store.showCreateDeclaredSkillDrawer).toBe(false)
+      })
+    })
 
-      expect(hideDrawerSpy).toHaveBeenCalled()
+    BddTest().and('canLeave is false', () => {
+      beforeEach(async () => {
+        mockCanLeave.mockResolvedValue(false)
+        const cancelButton = getCancelButton()
+        await cancelButton?.trigger('click')
+        await wrapper.vm.$nextTick()
+      })
+
+      BddTest().then('it should not hide the declared skill drawer', () => {
+        const store = useDeclaredSkillsStore()
+        expect(store.showCreateDeclaredSkillDrawer).toBe(true)
+      })
+
+      BddTest().and('confirming the modal', () => {
+        beforeEach(async () => {
+          const confirmationModal = wrapper.findComponent({ name: 'ConfirmationModal' })
+          await confirmationModal.vm.$emit('confirm')
+          await wrapper.vm.$nextTick()
+        })
+
+        BddTest().then('it should call guard confirm', () => {
+          expect(mockConfirm).toHaveBeenCalledTimes(1)
+        })
+      })
+
+      BddTest().and('closing the modal', () => {
+        beforeEach(async () => {
+          const confirmationModal = wrapper.findComponent({ name: 'ConfirmationModal' })
+          await confirmationModal.vm.$emit('close')
+          await wrapper.vm.$nextTick()
+        })
+
+        BddTest().then('it should call guard cancel', () => {
+          expect(mockCancel).toHaveBeenCalledTimes(1)
+        })
+      })
     })
   })
 

--- a/src/features/student/declaredSkills/components/overlays/AddDeclaredSkillDrawer/AddDeclaredSkillDrawer.vue
+++ b/src/features/student/declaredSkills/components/overlays/AddDeclaredSkillDrawer/AddDeclaredSkillDrawer.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ConfirmationModal, FormCancelConfirmButtons } from '@/common/components'
 import { useModal } from '@/common/composables'
+import { useUnsavedChangesGuard } from '@/common/composables/use-unsaved-changes-guard/use-unsaved-changes-guard'
 import DeclaredSkillLevelRadioButtonSetFormField from '@/features/student/declaredSkills/components/interactions/formFields/DeclaredSkillLevelRadioButtonSetFormField/DeclaredSkillLevelRadioButtonSetFormField.vue'
 import DeclaredSkillReflectionFormField
   from '@/features/student/declaredSkills/components/interactions/formFields/DeclaredSkillReflectionFormField/DeclaredSkillReflectionFormField.vue'
@@ -37,19 +38,17 @@ const isDirty = computed(() => {
   return state.value.isDirty
 })
 
-function handleCancel () {
-  if (isDirty.value) {
-    displayConfirmationModal()
-  }
-  else {
-    confirmCancel()
-  }
-}
+const { canLeave, confirm, cancel } = useUnsavedChangesGuard({
+  isDirty,
+  openModal: displayConfirmationModal,
+  closeModal: hideConfirmationModal
+})
 
-function confirmCancel () {
-  form.reset()
-  declaredSkillsStore.hideCreateDeclaredSkillDrawer()
-  hideConfirmationModal()
+async function handleCancel () {
+  if (await canLeave()) {
+    form.reset()
+    declaredSkillsStore.hideCreateDeclaredSkillDrawer()
+  }
 }
 </script>
 
@@ -123,8 +122,8 @@ function confirmCancel () {
   <ConfirmationModal
     :show="showConfirmationModal"
     :description="t('student.declaredSkills.overlays.AddDeclaredSkillDrawer.confirmationModal.description')"
-    @close="hideConfirmationModal"
-    @confirm="confirmCancel"
+    @close="cancel"
+    @confirm="confirm"
   />
 </template>
 

--- a/src/features/student/declaredSkills/views/StudentUpdateDeclaredSkillView/StudentUpdateDeclaredSkillView.test.ts
+++ b/src/features/student/declaredSkills/views/StudentUpdateDeclaredSkillView/StudentUpdateDeclaredSkillView.test.ts
@@ -1,4 +1,5 @@
 import type { VueWrapper } from '@vue/test-utils'
+import { ConfirmationModalStub } from '@/common/components/ConfirmationModal/ConfirmationModal.stub'
 import { ROUTES } from '@/common/constants'
 import StudentUpdateDeclaredSkillView from '@/features/student/declaredSkills/views/StudentUpdateDeclaredSkillView/StudentUpdateDeclaredSkillView.vue'
 import { UpdateInProgressBadgeStub } from '@/features/student/global/components/badges/UpdateInProgressBadge/UpdateInProgressBadge.stub'
@@ -15,6 +16,24 @@ vi.mock('@/common/composables', async (importOriginal) => {
     useNavigation: () => ({
       navigateToStudentDeclaredSkill,
     }),
+  }
+})
+
+const mockCanLeave = vi.fn<() => Promise<boolean>>()
+const mockConfirm = vi.fn()
+const mockCancel = vi.fn()
+
+vi.mock('@/common/composables/use-unsaved-changes-guard/use-unsaved-changes-guard', async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import('@/common/composables/use-unsaved-changes-guard/use-unsaved-changes-guard')
+  >()
+  return {
+    ...actual,
+    useUnsavedChangesGuard: () => ({
+      canLeave: mockCanLeave,
+      confirm: mockConfirm,
+      cancel: mockCancel
+    })
   }
 })
 
@@ -39,7 +58,7 @@ const PageTitleStubWithBack = {
 
 const UpdateDeclaredSkillFormStub = {
   name: 'UpdateDeclaredSkillForm',
-  props: ['declaredSkillProgressDetails', 'onSkillUpdated'],
+  props: ['declaredSkillProgressDetails', 'onSkillUpdated', 'onCancel'],
   emits: ['dirty-change'],
   template: '<div class="update-form-stub" />',
 }
@@ -56,7 +75,8 @@ const stubs = {
   AvTab: AvTabStub,
   UpdateDeclaredSkillForm: UpdateDeclaredSkillFormStub,
   UpdateDeclaredSkillAssociations: UpdateDeclaredSkillAssociationsStub,
-  UpdateInProgressBadge: UpdateInProgressBadgeStub
+  UpdateInProgressBadge: UpdateInProgressBadgeStub,
+  ConfirmationModal: ConfirmationModalStub
 }
 
 BddTest().given('a student update declared skill view component', () => {
@@ -64,6 +84,7 @@ BddTest().given('a student update declared skill view component', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    mockCanLeave.mockResolvedValue(true)
 
     wrapper = mountComponent(StudentUpdateDeclaredSkillView, {
       props: {
@@ -119,6 +140,7 @@ BddTest().given('a student update declared skill view component', () => {
         const form = wrapper.findComponent(UpdateDeclaredSkillFormStub)
         expect(form.exists()).toBe(true)
         expect(typeof form.props('onSkillUpdated')).toBe('function')
+        expect(typeof form.props('onCancel')).toBe('function')
         expect(form.props('declaredSkillProgressDetails')).toMatchObject({
           id: '123',
           title: 'Conduire un projet de bout en bout'
@@ -137,6 +159,12 @@ BddTest().given('a student update declared skill view component', () => {
         expect(associations.exists()).toBe(true)
         expect(associations.props('declaredSkillId')).toBe('123')
       })
+    })
+
+    BddTest().then('it should render the confirmation modal initially hidden', () => {
+      const modal = wrapper.findComponent(ConfirmationModalStub)
+      expect(modal.exists()).toBe(true)
+      expect(modal.props('show')).toBe(false)
     })
   })
 
@@ -183,6 +211,65 @@ BddTest().given('a student update declared skill view component', () => {
 
       badge = wrapper.find('[data-testid="update-in-progress-badge"]')
       expect(badge.exists()).toBe(false)
+    })
+  })
+
+  BddTest().when('the cancel action is triggered on the form', () => {
+    BddTest().and('canLeave is true', () => {
+      beforeEach(async () => {
+        await vi.waitFor(() => {
+          const form = wrapper.findComponent({ name: 'UpdateDeclaredSkillForm' })
+          expect(form.exists()).toBe(true)
+        })
+        const form = wrapper.findComponent({ name: 'UpdateDeclaredSkillForm' })
+        await form.vm.$props.onCancel()
+        await wrapper.vm.$nextTick()
+      })
+
+      BddTest().then('it should navigate to declared skill view', () => {
+        expect(navigateToStudentDeclaredSkill).toHaveBeenCalledTimes(1)
+      })
+    })
+
+    BddTest().and('canLeave is false', () => {
+      beforeEach(async () => {
+        mockCanLeave.mockResolvedValue(false)
+        await vi.waitFor(() => {
+          const form = wrapper.findComponent({ name: 'UpdateDeclaredSkillForm' })
+          expect(form.exists()).toBe(true)
+        })
+        const form = wrapper.findComponent({ name: 'UpdateDeclaredSkillForm' })
+        await form.vm.$props.onCancel()
+        await wrapper.vm.$nextTick()
+      })
+
+      BddTest().then('it should not navigate', () => {
+        expect(navigateToStudentDeclaredSkill).not.toHaveBeenCalled()
+      })
+
+      BddTest().and('confirming the modal', () => {
+        beforeEach(async () => {
+          const confirmationModal = wrapper.findComponent({ name: 'ConfirmationModal' })
+          await confirmationModal.vm.$emit('confirm')
+          await wrapper.vm.$nextTick()
+        })
+
+        BddTest().then('it should call guard confirm', () => {
+          expect(mockConfirm).toHaveBeenCalledTimes(1)
+        })
+      })
+
+      BddTest().and('closing the modal', () => {
+        beforeEach(async () => {
+          const confirmationModal = wrapper.findComponent({ name: 'ConfirmationModal' })
+          await confirmationModal.vm.$emit('close')
+          await wrapper.vm.$nextTick()
+        })
+
+        BddTest().then('it should call guard cancel', () => {
+          expect(mockCancel).toHaveBeenCalledTimes(1)
+        })
+      })
     })
   })
 })

--- a/src/features/student/declaredSkills/views/StudentUpdateDeclaredSkillView/StudentUpdateDeclaredSkillView.vue
+++ b/src/features/student/declaredSkills/views/StudentUpdateDeclaredSkillView/StudentUpdateDeclaredSkillView.vue
@@ -1,12 +1,11 @@
 <script setup lang="ts">
-import PageTitle from '@/common/components/PageTitle/PageTitle.vue'
-import { useNavigation } from '@/common/composables'
+import { ConfirmationModal, PageTitle } from '@/common/components'
+import { useModal, useNavigation } from '@/common/composables'
+import { useUnsavedChangesGuard } from '@/common/composables/use-unsaved-changes-guard/use-unsaved-changes-guard'
 import { ROUTES } from '@/common/constants'
 import { useDeclaredSkillDetailedQuery } from '@/features/student/declaredSkills/queries/use-declared-skills.query/use-declared-skills.query'
-import UpdateDeclaredSkillAssociations
-  from '@/features/student/declaredSkills/views/StudentUpdateDeclaredSkillView/components/UpdateDeclaredSkillAssociations/UpdateDeclaredSkillAssociations.vue'
-import UpdateDeclaredSkillForm
-  from '@/features/student/declaredSkills/views/StudentUpdateDeclaredSkillView/components/UpdateDeclaredSkillForm/UpdateDeclaredSkillForm.vue'
+import UpdateDeclaredSkillAssociations from '@/features/student/declaredSkills/views/StudentUpdateDeclaredSkillView/components/UpdateDeclaredSkillAssociations/UpdateDeclaredSkillAssociations.vue'
+import UpdateDeclaredSkillForm from '@/features/student/declaredSkills/views/StudentUpdateDeclaredSkillView/components/UpdateDeclaredSkillForm/UpdateDeclaredSkillForm.vue'
 import UpdateInProgressBadge from '@/features/student/global/components/badges/UpdateInProgressBadge/UpdateInProgressBadge.vue'
 import { ICONS } from '@/features/student/global/icons'
 import { AvTab, AvTabs, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
@@ -17,6 +16,7 @@ interface StudentUpdateDeclaredSkillViewProps {
 }
 
 const { skillId } = defineProps<StudentUpdateDeclaredSkillViewProps>()
+
 enum StudentUpdateDeclaredSkillViewTabs {
   DETAILS = 0,
   ASSOCIATIONS = 1
@@ -39,9 +39,31 @@ const breadcrumbLinks = computed(() => [
 function backToStudentDeclaredSkillViewTabs () {
   navigateToStudentDeclaredSkill()
 }
+
+const isDirty = computed(() => updateInProgress.value)
+
+const { showModal, displayModal, hideModal } = useModal()
+
+const { canLeave, confirm, cancel } = useUnsavedChangesGuard({
+  isDirty,
+  openModal: displayModal,
+  closeModal: hideModal
+})
+
+async function handleCancel () {
+  if (await canLeave()) {
+    backToStudentDeclaredSkillViewTabs()
+  }
+}
 </script>
 
 <template>
+  <ConfirmationModal
+    :show="showModal"
+    @confirm="confirm"
+    @close="cancel"
+  />
+
   <PageTitle
     :title="t('student.declaredSkills.views.StudentUpdateDeclaredSkillView.title')"
     :breadcrumb-links="breadcrumbLinks"
@@ -66,7 +88,7 @@ function backToStudentDeclaredSkillViewTabs () {
         v-if="declaredSkillDetailed"
         :declared-skill-progress-details="declaredSkillDetailed!"
         :on-skill-updated="backToStudentDeclaredSkillViewTabs"
-        :on-cancel="backToStudentDeclaredSkillViewTabs"
+        :on-cancel="handleCancel"
         @dirty-change="updateInProgress = $event"
       />
     </AvTab>

--- a/src/features/student/personalCareer/components/overlays/AddDeclaredExperienceDrawer/AddDeclaredExperienceDrawer.test.ts
+++ b/src/features/student/personalCareer/components/overlays/AddDeclaredExperienceDrawer/AddDeclaredExperienceDrawer.test.ts
@@ -15,6 +15,7 @@ import { MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
 import { AvAccordionStub, AvCancelConfirmButtonsStub, AvDrawerStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import { mountComponent } from 'tests/utils'
+import { beforeEach, expect, vi } from 'vitest'
 
 const mockAddSuccessMessage = vi.fn()
 const mockAddErrorMessage = vi.fn()
@@ -27,6 +28,24 @@ vi.mock('@/store', async () => {
       addSuccessMessage: mockAddSuccessMessage,
       addErrorMessage: mockAddErrorMessage
     }))
+  }
+})
+
+const mockCanLeave = vi.fn<() => Promise<boolean>>()
+const mockConfirm = vi.fn()
+const mockCancel = vi.fn()
+
+vi.mock('@/common/composables/use-unsaved-changes-guard/use-unsaved-changes-guard', async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import('@/common/composables/use-unsaved-changes-guard/use-unsaved-changes-guard')
+  >()
+  return {
+    ...actual,
+    useUnsavedChangesGuard: () => ({
+      canLeave: mockCanLeave,
+      confirm: mockConfirm,
+      cancel: mockCancel
+    })
   }
 })
 
@@ -54,6 +73,7 @@ BddTest().given('an add declared experience drawer avIconText', () => {
 
   beforeEach(async () => {
     vi.clearAllMocks()
+    mockCanLeave.mockResolvedValue(true)
     setActivePinia(createPinia())
 
     const store = usePersonalCareerStore()
@@ -61,8 +81,7 @@ BddTest().given('an add declared experience drawer avIconText', () => {
 
     wrapper = mountComponent<typeof AddDeclaredExperienceDrawer>(
       AddDeclaredExperienceDrawer,
-      { global: { stubs }
-      },
+      { global: { stubs } },
       { usePinia: false }
     )
 
@@ -121,7 +140,6 @@ BddTest().given('an add declared experience drawer avIconText', () => {
 
     BddTest().then('it should be disabled initially when form is invalid', async () => {
       const cancelConfirmButtons = getCancelConfirmButtons()
-
       expect(cancelConfirmButtons.props('confirmDisabled')).toBe(true)
     })
 
@@ -152,26 +170,84 @@ BddTest().given('an add declared experience drawer avIconText', () => {
     })
 
     BddTest().and('escape is pressed on drawer', () => {
-      BddTest().then('it should hide drawer when form is not dirty', async () => {
-        const store = usePersonalCareerStore()
-        const hideDrawerSpy = vi.spyOn(store, 'hideAddDeclaredExperienceDrawer')
-        const drawer = wrapper.findComponent({ name: 'AvDrawer' })
+      BddTest().and('canLeave is true', () => {
+        beforeEach(async () => {
+          const drawer = wrapper.findComponent({ name: 'AvDrawer' })
+          await drawer.vm.$emit('escape-pressed')
+          await wrapper.vm.$nextTick()
+        })
 
-        await drawer.vm.$emit('escape-pressed')
+        BddTest().then('it should hide the drawer', () => {
+          const store = usePersonalCareerStore()
+          expect(store.showAddDeclaredExperienceDrawer).toBe(false)
+        })
+      })
 
-        expect(hideDrawerSpy).toHaveBeenCalled()
+      BddTest().and('canLeave is false', () => {
+        beforeEach(async () => {
+          mockCanLeave.mockResolvedValue(false)
+          const drawer = wrapper.findComponent({ name: 'AvDrawer' })
+          await drawer.vm.$emit('escape-pressed')
+          await wrapper.vm.$nextTick()
+        })
+
+        BddTest().then('it should not hide the drawer', () => {
+          const store = usePersonalCareerStore()
+          expect(store.showAddDeclaredExperienceDrawer).toBe(true)
+        })
       })
     })
 
     BddTest().and('cancel button is clicked', () => {
-      BddTest().then('it should hide drawer when form is not dirty', async () => {
-        const store = usePersonalCareerStore()
-        const hideDrawerSpy = vi.spyOn(store, 'hideAddDeclaredExperienceDrawer')
+      BddTest().and('canLeave is true', () => {
+        beforeEach(async () => {
+          const cancelConfirmButtons = getCancelConfirmButtons()
+          await cancelConfirmButtons.vm.$emit('cancel')
+          await wrapper.vm.$nextTick()
+        })
 
-        const cancelConfirmButtons = getCancelConfirmButtons()
-        await cancelConfirmButtons.vm.$emit('cancel')
+        BddTest().then('it should hide the drawer', () => {
+          const store = usePersonalCareerStore()
+          expect(store.showAddDeclaredExperienceDrawer).toBe(false)
+        })
+      })
 
-        expect(hideDrawerSpy).toHaveBeenCalled()
+      BddTest().and('canLeave is false', () => {
+        beforeEach(async () => {
+          mockCanLeave.mockResolvedValue(false)
+          const cancelConfirmButtons = getCancelConfirmButtons()
+          await cancelConfirmButtons.vm.$emit('cancel')
+          await wrapper.vm.$nextTick()
+        })
+
+        BddTest().then('it should not hide the drawer', () => {
+          const store = usePersonalCareerStore()
+          expect(store.showAddDeclaredExperienceDrawer).toBe(true)
+        })
+
+        BddTest().and('confirming the modal', () => {
+          beforeEach(async () => {
+            const confirmationModal = wrapper.findComponent({ name: 'ConfirmationModal' })
+            await confirmationModal.vm.$emit('confirm')
+            await wrapper.vm.$nextTick()
+          })
+
+          BddTest().then('it should call guard confirm', () => {
+            expect(mockConfirm).toHaveBeenCalledTimes(1)
+          })
+        })
+
+        BddTest().and('closing the modal', () => {
+          beforeEach(async () => {
+            const confirmationModal = wrapper.findComponent({ name: 'ConfirmationModal' })
+            await confirmationModal.vm.$emit('close')
+            await wrapper.vm.$nextTick()
+          })
+
+          BddTest().then('it should call guard cancel', () => {
+            expect(mockCancel).toHaveBeenCalledTimes(1)
+          })
+        })
       })
     })
   })

--- a/src/features/student/personalCareer/components/overlays/AddDeclaredExperienceDrawer/AddDeclaredExperienceDrawer.vue
+++ b/src/features/student/personalCareer/components/overlays/AddDeclaredExperienceDrawer/AddDeclaredExperienceDrawer.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ConfirmationModal, FormCancelConfirmButtons } from '@/common/components'
 import { useModal } from '@/common/composables'
+import { useUnsavedChangesGuard } from '@/common/composables/use-unsaved-changes-guard/use-unsaved-changes-guard'
 import DeclaredExperienceActivitySectorFormField from '@/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceActivitySectorFormField/DeclaredExperienceActivitySectorFormField.vue'
 import DeclaredExperienceDescriptionFormField from '@/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceDescriptionFormField/DeclaredExperienceDescriptionFormField.vue'
 import DeclaredExperienceExternalLinkFormField from '@/features/student/personalCareer/components/interactions/formFields/DeclaredExperienceExternalLinkFormField/DeclaredExperienceExternalLinkFormField.vue'
@@ -38,19 +39,17 @@ const isDirty = computed(() => {
   return state.value.isDirty
 })
 
-function handleCancel () {
-  if (isDirty.value) {
-    displayConfirmationModal()
-  }
-  else {
-    confirmCancel()
-  }
-}
+const { canLeave, confirm, cancel } = useUnsavedChangesGuard({
+  isDirty,
+  openModal: displayConfirmationModal,
+  closeModal: hideConfirmationModal
+})
 
-function confirmCancel () {
-  form.reset()
-  personalCareerStore.hideAddDeclaredExperienceDrawer()
-  hideConfirmationModal()
+async function handleCancel () {
+  if (await canLeave()) {
+    form.reset()
+    personalCareerStore.hideAddDeclaredExperienceDrawer()
+  }
 }
 
 const activeAccordion = ref(0)
@@ -124,7 +123,7 @@ const activeAccordion = ref(0)
   <ConfirmationModal
     :show="showConfirmationModal"
     :description="t('student.personalCareer.overlays.AddDeclaredExperienceDrawer.confirmationModal.description')"
-    @close="hideConfirmationModal"
-    @confirm="confirmCancel"
+    @close="cancel"
+    @confirm="confirm"
   />
 </template>

--- a/src/features/student/personalCareer/components/overlays/AddDeclaredProgramDrawer/AddDeclaredProgramDrawer.test.ts
+++ b/src/features/student/personalCareer/components/overlays/AddDeclaredProgramDrawer/AddDeclaredProgramDrawer.test.ts
@@ -25,6 +25,24 @@ vi.mock('@/store', async () => {
   }
 })
 
+const mockCanLeave = vi.fn<() => Promise<boolean>>()
+const mockConfirm = vi.fn()
+const mockCancel = vi.fn()
+
+vi.mock('@/common/composables/use-unsaved-changes-guard/use-unsaved-changes-guard', async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import('@/common/composables/use-unsaved-changes-guard/use-unsaved-changes-guard')
+  >()
+  return {
+    ...actual,
+    useUnsavedChangesGuard: () => ({
+      canLeave: mockCanLeave,
+      confirm: mockConfirm,
+      cancel: mockCancel
+    })
+  }
+})
+
 BddTest().given('an add declared program drawer component', () => {
   let wrapper: ReturnType<typeof mountComponent<typeof AddDeclaredProgramDrawer>>
 
@@ -45,6 +63,7 @@ BddTest().given('an add declared program drawer component', () => {
 
   beforeEach(async () => {
     vi.clearAllMocks()
+    mockCanLeave.mockResolvedValue(true)
     setActivePinia(createPinia())
 
     const store = usePersonalCareerStore()
@@ -52,14 +71,8 @@ BddTest().given('an add declared program drawer component', () => {
 
     wrapper = mountComponent<typeof AddDeclaredProgramDrawer>(
       AddDeclaredProgramDrawer,
-      {
-        global: {
-          stubs
-        }
-      },
-      {
-        usePinia: false
-      }
+      { global: { stubs } },
+      { usePinia: false }
     )
 
     await wrapper.vm.$nextTick()
@@ -113,7 +126,6 @@ BddTest().given('an add declared program drawer component', () => {
 
     BddTest().then('it should be disabled initially when form is invalid', async () => {
       const cancelConfirmButtons = getCancelConfirmButtons()
-
       expect(cancelConfirmButtons.props('confirmDisabled')).toBe(true)
     })
 
@@ -158,26 +170,84 @@ BddTest().given('an add declared program drawer component', () => {
     })
 
     BddTest().and('escape is pressed on drawer', () => {
-      BddTest().then('it should hide drawer when form is not dirty', async () => {
-        const store = usePersonalCareerStore()
-        const hideDrawerSpy = vi.spyOn(store, 'hideAddDeclaredProgramDrawer')
-        const drawer = wrapper.findComponent({ name: 'AvDrawer' })
+      BddTest().and('canLeave is true', () => {
+        beforeEach(async () => {
+          const drawer = wrapper.findComponent({ name: 'AvDrawer' })
+          await drawer.vm.$emit('escape-pressed')
+          await wrapper.vm.$nextTick()
+        })
 
-        await drawer.vm.$emit('escape-pressed')
+        BddTest().then('it should hide the drawer', () => {
+          const store = usePersonalCareerStore()
+          expect(store.showAddDeclaredProgramDrawer).toBe(false)
+        })
+      })
 
-        expect(hideDrawerSpy).toHaveBeenCalled()
+      BddTest().and('canLeave is false', () => {
+        beforeEach(async () => {
+          mockCanLeave.mockResolvedValue(false)
+          const drawer = wrapper.findComponent({ name: 'AvDrawer' })
+          await drawer.vm.$emit('escape-pressed')
+          await wrapper.vm.$nextTick()
+        })
+
+        BddTest().then('it should not hide the drawer', () => {
+          const store = usePersonalCareerStore()
+          expect(store.showAddDeclaredProgramDrawer).toBe(true)
+        })
       })
     })
 
     BddTest().and('cancel button is clicked', () => {
-      BddTest().then('it should hide drawer when form is not dirty', async () => {
-        const store = usePersonalCareerStore()
-        const hideDrawerSpy = vi.spyOn(store, 'hideAddDeclaredProgramDrawer')
+      BddTest().and('canLeave is true', () => {
+        beforeEach(async () => {
+          const cancelConfirmButtons = getCancelConfirmButtons()
+          await cancelConfirmButtons.vm.$emit('cancel')
+          await wrapper.vm.$nextTick()
+        })
 
-        const cancelConfirmButtons = getCancelConfirmButtons()
-        await cancelConfirmButtons.vm.$emit('cancel')
+        BddTest().then('it should hide the drawer', () => {
+          const store = usePersonalCareerStore()
+          expect(store.showAddDeclaredProgramDrawer).toBe(false)
+        })
+      })
 
-        expect(hideDrawerSpy).toHaveBeenCalled()
+      BddTest().and('canLeave is false', () => {
+        beforeEach(async () => {
+          mockCanLeave.mockResolvedValue(false)
+          const cancelConfirmButtons = getCancelConfirmButtons()
+          await cancelConfirmButtons.vm.$emit('cancel')
+          await wrapper.vm.$nextTick()
+        })
+
+        BddTest().then('it should not hide the drawer', () => {
+          const store = usePersonalCareerStore()
+          expect(store.showAddDeclaredProgramDrawer).toBe(true)
+        })
+
+        BddTest().and('confirming the modal', () => {
+          beforeEach(async () => {
+            const confirmationModal = wrapper.findComponent({ name: 'ConfirmationModal' })
+            await confirmationModal.vm.$emit('confirm')
+            await wrapper.vm.$nextTick()
+          })
+
+          BddTest().then('it should call guard confirm', () => {
+            expect(mockConfirm).toHaveBeenCalledTimes(1)
+          })
+        })
+
+        BddTest().and('closing the modal', () => {
+          beforeEach(async () => {
+            const confirmationModal = wrapper.findComponent({ name: 'ConfirmationModal' })
+            await confirmationModal.vm.$emit('close')
+            await wrapper.vm.$nextTick()
+          })
+
+          BddTest().then('it should call guard cancel', () => {
+            expect(mockCancel).toHaveBeenCalledTimes(1)
+          })
+        })
       })
     })
   })

--- a/src/features/student/personalCareer/components/overlays/AddDeclaredProgramDrawer/AddDeclaredProgramDrawer.vue
+++ b/src/features/student/personalCareer/components/overlays/AddDeclaredProgramDrawer/AddDeclaredProgramDrawer.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ConfirmationModal, FormCancelConfirmButtons } from '@/common/components'
 import { useModal } from '@/common/composables'
+import { useUnsavedChangesGuard } from '@/common/composables/use-unsaved-changes-guard/use-unsaved-changes-guard'
 import DeclaredProgramDescriptionFormField from '@/features/student/personalCareer/components/interactions/formFields/DeclaredProgramDescriptionFormField/DeclaredProgramDescriptionFormField.vue'
 import DeclaredProgramOrganizationFormField from '@/features/student/personalCareer/components/interactions/formFields/DeclaredProgramOrganizationFormField/DeclaredProgramOrganizationFormField.vue'
 import DeclaredProgramPeriodFormField from '@/features/student/personalCareer/components/interactions/formFields/DeclaredProgramPeriodFormField/DeclaredProgramPeriodFormField.vue'
@@ -34,19 +35,17 @@ const isDirty = computed(() => {
   return state.value.isDirty
 })
 
-function handleCancel () {
-  if (isDirty.value) {
-    displayConfirmationModal()
-  }
-  else {
-    confirmCancel()
-  }
-}
+const { canLeave, confirm, cancel } = useUnsavedChangesGuard({
+  isDirty,
+  openModal: displayConfirmationModal,
+  closeModal: hideConfirmationModal
+})
 
-function confirmCancel () {
-  form.reset()
-  declaredProgramsStore.hideAddDeclaredProgramDrawer()
-  hideConfirmationModal()
+async function handleCancel () {
+  if (await canLeave()) {
+    form.reset()
+    declaredProgramsStore.hideAddDeclaredProgramDrawer()
+  }
 }
 
 const activeAccordion = ref(0)
@@ -124,7 +123,7 @@ const isDemo = __DEMO_MODE__
   <ConfirmationModal
     :show="showConfirmationModal"
     :description="t('student.personalCareer.overlays.AddDeclaredProgramDrawer.confirmationModal.description')"
-    @close="hideConfirmationModal"
-    @confirm="confirmCancel"
+    @close="cancel"
+    @confirm="confirm"
   />
 </template>

--- a/src/features/student/selfKnowledge/components/overlays/AddSelfKnowledgeCategoryElementDrawer/AddSelfKnowledgeCategoryElementDrawer.test.ts
+++ b/src/features/student/selfKnowledge/components/overlays/AddSelfKnowledgeCategoryElementDrawer/AddSelfKnowledgeCategoryElementDrawer.test.ts
@@ -24,6 +24,24 @@ vi.mock('@/store', async () => {
   }
 })
 
+const mockCanLeave = vi.fn<() => Promise<boolean>>()
+const mockConfirm = vi.fn()
+const mockCancel = vi.fn()
+
+vi.mock('@/common/composables/use-unsaved-changes-guard/use-unsaved-changes-guard', async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import('@/common/composables/use-unsaved-changes-guard/use-unsaved-changes-guard')
+  >()
+  return {
+    ...actual,
+    useUnsavedChangesGuard: () => ({
+      canLeave: mockCanLeave,
+      confirm: mockConfirm,
+      cancel: mockCancel
+    })
+  }
+})
+
 BddTest().given('an add self knowledge category element drawer component', () => {
   let wrapper: ReturnType<typeof mountComponent<typeof AddSelfKnowledgeCategoryElementDrawer>>
 
@@ -49,6 +67,7 @@ BddTest().given('an add self knowledge category element drawer component', () =>
 
   beforeEach(async () => {
     vi.clearAllMocks()
+    mockCanLeave.mockResolvedValue(true)
     setActivePinia(createPinia())
 
     const store = useSelfKnowledgeStore()
@@ -56,14 +75,8 @@ BddTest().given('an add self knowledge category element drawer component', () =>
 
     wrapper = mountComponent<typeof AddSelfKnowledgeCategoryElementDrawer>(
       AddSelfKnowledgeCategoryElementDrawer,
-      {
-        global: {
-          stubs
-        }
-      },
-      {
-        usePinia: false
-      }
+      { global: { stubs } },
+      { usePinia: false }
     )
 
     await wrapper.vm.$nextTick()
@@ -132,27 +145,85 @@ BddTest().given('an add self knowledge category element drawer component', () =>
     })
   })
 
-  BddTest().when('escape is pressed on drawer', () => {
-    BddTest().then('it should closeAddElementDrawer when form is not dirty', async () => {
-      const store = useSelfKnowledgeStore()
-      const hideDrawerSpy = vi.spyOn(store, 'closeAddElementDrawer')
-      const drawer = wrapper.findComponent({ name: 'AvDrawer' })
+  BddTest().and('escape is pressed on drawer', () => {
+    BddTest().and('canLeave is true', () => {
+      beforeEach(async () => {
+        const drawer = wrapper.findComponent({ name: 'AvDrawer' })
+        await drawer.vm.$emit('escape-pressed')
+        await wrapper.vm.$nextTick()
+      })
 
-      await drawer.vm.$emit('escape-pressed')
+      BddTest().then('it should hide the drawer', () => {
+        const store = useSelfKnowledgeStore()
+        expect(store.showAddElementDrawer).toBe(false)
+      })
+    })
 
-      expect(hideDrawerSpy).toHaveBeenCalled()
+    BddTest().and('canLeave is false', () => {
+      beforeEach(async () => {
+        mockCanLeave.mockResolvedValue(false)
+        const drawer = wrapper.findComponent({ name: 'AvDrawer' })
+        await drawer.vm.$emit('escape-pressed')
+        await wrapper.vm.$nextTick()
+      })
+
+      BddTest().then('it should not hide the drawer', () => {
+        const store = useSelfKnowledgeStore()
+        expect(store.showAddElementDrawer).toBe(true)
+      })
     })
   })
 
-  BddTest().when('cancel button is clicked', () => {
-    BddTest().then('it should closeAddElementDrawer when form is not dirty', async () => {
-      const store = useSelfKnowledgeStore()
-      const hideDrawerSpy = vi.spyOn(store, 'closeAddElementDrawer')
+  BddTest().and('cancel button is clicked', () => {
+    BddTest().and('canLeave is true', () => {
+      beforeEach(async () => {
+        const cancelConfirmButtons = getCancelConfirmButtons()
+        await cancelConfirmButtons.vm.$emit('cancel')
+        await wrapper.vm.$nextTick()
+      })
 
-      const cancelConfirmButtons = getCancelConfirmButtons()
-      await cancelConfirmButtons.vm.$emit('cancel')
+      BddTest().then('it should hide the drawer', () => {
+        const store = useSelfKnowledgeStore()
+        expect(store.showAddElementDrawer).toBe(false)
+      })
+    })
 
-      expect(hideDrawerSpy).toHaveBeenCalled()
+    BddTest().and('canLeave is false', () => {
+      beforeEach(async () => {
+        mockCanLeave.mockResolvedValue(false)
+        const cancelConfirmButtons = getCancelConfirmButtons()
+        await cancelConfirmButtons.vm.$emit('cancel')
+        await wrapper.vm.$nextTick()
+      })
+
+      BddTest().then('it should not hide the drawer', () => {
+        const store = useSelfKnowledgeStore()
+        expect(store.showAddElementDrawer).toBe(true)
+      })
+
+      BddTest().and('confirming the modal', () => {
+        beforeEach(async () => {
+          const confirmationModal = wrapper.findComponent({ name: 'ConfirmationModal' })
+          await confirmationModal.vm.$emit('confirm')
+          await wrapper.vm.$nextTick()
+        })
+
+        BddTest().then('it should call guard confirm', () => {
+          expect(mockConfirm).toHaveBeenCalledTimes(1)
+        })
+      })
+
+      BddTest().and('closing the modal', () => {
+        beforeEach(async () => {
+          const confirmationModal = wrapper.findComponent({ name: 'ConfirmationModal' })
+          await confirmationModal.vm.$emit('close')
+          await wrapper.vm.$nextTick()
+        })
+
+        BddTest().then('it should call guard cancel', () => {
+          expect(mockCancel).toHaveBeenCalledTimes(1)
+        })
+      })
     })
   })
 

--- a/src/features/student/selfKnowledge/components/overlays/AddSelfKnowledgeCategoryElementDrawer/AddSelfKnowledgeCategoryElementDrawer.vue
+++ b/src/features/student/selfKnowledge/components/overlays/AddSelfKnowledgeCategoryElementDrawer/AddSelfKnowledgeCategoryElementDrawer.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ConfirmationModal, FormCancelConfirmButtons } from '@/common/components'
 import { useModal } from '@/common/composables'
+import { useUnsavedChangesGuard } from '@/common/composables/use-unsaved-changes-guard/use-unsaved-changes-guard'
 import CategoryElementDescriptionTextareaFormField from '@/features/student/selfKnowledge/components/interactions/formFields/CategoryElementDescriptionTextareaFormField/CategoryElementDescriptionTextareaFormField.vue'
 import CategoryElementRatingRadioButtonSetFormField from '@/features/student/selfKnowledge/components/interactions/formFields/CategoryElementRatingRadioButtonSetFormField/CategoryElementRatingRadioButtonSetFormField.vue'
 import CategoryElementTitleInputFormField from '@/features/student/selfKnowledge/components/interactions/formFields/CategoryElementTitleInputFormField/CategoryElementTitleInputFormField.vue'
@@ -42,6 +43,12 @@ const {
   hideModal: hideDiscardChangesModal
 } = useModal()
 
+const { canLeave, confirm, cancel } = useUnsavedChangesGuard({
+  isDirty: isFormDirty,
+  openModal: displayDiscardChangesModal,
+  closeModal: hideDiscardChangesModal
+})
+
 const activeAccordion = ref(0)
 
 function confirmCancel () {
@@ -51,11 +58,8 @@ function confirmCancel () {
   hideDiscardChangesModal()
 }
 
-function handleCancel () {
-  if (isFormDirty.value) {
-    displayDiscardChangesModal()
-  }
-  else {
+async function handleCancel () {
+  if (await canLeave()) {
     confirmCancel()
   }
 }
@@ -77,8 +81,8 @@ const isDemo = __DEMO_MODE__
   <ConfirmationModal
     :show="showDiscardChangesModal"
     :title="t('student.selfKnowledge.overlays.AddSelfKnowledgeCategoryElementDrawer.confirmationModal.title')"
-    @confirm="confirmCancel"
-    @close="hideDiscardChangesModal"
+    @confirm="confirm"
+    @close="cancel"
   />
   <AvDrawer
     :show="showDrawer"

--- a/src/features/student/traces/views/StudentToolsTracesView/components/StudentToolsTracesAddTraceDrawer/StudentToolsTracesAddTraceDrawer.test.ts
+++ b/src/features/student/traces/views/StudentToolsTracesView/components/StudentToolsTracesAddTraceDrawer/StudentToolsTracesAddTraceDrawer.test.ts
@@ -23,6 +23,24 @@ vi.mock('@/store', async () => {
   }
 })
 
+const mockCanLeave = vi.fn<() => Promise<boolean>>()
+const mockConfirm = vi.fn()
+const mockCancel = vi.fn()
+
+vi.mock('@/common/composables/use-unsaved-changes-guard/use-unsaved-changes-guard', async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import('@/common/composables/use-unsaved-changes-guard/use-unsaved-changes-guard')
+  >()
+  return {
+    ...actual,
+    useUnsavedChangesGuard: () => ({
+      canLeave: mockCanLeave,
+      confirm: mockConfirm,
+      cancel: mockCancel
+    })
+  }
+})
+
 BddTest().given('a student tools traces add trace drawer component', () => {
   let wrapper: VueWrapper<InstanceType<typeof StudentToolsTracesAddTraceDrawer>>
 
@@ -102,6 +120,7 @@ BddTest().given('a student tools traces add trace drawer component', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    mockCanLeave.mockResolvedValue(true)
 
     wrapper = mountComponent<typeof StudentToolsTracesAddTraceDrawer>(StudentToolsTracesAddTraceDrawer, {
       global: {
@@ -175,24 +194,83 @@ BddTest().given('a student tools traces add trace drawer component', () => {
   })
 
   BddTest().when('escape is pressed on drawer', () => {
-    BddTest().then('it should hideCreateTraceDrawer', async () => {
-      const store = useTracesStore()
-      const hideDrawerSpy = vi.spyOn(store, 'hideCreateTraceDrawer')
-      const drawer = wrapper.findComponent({ name: 'AvDrawer' })
+    BddTest().and('canLeave is true', () => {
+      beforeEach(async () => {
+        const drawer = wrapper.findComponent({ name: 'AvDrawer' })
+        await drawer.vm.$emit('escape-pressed')
+        await wrapper.vm.$nextTick()
+      })
 
-      await drawer.vm.$emit('escape-pressed')
+      BddTest().then('it should hide the drawer', () => {
+        const store = useTracesStore()
+        expect(store.showCreateTraceDrawer).toBe(false)
+      })
+    })
 
-      expect(hideDrawerSpy).toHaveBeenCalled()
+    BddTest().and('canLeave is false', () => {
+      beforeEach(async () => {
+        mockCanLeave.mockResolvedValue(false)
+        const drawer = wrapper.findComponent({ name: 'AvDrawer' })
+        await drawer.vm.$emit('escape-pressed')
+        await wrapper.vm.$nextTick()
+      })
+
+      BddTest().then('it should not hide the drawer', () => {
+        const store = useTracesStore()
+        expect(store.showCreateTraceDrawer).toBe(true)
+      })
     })
   })
 
   BddTest().when('cancel button is clicked', () => {
-    BddTest().then('it should hideCreateTraceDrawer', async () => {
-      const store = useTracesStore()
-      const hideDrawerSpy = vi.spyOn(store, 'hideCreateTraceDrawer')
-      await clickCancelButton()
+    BddTest().and('canLeave is true', () => {
+      beforeEach(async () => {
+        await clickCancelButton()
+        await wrapper.vm.$nextTick()
+      })
 
-      expect(hideDrawerSpy).toHaveBeenCalled()
+      BddTest().then('it should hide the drawer', () => {
+        const store = useTracesStore()
+        expect(store.showCreateTraceDrawer).toBe(false)
+      })
+    })
+
+    BddTest().and('canLeave is false', () => {
+      beforeEach(async () => {
+        mockCanLeave.mockResolvedValue(false)
+        await fillFormFields()
+        await clickCancelButton()
+        await wrapper.vm.$nextTick()
+      })
+
+      BddTest().then('it should not hide the drawer', () => {
+        const store = useTracesStore()
+        expect(store.showCreateTraceDrawer).toBe(true)
+      })
+
+      BddTest().and('confirming the modal', () => {
+        beforeEach(async () => {
+          const confirmationModal = wrapper.findComponent({ name: 'ConfirmationModal' })
+          await confirmationModal.vm.$emit('confirm')
+          await wrapper.vm.$nextTick()
+        })
+
+        BddTest().then('it should call guard confirm', () => {
+          expect(mockConfirm).toHaveBeenCalledTimes(1)
+        })
+      })
+
+      BddTest().and('closing the modal', () => {
+        beforeEach(async () => {
+          const confirmationModal = wrapper.findComponent({ name: 'ConfirmationModal' })
+          await confirmationModal.vm.$emit('close')
+          await wrapper.vm.$nextTick()
+        })
+
+        BddTest().then('it should call guard cancel', () => {
+          expect(mockCancel).toHaveBeenCalledTimes(1)
+        })
+      })
     })
   })
 
@@ -333,43 +411,6 @@ BddTest().given('a student tools traces add trace drawer component', () => {
 
       const typeConfigs = section.props('typeConfigs') as { key: string }[]
       expect(typeConfigs.some(c => c.key === EAssociationTypeKey.ACTIVITIES)).toBe(true)
-    })
-  })
-
-  BddTest().when('form is dirty and cancel is clicked', () => {
-    BddTest().then('it should show confirmation modal when form has changes', async () => {
-      await fillFormFields()
-      await clickCancelButton()
-      await wrapper.vm.$nextTick()
-
-      const confirmationModal = wrapper.findComponent({ name: 'ConfirmationModal' })
-      expect(confirmationModal.props('show')).toBe(true)
-    })
-
-    BddTest().then('it should hide drawer when confirmation modal confirm is triggered', async () => {
-      const store = useTracesStore()
-      const hideDrawerSpy = vi.spyOn(store, 'hideCreateTraceDrawer')
-
-      await fillFormFields()
-      await clickCancelButton()
-      await wrapper.vm.$nextTick()
-
-      const confirmationModal = wrapper.findComponent({ name: 'ConfirmationModal' })
-      await confirmationModal.vm.$emit('confirm')
-
-      expect(hideDrawerSpy).toHaveBeenCalled()
-    })
-
-    BddTest().then('it should hide confirmation modal when close is triggered', async () => {
-      await fillFormFields()
-      await clickCancelButton()
-      await wrapper.vm.$nextTick()
-
-      const confirmationModal = wrapper.findComponent({ name: 'ConfirmationModal' })
-      await confirmationModal.vm.$emit('close')
-      await wrapper.vm.$nextTick()
-
-      expect(confirmationModal.props('show')).toBe(false)
     })
   })
 })

--- a/src/features/student/traces/views/StudentToolsTracesView/components/StudentToolsTracesAddTraceDrawer/StudentToolsTracesAddTraceDrawer.vue
+++ b/src/features/student/traces/views/StudentToolsTracesView/components/StudentToolsTracesAddTraceDrawer/StudentToolsTracesAddTraceDrawer.vue
@@ -3,6 +3,7 @@ import type { AssociateElementOption, AssociateElementTypeConfig } from '@/featu
 import type { IdTitle } from '@/types'
 import { ConfirmationModal, FormCancelConfirmButtons } from '@/common/components'
 import { useModal } from '@/common/composables'
+import { useUnsavedChangesGuard } from '@/common/composables/use-unsaved-changes-guard/use-unsaved-changes-guard'
 import {
   useSearchActivitiesForAssociationQuery,
   useSearchDeclaredSkillsForAssociationWithTraceQuery
@@ -24,14 +25,6 @@ const { addSuccessMessage } = useToasterStore()
 
 const showDrawer = toRef(tracesStore, 'showCreateTraceDrawer')
 
-const {
-  showModal: showDiscardChangesModal,
-  displayModal: displayDiscardChangesModal,
-  hideModal: hideDiscardChangesModal
-} = useModal()
-
-const activeAccordion = ref(0)
-
 const searchQuery = ref('')
 const associationSelections = ref<Record<string, IdTitle[]>>({})
 const activeTypeKey = ref<string>(EAssociationTypeKey.DECLARED_SKILLS)
@@ -48,6 +41,24 @@ const { form, isFormValid, isSubmitting } = useCreateTraceForm(onTraceCreated)
 
 const isFormDirty = form.useStore(state => state.isDirty)
 
+const {
+  showModal: showDiscardChangesModal,
+  displayModal: displayDiscardChangesModal,
+  hideModal: hideDiscardChangesModal
+} = useModal()
+
+const {
+  canLeave,
+  confirm,
+  cancel
+} = useUnsavedChangesGuard({
+  isDirty: isFormDirty,
+  openModal: displayDiscardChangesModal,
+  closeModal: hideDiscardChangesModal
+})
+
+const activeAccordion = ref(0)
+
 function confirmCancel () {
   form.reset()
   associationSelections.value = {}
@@ -55,14 +66,10 @@ function confirmCancel () {
   activeTypeKey.value = EAssociationTypeKey.DECLARED_SKILLS
   activeAccordion.value = 0
   tracesStore.hideCreateTraceDrawer()
-  hideDiscardChangesModal()
 }
 
-function handleCancel () {
-  if (isFormDirty.value) {
-    displayDiscardChangesModal()
-  }
-  else {
+async function handleCancel () {
+  if (await canLeave()) {
     confirmCancel()
   }
 }
@@ -164,8 +171,8 @@ watch(associationSelections, (newSelections) => {
 <template>
   <ConfirmationModal
     :show="showDiscardChangesModal"
-    @confirm="confirmCancel"
-    @close="hideDiscardChangesModal"
+    @confirm="confirm"
+    @close="cancel"
   />
   <AvDrawer
     :show="showDrawer"


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
- Adds the `useUnsavedChangesGuard` confirmation guard to all eligible forms in order to warn the user about unsaved changes when navigating away (route changes, page reloads, or tab closure), in addition to the existing confirmation triggered by the `Cancel` button

---

### Reference to an Issue, Feature, Task, User Story or another PR
- Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/993

---

**Modified areas:**
- `src/common/components/overlay/drawers/UpdateProfileDrawer/UpdateProfileDrawer.test.ts`
- `src/common/components/overlay/drawers/UpdateProfileDrawer/UpdateProfileDrawer.vue`
- `src/features/student/buildProject/components/overlays/UpdateActivityDrawer/UpdateActivityDrawer.test.ts`
- `src/features/student/buildProject/components/overlays/UpdateActivityDrawer/UpdateActivityDrawer.vue`
- `src/features/student/declaredSkills/components/overlays/AddDeclaredSkillDrawer/AddDeclaredSkillDrawer.test.ts`
- `src/features/student/declaredSkills/components/overlays/AddDeclaredSkillDrawer/AddDeclaredSkillDrawer.vue`
- `src/features/student/declaredSkills/views/StudentUpdateDeclaredSkillView/StudentUpdateDeclaredSkillView.test.ts`
- `src/features/student/declaredSkills/views/StudentUpdateDeclaredSkillView/StudentUpdateDeclaredSkillView.vue`
- `src/features/student/personalCareer/components/overlays/AddDeclaredExperienceDrawer/AddDeclaredExperienceDrawer.test.ts`
- `src/features/student/personalCareer/components/overlays/AddDeclaredExperienceDrawer/AddDeclaredExperienceDrawer.vue`
- `src/features/student/personalCareer/components/overlays/AddDeclaredProgramDrawer/AddDeclaredProgramDrawer.test.ts`
- `src/features/student/personalCareer/components/overlays/AddDeclaredProgramDrawer/AddDeclaredProgramDrawer.vue`
- `src/features/student/selfKnowledge/components/overlays/AddSelfKnowledgeCategoryElementDrawer/AddSelfKnowledgeCategoryElementDrawer.test.ts`
- `src/features/student/selfKnowledge/components/overlays/AddSelfKnowledgeCategoryElementDrawer/AddSelfKnowledgeCategoryElementDrawer.vue`
- `src/features/student/traces/views/StudentToolsTracesView/components/StudentToolsTracesAddTraceDrawer/StudentToolsTracesAddTraceDrawer.test.ts`
- `src/features/student/traces/views/StudentToolsTracesView/components/StudentToolsTracesAddTraceDrawer/StudentToolsTracesAddTraceDrawer.vue`

---

### Target Branch
`develop`

---

### Additional Notes
- Some forms do not display a confirmation modal; therefore, the navigation guard does not apply to them

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process