### PR TITLE
fix(1459): fix missing i18n keys and fail tests on intlify warnings

### DIFF
--- a/src/common/views/NotFoundView/NotFoundView.test.ts
+++ b/src/common/views/NotFoundView/NotFoundView.test.ts
@@ -58,8 +58,8 @@ BddTest().given('a not found view', () => {
     beforeEach(() => {
       wrapper = mount(NotFoundView, {
         props: {
-          titleKey: 'titre test',
-          descriptionKey: 'description test',
+          titleKey: 'global.text',
+          descriptionKey: 'global.text',
         },
         global: {
           stubs: {
@@ -70,8 +70,8 @@ BddTest().given('a not found view', () => {
     })
 
     BddTest().then('it should render the title/description from the given keys', () => {
-      expect(wrapper.find('h3').text()).toBe('titre test')
-      expect(wrapper.find('p').text()).toBe('description test')
+      expect(wrapper.find('h3').text()).toBe('Texte')
+      expect(wrapper.find('p').text()).toBe('Texte')
     })
   })
 })

--- a/src/features/student/personalCareer/locales/fr.json
+++ b/src/features/student/personalCareer/locales/fr.json
@@ -234,7 +234,7 @@
             },
             "DeleteDeclaredExperiencesModal": {
               "confirm": "Supprimer l'expérience sélectionnée | Supprimer les expériences sélectionnées ({count})",
-              "noDeclaredPrograms": "Aucune expérience à supprimer.",
+              "noDeclaredExperiences": "Aucune expérience à supprimer.",
               "title": "Quelle(s) expérience(s) souhaitez-vous supprimer ?"
             },
             "title": "Mes expériences",

--- a/vitest-setup.ts
+++ b/vitest-setup.ts
@@ -9,16 +9,16 @@ window.matchMedia = function () {
 }
 
 const IGNORED_WARNINGS = []
-
+const FAILED_WARNINGS: string[] = ['[Vue warn]', '[intlify]']
 const originalWarn = console.warn
+
+const isIgnoredWarning = (message: string) => IGNORED_WARNINGS.some(text => message.includes(text))
 
 function setupWarningHandler () {
   console.warn = (...args: any[]) => {
     const message = args.map(String).join(' ')
 
-    const isIgnoredWarning = (message: string) => IGNORED_WARNINGS.some(text => message.includes(text))
-
-    if (message.includes('[Vue warn]')) {
+    if (FAILED_WARNINGS.some(warningPrefix => message.includes(warningPrefix))) {
       if (isIgnoredWarning(message)) {
         originalWarn(...args)
         return


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> Correction des clés i18n manquantes dans les fichiers de traduction et configuration de Vitest pour faire échouer les tests lorsqu'un warning `[intlify]` est détecté.

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1459

---

### Documentation
> Aucune mise à jour de documentation nécessaire.

---

### Target Branch
> `develop`

---

### Additional Notes
> - Renommage de la clé `noDeclaredPrograms` en `noDeclaredExperiences` dans `personalCareer/locales/fr.json` pour correspondre à la clé réellement utilisée dans le code.
> - Dans `NotFoundView.test.ts`, remplacement des clés de test inexistantes (`'titre test'`, `'description test'`) par une clé valide (`global.text`).
> - Dans `vitest-setup.ts`, extension du handler de warnings pour inclure les préfixes `[intlify]` en plus de `[Vue warn]`, afin que les tests échouent automatiquement si une clé i18n est manquante.

---

### Known Limitations or Side Effects
> Aucune.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [x] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and detaiils for the update process