### PR TITLE
fix(1460): fetch available associations once based on selected type i…

### DIFF
--- a/src/features/student/traces/queries/use-traces.query/use-traces.query.test.ts
+++ b/src/features/student/traces/queries/use-traces.query/use-traces.query.test.ts
@@ -1,6 +1,7 @@
 import type { BaseApiException } from '@/common/exceptions'
 import type { MutationArgs } from '@/types'
 import type { UseQueryReturnType } from '@tanstack/vue-query'
+import type { Ref } from 'vue'
 import { createMockedSearchActivitiesForAssociationResponse, invalidTraceId, mockedSkillSearchResults, mockedTraceActivitySearchResults, mockedTraceDetailed, mockedTracesSummary } from '@/__mocks__/fixtures/student'
 import { associateTraceWithDeclaredSkillsErrorHandler, searchSkillsForAssociationErrorHandler } from '@/__mocks__/msw/handlers/student/traces.handlers'
 import { server } from '@/__mocks__/msw/server'
@@ -1276,16 +1277,109 @@ BddTest().given('a useSearchActivitiesForAssociationQuery composable', () => {
         })
       })
     })
+
+    BddTest().when('enabled is explicitly false', () => {
+      beforeEach(async () => {
+        searchActivitiesForAssociationSpy.mockResolvedValue(createMockedSearchActivitiesForAssociationResponse())
+        mountQueryComposable(() => useSearchActivitiesForAssociationQuery({
+          traceId,
+          params,
+          enabled: ref(false)
+        }))
+        await flushPromises()
+      })
+
+      BddTest().then('it should not call the searchDeclaredActivityForAssociation API', () => {
+        expect(searchActivitiesForAssociationSpy).not.toHaveBeenCalled()
+      })
+    })
+
+    BddTest().when('enabled is explicitly true', () => {
+      let queryResult: ReturnType<typeof useSearchActivitiesForAssociationQuery>
+
+      beforeEach(async () => {
+        searchActivitiesForAssociationSpy.mockResolvedValue(createMockedSearchActivitiesForAssociationResponse())
+        queryResult = mountQueryComposable(() => useSearchActivitiesForAssociationQuery({
+          traceId,
+          params,
+          enabled: ref(true)
+        }))
+        await flushPromises()
+      })
+
+      BddTest().then('it should call the searchDeclaredActivityForAssociation API', () => {
+        expect(searchActivitiesForAssociationSpy).toHaveBeenCalledWith(traceId.value, params.value)
+      })
+
+      BddTest().then('it should mark the query as successful', () => {
+        expect(queryResult.isSuccess.value).toBe(true)
+      })
+    })
+
+    BddTest().when('enabled switches from false to true', () => {
+      let enabled: Ref<boolean>
+      let queryResult: ReturnType<typeof useSearchActivitiesForAssociationQuery>
+
+      beforeEach(async () => {
+        searchActivitiesForAssociationSpy.mockResolvedValue(createMockedSearchActivitiesForAssociationResponse())
+        enabled = ref(false)
+        queryResult = mountQueryComposable(() => useSearchActivitiesForAssociationQuery({
+          traceId,
+          params,
+          enabled
+        }))
+        await flushPromises()
+      })
+
+      BddTest().then('it should not call the searchDeclaredActivityForAssociation API while disabled', () => {
+        expect(searchActivitiesForAssociationSpy).not.toHaveBeenCalled()
+      })
+
+      BddTest().then('it should call the searchDeclaredActivityForAssociation API once enabled', async () => {
+        enabled.value = true
+        await flushPromises()
+        expect(searchActivitiesForAssociationSpy).toHaveBeenCalledWith(traceId.value, params.value)
+        expect(queryResult.isSuccess.value).toBe(true)
+      })
+    })
+
+    BddTest().when('enabled switches from true to false', () => {
+      let enabled: Ref<boolean>
+
+      beforeEach(async () => {
+        enabled = ref(true)
+        mountQueryComposable(() => useSearchActivitiesForAssociationQuery({
+          traceId,
+          params,
+          enabled
+        }))
+        await flushPromises()
+      })
+
+      BddTest().then('it should call the searchDeclaredActivityForAssociation API while enabled', () => {
+        expect(searchActivitiesForAssociationSpy).toHaveBeenCalledTimes(1)
+      })
+
+      BddTest().then('it should not re-call the searchDeclaredActivityForAssociation API after being disabled even if params change', async () => {
+        enabled.value = false
+        await flushPromises()
+        expect(searchActivitiesForAssociationSpy).toHaveBeenCalledTimes(1)
+      })
+    })
   })
 
-  BddTest().and('an empty trace ID', () => {
+  BddTest().and('an empty trace ID with enabled true', () => {
     const traceId = ref('')
     const params: SearchActivitiesForAssociationQueryParams['params'] = ref({ page: 0, pageSize: 10, search: '' })
 
-    BddTest().when('the query is mounted', () => {
+    BddTest().when('the query is mounted with enabled true but empty traceId', () => {
       beforeEach(async () => {
         searchActivitiesForAssociationSpy.mockResolvedValue(createMockedSearchActivitiesForAssociationResponse())
-        mountQueryComposable(() => useSearchActivitiesForAssociationQuery({ traceId, params }))
+        mountQueryComposable(() => useSearchActivitiesForAssociationQuery({
+          traceId,
+          params,
+          enabled: ref(true)
+        }))
         await flushPromises()
       })
 
@@ -1472,15 +1566,105 @@ BddTest().given('a useSearchDeclaredSkillsForAssociationWithTraceQuery composabl
         })
       })
     })
+
+    BddTest().when('enabled is explicitly false', () => {
+      beforeEach(async () => {
+        mountQueryComposable(() => useSearchDeclaredSkillsForAssociationWithTraceQuery({
+          traceId,
+          params,
+          enabled: ref(false)
+        }))
+        await flushPromises()
+      })
+
+      BddTest().then('it should not call the searchDeclaredSkillForAssociation API', () => {
+        expect(searchDeclaredSkillForAssociationSpy).not.toHaveBeenCalled()
+      })
+    })
+
+    BddTest().when('enabled is explicitly true', () => {
+      let queryResult: ReturnType<typeof useSearchDeclaredSkillsForAssociationWithTraceQuery>
+
+      beforeEach(async () => {
+        queryResult = mountQueryComposable(() => useSearchDeclaredSkillsForAssociationWithTraceQuery({
+          traceId,
+          params,
+          enabled: ref(true)
+        }))
+        await flushPromises()
+      })
+
+      BddTest().then('it should call the searchDeclaredSkillForAssociation API', () => {
+        expect(searchDeclaredSkillForAssociationSpy).toHaveBeenCalledWith(traceId.value, params.value)
+      })
+
+      BddTest().then('it should mark the query as successful', () => {
+        expect(queryResult.isSuccess.value).toBe(true)
+      })
+    })
+
+    BddTest().when('enabled switches from false to true', () => {
+      let enabled: Ref<boolean>
+      let queryResult: ReturnType<typeof useSearchDeclaredSkillsForAssociationWithTraceQuery>
+
+      beforeEach(async () => {
+        enabled = ref(false)
+        queryResult = mountQueryComposable(() => useSearchDeclaredSkillsForAssociationWithTraceQuery({
+          traceId,
+          params,
+          enabled
+        }))
+        await flushPromises()
+      })
+
+      BddTest().then('it should not call the searchDeclaredSkillForAssociation API while disabled', () => {
+        expect(searchDeclaredSkillForAssociationSpy).not.toHaveBeenCalled()
+      })
+
+      BddTest().then('it should call the searchDeclaredSkillForAssociation API once enabled', async () => {
+        enabled.value = true
+        await flushPromises()
+        expect(searchDeclaredSkillForAssociationSpy).toHaveBeenCalledWith(traceId.value, params.value)
+        expect(queryResult.isSuccess.value).toBe(true)
+      })
+    })
+
+    BddTest().when('enabled switches from true to false', () => {
+      let enabled: Ref<boolean>
+
+      beforeEach(async () => {
+        enabled = ref(true)
+        mountQueryComposable(() => useSearchDeclaredSkillsForAssociationWithTraceQuery({
+          traceId,
+          params,
+          enabled
+        }))
+        await flushPromises()
+      })
+
+      BddTest().then('it should call the searchDeclaredSkillForAssociation API while enabled', () => {
+        expect(searchDeclaredSkillForAssociationSpy).toHaveBeenCalledTimes(1)
+      })
+
+      BddTest().then('it should not re-call the searchDeclaredSkillForAssociation API after being disabled even if params change', async () => {
+        enabled.value = false
+        await flushPromises()
+        expect(searchDeclaredSkillForAssociationSpy).toHaveBeenCalledTimes(1)
+      })
+    })
   })
 
-  BddTest().and('an empty trace ID', () => {
+  BddTest().and('an empty trace ID with enabled true', () => {
     const traceId = ref('')
     const params: UseDeclaredSkillsForAssociationQueryParams['params'] = ref({ page: 0, pageSize: 10 })
 
-    BddTest().when('the query is mounted', () => {
+    BddTest().when('the query is mounted with enabled true but empty traceId', () => {
       beforeEach(async () => {
-        mountQueryComposable(() => useSearchDeclaredSkillsForAssociationWithTraceQuery({ traceId, params }))
+        mountQueryComposable(() => useSearchDeclaredSkillsForAssociationWithTraceQuery({
+          traceId,
+          params,
+          enabled: ref(true)
+        }))
         await flushPromises()
       })
 

--- a/src/features/student/traces/queries/use-traces.query/use-traces.query.ts
+++ b/src/features/student/traces/queries/use-traces.query/use-traces.query.ts
@@ -273,6 +273,7 @@ export function useDeleteTraceAssociationsMutation ({
 export interface SearchActivitiesForAssociationQueryParams {
   traceId: MaybeRef<string>
   params?: MaybeRef<SearchDeclaredActivityForAssociationParams | undefined>
+  enabled?: MaybeRef<boolean>
 }
 
 export type SearchActivitiesForAssociationQueryReturnType =
@@ -288,7 +289,8 @@ export type SearchActivitiesForAssociationQueryReturnType =
 
 export function useSearchActivitiesForAssociationQuery ({
   traceId,
-  params
+  params,
+  enabled
 }: SearchActivitiesForAssociationQueryParams): SearchActivitiesForAssociationQueryReturnType {
   const queryKey = computed(() => [
     ...tracesSearchAssociationActivitiesQueryKey,
@@ -303,7 +305,7 @@ export function useSearchActivitiesForAssociationQuery ({
   const query = useQuery<PagedResponseAssociationSearchResultDeclaredActivityDTO, BaseApiException>({
     queryKey,
     queryFn,
-    enabled: computed(() => toValue(traceId).trim().length > 0),
+    enabled: computed(() => (enabled === undefined || toValue(enabled)) && toValue(traceId).trim().length > 0),
     placeholderData: keepPreviousData
   })
 
@@ -354,6 +356,7 @@ export function useAssociateTraceWithActivitiesMutation ({
 export interface UseDeclaredSkillsForAssociationQueryParams {
   traceId: MaybeRef<string>
   params?: MaybeRef<SearchDeclaredSkillForAssociationParams | undefined>
+  enabled?: MaybeRef<boolean>
 }
 
 export type SearchDeclaredSkillsForAssociationWithTraceQueryReturnType =
@@ -369,7 +372,8 @@ export type SearchDeclaredSkillsForAssociationWithTraceQueryReturnType =
 
 export function useSearchDeclaredSkillsForAssociationWithTraceQuery ({
   traceId,
-  params
+  params,
+  enabled
 }: UseDeclaredSkillsForAssociationQueryParams): SearchDeclaredSkillsForAssociationWithTraceQueryReturnType {
   const queryKey = computed(() => [
     ...tracesSearchAssociationSkillsQueryKey,
@@ -384,7 +388,7 @@ export function useSearchDeclaredSkillsForAssociationWithTraceQuery ({
   const query = useQuery<PagedResponseAssociationSearchResultDeclaredSkillIDTO, BaseApiException>({
     queryKey,
     queryFn,
-    enabled: computed(() => toValue(traceId).trim().length > 0),
+    enabled: computed(() => (enabled === undefined || toValue(enabled)) && toValue(traceId).trim().length > 0),
     placeholderData: keepPreviousData
   })
 

--- a/src/features/student/traces/views/StudentToolsTracesView/components/StudentToolsTracesAddTraceDrawer/StudentToolsTracesAddTraceDrawer.vue
+++ b/src/features/student/traces/views/StudentToolsTracesView/components/StudentToolsTracesAddTraceDrawer/StudentToolsTracesAddTraceDrawer.vue
@@ -100,7 +100,8 @@ const {
   isLoading: isSkillsLoading
 } = useSearchDeclaredSkillsForAssociationWithTraceQuery({
   traceId: searchTraceId,
-  params: makeSearchParams(EAssociationTypeKey.DECLARED_SKILLS)
+  params: makeSearchParams(EAssociationTypeKey.DECLARED_SKILLS),
+  enabled: computed(() => activeTypeKey.value === EAssociationTypeKey.DECLARED_SKILLS)
 })
 
 const {
@@ -108,7 +109,8 @@ const {
   isLoading: isActivitiesLoading
 } = useSearchActivitiesForAssociationQuery({
   traceId: searchTraceId,
-  params: makeSearchParams(EAssociationTypeKey.ACTIVITIES)
+  params: makeSearchParams(EAssociationTypeKey.ACTIVITIES),
+  enabled: computed(() => activeTypeKey.value === EAssociationTypeKey.ACTIVITIES)
 })
 
 const typeConfigs = computed<AssociateElementTypeConfig[]>(() => [


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
- Added an `enabled` parameter to `useSearchDeclaredSkillsForAssociationWithTraceQuery` and `useSearchActivitiesForAssociationQuery` to explicitly control when API calls are triggered, independently of whether `traceId` is empty or not
- Updated the `StudentToolsTracesAddTraceDrawer` component so that association-fetching API calls are conditionally enabled based on the currently selected association type

---

### Reference to an Issue, Feature, Task, User Story or another PR
- Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1460

---

**Modified areas:**
- `src/features/student/traces/queries/use-traces.query/use-traces.query.test.ts`
- `src/features/student/traces/queries/use-traces.query/use-traces.query.ts`
- `src/features/student/traces/views/StudentToolsTracesView/components/StudentToolsTracesAddTraceDrawer/StudentToolsTracesAddTraceDrawer.vue`

---

### Target Branch
`develop`

---

### Additional Notes
- The `enabled` parameter was introduced instead of relying on `traceId` nullability checks, as it provides a cleaner and more explicit control over query activation

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process