### PR TITLE
fix(1467): stabilize AssociateActivitiesToDeclaredSkillModal tests

### DIFF
--- a/src/features/student/declaredSkills/components/overlays/modals/AssociateActivitiesToDeclaredSkillModal/AssociateActivitiesToDeclaredSkillModal.test.ts
+++ b/src/features/student/declaredSkills/components/overlays/modals/AssociateActivitiesToDeclaredSkillModal/AssociateActivitiesToDeclaredSkillModal.test.ts
@@ -1,3 +1,4 @@
+import type { AssociationActivity } from '@/features/student/traces/views/StudentTraceView/components/overlays/modals/AssociateActivitiesModal/AssociateActivitiesModal.vue'
 import type { VueWrapper } from '@vue/test-utils'
 import {
   associateDeclaredSkillWithDeclaredActivityErrorHandler,
@@ -75,16 +76,18 @@ BddTest().given('an associate activities to declared skill modal', () => {
     })
 
     BddTest().and('the inner modal emits search event', () => {
+      let initialActivities: AssociationActivity[]
+
       beforeEach(async () => {
+        initialActivities = modal.props('activities') as AssociationActivity[]
         modal.vm.$emit('search', 'valeurs')
         await flushPromises()
       })
 
-      BddTest().then('it should filter activities through the query', async () => {
+      BddTest().then('it should update activities after search', async () => {
         await vi.waitFor(() => {
-          const updatedModal = wrapper.findComponent(AssociateActivitiesModalStub) as VueWrapper<InstanceType<typeof AssociateActivitiesModalStub>>
-          const activities = updatedModal.props('activities')
-          expect(activities.length).toBeGreaterThanOrEqual(0)
+          const updatedModal = wrapper.findComponent(AssociateActivitiesModalStub)
+          expect(updatedModal.props('activities')).not.toEqual(initialActivities)
         })
       })
     })
@@ -97,21 +100,19 @@ BddTest().given('an associate activities to declared skill modal', () => {
         })
 
         modal.vm.$emit('associate', ['activity-search-1', 'activity-search-2'])
-        await flushPromises()
-      })
-
-      BddTest().then('it should emit associated event', async () => {
         await vi.waitFor(() => {
           expect(wrapper.emitted('associated')).toBeTruthy()
         })
       })
 
-      BddTest().then('it should show a success toaster with the correct count', async () => {
-        await vi.waitFor(() => {
-          expect(mockAddSuccessMessage).toHaveBeenCalledWith({
-            timeout: 2000,
-            description: expect.stringContaining('2')
-          })
+      BddTest().then('it should emit associated event', () => {
+        expect(wrapper.emitted('associated')).toHaveLength(1)
+      })
+
+      BddTest().then('it should show a success toaster with the correct count', () => {
+        expect(mockAddSuccessMessage).toHaveBeenCalledWith({
+          timeout: 2000,
+          description: expect.stringContaining('2')
         })
       })
 
@@ -126,7 +127,7 @@ BddTest().given('an associate activities to declared skill modal', () => {
       })
 
       BddTest().then('it should emit cancel', () => {
-        expect(wrapper.emitted('cancel')).toBeTruthy()
+        expect(wrapper.emitted('cancel')).toHaveLength(1)
       })
     })
   })


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
- Fixed flaky tests in `AssociateActivitiesToDeclaredSkillModal`

---

### Reference to an Issue, Feature, Task, User Story or another PR
- Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1467

---

**Modified areas:**
- `src/features/student/declaredSkills/components/overlays/modals/AssociateActivitiesToDeclaredSkillModal/AssociateActivitiesToDeclaredSkillModal.test.ts`

---

### Target Branch
`develop`

---

### Additional Notes
- The test `it should update activities after search` likely belongs at the `SearchAssociationLayout` component level; For now, it has been slightly strengthened, but it relies on the assumption that the list necessarily changes after a search

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process