### PR TITLE
fix(1465): prevent displaying confirmation modal after submit

### DIFF
--- a/src/features/student/traces/views/StudentToolsTracesView/components/StudentToolsTracesAddTraceDrawer/StudentToolsTracesAddTraceDrawer.vue
+++ b/src/features/student/traces/views/StudentToolsTracesView/components/StudentToolsTracesAddTraceDrawer/StudentToolsTracesAddTraceDrawer.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import type { AssociateElementOption, AssociateElementTypeConfig } from '@/features/student/traces/types/traces.types'
-import type { IdTitle } from '@/types'
 import { ConfirmationModal, FormCancelConfirmButtons } from '@/common/components'
 import { useModal } from '@/common/composables'
 import { useUnsavedChangesGuard } from '@/common/composables/use-unsaved-changes-guard/use-unsaved-changes-guard'
@@ -26,7 +25,6 @@ const { addSuccessMessage } = useToasterStore()
 const showDrawer = toRef(tracesStore, 'showCreateTraceDrawer')
 
 const searchQuery = ref('')
-const associationSelections = ref<Record<string, IdTitle[]>>({})
 const activeTypeKey = ref<string>(EAssociationTypeKey.DECLARED_SKILLS)
 
 function onTraceCreated () {
@@ -61,7 +59,6 @@ const activeAccordion = ref(0)
 
 function confirmCancel () {
   form.reset()
-  associationSelections.value = {}
   searchQuery.value = ''
   activeTypeKey.value = EAssociationTypeKey.DECLARED_SKILLS
   activeAccordion.value = 0
@@ -164,10 +161,6 @@ function onTypeChange (typeKey: string) {
 }
 
 const associationSelectionsField = form.useField({ name: 'associationSelections' })
-
-watch(associationSelections, (newSelections) => {
-  associationSelectionsField.api.handleChange(newSelections)
-}, { deep: true })
 </script>
 
 <template>
@@ -218,11 +211,12 @@ watch(associationSelections, (newSelections) => {
               :icon="MDI_ICONS.PLUS_CIRCLE_OUTLINE"
             >
               <AssociateElementsDrawerSection
-                v-model:selections-by-type="associationSelections"
+                :selections-by-type="associationSelectionsField.state.value.value"
                 :type-configs="typeConfigs"
                 :options="currentOptions"
                 :loading="isSearchLoading"
                 data-testid="associate-elements-section"
+                @update:selections-by-type="associationSelectionsField.api.handleChange"
                 @search="onSearch"
                 @type-change="onTypeChange"
               />


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
Suppression du `ref` intermédiaire `associationSelections` et de son watcher dans `StudentToolsTracesAddTraceDrawer`.

La cause racine était que `TanStack Form` marque `isDirty: true` de manière **inconditionnelle** à chaque appel de `handleChange` (via `setFieldValue`), sans comparer la valeur avec la valeur initiale. Le watcher appelait `handleChange({})` après `form.reset()`, ce qui redirtifiait immédiatement le formulaire, provoquant l'affichage de la modale de confirmation à la fermeture du drawer.

Le champ `associationSelectionsField` est maintenant bindé directement dans le template via `:selections-by-type` et `@update:selections-by-type`. Ainsi, `form.reset()` réinitialise le champ via le store interne sans passer par `handleChange`, et `isDirty` reste correctement à `false` après soumission.

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1465

---

### Documentation
Aucune mise à jour de documentation nécessaire.

---

### Target Branch
`develop`

---

### Additional Notes
- `form.reset()` de TanStack Form réinitialise les valeurs des champs directement dans le store interne, ce qui ne déclenche pas `handleChange` et ne modifie donc pas le `isDirty` des meta du champ.
- L'import de type `IdTitle` et la ligne `associationSelections.value = {}` dans `confirmCancel` ont également été supprimés car devenus inutiles.

---

### Known Limitations or Side Effects
Aucun.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [x] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and detaiils for the update process