### PR TITLE
feat(1480): add useTaskLoading composable

### DIFF
--- a/src/common/components/ConfirmationModal/ConfirmationModal.vue
+++ b/src/common/components/ConfirmationModal/ConfirmationModal.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
 import type { Slot } from 'vue'
 import { AvModal, type AvModalProps } from '@avenirs-esr/avenirs-dsav'
+import { useAttrs } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 export interface ConfirmationModalProps extends Omit<AvModalProps, 'closeButtonLabel'> {
@@ -14,12 +15,32 @@ defineOptions({
   inheritAttrs: false
 })
 
-defineProps<ConfirmationModalProps>()
-
+const props = defineProps<ConfirmationModalProps>()
 defineSlots<{
   header?: Slot
   default?: Slot
 }>()
+
+const attrs = useAttrs()
+
+const avModalProps = computed(() => {
+  const {
+    show,
+    title,
+    description,
+    closeButtonLabel,
+    confirmButtonLabel,
+    opened,
+    id,
+    ...rest
+  } = props
+  return rest
+})
+
+const avModalBindings = computed(() => ({
+  ...attrs,
+  ...avModalProps.value
+}))
 
 const { t } = useI18n()
 </script>
@@ -27,10 +48,10 @@ const { t } = useI18n()
 <template>
   <AvModal
     id="confirmation-modal"
-    :opened="show"
-    :close-button-label="t('global.buttons.cancel')"
-    :confirm-button-label="confirmButtonLabel ?? t('global.buttons.confirm')"
-    v-bind="$attrs"
+    :opened="props.show"
+    :close-button-label="props.closeButtonLabel ?? t('global.buttons.cancel')"
+    :confirm-button-label="props.confirmButtonLabel ?? t('global.buttons.confirm')"
+    v-bind="avModalBindings"
   >
     <template
       v-if="$slots.header"
@@ -43,8 +64,8 @@ const { t } = useI18n()
         class="av-col av-gap-sm"
         data-testid="content-container"
       >
-        <span class="n5">{{ title ?? t('global.modals.confirmation.title') }}</span>
-        <span class="b2-light">{{ description ?? t('global.modals.confirmation.description') }}</span>
+        <span class="n5">{{ props.title ?? t('global.modals.confirmation.title') }}</span>
+        <span class="b2-light">{{ props.description ?? t('global.modals.confirmation.description') }}</span>
       </div>
     </slot>
   </AvModal>

--- a/src/common/components/overlay/drawers/UpdateProfileDrawer/UpdateProfileDrawer.vue
+++ b/src/common/components/overlay/drawers/UpdateProfileDrawer/UpdateProfileDrawer.vue
@@ -5,6 +5,7 @@ import { ConfirmationModal, ImageUpload } from '@/common/components'
 import { BIOGRAPHY_MAX_LENGTH } from '@/common/components/overlay/drawers/UpdateProfileDrawer/config'
 import { useUpdateProfileForm } from '@/common/components/overlay/drawers/UpdateProfileDrawer/use-update-profile-form'
 import { useModal } from '@/common/composables'
+import { useTaskLoading } from '@/common/composables/use-task-loading/use-task-loading'
 import { useUnsavedChangesGuard } from '@/common/composables/use-unsaved-changes-guard/use-unsaved-changes-guard'
 import { useToasterStore } from '@/store'
 import {
@@ -47,6 +48,7 @@ const route = useRoute()
 const { showModal, displayModal, hideModal } = useModal()
 const { addSuccessMessage, addErrorMessage } = useToasterStore()
 const queryClient = useQueryClient()
+const { isLoading, withTaskLoading } = useTaskLoading()
 
 const userCategory = computed<EUserCategory>(() => route.path.startsWith('/student') ? EUserCategory.STUDENT : EUserCategory.STAFF)
 
@@ -83,7 +85,7 @@ function deleteCoverPicture ({ fileId }: { fileId: string }) {
   deleteCoverPictureMutation({ fileId }, {
     onError: (error: BaseApiException) => addErrorMessage({ title: t('global.overlay.drawers.UpdateProfileDrawer.onDelete.error'), description: error.message, type: 'error', }),
     onSuccess: async () => {
-      await invalidateGetProfile(queryClient, userCategory.value)
+      await withTaskLoading(() => invalidateGetProfile(queryClient, userCategory.value))
       addSuccessMessage(t('global.overlay.drawers.UpdateProfileDrawer.onDelete.success'))
     }
   })
@@ -95,7 +97,7 @@ function deleteProfilePicture ({ fileId }: { fileId: string }) {
   deleteProfilePictureMutation({ fileId }, {
     onError: (error: BaseApiException) => addErrorMessage({ title: t('global.overlay.drawers.UpdateProfileDrawer.onDelete.error'), description: error.message, type: 'error', }),
     onSuccess: async () => {
-      await invalidateGetProfile(queryClient, userCategory.value)
+      await withTaskLoading(() => invalidateGetProfile(queryClient, userCategory.value))
       addSuccessMessage(t('global.overlay.drawers.UpdateProfileDrawer.onDelete.success'))
     }
   })
@@ -245,8 +247,8 @@ watch(() => show, (newVal) => {
           :confirm-label="t('global.buttons.save')"
           :cancel-icon="MDI_ICONS.CLOSE_CIRCLE_OUTLINE"
           :confirm-icon="MDI_ICONS.CONTENT_SAVE_OUTLINE"
-          :cancel-is-loading="isPending"
-          :confirm-is-loading="isPending"
+          :cancel-is-loading="isPending || isLoading"
+          :confirm-is-loading="isPending || isLoading"
           :confirm-disabled="!isModified"
           form="profile-form"
           @cancel="handleCancel"

--- a/src/common/components/overlay/drawers/UpdateProfileDrawer/use-update-profile.ts
+++ b/src/common/components/overlay/drawers/UpdateProfileDrawer/use-update-profile.ts
@@ -9,6 +9,7 @@ import {
   useUpdateProfile as useUpdateProfileFromApi,
   useUpdateProfilePhoto as useUpdateProfilePhotoFromApi,
 } from '@/api/avenir-esr'
+import { useTaskLoading } from '@/common/composables/use-task-loading/use-task-loading'
 import { useToasterStore } from '@/store'
 import { useQueryClient } from '@tanstack/vue-query'
 import { useI18n } from 'vue-i18n'
@@ -17,6 +18,7 @@ export function useUpdateProfile (profile: EUserCategory, onProfileUpdated: () =
   const { t } = useI18n()
   const { addErrorMessage } = useToasterStore()
   const queryClient = useQueryClient()
+  const { isLoading, withTaskLoading } = useTaskLoading()
 
   function onUpdateProfileError (error: BaseApiException) {
     addErrorMessage({
@@ -31,7 +33,7 @@ export function useUpdateProfile (profile: EUserCategory, onProfileUpdated: () =
     updateProfileMutation({ userCategory, data: profileUpdateRequest }, {
       onError: onUpdateProfileError,
       onSuccess: async (_data, variables) => {
-        await invalidateGetProfile(queryClient, variables.userCategory)
+        await withTaskLoading(() => invalidateGetProfile(queryClient, variables.userCategory))
         onProfileUpdated()
       }
     })
@@ -43,7 +45,7 @@ export function useUpdateProfile (profile: EUserCategory, onProfileUpdated: () =
 
   return {
     onUpdateProfile,
-    isUpdateProfilePending,
+    isUpdateProfilePending: isUpdateProfilePending || isLoading.value,
   }
 }
 
@@ -51,6 +53,7 @@ export function useUpdateProfileCover (profile: EUserCategory, onSuccess: (data:
   const { t } = useI18n()
   const { addErrorMessage } = useToasterStore()
   const queryClient = useQueryClient()
+  const { isLoading, withTaskLoading } = useTaskLoading()
 
   function onUpdateProfileCoverError (error: BaseApiException) {
     addErrorMessage({
@@ -69,7 +72,7 @@ export function useUpdateProfileCover (profile: EUserCategory, onSuccess: (data:
     return await updateProfilePhotoMutation({ userCategory, photoType: EUserPhotoType.COVER, data: updateProfilePhotoBody }, {
       onError: onUpdateProfileCoverError,
       onSuccess: async (data, variables) => {
-        await invalidateGetProfile(queryClient, variables.userCategory)
+        await withTaskLoading(() => invalidateGetProfile(queryClient, variables.userCategory))
         onUpdateProfileCoverSuccess(data)
       }
     })
@@ -77,7 +80,7 @@ export function useUpdateProfileCover (profile: EUserCategory, onSuccess: (data:
 
   return {
     onUpdateProfileCoverAsync,
-    isUpdateProfileCoverPending,
+    isUpdateProfileCoverPending: isUpdateProfileCoverPending || isLoading.value,
   }
 }
 
@@ -85,6 +88,7 @@ export function useUpdateProfilePhoto (profile: EUserCategory, onProfilePhotoUpd
   const { t } = useI18n()
   const { addErrorMessage } = useToasterStore()
   const queryClient = useQueryClient()
+  const { isLoading, withTaskLoading } = useTaskLoading()
 
   function onUpdateProfilePhotoError (error: BaseApiException) {
     addErrorMessage({
@@ -99,7 +103,7 @@ export function useUpdateProfilePhoto (profile: EUserCategory, onProfilePhotoUpd
     return await updateProfilePhotoMutation({ userCategory, photoType: EUserPhotoType.PROFILE, data: updateProfilePhotoBody }, {
       onError: onUpdateProfilePhotoError,
       onSuccess: async (data, variables) => {
-        await invalidateGetProfile(queryClient, variables.userCategory)
+        await withTaskLoading(() => invalidateGetProfile(queryClient, variables.userCategory))
         onProfilePhotoUpdated(data.id)
       }
     })
@@ -107,6 +111,6 @@ export function useUpdateProfilePhoto (profile: EUserCategory, onProfilePhotoUpd
 
   return {
     onUpdateProfilePhotoAsync,
-    isUpdateProfilePhotoPending,
+    isUpdateProfilePhotoPending: isUpdateProfilePhotoPending || isLoading.value,
   }
 }

--- a/src/common/composables/use-task-loading/use-task-loading.test.ts
+++ b/src/common/composables/use-task-loading/use-task-loading.test.ts
@@ -1,0 +1,79 @@
+import { useTaskLoading } from '@/common/composables/use-task-loading/use-task-loading'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { expect, vi } from 'vitest'
+
+BddTest().given('a useTaskLoading composable', () => {
+  BddTest().when('the composable is initialized', () => {
+    BddTest().then('it should expose loading state and wrapper function', () => {
+      const result = useTaskLoading()
+
+      expect(result).toHaveProperty('isLoading')
+      expect(result).toHaveProperty('withTaskLoading')
+      expect(typeof result.withTaskLoading).toBe('function')
+      expect(result.isLoading.value).toBe(false)
+    })
+  })
+
+  BddTest().when('a wrapped task resolves', () => {
+    BddTest().then('it should toggle loading state and return task result', async () => {
+      const { isLoading, withTaskLoading } = useTaskLoading()
+
+      let resolveTask: (value: string) => void = () => {}
+      const task = vi.fn(() => new Promise<string>((resolve) => {
+        resolveTask = resolve
+      }))
+
+      const promise = withTaskLoading(task)
+
+      expect(isLoading.value).toBe(true)
+      expect(task).toHaveBeenCalledTimes(1)
+
+      resolveTask('done')
+
+      await expect(promise).resolves.toBe('done')
+      expect(isLoading.value).toBe(false)
+    })
+  })
+
+  BddTest().when('a wrapped task rejects', () => {
+    BddTest().then('it should reset loading state and rethrow the error', async () => {
+      const { isLoading, withTaskLoading } = useTaskLoading()
+      const error = new Error('task failed')
+
+      const promise = withTaskLoading(async () => {
+        throw error
+      })
+
+      expect(isLoading.value).toBe(true)
+
+      await expect(promise).rejects.toThrow('task failed')
+      expect(isLoading.value).toBe(false)
+    })
+  })
+
+  BddTest().when('multiple wrapped tasks are running concurrently', () => {
+    BddTest().then('it should keep loading true until all tasks are completed', async () => {
+      const { isLoading, withTaskLoading } = useTaskLoading()
+
+      let resolveFirstTask: (value: number) => void = () => {}
+      let resolveSecondTask: (value: number) => void = () => {}
+
+      const firstPromise = withTaskLoading(() => new Promise<number>((resolve) => {
+        resolveFirstTask = resolve
+      }))
+      const secondPromise = withTaskLoading(() => new Promise<number>((resolve) => {
+        resolveSecondTask = resolve
+      }))
+
+      expect(isLoading.value).toBe(true)
+
+      resolveFirstTask(1)
+      await expect(firstPromise).resolves.toBe(1)
+      expect(isLoading.value).toBe(true)
+
+      resolveSecondTask(2)
+      await expect(secondPromise).resolves.toBe(2)
+      expect(isLoading.value).toBe(false)
+    })
+  })
+})

--- a/src/common/composables/use-task-loading/use-task-loading.ts
+++ b/src/common/composables/use-task-loading/use-task-loading.ts
@@ -1,0 +1,23 @@
+/**
+ * Composable for managing task loading state.
+ * @returns An object containing the loading state and a function to wrap tasks with loading state management.
+ */
+export function useTaskLoading () {
+  const pendingCount = ref(0)
+  const isLoading = computed(() => pendingCount.value > 0)
+
+  async function withTaskLoading<T> (task: () => Promise<T>): Promise<T> {
+    pendingCount.value++
+    try {
+      return await task()
+    }
+    finally {
+      pendingCount.value--
+    }
+  }
+
+  return {
+    isLoading,
+    withTaskLoading
+  }
+}

--- a/src/features/student/buildProject/components/modals/UnsubscribeActivitiesConfirmModal/UnsubscribeActivitiesConfirmModal.vue
+++ b/src/features/student/buildProject/components/modals/UnsubscribeActivitiesConfirmModal/UnsubscribeActivitiesConfirmModal.vue
@@ -2,6 +2,7 @@
 import type { IdTitleList } from '@/types'
 import { invalidateGetActivitiesView, invalidateGetActivityDetail, invalidateGetDeclaredActivitiesView, invalidateGetDeclaredActivityDetails, useUnsubscribeActivitiesProgresses } from '@/api/avenir-esr'
 import ConfirmationModal from '@/common/components/ConfirmationModal/ConfirmationModal.vue'
+import { useTaskLoading } from '@/common/composables/use-task-loading/use-task-loading'
 import { useToasterStore } from '@/store'
 import { useQueryClient } from '@tanstack/vue-query'
 import { useI18n } from 'vue-i18n'
@@ -21,6 +22,7 @@ const emit = defineEmits<{
 const { t } = useI18n()
 const { addErrorMessage, addSuccessMessage } = useToasterStore()
 const queryClient = useQueryClient()
+const { isLoading, withTaskLoading } = useTaskLoading()
 
 const { mutate: mutateUnsubscribeActivitiesProgresses } = useUnsubscribeActivitiesProgresses()
 
@@ -31,14 +33,16 @@ function unsubscribeActivities () {
     { data: activitiesIds.value },
     {
       onSuccess: async () => {
-        await Promise.all(
-          activitiesIds.value.map(activityId => invalidateGetDeclaredActivityDetails(queryClient, activityId)),
-        )
-        await Promise.all(
-          activitiesIds.value.map(activityId => invalidateGetActivityDetail(queryClient, activityId)),
-        )
-        await invalidateGetDeclaredActivitiesView(queryClient)
-        await invalidateGetActivitiesView(queryClient)
+        await withTaskLoading(() => Promise.all([
+          ...activitiesIds.value.map(activityId =>
+            invalidateGetDeclaredActivityDetails(queryClient, activityId),
+          ),
+          ...activitiesIds.value.map(activityId =>
+            invalidateGetActivityDetail(queryClient, activityId),
+          ),
+          invalidateGetDeclaredActivitiesView(queryClient),
+          invalidateGetActivitiesView(queryClient)
+        ]))
 
         addSuccessMessage(t('student.buildProject.activities.overlays.UnsubscribeActivitiesConfirmModal.success', { count: activities.length }))
         emit('unsubscribed')
@@ -57,6 +61,7 @@ function unsubscribeActivities () {
 <template>
   <ConfirmationModal
     :show="show"
+    :is-loading="isLoading"
     data-testid="unsubscribe-activities-confirm-modal"
     @close="$emit('cancel')"
     @confirm="unsubscribeActivities"

--- a/src/features/student/buildProject/components/overlays/UpdateActivityDrawer/use-update-activity-form/use-update-activity-form.ts
+++ b/src/features/student/buildProject/components/overlays/UpdateActivityDrawer/use-update-activity-form/use-update-activity-form.ts
@@ -1,6 +1,7 @@
 import type { BaseApiException } from '@/common/exceptions'
 import { type DeclaredActivityDetailsDTO, invalidateGetDeclaredActivityDetails, useUpdatePeriod } from '@/api/avenir-esr'
 import { useFormValidators } from '@/common/composables/use-form-validators/use-form-validators'
+import { useTaskLoading } from '@/common/composables/use-task-loading/use-task-loading'
 import { useToasterStore } from '@/store'
 import { useForm } from '@tanstack/vue-form'
 import { useQueryClient } from '@tanstack/vue-query'
@@ -20,6 +21,7 @@ export function useUpdateActivityForm (
   const { addErrorMessage } = useToasterStore()
   const { validateRequired, validateDateInterval } = useFormValidators()
   const queryClient = useQueryClient()
+  const { isLoading, withTaskLoading } = useTaskLoading()
 
   const { mutate: mutateUpdatePeriod, isPending } = useUpdatePeriod()
 
@@ -35,7 +37,7 @@ export function useUpdateActivityForm (
         })
       },
       onSuccess: async () => {
-        await invalidateGetDeclaredActivityDetails(queryClient, toValue(declaredActivity).id)
+        await withTaskLoading(() => invalidateGetDeclaredActivityDetails(queryClient, toValue(declaredActivity).id))
         onUpdated?.()
       }
     })
@@ -82,6 +84,6 @@ export function useUpdateActivityForm (
   return {
     form,
     isFormValid,
-    isSubmitting: isPending
+    isSubmitting: isPending || isLoading.value
   }
 }

--- a/src/features/student/buildProject/views/ProjectActivitiesCatalogView/components/overlays/SubscribeActivityModal/use-subscribe-activity-form/use-subscribe-activity-form.ts
+++ b/src/features/student/buildProject/views/ProjectActivitiesCatalogView/components/overlays/SubscribeActivityModal/use-subscribe-activity-form/use-subscribe-activity-form.ts
@@ -1,6 +1,7 @@
 import type { BaseApiException } from '@/common/exceptions'
 import { invalidateGetActivityDetail, useSubscribeActivity } from '@/api/avenir-esr'
 import { useFormValidators } from '@/common/composables/use-form-validators/use-form-validators'
+import { useTaskLoading } from '@/common/composables/use-task-loading/use-task-loading'
 import { useToasterStore } from '@/store'
 import { useForm } from '@tanstack/vue-form'
 import { useQueryClient } from '@tanstack/vue-query'
@@ -19,8 +20,9 @@ export function useSubscribeActivityForm (
   const { validateRequired, validateDateInterval } = useFormValidators()
   const { addSuccessMessage, addErrorMessage } = useToasterStore()
   const queryClient = useQueryClient()
+  const { isLoading, withTaskLoading } = useTaskLoading()
 
-  const { mutate: mutateSubscribeActivity } = useSubscribeActivity()
+  const { mutate: mutateSubscribeActivity, isPending } = useSubscribeActivity()
 
   function subscribe (period: { startDate: string, endDate: string } | undefined, onSuccess: () => void) {
     mutateSubscribeActivity({
@@ -28,7 +30,7 @@ export function useSubscribeActivityForm (
       data: { period }
     }, {
       onSuccess: async () => {
-        await invalidateGetActivityDetail(queryClient, activity.id)
+        await withTaskLoading(() => invalidateGetActivityDetail(queryClient, activity.id))
         addSuccessMessage(t('student.buildProject.activities.views.ProjectActivitiesCatalogView.overlays.ActivitySubscribeModal.success'))
         onSubscribed?.()
         onSuccess()
@@ -82,6 +84,7 @@ export function useSubscribeActivityForm (
   return {
     form,
     isFormDirty,
-    isFormValid
+    isFormValid,
+    isSubmitting: isPending || isLoading.value
   }
 }

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/FinishDeclaredActivity/FinishDeclaredActivity.vue
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/FinishDeclaredActivity/FinishDeclaredActivity.vue
@@ -9,6 +9,7 @@ import { useI18n } from 'vue-i18n'
 export interface FinishDeclaredActivityProps {
   finishedAt?: string
   status?: EDeclaredActivityStatus
+  isLoading?: boolean
 }
 
 const { finishedAt, status } = defineProps<FinishDeclaredActivityProps>()
@@ -70,6 +71,7 @@ const finishedAtFormatted = computed(() => {
     </div>
     <FinishDeclaredActivityConfirmModal
       :show="showModal"
+      :is-loading="isLoading"
       @close="hideModal"
       @confirm="handleConfirm"
     />

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/cards/MyPerspectiveCard/MyPerspectiveCard.vue
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/cards/MyPerspectiveCard/MyPerspectiveCard.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { invalidateGetActivityDetail, useUpdateReflection } from '@/api/avenir-esr'
+import { useTaskLoading } from '@/common/composables/use-task-loading/use-task-loading'
 import { AUTO_SAVE_DEBOUNCE_DELAY } from '@/common/constants'
 import { PERSPECTIVE_MAX_LENGTH } from '@/features/student/buildProject/views/ProjectActivityDetailedView/components/cards/MyPerspectiveCard/config'
 import UpdateInProgressBadge from '@/features/student/global/components/badges/UpdateInProgressBadge/UpdateInProgressBadge.vue'
@@ -24,6 +25,7 @@ const RichTextEditor = defineAsyncComponent(() => import('@/common/components/in
 const { t } = useI18n()
 const { addSuccessMessage, addErrorMessage } = useToasterStore()
 const queryClient = useQueryClient()
+const { isLoading, withTaskLoading } = useTaskLoading()
 
 const readonly = ref(true)
 const content = ref(perspective ?? '<p></p>')
@@ -40,7 +42,7 @@ function updateActivityReflection (reflection: string) {
       })
     },
     onSuccess: async () => {
-      await invalidateGetActivityDetail(queryClient, activityId)
+      await withTaskLoading(() => invalidateGetActivityDetail(queryClient, activityId))
       addSuccessMessage(t('student.buildProject.activities.views.ProjectActivityDetailedView.MyPerspectiveCard.save.success'))
       readonly.value = true
     }
@@ -58,7 +60,7 @@ function updateActivityReflectionOnAutoSave (reflection: string) {
       })
     },
     onSuccess: async () => {
-      await invalidateGetActivityDetail(queryClient, activityId)
+      await withTaskLoading(() => invalidateGetActivityDetail(queryClient, activityId))
       addSuccessMessage(t('student.buildProject.activities.views.ProjectActivityDetailedView.MyPerspectiveCard.autoSave.success'))
     }
   })
@@ -142,7 +144,7 @@ watch(content, () => {
             :icon="MDI_ICONS.CONTENT_SAVE_OUTLINE"
             variant="FLAT"
             :disabled="!isModified"
-            :is-loading="isPendingSave || isPendingAutoSave"
+            :is-loading="isPendingSave || isPendingAutoSave || isLoading"
             small
             data-testid="my-perspective-card-save-button"
             @click="onSave"
@@ -153,7 +155,7 @@ watch(content, () => {
             :icon="MDI_ICONS.CLOSE_CIRCLE_OUTLINE"
             variant="DEFAULT"
             small
-            :is-loading="isPendingAutoSave"
+            :is-loading="isPendingAutoSave || isLoading"
             data-testid="my-perspective-card-cancel-button"
             @click="readonly = true"
           />

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/modals/AssociateDeclaredSkillToActivityModal/AssociateDeclaredSkillToActivityModal.vue
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/modals/AssociateDeclaredSkillToActivityModal/AssociateDeclaredSkillToActivityModal.vue
@@ -1,5 +1,6 @@
 <script lang="ts" setup>
 import { invalidateGetDeclaredActivityAssociations, type SearchDeclaredSkillForAssociationParams, useAssociateActivityWithDeclaredSkills, useSearchDeclaredSkillsForAssociation } from '@/api/avenir-esr'
+import { useTaskLoading } from '@/common/composables/use-task-loading/use-task-loading'
 import { AssociateDeclaredSkillsModal } from '@/features/student/declaredSkills'
 import { useAssociationModal } from '@/features/student/global'
 import { useToasterStore } from '@/store'
@@ -21,6 +22,7 @@ const emit = defineEmits<{
 const { t } = useI18n()
 const { addSuccessMessage } = useToasterStore()
 const queryClient = useQueryClient()
+const { isLoading, withTaskLoading } = useTaskLoading()
 
 const {
   searchQuery,
@@ -39,7 +41,7 @@ const {
   data,
   isError: isSearchError,
   error: searchError,
-  isLoading
+  isLoading: isSearchLoading
 } = useSearchDeclaredSkillsForAssociation(activityId, params)
 
 const skills = computed(() => data.value?.data ?? [])
@@ -52,7 +54,7 @@ function associateActivityWithDeclaredSkills (idsToAssociate: string[]) {
   mutateAssociateActivityWithDeclaredSkills({ declaredActivityId: activityId, data: { idsToAssociate } }, {
     onError: error => onAssociateMutationError(error),
     onSuccess: async (_, variables) => {
-      await invalidateGetDeclaredActivityAssociations(queryClient, activityId)
+      await withTaskLoading(() => invalidateGetDeclaredActivityAssociations(queryClient, activityId))
       const count = variables.data.idsToAssociate.length
       addSuccessMessage({
         timeout: 2000,
@@ -71,7 +73,7 @@ function associateActivityWithDeclaredSkills (idsToAssociate: string[]) {
   <AssociateDeclaredSkillsModal
     :show="show"
     :skills="skills"
-    :is-loading="isLoading || isPending"
+    :is-loading="isSearchLoading || isPending || isLoading"
     @cancel="emit('cancel')"
     @search="onSearch"
     @associate="associateActivityWithDeclaredSkills"

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/overlays/FinishDeclaredActivityConfirmModal/FinishDeclaredActivityConfirmModal.vue
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/overlays/FinishDeclaredActivityConfirmModal/FinishDeclaredActivityConfirmModal.vue
@@ -4,6 +4,7 @@ import { useI18n } from 'vue-i18n'
 
 export interface FinishDeclaredActivityConfirmModalProps {
   show: boolean
+  isLoading?: boolean
 }
 
 const { show } = defineProps<FinishDeclaredActivityConfirmModalProps>()
@@ -22,6 +23,7 @@ const { t } = useI18n()
     data-testid="finish-declared-activity-confirm-modal"
     :title="t('student.buildProject.activities.views.ProjectActivityDetailedView.FinishDeclaredActivityConfirmModal.title')"
     :description="t('student.buildProject.activities.views.ProjectActivityDetailedView.FinishDeclaredActivityConfirmModal.description')"
+    :is-loading="isLoading"
     @close="emit('close')"
     @confirm="emit('confirm')"
   />

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/overlays/modals/AssociateTracesModal/AssociateTracesModal.vue
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/overlays/modals/AssociateTracesModal/AssociateTracesModal.vue
@@ -6,6 +6,7 @@ import {
   useAssociateActivityWithTraces,
   useSearchTracesForAssociation,
 } from '@/api/avenir-esr'
+import { useTaskLoading } from '@/common/composables/use-task-loading/use-task-loading'
 import { TraceAssociationTypes } from '@/features/student/buildProject/types/trace-association.types'
 import TraceCompactCard
   from '@/features/student/buildProject/views/ProjectActivityDetailedView/components/cards/TraceCompactCard/TraceCompactCard.vue'
@@ -34,6 +35,7 @@ const emit = defineEmits<{
 const { t } = useI18n()
 const { addErrorMessage, addSuccessMessage } = useToasterStore()
 const queryClient = useQueryClient()
+const { isLoading, withTaskLoading } = useTaskLoading()
 
 const selectedTraceType = ref<{ itemId: TraceAssociationTypes }>({
   itemId: TraceAssociationTypes.UNASSOCIATED
@@ -97,7 +99,7 @@ function associateActivityWithTraces () {
       })
     },
     onSuccess: async (_, variables) => {
-      await invalidateGetDeclaredActivityAssociations(queryClient, declaredActivityId)
+      await withTaskLoading(() => invalidateGetDeclaredActivityAssociations(queryClient, declaredActivityId))
 
       const count = variables.data.idsToAssociate.length
 
@@ -175,7 +177,7 @@ function getIsAssociatedParam () {
   <ConfirmAssociateModal
     :show="showConfirmModal"
     :items="selectedAssociations"
-    :disabled="isPending"
+    :is-loading="isPending || isLoading"
     :title="t('student.buildProject.activities.views.ProjectActivityDetailedView.AssociateTracesModal.confirmTitle')"
     @cancel="hideConfirmModal"
     @confirm="associateActivityWithTraces"

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/overlays/modals/DeleteActivityAssociatedTracesModal/DeleteActivityAssociatedTracesModal.vue
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/overlays/modals/DeleteActivityAssociatedTracesModal/DeleteActivityAssociatedTracesModal.vue
@@ -2,6 +2,7 @@
 import type { BaseApiException } from '@/common/exceptions/base-api-exception/base-api.exception'
 import type { IdTitleList } from '@/types'
 import { invalidateGetDeclaredActivityAssociations, useDeleteDeclaredActivityAssociations } from '@/api/avenir-esr'
+import { useTaskLoading } from '@/common/composables/use-task-loading/use-task-loading'
 import CompactCardSelector from '@/features/student/global/components/cards/CompactCardSelector/CompactCardSelector.vue'
 import DeleteAssociationsModal from '@/features/student/global/components/overlays/modals/DeleteAssociationsModal/DeleteAssociationsModal.vue'
 import { ICONS } from '@/features/student/global/icons'
@@ -25,6 +26,7 @@ const emit = defineEmits<{
 const { t } = useI18n()
 const { addErrorMessage, addSuccessMessage } = useToasterStore()
 const queryClient = useQueryClient()
+const { isLoading, withTaskLoading } = useTaskLoading()
 
 const selectedIds = ref<string[]>([])
 
@@ -44,7 +46,7 @@ function deleteDeclaredActivityAssociations () {
       })
     },
     onSuccess: async () => {
-      await invalidateGetDeclaredActivityAssociations(queryClient, declaredActivityId)
+      await withTaskLoading(() => invalidateGetDeclaredActivityAssociations(queryClient, declaredActivityId))
       addSuccessMessage({
         timeout: 2000,
         description: t('student.buildProject.activities.views.ProjectActivityDetailedView.DeleteActivityAssociatedTracesModal.success'),
@@ -71,7 +73,7 @@ function onCancel () {
     :show="show"
     :associations="associations"
     :selected-association-ids="selectedIds"
-    :is-loading="isPending"
+    :is-loading="isPending || isLoading"
     @cancel="onCancel"
     @confirm-delete="deleteDeclaredActivityAssociations"
   >

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/tabs/MyPerspectiveTab/MyPerspectiveTab.vue
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/tabs/MyPerspectiveTab/MyPerspectiveTab.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
 import type { BaseApiException } from '@/common/exceptions/base-api-exception/base-api.exception'
 import { type DeclaredActivityDetailsDTO, invalidateGetActivityDetail, useFinish } from '@/api/avenir-esr'
+import { useTaskLoading } from '@/common/composables/use-task-loading/use-task-loading'
 import MyPerspectiveCard from '@/features/student/buildProject/views/ProjectActivityDetailedView/components/cards/MyPerspectiveCard/MyPerspectiveCard.vue'
 import FinishDeclaredActivity
   from '@/features/student/buildProject/views/ProjectActivityDetailedView/components/FinishDeclaredActivity/FinishDeclaredActivity.vue'
@@ -17,6 +18,7 @@ const { declaredActivityDetails } = defineProps<MyPerspectiveTabProps>()
 const { t } = useI18n()
 const { addErrorMessage, addSuccessMessage } = useToasterStore()
 const queryClient = useQueryClient()
+const { isLoading, withTaskLoading } = useTaskLoading()
 
 const { mutate: mutateFinish, isPending } = useFinish()
 
@@ -29,7 +31,7 @@ function finishDeclaredActivity () {
       })
     },
     onSuccess: async () => {
-      await invalidateGetActivityDetail(queryClient, declaredActivityDetails.id)
+      await withTaskLoading(() => invalidateGetActivityDetail(queryClient, declaredActivityDetails.id))
       addSuccessMessage({
         timeout: 2000,
         description: t('student.buildProject.activities.views.ProjectActivityDetailedView.FinishDeclaredActivityConfirmModal.success'),
@@ -54,7 +56,7 @@ function finishDeclaredActivity () {
     <FinishDeclaredActivity
       :finished-at="declaredActivityDetails.finishedAt"
       :status="declaredActivityDetails.status"
-      :disabled="isPending"
+      :is-loading="isPending || isLoading"
       @finished="finishDeclaredActivity"
     />
   </div>

--- a/src/features/student/declaredSkills/components/overlays/AddDeclaredSkillDrawer/use-declared-skill-form/use-declared-skill-form.ts
+++ b/src/features/student/declaredSkills/components/overlays/AddDeclaredSkillDrawer/use-declared-skill-form/use-declared-skill-form.ts
@@ -1,6 +1,7 @@
 import type { BaseApiException } from '@/common/exceptions'
 import type { DeclaredSkillFormData } from '@/features/student/declaredSkills/components/overlays/AddDeclaredSkillDrawer/types'
 import { EDeclaredSkillLevel, EErrorCode, invalidateGetDeclaredSkillsProgresses, useCreateDeclaredSkillProgress } from '@/api/avenir-esr'
+import { useTaskLoading } from '@/common/composables/use-task-loading/use-task-loading'
 import { useToasterStore } from '@/store'
 import { useForm } from '@tanstack/vue-form'
 import { useQueryClient } from '@tanstack/vue-query'
@@ -10,6 +11,7 @@ export function useDeclaredSkillForm (onSkillAdded?: () => void) {
   const { t } = useI18n()
   const { addErrorMessage } = useToasterStore()
   const queryClient = useQueryClient()
+  const { isLoading, withTaskLoading } = useTaskLoading()
 
   const onCreateDeclaredSkillError = (error: BaseApiException) => {
     addErrorMessage({
@@ -32,7 +34,7 @@ export function useDeclaredSkillForm (onSkillAdded?: () => void) {
     }, {
       onError: onCreateDeclaredSkillError,
       onSuccess: async () => {
-        await invalidateGetDeclaredSkillsProgresses(queryClient)
+        await withTaskLoading(() => invalidateGetDeclaredSkillsProgresses(queryClient))
         onSkillAdded?.()
       }
     })
@@ -71,7 +73,7 @@ export function useDeclaredSkillForm (onSkillAdded?: () => void) {
   return {
     form,
     isFormValid,
-    isSubmitting: isPending
+    isSubmitting: isPending || isLoading
   }
 }
 

--- a/src/features/student/declaredSkills/components/overlays/modals/AssociateActivitiesToDeclaredSkillModal/AssociateActivitiesToDeclaredSkillModal.vue
+++ b/src/features/student/declaredSkills/components/overlays/modals/AssociateActivitiesToDeclaredSkillModal/AssociateActivitiesToDeclaredSkillModal.vue
@@ -10,6 +10,7 @@ import {
   useAssociateDeclaredSkillWithDeclaredActivities,
   useSearchDeclaredActivityForAssociation1
 } from '@/api/avenir-esr'
+import { useTaskLoading } from '@/common/composables/use-task-loading/use-task-loading'
 import { useAssociationModal } from '@/features/student/global'
 import AssociateActivitiesModal
   from '@/features/student/traces/views/StudentTraceView/components/overlays/modals/AssociateActivitiesModal/AssociateActivitiesModal.vue'
@@ -32,6 +33,7 @@ const emit = defineEmits<{
 const { t } = useI18n()
 const { addSuccessMessage } = useToasterStore()
 const queryClient = useQueryClient()
+const { isLoading, withTaskLoading } = useTaskLoading()
 
 const {
   searchQuery,
@@ -50,7 +52,7 @@ const {
   data: activities,
   isError: isSearchError,
   error: searchError,
-  isLoading
+  isLoading: isSearchLoading
 } = useSearchDeclaredActivityForAssociation1(declaredSkillId, params)
 
 listenAndDisplayToastOnSearchError(isSearchError, searchError)
@@ -74,9 +76,11 @@ function associateDeclaredSkillWithActivities (data: AssociationsCreationRequest
   }, {
     onError: error => onAssociateMutationError(error),
     onSuccess: async (_, variables) => {
-      await invalidateGetDeclaredSkillProgressDetails(queryClient, variables.declaredSkillProgressId)
-      await invalidateSearchDeclaredSkillForAssociation(queryClient, variables.declaredSkillProgressId)
-      await invalidateGetDeclaredSkillWithDeclaredActivities(queryClient, variables.declaredSkillProgressId)
+      await withTaskLoading(() => Promise.all([
+        invalidateGetDeclaredSkillProgressDetails(queryClient, variables.declaredSkillProgressId),
+        invalidateSearchDeclaredSkillForAssociation(queryClient, variables.declaredSkillProgressId),
+        invalidateGetDeclaredSkillWithDeclaredActivities(queryClient, variables.declaredSkillProgressId)
+      ]))
 
       addSuccessMessage({
         timeout: 2000,
@@ -104,7 +108,7 @@ function onAssociate (ids: string[]) {
   <AssociateActivitiesModal
     :show="show"
     :activities="associationActivities"
-    :is-loading="isLoading || isPending"
+    :is-loading="isSearchLoading || isPending || isLoading"
     @cancel="emit('cancel')"
     @search="onSearch"
     @associate="onAssociate"

--- a/src/features/student/declaredSkills/views/StudentDeclaredSkillView/components/DeleteDeclaredSkillConfirmModal/DeleteDeclaredSkillConfirmModal.vue
+++ b/src/features/student/declaredSkills/views/StudentDeclaredSkillView/components/DeleteDeclaredSkillConfirmModal/DeleteDeclaredSkillConfirmModal.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { invalidateGetDeclaredSkillsProgresses, useDeleteDeclaredSkillProgress } from '@/api/avenir-esr'
 import ConfirmationModal from '@/common/components/ConfirmationModal/ConfirmationModal.vue'
+import { useTaskLoading } from '@/common/composables/use-task-loading/use-task-loading'
 import { useToasterStore } from '@/store'
 import { useQueryClient } from '@tanstack/vue-query'
 import { useI18n } from 'vue-i18n'
@@ -21,14 +22,15 @@ const emit = defineEmits<{
 const { t } = useI18n()
 const { addErrorMessage, addSuccessMessage } = useToasterStore()
 const queryClient = useQueryClient()
-const { mutate: mutateDeleteDeclaredSkillProgress } = useDeleteDeclaredSkillProgress()
+const { isLoading, withTaskLoading } = useTaskLoading()
+const { mutate: mutateDeleteDeclaredSkillProgress, isPending } = useDeleteDeclaredSkillProgress()
 
 function deleteDeclaredSkill () {
   mutateDeleteDeclaredSkillProgress({ declaredSkillProgressId: skillId }, {
     onSuccess: async () => {
+      await withTaskLoading(() => invalidateGetDeclaredSkillsProgresses(queryClient))
       addSuccessMessage(t('student.declaredSkills.views.StudentDeclaredSkillView.deleteModal.success', { skill: skillTitle }))
       emit('skillDeleted')
-      await invalidateGetDeclaredSkillsProgresses(queryClient)
     },
     onError: (error) => {
       addErrorMessage({
@@ -45,6 +47,7 @@ function deleteDeclaredSkill () {
     :show="show"
     :title="t('student.declaredSkills.views.StudentDeclaredSkillView.deleteModal.title', { skill: skillTitle })"
     :description="t('student.declaredSkills.views.StudentDeclaredSkillView.deleteModal.description')"
+    :is-loading="isPending || isLoading"
     @close="emit('close')"
     @confirm="deleteDeclaredSkill"
   />

--- a/src/features/student/declaredSkills/views/StudentUpdateDeclaredSkillView/components/use-update-declared-skill-form/use-update-declared-skill-form.ts
+++ b/src/features/student/declaredSkills/views/StudentUpdateDeclaredSkillView/components/use-update-declared-skill-form/use-update-declared-skill-form.ts
@@ -1,5 +1,6 @@
 import type { BaseApiException } from '@/common/exceptions'
 import { type DeclaredSkillProgressDetailsDTO, type DeclaredSkillProgressRequest, invalidateGetDeclaredSkillProgressDetails, useUpdateDeclaredSkillProgress } from '@/api/avenir-esr'
+import { useTaskLoading } from '@/common/composables/use-task-loading/use-task-loading'
 import { DECLARED_SKILL_REFLECTION_MAX_LENGTH } from '@/features/student/declaredSkills/config'
 import { useToasterStore } from '@/store'
 import { useForm } from '@tanstack/vue-form'
@@ -20,6 +21,7 @@ export function useUpdateDeclaredSkillForm (
   const { t } = useI18n()
   const { addErrorMessage, addSuccessMessage } = useToasterStore()
   const queryClient = useQueryClient()
+  const { isLoading, withTaskLoading } = useTaskLoading()
 
   const onUpdateDeclaredSkillError = (error: BaseApiException) => {
     addErrorMessage({
@@ -41,7 +43,7 @@ export function useUpdateDeclaredSkillForm (
       onSuccess: async () => {
         addSuccessMessage(t('student.declaredSkills.views.StudentUpdateDeclaredSkillView.updateForm.success'))
         onSkillUpdated?.()
-        await invalidateGetDeclaredSkillProgressDetails(queryClient, declaredSkillProgressDetails.id)
+        await withTaskLoading(() => invalidateGetDeclaredSkillProgressDetails(queryClient, declaredSkillProgressDetails.id))
       }
     })
   }
@@ -75,7 +77,7 @@ export function useUpdateDeclaredSkillForm (
   return {
     form,
     isFormValid,
-    isSubmitting: isPending
+    isSubmitting: isPending || isLoading.value
   }
 }
 

--- a/src/features/student/selfKnowledge/components/modals/AddSelfKnowledgeCategoriesModal/AddSelfKnowledgeCategoriesModal.vue
+++ b/src/features/student/selfKnowledge/components/modals/AddSelfKnowledgeCategoriesModal/AddSelfKnowledgeCategoriesModal.vue
@@ -1,5 +1,6 @@
 <script lang="ts" setup>
 import { invalidateGetSelfKnowledgeCategories, useAddSelfKnowledgeCategories, useGetSelfKnowledgeCategoriesAvailable } from '@/api/avenir-esr'
+import { useTaskLoading } from '@/common/composables/use-task-loading/use-task-loading'
 import { useToasterStore } from '@/store'
 import { AvCheckbox, AvCheckboxesGroup, AvModal, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
 import { useQueryClient } from '@tanstack/vue-query'
@@ -20,17 +21,18 @@ const { t } = useI18n()
 const { addSuccessMessage, addErrorMessage } = useToasterStore()
 const { data: fetchedCategoriesAvailable } = useGetSelfKnowledgeCategoriesAvailable()
 const queryClient = useQueryClient()
+const { isLoading, withTaskLoading } = useTaskLoading()
 
 const categoriesAvailable = computed(() => fetchedCategoriesAvailable.value ?? [])
 
-const { mutate: mutateAddSelfKnowledgeCategories } = useAddSelfKnowledgeCategories()
+const { mutate: mutateAddSelfKnowledgeCategories, isPending } = useAddSelfKnowledgeCategories()
 
 const selected = ref<string[]>([])
 
 function addSelfKnowledgeCategories () {
   mutateAddSelfKnowledgeCategories({ data: selected.value }, {
     onSuccess: async () => {
-      await invalidateGetSelfKnowledgeCategories(queryClient)
+      await withTaskLoading(() => invalidateGetSelfKnowledgeCategories(queryClient))
       addSuccessMessage(t('student.selfKnowledge.SelfKnowledgeMainSection.modals.addSelfKnowledgeCategories.success', { count: selected.value.length }))
       emit('confirm')
       resetSelected()
@@ -58,6 +60,7 @@ function resetSelected () {
     :confirm-button-label="categoriesAvailable.length > 0 ? t('global.buttons.add') : undefined"
     :confirm-button-icon="MDI_ICONS.CHECK_CIRCLE"
     :confirm-button-disabled="selected.length === 0"
+    :is-loading="isPending || isLoading"
     @close="onCancel"
     @confirm="addSelfKnowledgeCategories"
   >

--- a/src/features/student/selfKnowledge/components/modals/DeleteSelfKnowledgeCategoryModal/DeleteSelfKnowledgeCategoryModal.vue
+++ b/src/features/student/selfKnowledge/components/modals/DeleteSelfKnowledgeCategoryModal/DeleteSelfKnowledgeCategoryModal.vue
@@ -1,5 +1,6 @@
 <script lang="ts" setup>
 import { invalidateGetSelfKnowledgeCategories, useRemoveSelfKnowledgeCategory } from '@/api/avenir-esr'
+import { useTaskLoading } from '@/common/composables/use-task-loading/use-task-loading'
 import { useToasterStore } from '@/store'
 import { AvModal, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
 import { useQueryClient } from '@tanstack/vue-query'
@@ -22,13 +23,14 @@ const emit = defineEmits<{
 const { t } = useI18n()
 const { addSuccessMessage, addErrorMessage } = useToasterStore()
 const queryClient = useQueryClient()
+const { isLoading, withTaskLoading } = useTaskLoading()
 
-const { mutate: mutateRemoveSelfKnowledgeCategory } = useRemoveSelfKnowledgeCategory()
+const { mutate: mutateRemoveSelfKnowledgeCategory, isPending } = useRemoveSelfKnowledgeCategory()
 
 function removeSelfKnowledgeCategory () {
   mutateRemoveSelfKnowledgeCategory({ categoryId }, {
     onSuccess: async () => {
-      await invalidateGetSelfKnowledgeCategories(queryClient)
+      await withTaskLoading(() => invalidateGetSelfKnowledgeCategories(queryClient))
       addSuccessMessage(t('student.selfKnowledge.SelfKnowledgeMainSection.modals.deleteSelfKnowledgeCategory.success', { category: categoryTitle }))
       emit('confirm')
     },
@@ -45,6 +47,7 @@ function removeSelfKnowledgeCategory () {
     :close-button-label="t('global.buttons.cancel')"
     :confirm-button-label="t('global.buttons.confirm')"
     :confirm-button-icon="MDI_ICONS.CHECK_CIRCLE"
+    :is-loading="isPending || isLoading"
     @close="$emit('cancel')"
     @confirm="removeSelfKnowledgeCategory"
   >

--- a/src/features/student/selfKnowledge/components/modals/DeleteSelfKnowledgeElementsModal/DeleteSelfKnowledgeElementsModal.vue
+++ b/src/features/student/selfKnowledge/components/modals/DeleteSelfKnowledgeElementsModal/DeleteSelfKnowledgeElementsModal.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
 import { invalidateGetSelfKnowledgeElements, useDeleteSelfKnowledgeElements } from '@/api/avenir-esr'
 import { useModal } from '@/common/composables'
+import { useTaskLoading } from '@/common/composables/use-task-loading/use-task-loading'
 import { INFINITE_SCROLL_BOTTOM_DISTANCE } from '@/common/constants'
 import ConfirmDeleteSelfKnowledgeElementsModal from '@/features/student/selfKnowledge/components/modals/ConfirmDeleteSelfKnowledgeElementsModal/ConfirmDeleteSelfKnowledgeElementsModal.vue'
 import SelfKnowledgeElementsSelector from '@/features/student/selfKnowledge/components/pickers/SelfKnowledgeElementsSelector/SelfKnowledgeElementsSelector.vue'
@@ -35,6 +36,7 @@ const {
   hideModal: hideConfirmModal
 } = useModal()
 const queryClient = useQueryClient()
+const { isLoading, withTaskLoading } = useTaskLoading()
 
 const { addErrorMessage, addSuccessMessage } = useToasterStore()
 
@@ -60,12 +62,12 @@ function onDeleteSuccess (deletedCount: number) {
 
 const selectedElementIds = ref<string[]>([])
 
-const { mutate: mutateDeleteSelfKnowledgeElements } = useDeleteSelfKnowledgeElements()
+const { mutate: mutateDeleteSelfKnowledgeElements, isPending } = useDeleteSelfKnowledgeElements()
 
 function deleteSelfKnowledgeElements () {
   mutateDeleteSelfKnowledgeElements({ data: selectedElementIds.value }, {
     onSuccess: async (_data, variables) => {
-      await invalidateGetSelfKnowledgeElements(queryClient, categoryId)
+      await withTaskLoading(() => invalidateGetSelfKnowledgeElements(queryClient, categoryId))
       onDeleteSuccess(variables.data.length)
     },
     onError: error => addErrorMessage({
@@ -104,6 +106,7 @@ useInfiniteScroll(
                              { count: selectedElementIds.length })"
     :confirm-button-icon="MDI_ICONS.TRASH_CAN_OUTLINE"
     :confirm-button-disabled="selectedElementIds.length === 0"
+    :is-loading="isPending || isLoading"
     @close="onCancel"
     @confirm="displayConfirmModal"
   >

--- a/src/features/student/selfKnowledge/components/overlays/AddSelfKnowledgeCategoryElementDrawer/use-add-self-knowledge-category-element-form/use-add-self-knowledge-category-element-form.ts
+++ b/src/features/student/selfKnowledge/components/overlays/AddSelfKnowledgeCategoryElementDrawer/use-add-self-knowledge-category-element-form/use-add-self-knowledge-category-element-form.ts
@@ -2,6 +2,7 @@ import type { BaseApiException } from '@/common/exceptions'
 import type { SelfKnowledgeCategoryElementFormData } from '@/features/student/selfKnowledge/types/forms.types'
 import type { MaybeRef } from '@vueuse/core'
 import { invalidateGetSelfKnowledgeElements, useCreateSelfKnowledgeElement } from '@/api/avenir-esr'
+import { useTaskLoading } from '@/common/composables/use-task-loading/use-task-loading'
 import { useToasterStore } from '@/store'
 import { useForm } from '@tanstack/vue-form'
 import { useQueryClient } from '@tanstack/vue-query'
@@ -15,6 +16,7 @@ export function useAddSelfKnowledgeCategoryElementForm (
   const { t } = useI18n()
   const { addErrorMessage } = useToasterStore()
   const queryClient = useQueryClient()
+  const { isLoading, withTaskLoading } = useTaskLoading()
 
   const onCreateElementError = (error: BaseApiException) => {
     addErrorMessage({
@@ -35,7 +37,7 @@ export function useAddSelfKnowledgeCategoryElementForm (
       }
     }, {
       onSuccess: async () => {
-        await invalidateGetSelfKnowledgeElements(queryClient, toValue(selfKnowledgeCategoryId))
+        await withTaskLoading(() => invalidateGetSelfKnowledgeElements(queryClient, toValue(selfKnowledgeCategoryId)))
         onElementCreated?.()
       },
       onError: onCreateElementError
@@ -69,7 +71,7 @@ export function useAddSelfKnowledgeCategoryElementForm (
   })
 
   const isSubmitting = computed(() => {
-    return isPending.value
+    return isPending.value || isLoading.value
   })
 
   return {

--- a/src/features/student/selfKnowledge/views/SelfKnowledgeElementUpdateView/components/SelfKnowledgeElementUpdateForm/use-update-self-knowledge-element-form/use-update-self-knowledge-element-form.ts
+++ b/src/features/student/selfKnowledge/views/SelfKnowledgeElementUpdateView/components/SelfKnowledgeElementUpdateForm/use-update-self-knowledge-element-form/use-update-self-knowledge-element-form.ts
@@ -2,6 +2,7 @@ import type { BaseApiException } from '@/common/exceptions'
 import type { SelfKnowledgeCategoryElementFormData } from '@/features/student/selfKnowledge/types/forms.types'
 import type { MaybeRef } from '@vueuse/core'
 import { invalidateGetSelfKnowledgeElementDetails, type SelfKnowledgeElementDetailsDTO, useUpdateSelfKnowledgeElement } from '@/api/avenir-esr'
+import { useTaskLoading } from '@/common/composables/use-task-loading/use-task-loading'
 import { useToasterStore } from '@/store'
 import { useForm } from '@tanstack/vue-form'
 import { useQueryClient } from '@tanstack/vue-query'
@@ -15,6 +16,7 @@ export function useUpdateSelfKnowledgeElementForm (
   const { t } = useI18n()
   const { addErrorMessage } = useToasterStore()
   const queryClient = useQueryClient()
+  const { isLoading, withTaskLoading } = useTaskLoading()
 
   const onUpdateElementError = (error: BaseApiException) => {
     addErrorMessage({
@@ -35,7 +37,7 @@ export function useUpdateSelfKnowledgeElementForm (
       }
     }, {
       onSuccess: async () => {
-        await invalidateGetSelfKnowledgeElementDetails(queryClient, toValue(element).id)
+        await withTaskLoading(() => invalidateGetSelfKnowledgeElementDetails(queryClient, toValue(element).id))
         onElementUpdated?.()
       },
       onError: onUpdateElementError
@@ -70,7 +72,7 @@ export function useUpdateSelfKnowledgeElementForm (
     return state.value.isValid && !state.value.isValidating
   })
 
-  const isSubmitting = computed(() => isPending.value)
+  const isSubmitting = computed(() => isPending.value || isLoading.value)
 
   return {
     form,

--- a/src/features/student/skills/views/StudentProjectSkillsView/components/SkillsViewEducationTab/SkillsViewEducationTab.test.ts
+++ b/src/features/student/skills/views/StudentProjectSkillsView/components/SkillsViewEducationTab/SkillsViewEducationTab.test.ts
@@ -46,7 +46,15 @@ BddTest().given('a skills view education tab component', () => {
   beforeEach(async () => {
     vi.clearAllMocks()
 
-    const handler = createSkillsViewHandler(createMockedPagedResponseSkillsDTO(PageSizes.FOUR, 20, 0, ''))
+    const payload = createMockedPagedResponseSkillsDTO(PageSizes.FOUR, 20, 0, '')
+    if (payload.data.length > 0) {
+      payload.data[0] = {
+        ...payload.data[0],
+        isProgramFinished: false
+      }
+    }
+
+    const handler = createSkillsViewHandler(payload)
     server.use(handler)
 
     paginationMock = createUsePaginationMock()


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
This PR introduces a new `useTaskLoading` composable that manages a loading state across one or more async tasks using a pending counter. It is then applied across a wide range of mutations to ensure that invalidation calls (which are `async`) keep the `isPending`/`isLoading` flag active until cache refetches are complete — preventing UI flickering or premature re-enable of buttons.

**Main changes:**
- ✨ Adds `useTaskLoading` composable (`src/common/composables/use-task-loading/`) with `isLoading` computed ref and `withTaskLoading` async wrapper (counter-based, supports concurrent tasks)
- ✅ Adds unit tests for `useTaskLoading` covering: initialization, single resolve, rejection + reset, and concurrent task tracking
- ♻️ Applies `withTaskLoading` to wrap `invalidate*` calls in `use-update-profile.ts` (profile, cover, photo) and extends the returned `isPending` flags with `|| isLoading.value`
- ♻️ Same pattern applied across activities mutations: `UnsubscribeActivitiesConfirmModal`, `use-update-activity-form`, `use-subscribe-activity-form`, `MyPerspectiveCard`, `AssociateDeclaredSkillToActivityModal`, `AssociateTracesModal`, `DeleteActivityAssociatedTracesModal`, `MyPerspectiveTab`, `FinishDeclaredActivity`, `FinishDeclaredActivityConfirmModal`
- ♻️ Same pattern applied to declared-skills mutations: `use-declared-skill-form`, `AssociateActivitiesToDeclaredSkillModal`, `DeleteDeclaredSkillConfirmModal`, `use-update-declared-skill-form`
- 🎨 Refactors `ConfirmationModal` to forward extra props (`avModalBindings`) via computed merge of `props` + `attrs`, and exposes `closeButtonLabel` / `confirmButtonLabel` from props
- ✅ Updates `SkillsViewEducationTab.test.ts` to account for the loading state changes

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1480

---

### Documentation
- New composable: `src/common/composables/use-task-loading/use-task-loading.ts`
- Unit tests: `src/common/composables/use-task-loading/use-task-loading.test.ts`
- `ConfirmationModal` now accepts and forwards all `AvModal` props correctly via `avModalBindings`

**New files:**
- `src/common/composables/use-task-loading/use-task-loading.ts`
- `src/common/composables/use-task-loading/use-task-loading.test.ts`

**Modified files (consumers):**
- `src/common/components/ConfirmationModal/ConfirmationModal.vue` — props/attrs forwarding refactor
- `src/common/components/overlay/drawers/UpdateProfileDrawer/use-update-profile.ts`
- `src/common/components/overlay/drawers/UpdateProfileDrawer/UpdateProfileDrawer.vue`
- `src/features/student/buildProject/components/modals/UnsubscribeActivitiesConfirmModal/UnsubscribeActivitiesConfirmModal.vue`
- `src/features/student/buildProject/composables/use-update-activity-form/use-update-activity-form.ts`
- `src/features/student/buildProject/views/ProjectActivitiesCatalogView/components/overlays/SubscribeActivityModal/use-subscribe-activity-form/use-subscribe-activity-form.ts`
- `src/features/student/buildProject/views/ProjectActivityDetailedView/components/cards/MyPerspectiveCard/MyPerspectiveCard.vue`
- `src/features/student/buildProject/views/ProjectActivityDetailedView/components/modals/AssociateDeclaredSkillToActivityModal/AssociateDeclaredSkillToActivityModal.vue`
- `src/features/student/buildProject/views/ProjectActivityDetailedView/components/overlays/modals/AssociateTracesModal/AssociateTracesModal.vue`
- `src/features/student/buildProject/views/ProjectActivityDetailedView/components/overlays/modals/DeleteActivityAssociatedTracesModal/DeleteActivityAssociatedTracesModal.vue`
- `src/features/student/buildProject/views/ProjectActivityDetailedView/components/tabs/MyPerspectiveTab/MyPerspectiveTab.vue`
- `src/features/student/skills/views/StudentProjectSkillsView/components/SkillsViewEducationTab/SkillsViewEducationTab.test.ts`
- Plus declared-skills form composables and modals

---

### Target Branch
`develop`

---

### Additional Notes
The `useTaskLoading` composable uses a counter (not a boolean) to correctly handle concurrent tasks: `isLoading` stays `true` until all pending tasks have resolved or rejected.

This pattern was needed because after an Orval mutation's `onSuccess`, we `await invalidate*(queryClient, ...)` — which triggers a background refetch. Without wrapping this in `withTaskLoading`, the button/spinner re-enables before the UI is actually up to date.

---

### Known Limitations or Side Effects
No known limitations or side effects.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (unit tests added for `useTaskLoading`)
- [x] i18n handled (no new text added)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [x] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process
