### PR TITLE
fix(1484): enforce max length constraint on trace link input

### DIFF
--- a/src/features/student/traces/components/interactions/inputs/TraceLinkInput/TraceLinkInput.stub.ts
+++ b/src/features/student/traces/components/interactions/inputs/TraceLinkInput/TraceLinkInput.stub.ts
@@ -6,8 +6,9 @@ export const TraceLinkInputStub = defineComponent({
     label: { type: String },
     errorMessage: { type: String },
     required: { type: Boolean },
+    maxlength: { type: Number },
     disabled: { type: Boolean },
   },
   emits: ['update:modelValue', 'blur'],
-  template: '<div><input type="text" :id="id" :value="modelValue" :required="required" @input="$emit(\'update:modelValue\', $event.target.value)" @blur="$emit(\'blur\')" /><span v-if="errorMessage" class="error">{{ errorMessage }}</span></div>',
+  template: '<div><input type="text" :id="id" :value="modelValue" :maxlength="maxlength" :required="required" @input="$emit(\'update:modelValue\', $event.target.value)" @blur="$emit(\'blur\')" /><span v-if="errorMessage" class="error">{{ errorMessage }}</span><span class="caption-light">{{ (modelValue?.length || 0) }} / {{ maxlength }} caractères (espaces compris)</span></div>',
 })

--- a/src/features/student/traces/components/interactions/inputs/TraceLinkInput/TraceLinkInput.test.ts
+++ b/src/features/student/traces/components/interactions/inputs/TraceLinkInput/TraceLinkInput.test.ts
@@ -1,4 +1,5 @@
 import TraceLinkInput from '@/features/student/traces/components/interactions/inputs/TraceLinkInput/TraceLinkInput.vue'
+import { TRACE_LINK_MAX_LENGTH } from '@/features/student/traces/config'
 import { MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
 import { AvInputStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { mount, type VueWrapper } from '@vue/test-utils'
@@ -24,20 +25,26 @@ BddTest().given('a trace link input component', () => {
       expect(input.exists()).toBe(true)
       expect(input.props('label')).toBe('Ajouter un lien')
       expect(input.props('placeholder')).toBe('Ajouter un lien...')
+      expect(input.props('maxlength')).toBe(TRACE_LINK_MAX_LENGTH)
       expect(input.props('prefixIcon')).toBe(MDI_ICONS.LINK)
       expect(input.props('isTextarea')).toBe(false)
       expect(input.props('labelVisible')).toBe(true)
       expect(input.props('disabled')).toBe(false)
       expect(input.props('required')).toBe(true)
     })
+
+    BddTest().then('it should render character count hint', () => {
+      const hint = wrapper.find('.caption-light')
+
+      expect(hint.exists()).toBe(true)
+      expect(hint.text()).toBe(`0 / ${TRACE_LINK_MAX_LENGTH} caractères (espaces compris)`)
+    })
   })
 
   BddTest().when('custom label is provided', () => {
     BddTest().then('it should use the custom label', () => {
       wrapper = mount(TraceLinkInput, {
-        props: {
-          label: 'Custom Label'
-        },
+        props: { label: 'Custom Label' },
         global: { stubs }
       })
 
@@ -50,9 +57,7 @@ BddTest().given('a trace link input component', () => {
   BddTest().when('custom placeholder is provided', () => {
     BddTest().then('it should use the custom placeholder', () => {
       wrapper = mount(TraceLinkInput, {
-        props: {
-          placeholder: 'Custom placeholder text'
-        },
+        props: { placeholder: 'Custom placeholder text' },
         global: { stubs }
       })
 
@@ -62,12 +67,23 @@ BddTest().given('a trace link input component', () => {
     })
   })
 
+  BddTest().when('custom maxlength is provided', () => {
+    BddTest().then('it should use the custom maxlength', () => {
+      wrapper = mount(TraceLinkInput, {
+        props: { maxlength: 500 },
+        global: { stubs }
+      })
+
+      const input = wrapper.findComponent({ name: 'AvInput' })
+
+      expect(input.props('maxlength')).toBe(500)
+    })
+  })
+
   BddTest().when('custom prefixIcon is provided', () => {
     BddTest().then('it should use the custom prefixIcon', () => {
       wrapper = mount(TraceLinkInput, {
-        props: {
-          prefixIcon: MDI_ICONS.ACCOUNT_CIRCLE_OUTLINE
-        },
+        props: { prefixIcon: MDI_ICONS.ACCOUNT_CIRCLE_OUTLINE },
         global: { stubs }
       })
 
@@ -80,9 +96,7 @@ BddTest().given('a trace link input component', () => {
   BddTest().when('the component is disabled', () => {
     BddTest().then('it should pass disabled state to AvInput', () => {
       wrapper = mount(TraceLinkInput, {
-        props: {
-          disabled: true
-        },
+        props: { disabled: true },
         global: { stubs }
       })
 
@@ -92,12 +106,10 @@ BddTest().given('a trace link input component', () => {
     })
   })
 
-  BddTest().when('required is true', () => {
+  BddTest().when('required is false', () => {
     BddTest().then('it should pass required state to AvInput', () => {
       wrapper = mount(TraceLinkInput, {
-        props: {
-          required: false
-        },
+        props: { required: false },
         global: { stubs }
       })
 
@@ -110,9 +122,7 @@ BddTest().given('a trace link input component', () => {
   BddTest().when('labelVisible is false', () => {
     BddTest().then('it should hide the label', () => {
       wrapper = mount(TraceLinkInput, {
-        props: {
-          labelVisible: false
-        },
+        props: { labelVisible: false },
         global: { stubs }
       })
 
@@ -125,9 +135,7 @@ BddTest().given('a trace link input component', () => {
   BddTest().when('isValid is true', () => {
     BddTest().then('it should pass valid state to AvInput', () => {
       wrapper = mount(TraceLinkInput, {
-        props: {
-          isValid: true
-        },
+        props: { isValid: true },
         global: { stubs }
       })
 
@@ -140,36 +148,41 @@ BddTest().given('a trace link input component', () => {
   BddTest().when('text is entered', () => {
     BddTest().then('it should update the model value', async () => {
       const input = wrapper.findComponent({ name: 'AvInput' })
-      await input.vm.$emit('update:modelValue', 'My trace name')
+      await input.vm.$emit('update:modelValue', 'My trace link')
       await wrapper.vm.$nextTick()
 
-      expect(wrapper.emitted('update:modelValue')?.[0]).toEqual(['My trace name'])
+      expect(wrapper.emitted('update:modelValue')?.[0]).toEqual(['My trace link'])
+    })
+
+    BddTest().then('it should update the character count hint', async () => {
+      wrapper = mount(TraceLinkInput, {
+        props: { modelValue: 'https://example.com' },
+        global: { stubs }
+      })
+
+      const hint = wrapper.find('.caption-light')
+
+      expect(hint.text()).toBe(`19 / ${TRACE_LINK_MAX_LENGTH} caractères (espaces compris)`)
     })
   })
 
   BddTest().when('a value is provided via v-model', () => {
     BddTest().then('it should pass the value to AvInput', () => {
-      const testValue = 'Test trace name'
-
       wrapper = mount(TraceLinkInput, {
-        props: {
-          modelValue: testValue
-        },
+        props: { modelValue: 'https://example.com' },
         global: { stubs }
       })
 
       const input = wrapper.findComponent({ name: 'AvInput' })
 
-      expect(input.props('modelValue')).toBe(testValue)
+      expect(input.props('modelValue')).toBe('https://example.com')
     })
   })
 
   BddTest().when('errorMessage is provided', () => {
     BddTest().then('it should pass the error message to AvInput', () => {
       wrapper = mount(TraceLinkInput, {
-        props: {
-          errorMessage: 'Lien invalide'
-        },
+        props: { errorMessage: 'Lien invalide' },
         global: { stubs }
       })
 
@@ -182,15 +195,26 @@ BddTest().given('a trace link input component', () => {
   BddTest().when('isTextarea is true', () => {
     BddTest().then('it should pass textarea state to AvInput', () => {
       wrapper = mount(TraceLinkInput, {
-        props: {
-          isTextarea: true
-        },
+        props: { isTextarea: true },
         global: { stubs }
       })
 
       const input = wrapper.findComponent({ name: 'AvInput' })
 
       expect(input.props('isTextarea')).toBe(true)
+    })
+  })
+
+  BddTest().when('the character count reaches maximum', () => {
+    BddTest().then('it should display the correct count in hint', () => {
+      wrapper = mount(TraceLinkInput, {
+        props: { modelValue: 'a'.repeat(TRACE_LINK_MAX_LENGTH) },
+        global: { stubs }
+      })
+
+      const hint = wrapper.find('.caption-light')
+
+      expect(hint.text()).toBe(`${TRACE_LINK_MAX_LENGTH} / ${TRACE_LINK_MAX_LENGTH} caractères (espaces compris)`)
     })
   })
 })

--- a/src/features/student/traces/components/interactions/inputs/TraceLinkInput/TraceLinkInput.vue
+++ b/src/features/student/traces/components/interactions/inputs/TraceLinkInput/TraceLinkInput.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { TRACE_LINK_MAX_LENGTH } from '@/features/student/traces/config'
 import { AvInput, type AvInputProps, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
 import { useAttrs } from 'vue'
 import { useI18n } from 'vue-i18n'
@@ -7,6 +8,7 @@ interface TraceLinkInputProps extends Omit<AvInputProps, 'label' | 'prefixIcon' 
   label?: string
   prefixIcon?: string
   placeholder?: string
+  maxlength?: number
 }
 
 const {
@@ -15,6 +17,7 @@ const {
   labelVisible = true,
   disabled = false,
   required = true,
+  maxlength = TRACE_LINK_MAX_LENGTH,
   label,
   prefixIcon,
   placeholder,
@@ -32,6 +35,7 @@ const avInputProps = computed(() => ({
   labelVisible,
   disabled,
   required,
+  maxlength,
   errorMessage,
   label: label ?? t('student.traces.interactions.inputs.TraceLinkInput.label'),
   prefixIcon: prefixIcon ?? MDI_ICONS.LINK,
@@ -43,5 +47,17 @@ const avInputProps = computed(() => ({
   <AvInput
     v-bind="avInputProps"
     v-model="modelValue"
-  />
+  >
+    <template
+      v-if="!$slots.maxLengthCaption"
+      #maxLengthCaption="{ currentValue }"
+    >
+      <span class="caption-light">
+        {{ t('global.inputs.textarea.limit', {
+          count: currentValue?.toString().length || 0,
+          maxlength,
+        }) }}
+      </span>
+    </template>
+  </AvInput>
 </template>

--- a/src/features/student/traces/config.ts
+++ b/src/features/student/traces/config.ts
@@ -1,0 +1,1 @@
+export const TRACE_LINK_MAX_LENGTH = 2000


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
- Enforce an 2000-character limit on the `Link` input in the trace form, aligning with the API's maximum accepted length

---

### Reference to an Issue, Feature, Task, User Story or another PR
- Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1484

---

**Modified areas:**
- `src/features/student/traces/components/interactions/inputs/TraceLinkInput/TraceLinkInput.stub.ts`
- `src/features/student/traces/components/interactions/inputs/TraceLinkInput/TraceLinkInput.test.ts`
- `src/features/student/traces/components/interactions/inputs/TraceLinkInput/TraceLinkInput.vue`

---

### Target Branch
`develop`

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process