### PR TITLE
feat(1483): use new search associations endpoints

### DIFF
--- a/api-specs/avenir-esr.swagger.json
+++ b/api-specs/avenir-esr.swagger.json
@@ -2242,63 +2242,6 @@
         }
       }
     },
-    "/me/declared/skill-progress/{declaredSkillProgressId}/search-for-association/declared-activities": {
-      "get": {
-        "tags": [
-          "declared-skill-progress-controller"
-        ],
-        "operationId": "searchDeclaredActivityForAssociation_1",
-        "parameters": [
-          {
-            "name": "declaredSkillProgressId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          },
-          {
-            "name": "keyword",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "page",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "format": "int32"
-            }
-          },
-          {
-            "name": "pageSize",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "format": "int32"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/PagedResponseAssociationSearchResultDeclaredActivityDTO"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/me/declared/skill-progress/{declaredSkillProgressId}/associations": {
       "get": {
         "tags": [
@@ -2351,13 +2294,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "type": "string",
-              "enum": [
-                "TRACE",
-                "DECLARED_ACTIVITY",
-                "DECLARED_SKILL",
-                "DECLARED_EXPERIENCE"
-              ]
+              "$ref": "#/components/schemas/EAssociationContextType"
             }
           },
           {
@@ -2493,13 +2430,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "type": "string",
-              "enum": [
-                "TRACE",
-                "DECLARED_ACTIVITY",
-                "DECLARED_SKILL",
-                "DECLARED_EXPERIENCE"
-              ]
+              "$ref": "#/components/schemas/EAssociationContextType"
             }
           },
           {
@@ -2728,63 +2659,6 @@
         }
       }
     },
-    "/me/activity-progress/{declaredActivityId}/search-for-association/declared-skills": {
-      "get": {
-        "tags": [
-          "declared-activity-controller"
-        ],
-        "operationId": "searchDeclaredSkillsForAssociation_1",
-        "parameters": [
-          {
-            "name": "declaredActivityId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          },
-          {
-            "name": "keyword",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "page",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "format": "int32"
-            }
-          },
-          {
-            "name": "pageSize",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "format": "int32"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/PagedResponseAssociationSearchResultDeclaredSkillIDTO"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/me/activity-progress/{declaredActivityId}/associations": {
       "get": {
         "tags": [
@@ -2876,13 +2750,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "type": "string",
-              "enum": [
-                "TRACE",
-                "DECLARED_ACTIVITY",
-                "DECLARED_SKILL",
-                "DECLARED_EXPERIENCE"
-              ]
+              "$ref": "#/components/schemas/EAssociationContextType"
             }
           },
           {

--- a/src/__mocks__/fixtures/student/skills.fixtures.ts
+++ b/src/__mocks__/fixtures/student/skills.fixtures.ts
@@ -1,6 +1,7 @@
 import { createMockedTraceAssociations } from '@/__mocks__/fixtures/student/activities.fixtures'
 import { mockedTraceOverview } from '@/__mocks__/fixtures/student/traces.fixtures'
 import {
+  type AssociationSearchResultDeclaredSkillIDTO,
   type DeclaredActivityAssociationDTO,
   type DeclaredSkillAssociationsDTO,
   type DeclaredSkillProgressDetailsDTO,
@@ -13,6 +14,7 @@ import {
   ESkillLevelStatus,
   ETraceAssociationType,
   type ExternalSkillDTO,
+  type PagedResponseAssociationSearchResultDeclaredSkillIDTO,
   type PagedResponseDeclaredSkillProgressDTO,
   type PagedResponseExternalSkillDTO,
   type PagedResponseSkillDTO,
@@ -271,6 +273,35 @@ export function createMockedAllSkillListItemDTO (): SkillListItemDTO[] {
   }
 
   return mockedAllSkills
+}
+
+export function createMockedPagedResponseAssociationSearchResultDeclaredSkillIDTO (
+  pageSize: number,
+  page: number,
+  keyword: string
+): PagedResponseAssociationSearchResultDeclaredSkillIDTO {
+  const allSkills: AssociationSearchResultDeclaredSkillIDTO[] = [
+    { id: 'skill-search-1', title: 'Conduire un projet de bout en bout', type: EExternalSkillType.ROME4, disabled: false },
+    { id: 'skill-search-2', title: 'Analyser et synthétiser des informations', type: EExternalSkillType.ROME4, disabled: false },
+    { id: 'skill-search-3', title: 'Développement web et compétence numérique', type: EExternalSkillType.ROME4, disabled: false },
+    { id: 'skill-search-4', title: 'Gestion de projet et compétences managériales', type: EExternalSkillType.ROME4, disabled: false },
+    { id: 'skill-search-5', title: 'Communication interpersonnelle', type: EExternalSkillType.ROME4, disabled: false },
+  ]
+
+  const filtered = keyword
+    ? allSkills.filter(s => s.title.toLowerCase().includes(keyword.toLowerCase()))
+    : allSkills
+
+  const start = page * pageSize
+  const end = start + pageSize
+  const data = filtered.slice(start, end)
+  const totalElements = filtered.length
+  const totalPages = Math.ceil(totalElements / pageSize)
+
+  return {
+    data,
+    page: { pageSize, totalElements, totalPages, page }
+  }
 }
 
 export function createMockedDeclaredSkillProgressDetailsDTO (skillId: string): DeclaredSkillProgressDetailsDTO {

--- a/src/__mocks__/msw/handlers/student/activities.handlers.ts
+++ b/src/__mocks__/msw/handlers/student/activities.handlers.ts
@@ -3,6 +3,7 @@ import {
   createLargeMockedPagedResponseDeclaredActivityViewDTO,
   createMockedDeclaredActivityAssociationsDTO,
   createMockedDeclaredActivityDetails,
+  createMockedPagedResponseAssociationSearchResultDeclaredActivityDTO,
   createMockedPagedResponseDeclaredActivityViewDTO,
   mockedActivityDetail,
   mockedDeclaredActivityAssociations,
@@ -29,12 +30,13 @@ import {
   getGetDeclaredActivityAssociationsUrl,
   getGetDeclaredActivityDetailsUrl,
   getGetLatestActivitiesViewUrl,
-  getSearchDeclaredSkillsForAssociation1Url,
+  getSearchDeclaredActivitiesForAssociationUrl,
   getSearchTracesForAssociationUrl,
   getSubscribeActivityUrl,
   getUnsubscribeActivitiesProgressesUrl,
   getUpdatePeriodUrl,
   getUpdateReflectionUrl,
+  type PagedResponseAssociationSearchResultDeclaredActivityDTO,
   type PagedResponseAssociationSearchResultTraceDTO,
   type PagedResponseDeclaredActivityViewDTO,
 } from '@/api/avenir-esr'
@@ -550,44 +552,6 @@ export const searchTracesForAssociationHandler = http.get(
   }
 )
 
-export const searchSkillsForAssociationHandler = http.get(
-  `*${getSearchDeclaredSkillsForAssociation1Url(':declaredActivityId')}`,
-  async ({ params, request }) => {
-    const { declaredActivityId } = params
-
-    if (!declaredActivityId || declaredActivityId === 'INVALID_DECLARED_ACTIVITY_ID') {
-      return HttpResponse.json(
-        { code: EErrorCode.ACTIVITY_NOT_FOUND, message: 'Declared activity not found' },
-        {
-          status: 404,
-          headers: {
-            'Content-Type': 'application/json'
-          }
-        }
-      )
-    }
-
-    const url = new URL(request.url)
-
-    const keyword = url.searchParams.get('keyword') ?? undefined
-    const page = Number.parseInt(url.searchParams.get('page') ?? '0')
-    const pageSize = Number.parseInt(url.searchParams.get('pageSize') ?? '20')
-
-    const response = createMockedSearchTracesForAssociationResponse({
-      keyword,
-      page,
-      pageSize,
-    })
-
-    return HttpResponse.json<PagedResponseAssociationSearchResultTraceDTO>(response, {
-      status: 200,
-      headers: {
-        'Content-Type': 'application/json'
-      }
-    })
-  }
-)
-
 export const searchTracesForAssociationErrorHandler = http.get(
   `*${getSearchTracesForAssociationUrl(':declaredActivityId')}`,
   async () => {
@@ -600,6 +564,40 @@ export const searchTracesForAssociationErrorHandler = http.get(
         }
       }
     )
+  }
+)
+
+export const searchDeclaredActivitiesForAssociationErrorHandler = http.get(
+  `*${getSearchDeclaredActivitiesForAssociationUrl()}`,
+  () => {
+    return HttpResponse.json(
+      { message: 'Internal server error' },
+      { status: 500 }
+    )
+  }
+)
+
+export const searchDeclaredActivitiesForAssociationHandler = http.get(
+  `*${getSearchDeclaredActivitiesForAssociationUrl()}*`,
+  ({ request }) => {
+    const url = new URL(request.url)
+    const searchParams = url.searchParams
+    const keyword = searchParams.get('keyword') ?? ''
+    const pageSize = Number(searchParams.get('pageSize') ?? 100)
+    const page = Number(searchParams.get('page') ?? 0)
+
+    const response = createMockedPagedResponseAssociationSearchResultDeclaredActivityDTO(
+      pageSize,
+      page,
+      keyword
+    )
+
+    return HttpResponse.json<PagedResponseAssociationSearchResultDeclaredActivityDTO>(response, {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json',
+      }
+    })
   }
 )
 
@@ -626,6 +624,7 @@ export const activitiesHandlers = [
   activityNavigationQuery,
   activitiesViewHandler,
   latestActivitiesHandler,
+  searchDeclaredActivitiesForAssociationHandler,
   activityDetailHandler,
   declaredActivityDetailsHandler,
   declaredActivityAssociationsHandler,
@@ -638,5 +637,4 @@ export const activitiesHandlers = [
   associateActivityWithDeclaredSkillsHandler,
   deleteDeclaredActivityAssociationsSuccessHandler,
   searchTracesForAssociationHandler,
-  searchSkillsForAssociationHandler
 ]

--- a/src/__mocks__/msw/handlers/student/skills.handlers.ts
+++ b/src/__mocks__/msw/handlers/student/skills.handlers.ts
@@ -1,8 +1,8 @@
 import { createDeclaredSkillAssociationResponseFixture } from '@/__mocks__/fixtures/student'
-import { createMockedPagedResponseAssociationSearchResultDeclaredActivityDTO } from '@/__mocks__/fixtures/student/activities.fixtures'
 import {
   createMockedAllSkillListItemDTO,
   createMockedDeclaredSkillProgressDetailsDTO,
+  createMockedPagedResponseAssociationSearchResultDeclaredSkillIDTO,
   createMockedPagedResponseDeclaredSkillProgressDTO,
   createMockedPagedResponseSkillsDTO,
   createMockedSearchExternalSkillsDTO,
@@ -28,9 +28,10 @@ import {
   getGetDeclaredSkillWithDeclaredActivitiesUrl,
   getGetDetailedSkillUrl,
   getGetSkillLevelProgressesUrl,
-  getSearchDeclaredActivityForAssociation1Url,
+  getSearchDeclaredSkillsForAssociationUrl,
   getUnassociateTracesUrl,
   getUpdateDeclaredSkillProgressUrl,
+  type PagedResponseAssociationSearchResultDeclaredSkillIDTO,
   type PagedResponseDeclaredSkillProgressDTO,
   type PagedResponseExternalSkillDTO,
   type PagedResponseSkillDTO,
@@ -100,8 +101,8 @@ export const detailedSkillProgressNotFoundErrorHandler = http.get(`*${getGetDecl
   )
 })
 
-export const associateDeclaredSkillWithDeclaredActivityErrorHandler = http.post(
-  `*${getAssociateDeclaredSkillWithDeclaredActivitiesUrl(':declaredSkillProgressId')}`,
+export const searchDeclaredSkillsForAssociationErrorHandler = http.get(
+  `*${getSearchDeclaredSkillsForAssociationUrl()}`,
   () => {
     return HttpResponse.json(
       { message: 'Internal server error' },
@@ -110,8 +111,32 @@ export const associateDeclaredSkillWithDeclaredActivityErrorHandler = http.post(
   }
 )
 
-export const searchActivitiesForAssociationWithDeclaredSkillErrorHandler = http.get(
-  `*${getSearchDeclaredActivityForAssociation1Url(':declaredSkillProgressId')}`,
+export const searchDeclaredSkillsForAssociationHandler = http.get(
+  `*${getSearchDeclaredSkillsForAssociationUrl()}*`,
+  ({ request }) => {
+    const url = new URL(request.url)
+    const searchParams = url.searchParams
+    const keyword = searchParams.get('keyword') ?? ''
+    const pageSize = Number(searchParams.get('pageSize') ?? 100)
+    const page = Number(searchParams.get('page') ?? 0)
+
+    const response = createMockedPagedResponseAssociationSearchResultDeclaredSkillIDTO(
+      pageSize,
+      page,
+      keyword
+    )
+
+    return HttpResponse.json<PagedResponseAssociationSearchResultDeclaredSkillIDTO>(response, {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json',
+      }
+    })
+  }
+)
+
+export const associateDeclaredSkillWithDeclaredActivityErrorHandler = http.post(
+  `*${getAssociateDeclaredSkillWithDeclaredActivitiesUrl(':declaredSkillProgressId')}`,
   () => {
     return HttpResponse.json(
       { message: 'Internal server error' },
@@ -138,38 +163,6 @@ export const associateDeclaredSkillWithDeclaredActivityHandler = http.post<
     }
 
     const response: DeclaredSkillAssociationsDTO = createDeclaredSkillAssociationResponseFixture(body)
-
-    return HttpResponse.json(response, {
-      status: 200,
-      headers: {
-        'Content-Type': 'application/json',
-      }
-    })
-  }
-)
-
-export const searchActivitiesForAssociationWithDeclaredSkillHandler = http.get(
-  `*${getSearchDeclaredActivityForAssociation1Url(':declaredSkillProgressId')}`,
-  ({ request, params }) => {
-    const url = new URL(request.url)
-    const searchParams = url.searchParams
-    const keyword = searchParams.get('keyword') ?? ''
-    const pageSize = Number(searchParams.get('pageSize') ?? 100)
-    const page = Number(searchParams.get('page') ?? 0)
-    const { declaredSkillProgressId } = params
-
-    if (declaredSkillProgressId === 'INVALID_SKILL_ID') {
-      return HttpResponse.json(
-        { code: 'DECLARED_SKILL_PROGRESS_NOT_FOUND', message: 'Internal server error' },
-        { status: 404 }
-      )
-    }
-
-    const response = createMockedPagedResponseAssociationSearchResultDeclaredActivityDTO(
-      pageSize,
-      page,
-      keyword
-    )
 
     return HttpResponse.json(response, {
       status: 200,
@@ -282,7 +275,7 @@ export const skillsHandlers = [
       }
     })
   }),
-
+  searchDeclaredSkillsForAssociationHandler,
   http.get<{ id: string }, DeclaredSkillProgressDetailsDTO>(`*${getGetDeclaredSkillProgressDetailsUrl(':id')}`, async ({ params }) => {
     const { id } = params
     const response = createMockedDeclaredSkillProgressDetailsDTO(id)
@@ -370,7 +363,6 @@ export const skillsHandlers = [
     })
   }),
   associateDeclaredSkillWithDeclaredActivityHandler,
-  searchActivitiesForAssociationWithDeclaredSkillHandler,
 
   http.get<{ declaredSkillProgressId: string }, DeclaredSkillAssociationsDTO>(
     `*${getGetDeclaredSkillWithDeclaredActivitiesUrl(':declaredSkillProgressId')}`,

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/modals/AssociateDeclaredSkillToActivityModal/AssociateDeclaredSkillToActivityModal.vue
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/modals/AssociateDeclaredSkillToActivityModal/AssociateDeclaredSkillToActivityModal.vue
@@ -1,9 +1,10 @@
 <script lang="ts" setup>
 import {
+  EAssociationContextType,
   invalidateGetDeclaredActivityAssociations,
-  type SearchDeclaredSkillForAssociationParams,
+  type SearchDeclaredSkillsForAssociationParams,
   useAssociateActivityWithDeclaredSkills,
-  useSearchDeclaredSkillsForAssociation1
+  useSearchDeclaredSkillsForAssociation
 } from '@/api/avenir-esr'
 import { useTaskLoading } from '@/common/composables/use-task-loading/use-task-loading'
 import { AssociateDeclaredSkillsModal } from '@/features/student/declaredSkills'
@@ -36,20 +37,20 @@ const {
   onAssociateMutationError
 } = useAssociationModal()
 
-const params = computed<SearchDeclaredSkillForAssociationParams>(() => ({
+const params = computed<SearchDeclaredSkillsForAssociationParams>(() => ({
+  excludeAssociatedWithElementId: activityId,
+  contextType: EAssociationContextType.DECLARED_ACTIVITY,
   keyword: searchQuery.value.trim() || undefined,
   page: 0,
   pageSize: 100,
 }))
 
 const {
-  data,
+  data: skills,
   isError: isSearchError,
   error: searchError,
   isLoading: isSearchLoading
-} = useSearchDeclaredSkillsForAssociation1(activityId, params)
-
-const skills = computed(() => data.value?.data ?? [])
+} = useSearchDeclaredSkillsForAssociation(params, { query: { select: response => response.data } })
 
 listenAndDisplayToastOnSearchError(isSearchError, searchError)
 
@@ -77,7 +78,7 @@ function associateActivityWithDeclaredSkills (idsToAssociate: string[]) {
 <template>
   <AssociateDeclaredSkillsModal
     :show="show"
-    :skills="skills"
+    :skills="skills ?? []"
     :is-loading="isSearchLoading || isPending || isLoading"
     @cancel="emit('cancel')"
     @search="onSearch"

--- a/src/features/student/declaredSkills/components/overlays/modals/AssociateActivitiesToDeclaredSkillModal/AssociateActivitiesToDeclaredSkillModal.test.ts
+++ b/src/features/student/declaredSkills/components/overlays/modals/AssociateActivitiesToDeclaredSkillModal/AssociateActivitiesToDeclaredSkillModal.test.ts
@@ -1,9 +1,7 @@
 import type { AssociationActivity } from '@/features/student/traces/views/StudentTraceView/components/overlays/modals/AssociateActivitiesModal/AssociateActivitiesModal.vue'
 import type { VueWrapper } from '@vue/test-utils'
-import {
-  associateDeclaredSkillWithDeclaredActivityErrorHandler,
-  searchActivitiesForAssociationWithDeclaredSkillErrorHandler
-} from '@/__mocks__/msw/handlers/student/skills.handlers'
+import { searchDeclaredActivitiesForAssociationErrorHandler } from '@/__mocks__/msw/handlers/student/activities.handlers'
+import { associateDeclaredSkillWithDeclaredActivityErrorHandler } from '@/__mocks__/msw/handlers/student/skills.handlers'
 import { server } from '@/__mocks__/msw/server'
 import AssociateActivitiesToDeclaredSkillModal, {
   type AssociateActivitiesToDeclaredSkillModalProps
@@ -149,7 +147,7 @@ BddTest().given('an associate activities to declared skill modal', () => {
 
   BddTest().when('loading activities fails', () => {
     beforeEach(async () => {
-      server.use(searchActivitiesForAssociationWithDeclaredSkillErrorHandler)
+      server.use(searchDeclaredActivitiesForAssociationErrorHandler)
 
       wrapper = mountComponent(AssociateActivitiesToDeclaredSkillModal, {
         props,

--- a/src/features/student/declaredSkills/components/overlays/modals/AssociateActivitiesToDeclaredSkillModal/AssociateActivitiesToDeclaredSkillModal.vue
+++ b/src/features/student/declaredSkills/components/overlays/modals/AssociateActivitiesToDeclaredSkillModal/AssociateActivitiesToDeclaredSkillModal.vue
@@ -4,11 +4,12 @@ import type {
 } from '@/features/student/traces/views/StudentTraceView/components/overlays/modals/AssociateActivitiesModal/AssociateActivitiesModal.vue'
 import {
   type AssociationsCreationRequest,
+  EAssociationContextType,
   invalidateGetDeclaredSkillProgressDetails,
   invalidateGetDeclaredSkillWithDeclaredActivities,
-  invalidateSearchDeclaredSkillForAssociation,
+  invalidateSearchDeclaredActivitiesForAssociation,
   useAssociateDeclaredSkillWithDeclaredActivities,
-  useSearchDeclaredActivityForAssociation1
+  useSearchDeclaredActivitiesForAssociation
 } from '@/api/avenir-esr'
 import { useTaskLoading } from '@/common/composables/use-task-loading/use-task-loading'
 import { useAssociationModal } from '@/features/student/global'
@@ -43,6 +44,8 @@ const {
 } = useAssociationModal()
 
 const params = computed(() => ({
+  excludeAssociatedWithElementId: declaredSkillId,
+  contextType: EAssociationContextType.DECLARED_SKILL,
   keyword: searchQuery.value.trim() || undefined,
   page: 0,
   pageSize: 100,
@@ -53,12 +56,16 @@ const {
   isError: isSearchError,
   error: searchError,
   isLoading: isSearchLoading
-} = useSearchDeclaredActivityForAssociation1(declaredSkillId, params)
+} = useSearchDeclaredActivitiesForAssociation(params, {
+  query: {
+    select: response => response.data,
+  }
+})
 
 listenAndDisplayToastOnSearchError(isSearchError, searchError)
 
 const associationActivities = computed<AssociationActivity[]>(() => activities.value
-  ? (activities.value.data).map(activity => ({
+  ? (activities.value).map(activity => ({
       id: activity.id,
       title: activity.title,
       thematic: activity.thematic,
@@ -78,7 +85,7 @@ function associateDeclaredSkillWithActivities (data: AssociationsCreationRequest
     onSuccess: async (_, variables) => {
       await withTaskLoading(() => Promise.all([
         invalidateGetDeclaredSkillProgressDetails(queryClient, variables.declaredSkillProgressId),
-        invalidateSearchDeclaredSkillForAssociation(queryClient, variables.declaredSkillProgressId),
+        invalidateSearchDeclaredActivitiesForAssociation(queryClient),
         invalidateGetDeclaredSkillWithDeclaredActivities(queryClient, variables.declaredSkillProgressId)
       ]))
 

--- a/src/features/student/traces/views/StudentToolsTracesView/components/StudentToolsTracesAddTraceDrawer/StudentToolsTracesAddTraceDrawer.vue
+++ b/src/features/student/traces/views/StudentToolsTracesView/components/StudentToolsTracesAddTraceDrawer/StudentToolsTracesAddTraceDrawer.vue
@@ -2,8 +2,7 @@
 import type { Association } from '@/features/student/global/types/associations.types'
 import type { AssociateElementTypeConfig } from '@/features/student/traces/types/traces.types'
 import {
-  SearchDeclaredActivitiesForAssociationContextType,
-  SearchDeclaredSkillsForAssociationContextType,
+  EAssociationContextType,
   useSearchDeclaredActivitiesForAssociation,
   useSearchDeclaredSkillsForAssociation,
 } from '@/api/avenir-esr'
@@ -98,7 +97,7 @@ const {
   data: skills,
   isLoading: isSkillsLoading
 } = useSearchDeclaredSkillsForAssociation(
-  computed(() => ({ contextType: SearchDeclaredSkillsForAssociationContextType.TRACE, ...searchParams.value })),
+  computed(() => ({ contextType: EAssociationContextType.TRACE, ...searchParams.value })),
   {
     query: {
       enabled: computed(() => activeAccordion.value === AddTraceAccordionGroupItems.ASSOCIATION && activeTypeKey.value === EAssociationTypeKey.DECLARED_SKILLS),
@@ -111,7 +110,7 @@ const {
   data: activities,
   isLoading: isActivitiesLoading
 } = useSearchDeclaredActivitiesForAssociation(
-  computed(() => ({ contextType: SearchDeclaredActivitiesForAssociationContextType.TRACE, ...searchParams.value })),
+  computed(() => ({ contextType: EAssociationContextType.TRACE, ...searchParams.value })),
   {
     query: {
       enabled: computed(() => activeAccordion.value === AddTraceAccordionGroupItems.ASSOCIATION && activeTypeKey.value === EAssociationTypeKey.ACTIVITIES),


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> Utilisation des nouveaux endpoints de recherche pour l'association de compétences et d'activités. L'endpoint de recherche des activités (`getSearchDeclaredActivitiesForAssociationUrl`) est désormais utilisé dans `AssociateDeclaredSkillToActivityModal`, et l'endpoint de recherche des compétences (`getSearchDeclaredSkillsForAssociationUrl`) dans `AssociateActivitiesToDeclaredSkillModal` et `StudentToolsTracesAddTraceDrawer`. Les handlers MSW et fixtures ont été mis à jour en conséquence.

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1483

---

### Documentation
> Aucune mise à jour de documentation nécessaire.

---

### Target Branch
> `develop`

---

### Additional Notes
> - Suppression de l'ancien handler `searchSkillsForAssociationHandler` dans `activities.handlers.ts` (remplacé par le bon handler côté skills)
> - Suppression de l'ancien handler `searchDeclaredActivityForAssociation1` dans `skills.handlers.ts` (remplacé par le bon handler côté activities)
> - Mise à jour du swagger pour refléter les nouveaux endpoints
> - Ajout du fixture `createMockedPagedResponseAssociationSearchResultDeclaredSkillIDTO` dans `skills.fixtures.ts`

---

### Known Limitations or Side Effects
> Aucune.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [x] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and detaiils for the update process