### PR TITLE
build: prevent generating orval api in case of breaking changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "lint-staged": "lint-staged",
     "generate:api": "orval",
     "check:api-diff": "node scripts/check-api-diff.mjs",
+    "pregenerate:api": "npm run check:api-diff",
     "postgenerate:api": "eslint ./src/api --fix",
     "generate:feature": "node scripts/generate-feature.mjs",
     "storybook": "storybook dev -p 6006",


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> Ajout d'un hook `pregenerate:api` dans `package.json` qui exécute le script `check:api-diff` avant la génération du client API via Orval. Si des breaking changes sont détectés entre la spec locale et la spec distante, la génération est bloquée et un rapport est affiché.

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Aucune issue associée.

---

### Documentation
> Aucune mise à jour de documentation requise. Le script `scripts/check-api-diff.mjs` existait déjà, seul le hook npm `pregenerate:api` a été ajouté.

---

### Target Branch
> `develop`

---

### Additional Notes
> Le script `check:api-diff` compare la spec OpenAPI locale (`api-specs/avenir-esr.swagger.json`) avec la spec distante (`https://dev.avenirs-esr.fr/apim/api-specs/openapi-merged.json`). En cas de breaking changes, le processus s'arrête avec un code d'erreur, empêchant ainsi la génération d'un client API potentiellement incompatible.

---

### Known Limitations or Side Effects
> - La vérification nécessite un accès réseau à `dev.avenirs-esr.fr`. En environnement CI sans accès réseau, la génération sera bloquée.
> - Si la spec distante est temporairement indisponible, la génération sera également bloquée.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and detaiils for the update process