### PR TITLE
test(e2e): complete home page E2E tests for nominal and empty datasets

### DIFF
--- a/e2e/framework/student/home/StudentHomePage.ts
+++ b/e2e/framework/student/home/StudentHomePage.ts
@@ -80,6 +80,11 @@ class StudentHomePage extends BasePage {
     await this.getSkillsWidget().verifyVisible()
   }
 
+  @Then('the educational skills widget is not visible')
+  async verifyEducationalSkillsWidgetNotVisible () {
+    await this.getSkillsWidget().isHidden()
+  }
+
   @Given('the next deliverables widget is visible')
   async verifyNextDeliverablesWidgetVisible () {
     await this.getDeliverablesWidget().verifyVisible()

--- a/e2e/tests/student/home.feature
+++ b/e2e/tests/student/home.feature
@@ -60,7 +60,32 @@ Feature: Student Home Page
       When the student clicks see all skills button
       Then the page navigates to skills page
       And the URL contains "/cofolio/student/education/skills"
-      
+
+    @high @skills @dataset-nominal
+    Scenario: Skills widget displays skills and see all button with partial data 
+      Then the skills widget shows at least one skill
+      And each skill card shows status badge
+      And the see all skills button is visible
+
+    @high @skills @dataset-nominal
+    Scenario: Skill cards are clickable and navigate to skill detail with partial data
+      And skill cards are displayed
+      When the student clicks a skill card
+      Then the page navigates to skill detail page
+      And the URL contains "/cofolio/student/skill/"
+
+    @medium @skills @dataset-nominal
+    Scenario: See all skills button navigates to skills page with partial data
+      When the student clicks see all skills button
+      Then the page navigates to skills page
+      And the URL contains "/cofolio/student/education/skills"
+
+  Rule: Skills Widget - Empty State
+
+    @high @skills @dataset-empty
+    Scenario: Skills widget is hidden when student has no skills
+      Then the educational skills widget is not visible 
+
   Rule: Navigation
 
     @high @navigation @desktop


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
Complete E2E tests for the student home page by adding scenarios 
for @dataset-nominal and @dataset-empty datasets on the skills widget.

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1144
---

### Target Branch
develop

---

### Additional Notes
- Added @dataset-nominal scenarios 
- Added @dataset-empty scenario 

---

### Known Limitations or Side Effects
Tests for home.deferred.feature and home.mobile.feature are not yet completed (WIP).

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process
