### PR TITLE
Test/1144 e2e home datasets empty

### DIFF
--- a/e2e/framework/shared/componentObjects/ProfileCard.ts
+++ b/e2e/framework/shared/componentObjects/ProfileCard.ts
@@ -39,6 +39,10 @@ export class ProfileCard extends BaseObject {
     await verifyTextLocator(this.getBio())
   }
 
+  async verifyBioHidden () {
+    await expect(this.getBio()).toBeHidden()
+  }
+
   async verifyCardContent () {
     await this.verifyProfileBanner()
     await this.verifyProfilePicture()

--- a/e2e/framework/student/home/StudentHomePage.ts
+++ b/e2e/framework/student/home/StudentHomePage.ts
@@ -80,6 +80,11 @@ class StudentHomePage extends BasePage {
     await this.getSkillsWidget().verifyVisible()
   }
 
+  @Then('the educational skills widget is not visible')
+  async verifyEducationalSkillsWidgetNotVisible () {
+    await this.getSkillsWidget().isHidden()
+  }
+
   @Given('the next deliverables widget is visible')
   async verifyNextDeliverablesWidgetVisible () {
     await this.getDeliverablesWidget().verifyVisible()

--- a/e2e/framework/student/home/StudentHomePage.ts
+++ b/e2e/framework/student/home/StudentHomePage.ts
@@ -80,8 +80,8 @@ class StudentHomePage extends BasePage {
     await this.getSkillsWidget().verifyVisible()
   }
 
-  @Then('the educational skills widget is not visible')
-  async verifyEducationalSkillsWidgetNotVisible () {
+  @Then('the educational skills widget is hidden')
+  async verifyEducationalSkillsWidgetHidden () {
     await this.getSkillsWidget().isHidden()
   }
 
@@ -98,6 +98,11 @@ class StudentHomePage extends BasePage {
   @Then('the last traces widget is visible')
   async verifyLastTracesWidgetVisible () {
     await this.getTracesWidget().verifyVisible()
+  }
+
+  @Then('the last traces widget is hidden')
+  async verifyLastTracesWidgetHidden () {
+    await this.getTracesWidget().isHidden()
   }
 
   @Then('the profile banner is visible')
@@ -118,6 +123,11 @@ class StudentHomePage extends BasePage {
   @Then('the student bio is visible')
   async verifyStudentBio () {
     await this.getStudentOverviewWidget().verifyStudentBio()
+  }
+
+  @Then('the student bio is hidden')
+  async verifyStudentBioHidden () {
+    await this.getStudentOverviewWidget().verifyStudentBioHidden()
   }
 
   @Then('profile action buttons are displayed')

--- a/e2e/framework/student/home/componentObjects/StudentOverviewWidget.ts
+++ b/e2e/framework/student/home/componentObjects/StudentOverviewWidget.ts
@@ -64,6 +64,10 @@ export class StudentOverviewWidget extends BaseObject {
     await this.getProfileCard().verifyBio()
   }
 
+  async verifyStudentBioHidden () {
+    await this.getProfileCard().verifyBioHidden()
+  }
+
   async verifyActionButtons () {
     await expect(this.getEditProfileButton()).toBeVisible()
     await expect(this.getEditProfileButton()).toHaveText(t('student.user.cards.StudentOverviewWidget.buttons.editProfile'))

--- a/e2e/tests/student/home.deferred.feature
+++ b/e2e/tests/student/home.deferred.feature
@@ -79,33 +79,30 @@ Feature: Student Home Page - out of MVP features
       Then the page navigates to deliverables page
       And the URL contains "/cofolio/student/deliverables"
 
-  Rule: Traces Widget
+   Rule: Skills Widget
 
     Background:
-      Given there are traces available
+      Given the educational skills widget is visible
 
-    @high @traces @dataset-full
-    Scenario: Traces widget is visible
-      Then the last traces widget is visible
+    @high @skills @dataset-full
+    Scenario: Skills widget displays skills and see all button
+      Then the skills widget shows at least one skill
+      And each skill card shows status badge
+      And the see all skills button is visible
 
-    @high @traces @dataset-full
-    Scenario: Traces widget displays 3 traces with type, and see all button
-      Then 3 trace cards are displayed
-      And each trace card shows type (solo/group)
-      And the see all traces button is visible
+    @high @skills @dataset-full
+    Scenario: Skill cards are clickable and navigate to skill detail
+      And skill cards are displayed
+      When the student clicks a skill card
+      Then the page navigates to skill detail page
+      And the URL contains "/cofolio/student/skill/"
 
-    @high @traces @dataset-full
-    Scenario: Trace cards are clickable and navigate to detailed trace page
-      When the student clicks a trace card
-      Then the page navigates to trace detail page
-      And the URL contains "/cofolio/student/trace"
+    @medium @skills @dataset-full
+    Scenario: See all skills button navigates to skills page
+      When the student clicks see all skills button
+      Then the page navigates to skills page
+      And the URL contains "/cofolio/student/education/skills"
 
-    @medium @traces @dataset-full
-    Scenario: See all traces button navigates to traces page
-      When the student clicks see all traces button
-      Then the page navigates to traces page
-      And the URL contains "/cofolio/student/tools/traces"
-  
   Rule: Navigation
     
     @medium @navigation @desktop

--- a/e2e/tests/student/home.feature
+++ b/e2e/tests/student/home.feature
@@ -17,12 +17,20 @@ Feature: Student Home Page
     Background:
       Given the profile overview widget is visible
 
-    @high @profile
+    @high @profile @dataset-full
     Scenario: Student can see profile section with edit profile button
       Then the profile banner is visible
       And the profile picture is visible
       And the student name is visible
       And the student bio is visible
+      And edit profile button is displayed
+
+    @high @profile @dataset-empty
+    Scenario: Student bio is hidden when no bio available
+      Then the profile banner is visible
+      And the profile picture is visible
+      And the student name is visible
+      And the student bio is hidden
       And edit profile button is displayed
       
     @high @profile
@@ -37,54 +45,38 @@ Feature: Student Home Page
       Then the update profile drawer is closed
       And the profile overview widget is still visible
 
-  Rule: Skills Widget
+  Rule: Traces Widget
 
     Background:
-      Given the educational skills widget is visible
+      Given there are traces available
 
-    @high @skills @dataset-full
-    Scenario: Skills widget displays skills and see all button
-      Then the skills widget shows at least one skill
-      And each skill card shows status badge
-      And the see all skills button is visible
+    @high @traces @dataset-full
+    Scenario: Traces widget is visible
+      Then the last traces widget is visible
 
-    @high @skills @dataset-full
-    Scenario: Skill cards are clickable and navigate to skill detail
-      And skill cards are displayed
-      When the student clicks a skill card
-      Then the page navigates to skill detail page
-      And the URL contains "/cofolio/student/skill/"
+    @high @traces @dataset-full
+    Scenario: Traces widget displays 3 traces with type, and see all button
+      Then 3 trace cards are displayed
+      And each trace card shows type (solo/group)
+      And the see all traces button is visible
 
-    @medium @skills @dataset-full
-    Scenario: See all skills button navigates to skills page
-      When the student clicks see all skills button
-      Then the page navigates to skills page
-      And the URL contains "/cofolio/student/education/skills"
+    @high @traces @dataset-full
+    Scenario: Trace cards are clickable and navigate to detailed trace page
+      When the student clicks a trace card
+      Then the page navigates to trace detail page
+      And the URL contains "/cofolio/student/trace"
 
-    @high @skills @dataset-nominal
-    Scenario: Skills widget displays skills and see all button with partial data 
-      Then the skills widget shows at least one skill
-      And each skill card shows status badge
-      And the see all skills button is visible
+    @medium @traces @dataset-full
+    Scenario: See all traces button navigates to traces page
+      When the student clicks see all traces button
+      Then the page navigates to traces page
+      And the URL contains "/cofolio/student/tools/traces"
 
-    @high @skills @dataset-nominal
-    Scenario: Skill cards are clickable and navigate to skill detail with partial data
-      And skill cards are displayed
-      When the student clicks a skill card
-      Then the page navigates to skill detail page
-      And the URL contains "/cofolio/student/skill/"
+  Rule: Traces Widget - Empty State
 
-    @medium @skills @dataset-nominal
-    Scenario: See all skills button navigates to skills page with partial data
-      When the student clicks see all skills button
-      Then the page navigates to skills page
-      And the URL contains "/cofolio/student/education/skills"
-
-  Rule: Skills Widget - Empty State
-
-    @high @skills @dataset-empty
-    Scenario: Skills widget is hidden when student has no skills
-      Then the educational skills widget is not visible 
+    @high @traces @dataset-empty
+    Scenario: Traces widget is hidden when student has no traces
+      Then the last traces widget is hidden
 
   Rule: Navigation
 

--- a/e2e/tests/student/home.feature
+++ b/e2e/tests/student/home.feature
@@ -60,7 +60,32 @@ Feature: Student Home Page
       When the student clicks see all skills button
       Then the page navigates to skills page
       And the URL contains "/cofolio/student/education/skills"
-      
+
+    @high @skills @dataset-nominal
+    Scenario: Skills widget displays skills and see all button with partial data 
+      Then the skills widget shows at least one skill
+      And each skill card shows status badge
+      And the see all skills button is visible
+
+    @high @skills @dataset-nominal
+    Scenario: Skill cards are clickable and navigate to skill detail with partial data
+      And skill cards are displayed
+      When the student clicks a skill card
+      Then the page navigates to skill detail page
+      And the URL contains "/cofolio/student/skill/"
+
+    @medium @skills @dataset-nominal
+    Scenario: See all skills button navigates to skills page with partial data
+      When the student clicks see all skills button
+      Then the page navigates to skills page
+      And the URL contains "/cofolio/student/education/skills"
+
+  Rule: Skills Widget - Empty State
+
+    @high @skills @dataset-empty
+    Scenario: Skills widget is hidden when student has no skills
+      Then the educational skills widget is not visible 
+
   Rule: Navigation
 
     @high @navigation @desktop

--- a/e2e/tests/student/home.mobile.feature
+++ b/e2e/tests/student/home.mobile.feature
@@ -6,11 +6,11 @@ Feature: Student Home Page (Mobile)
 
   Rule: Navigation
 
-    @high @navigation @dataset-full
+    @high @navigation
     Scenario: Mobile menu button is visible on mobile viewport
       Then the mobile menu button is visible
 
-    @high @navigation @dataset-full
+    @high @navigation
     Scenario: Navigation accessible via mobile menu
       Given the mobile menu button is visible
       When the student clicks mobile menu button
@@ -22,12 +22,12 @@ Feature: Student Home Page (Mobile)
     Background:
       Given the page is displayed on mobile viewport
 
-    @medium @responsive @dataset-full
+    @medium @responsive
     Scenario: Layout adapts to mobile single-column format
       Then all visible widgets span full width
       And no horizontal scrolling is required
 
-    @medium @scrolling @dataset-full
+    @medium @scrolling
     Scenario: Mobile scrolling works smoothly
       When the user scrolls down through the page
       Then all widgets load and display correctly

--- a/src/__mocks__/msw/handlers/student/overviews.handlers.ts
+++ b/src/__mocks__/msw/handlers/student/overviews.handlers.ts
@@ -1,4 +1,5 @@
 import { createUpdatedCoverMock, createUpdatedPhotoMock, createUpdatedProfileMock, invalidProfile, mockedProfileOverview } from '@/__mocks__/fixtures/student'
+import { isEmptyDataSetRequest } from '@/__mocks__/msw/utils'
 import {
   EUserCategory,
   EUserPhotoType,
@@ -70,7 +71,16 @@ export const getProfileErrorHandler = http.get(`*${getGetProfileUrl(EUserCategor
 })
 
 export const overviewsHandlers = [
-  http.get<PathParams, ProfileOverviewDTO>(`*${getGetProfileUrl(EUserCategory.STUDENT)}`, () => {
+  http.get<PathParams, ProfileOverviewDTO>(`*${getGetProfileUrl(EUserCategory.STUDENT)}`, ({ request }) => {
+    if (isEmptyDataSetRequest(request)) {
+      return HttpResponse.json<ProfileOverviewDTO>({
+        ...mockedProfileOverview,
+        bio: ''
+      }, {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      })
+    }
     return HttpResponse.json<ProfileOverviewDTO>(mockedProfileOverview, {
       status: 200,
       headers: {

--- a/src/__mocks__/msw/handlers/student/traces.handlers.ts
+++ b/src/__mocks__/msw/handlers/student/traces.handlers.ts
@@ -12,6 +12,7 @@ import {
   mockedTracesConfiguration,
   mockedTracesSummary
 } from '@/__mocks__/fixtures/student'
+import { isEmptyDataSetRequest } from '@/__mocks__/msw/utils'
 import {
   type AttachmentUploadDTO,
   type CreateTraceDTO,
@@ -306,8 +307,14 @@ export const tracesHandlers = [
     })
   }),
 
-  http.get<PathParams, TraceDetailDTO>(`*${getGetTraceOverviewUrl()}`, async () => {
+  http.get<PathParams, TraceDetailDTO>(`*${getGetTraceOverviewUrl()}`, async ({ request }) => {
     await delay(100)
+    if (isEmptyDataSetRequest(request)) {
+      return HttpResponse.json([], {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      })
+    }
     return HttpResponse.json(mockedTraceOverview, {
       status: 200,
       headers: {


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
Complete E2E tests for the student home page by adding scenarios
for @dataset-full and @dataset-empty datasets on profile section
and traces widget. Also removed @dataset-full tag from mobile
scenarios to cover all datasets automaticall

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1144

---

### Target Branch
develop

---

### Additional Notes
- Added @dataset-empty scenarios for profile section (bio hidden/visible)
- Added  @dataset-full and @dataset-empty scenario for traces widget
- Added verifyLastTracesWidgetHidden step definition in StudentHomePage.ts
- Added verifyStudentBioHidden in ProfileCard.ts and StudentOverviewWidget.ts
- Removed @dataset-full tag from mobile scenarios to cover all datasets

---


## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and detaiils for the update process
