### PR TITLE
fix(1548): ProjectHelperModal - close on click outside

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "avenirs-cofolio-client",
       "version": "0.0.0",
       "dependencies": {
-        "@avenirs-esr/avenirs-dsav": "^0.1.192",
+        "@avenirs-esr/avenirs-dsav": "^0.1.193",
         "@tanstack/vue-form": "^1.15.0",
         "@tanstack/vue-query": "^5.74.9",
         "@vue-flow/core": "^1.48.0",
@@ -348,9 +348,9 @@
       "license": "ISC"
     },
     "node_modules/@avenirs-esr/avenirs-dsav": {
-      "version": "0.1.192",
-      "resolved": "https://registry.npmjs.org/@avenirs-esr/avenirs-dsav/-/avenirs-dsav-0.1.192.tgz",
-      "integrity": "sha512-wJX+h+ec1oHd12/SrA/sA85MLEkHyXxA1fkvpG/GKdcMBffwYeWiiPnDzxVBCZvmgcYFvEMCIgYMG8hsYz6UnQ==",
+      "version": "0.1.193",
+      "resolved": "https://registry.npmjs.org/@avenirs-esr/avenirs-dsav/-/avenirs-dsav-0.1.193.tgz",
+      "integrity": "sha512-ZInn0MBTG94Q/8pxgRiA140T83MvY8/EwElkKBw8n8u8qzVGZ16uDL1IHoPyGkcEnW7FaRqw1In3HxyZSZ39MQ==",
       "dependencies": {
         "@tiptap/extension-character-count": "^3.20.2",
         "@tiptap/extension-image": "^3.20.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
-    "@avenirs-esr/avenirs-dsav": "^0.1.192",
+    "@avenirs-esr/avenirs-dsav": "^0.1.193",
     "@tanstack/vue-form": "^1.15.0",
     "@tanstack/vue-query": "^5.74.9",
     "@vue-flow/core": "^1.48.0",

--- a/src/features/student/global/views/StudentProjectTrajectoriesView/components/StudentProjectTrajectoriesHelperModal/StudentProjectTrajectoriesHelperModal.vue
+++ b/src/features/student/global/views/StudentProjectTrajectoriesView/components/StudentProjectTrajectoriesHelperModal/StudentProjectTrajectoriesHelperModal.vue
@@ -18,6 +18,7 @@ const { data: config } = useGetBuildLifeProjectConfig()
     :opened="showModal"
     :close-button-label="t('student.global.views.studentProjectTrajectoriesView.buildProject.projectTrajectoriesHelperModal.closeButtonLabel')"
     @close="onClose"
+    @click-outside="onClose"
   >
     <div
       v-if="config"


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
This PR fixes the helper modal in the StudentProjectTrajectoriesView so that clicking outside the modal closes it.

**Main changes:**
- 🐛 Add `@click-outside` handler on `StudentProjectTrajectoriesHelperModal` to close the modal when clicking outside
- ⬆️ Bump `@avenirs-esr/avenirs-dsav` from `^0.1.192` to `^0.1.193`

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1548

---

### Documentation
No documentation changes required.

**Modified files:**
- `src/features/student/global/views/StudentProjectTrajectoriesView/components/StudentProjectTrajectoriesHelperModal/StudentProjectTrajectoriesHelperModal.vue` - Add `@click-outside="onClose"` event handler
- `package.json` / `package-lock.json` - Bump `@avenirs-esr/avenirs-dsav` to `^0.1.193`

---

### Target Branch
`develop`

---

### Additional Notes
The DSAV library version bump was required to include the `click-outside` event support in the modal component.

---

### Known Limitations or Side Effects
No known limitations or side effects.

---

## ✅ Checklist

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [ ] No unnecessary code (e.g., debug logs, commented code)
- [ ] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process