### PR TITLE
fix(1559): add maxlength on change validators

### DIFF
--- a/src/common/components/overlay/drawers/UpdateProfileDrawer/UpdateProfileDrawer.test.ts
+++ b/src/common/components/overlay/drawers/UpdateProfileDrawer/UpdateProfileDrawer.test.ts
@@ -200,6 +200,27 @@ BddTest().given('given an update profile drawer', () => {
     resetForm: mockedResetForm,
   }
 
+  function createUseUpdateProfileFormMock (overrides?: Partial<ReturnType<typeof useUpdateProfileForm>>) {
+    return {
+      form: mockedForm as any,
+      isPending: computed(() => false),
+      isModified: computed(() => false),
+      isFormValid: computed(() => false),
+      hasIdentityErrors: computed(() => false),
+      hasPicturesErrors: computed(() => false),
+      hasCoverPictureErrors: computed(() => false),
+      hasProfilePictureErrors: computed(() => false),
+      resetForm: mockedResetForm,
+      onCoverPictureUpdate: vi.fn(),
+      onProfilePictureUpdate: vi.fn(),
+      onUpdateProfileCoverSuccess: vi.fn(),
+      onUpdateProfilePhotoSuccess: vi.fn(),
+      coverPictureFile: ref<File | null>(null),
+      profilePictureFile: ref<File | null>(null),
+      ...overrides,
+    }
+  }
+
   const userSummaryWithMissingFields = {
     firstname: '',
     lastname: '',
@@ -239,18 +260,7 @@ BddTest().given('given an update profile drawer', () => {
       path: '/student/home'
     } as any)
 
-    mockedUseUpdateProfileForm.mockImplementation(() => ({
-      form: mockedForm as any,
-      isPending: computed(() => false),
-      isModified: computed(() => false),
-      resetForm: mockedResetForm,
-      onCoverPictureUpdate: vi.fn(),
-      onProfilePictureUpdate: vi.fn(),
-      onUpdateProfileCoverSuccess: vi.fn(),
-      onUpdateProfilePhotoSuccess: vi.fn(),
-      coverPictureFile: ref<File | null>(null),
-      profilePictureFile: ref<File | null>(null),
-    }))
+    mockedUseUpdateProfileForm.mockImplementation(() => createUseUpdateProfileFormMock())
 
     wrapper = mountComponent(UpdateProfileDrawer, {
       props: defaultProps,
@@ -298,17 +308,9 @@ BddTest().given('given an update profile drawer', () => {
       beforeEach(() => {
         vi.clearAllMocks()
 
-        mockedUseUpdateProfileForm.mockImplementation(() => ({
+        mockedUseUpdateProfileForm.mockImplementation(() => createUseUpdateProfileFormMock({
           form: mockedFormWithEmptyFields as any,
           isPending: computed(() => true),
-          isModified: computed(() => false),
-          resetForm: mockedResetForm,
-          onCoverPictureUpdate: vi.fn(),
-          onProfilePictureUpdate: vi.fn(),
-          onUpdateProfileCoverSuccess: vi.fn(),
-          onUpdateProfilePhotoSuccess: vi.fn(),
-          coverPictureFile: ref<File | null>(null),
-          profilePictureFile: ref<File | null>(null),
         }))
 
         wrapper = mountComponent(UpdateProfileDrawer, {
@@ -344,17 +346,8 @@ BddTest().given('given an update profile drawer', () => {
 
     BddTest().when('the update profile form composable is pending', () => {
       beforeEach(() => {
-        mockedUseUpdateProfileForm.mockImplementation(() => ({
-          form: mockedForm as any,
+        mockedUseUpdateProfileForm.mockImplementation(() => createUseUpdateProfileFormMock({
           isPending: computed(() => true),
-          isModified: computed(() => false),
-          resetForm: mockedResetForm,
-          onCoverPictureUpdate: vi.fn(),
-          onProfilePictureUpdate: vi.fn(),
-          onUpdateProfileCoverSuccess: vi.fn(),
-          onUpdateProfilePhotoSuccess: vi.fn(),
-          coverPictureFile: ref<File | null>(null),
-          profilePictureFile: ref<File | null>(null),
         }))
 
         wrapper = mountComponent(UpdateProfileDrawer, {
@@ -376,17 +369,8 @@ BddTest().given('given an update profile drawer', () => {
 
     BddTest().when('inputs are modified', () => {
       beforeEach(() => {
-        mockedUseUpdateProfileForm.mockImplementation(() => ({
-          form: mockedForm as any,
-          isPending: computed(() => false),
+        mockedUseUpdateProfileForm.mockImplementation(() => createUseUpdateProfileFormMock({
           isModified: computed(() => true),
-          resetForm: mockedResetForm,
-          onCoverPictureUpdate: vi.fn(),
-          onProfilePictureUpdate: vi.fn(),
-          onUpdateProfileCoverSuccess: vi.fn(),
-          onUpdateProfilePhotoSuccess: vi.fn(),
-          coverPictureFile: ref<File | null>(null),
-          profilePictureFile: ref<File | null>(null),
         }))
       })
 
@@ -432,17 +416,8 @@ BddTest().given('given an update profile drawer', () => {
       BddTest().and('canLeave is false', () => {
         beforeEach(async () => {
           mockCanLeave.mockResolvedValue(false)
-          mockedUseUpdateProfileForm.mockImplementation(() => ({
-            form: mockedForm as any,
-            isPending: computed(() => false),
+          mockedUseUpdateProfileForm.mockImplementation(() => createUseUpdateProfileFormMock({
             isModified: computed(() => true),
-            resetForm: mockedResetForm,
-            onCoverPictureUpdate: vi.fn(),
-            onProfilePictureUpdate: vi.fn(),
-            onUpdateProfileCoverSuccess: vi.fn(),
-            onUpdateProfilePhotoSuccess: vi.fn(),
-            coverPictureFile: ref<File | null>(null),
-            profilePictureFile: ref<File | null>(null),
           }))
           wrapper = mountComponent(UpdateProfileDrawer, {
             props: defaultProps,
@@ -476,17 +451,8 @@ BddTest().given('given an update profile drawer', () => {
       BddTest().and('canLeave is false', () => {
         beforeEach(async () => {
           mockCanLeave.mockResolvedValue(false)
-          mockedUseUpdateProfileForm.mockImplementation(() => ({
-            form: mockedForm as any,
-            isPending: computed(() => false),
+          mockedUseUpdateProfileForm.mockImplementation(() => createUseUpdateProfileFormMock({
             isModified: computed(() => true),
-            resetForm: mockedResetForm,
-            onCoverPictureUpdate: vi.fn(),
-            onProfilePictureUpdate: vi.fn(),
-            onUpdateProfileCoverSuccess: vi.fn(),
-            onUpdateProfilePhotoSuccess: vi.fn(),
-            coverPictureFile: ref<File | null>(null),
-            profilePictureFile: ref<File | null>(null),
           }))
           wrapper = mountComponent(UpdateProfileDrawer, {
             props: defaultProps,
@@ -542,16 +508,9 @@ BddTest().given('given an update profile drawer', () => {
       beforeEach(() => {
         mockedUseUpdateProfileForm.mockImplementation((_data, _profile: EUserCategory, onSuccess: () => void) => {
           const obj = {
-            form: mockedForm as any,
-            isPending: computed(() => false),
-            isModified: computed(() => true),
-            resetForm: mockedResetForm,
-            onCoverPictureUpdate: vi.fn(),
-            onProfilePictureUpdate: vi.fn(),
-            onUpdateProfileCoverSuccess: vi.fn(),
-            onUpdateProfilePhotoSuccess: vi.fn(),
-            coverPictureFile: ref<File | null>(null),
-            profilePictureFile: ref<File | null>(null),
+            ...createUseUpdateProfileFormMock({
+              isModified: computed(() => true),
+            }),
             simulateSuccess: () => {
               onSuccess()
             }

--- a/src/common/components/overlay/drawers/UpdateProfileDrawer/UpdateProfileDrawer.vue
+++ b/src/common/components/overlay/drawers/UpdateProfileDrawer/UpdateProfileDrawer.vue
@@ -56,6 +56,10 @@ const {
   form,
   isPending,
   isModified,
+  isFormValid,
+  hasIdentityErrors,
+  hasCoverPictureErrors,
+  hasProfilePictureErrors,
   coverPictureFile,
   onCoverPictureUpdate,
   profilePictureFile,
@@ -158,6 +162,7 @@ watch(() => show, (newVal) => {
           <AvAccordion
             :title="t('global.overlay.drawers.UpdateProfileDrawer.identity.title')"
             :icon="MDI_ICONS.ACCOUNT_STUDENT_OUTLINE"
+            :class="{ 'update-profile-drawer__accordion--error': hasIdentityErrors }"
           >
             <div class="av-col av-gap-md">
               <AvInput
@@ -210,6 +215,7 @@ watch(() => show, (newVal) => {
           <AvAccordion
             :title="t('global.overlay.drawers.UpdateProfileDrawer.pictures.banner')"
             :icon="MDI_ICONS.IMAGE_OUTLINE"
+            :class="{ 'update-profile-drawer__accordion--error': hasCoverPictureErrors }"
           >
             <div data-image-upload-delete-zone>
               <ImageUpload
@@ -225,6 +231,7 @@ watch(() => show, (newVal) => {
           <AvAccordion
             :title="t('global.overlay.drawers.UpdateProfileDrawer.pictures.picture')"
             :icon="MDI_ICONS.IMAGE_OUTLINE"
+            :class="{ 'update-profile-drawer__accordion--error': hasProfilePictureErrors }"
           >
             <div data-image-upload-delete-zone>
               <ImageUpload
@@ -249,7 +256,7 @@ watch(() => show, (newVal) => {
           :confirm-icon="MDI_ICONS.CONTENT_SAVE_OUTLINE"
           :cancel-is-loading="isPending || isLoading"
           :confirm-is-loading="isPending || isLoading"
-          :confirm-disabled="!isModified"
+          :confirm-disabled="!isModified || !isFormValid"
           form="profile-form"
           @cancel="handleCancel"
           @confirm="confirm"
@@ -264,3 +271,12 @@ watch(() => show, (newVal) => {
     @close="cancel"
   />
 </template>
+
+<style scoped lang="scss">
+.update-profile-drawer__accordion--error {
+  :deep(.av-accordion__trigger) {
+    border: 1px solid var(--dark-background-error);
+    color: var(--dark-background-error);
+  }
+}
+</style>

--- a/src/common/components/overlay/drawers/UpdateProfileDrawer/use-update-profile-form.ts
+++ b/src/common/components/overlay/drawers/UpdateProfileDrawer/use-update-profile-form.ts
@@ -2,6 +2,7 @@ import type { BaseApiException } from '@/common/exceptions'
 import { EUserCategory, type ProfileOverviewDTO } from '@/api/avenir-esr'
 import { BIOGRAPHY_MAX_LENGTH } from '@/common/components/overlay/drawers/UpdateProfileDrawer/config'
 import { useUpdateProfile, useUpdateProfileCover, useUpdateProfilePhoto } from '@/common/components/overlay/drawers/UpdateProfileDrawer/use-update-profile'
+import { useFormValidators } from '@/common/composables/use-form-validators/use-form-validators'
 import { useToasterStore } from '@/store'
 import { isValidEmail } from '@avenirs-esr/avenirs-dsav'
 import { useForm, useStore } from '@tanstack/vue-form'
@@ -17,6 +18,7 @@ export function useUpdateProfileForm (initialData: UseUpdateProfileFormData, pro
   const { onUpdateProfile, isUpdateProfilePending } = useUpdateProfile(profile, onSuccess)
   const { onUpdateProfileCoverAsync, isUpdateProfileCoverPending } = useUpdateProfileCover(profile, onUpdateProfileCoverSuccess)
   const { onUpdateProfilePhotoAsync, isUpdateProfilePhotoPending } = useUpdateProfilePhoto(profile, onUpdateProfilePhotoSuccess)
+  const { validateMaxLength, hasFieldErrors } = useFormValidators()
 
   const coverPictureFile = ref<File | null>(null)
   const profilePictureFile = ref<File | null>(null)
@@ -30,7 +32,14 @@ export function useUpdateProfileForm (initialData: UseUpdateProfileFormData, pro
   const form = useForm({
     defaultValues: { ...initialData },
     validators: {
-      onSubmit ({ value }) {
+      onChange ({ value }: { value: UseUpdateProfileFormData }) {
+        return {
+          fields: {
+            bio: validateMaxLength(value.bio, BIOGRAPHY_MAX_LENGTH)
+          }
+        }
+      },
+      onSubmit ({ value }: { value: UseUpdateProfileFormData }) {
         return {
           fields: {
             email: value.email && !isValidEmail(value.email) ? t('global.error.form.invalidEmail') : undefined,
@@ -100,6 +109,19 @@ export function useUpdateProfileForm (initialData: UseUpdateProfileFormData, pro
     !isDefaultValue.value || !!coverPictureFile.value || !!profilePictureFile.value
   )
 
+  const hasIdentityErrors = hasFieldErrors(form, ['email', 'bio'])
+
+  const hasPicturesErrors = hasFieldErrors(form, ['coverPicture', 'profilePicture'])
+
+  const hasCoverPictureErrors = hasFieldErrors(form, ['coverPicture'])
+
+  const hasProfilePictureErrors = hasFieldErrors(form, ['profilePicture'])
+
+  const isFormValid = computed(() => {
+    const state = form.useStore(state => state)
+    return state.value.isDirty && state.value.isValid && !state.value.isValidating
+  })
+
   function resetForm () {
     form.reset(initialData)
     coverPictureFile.value = null
@@ -110,6 +132,11 @@ export function useUpdateProfileForm (initialData: UseUpdateProfileFormData, pro
     form,
     isPending,
     isModified,
+    isFormValid,
+    hasIdentityErrors,
+    hasPicturesErrors,
+    hasCoverPictureErrors,
+    hasProfilePictureErrors,
     resetForm,
     coverPictureFile,
     onCoverPictureUpdate,

--- a/src/common/composables/use-form-validators/use-form-validators.test.ts
+++ b/src/common/composables/use-form-validators/use-form-validators.test.ts
@@ -19,6 +19,7 @@ BddTest().given('a form validators composable', () => {
       expect(composableResult.validateMaxLength).toBeDefined()
       expect(composableResult.validateDateInterval).toBeDefined()
       expect(composableResult.validateLink).toBeDefined()
+      expect(composableResult.hasFieldErrors).toBeDefined()
     })
   })
 

--- a/src/common/composables/use-form-validators/use-form-validators.ts
+++ b/src/common/composables/use-form-validators/use-form-validators.ts
@@ -1,7 +1,13 @@
+import type { FormApi } from '@tanstack/vue-form'
+import type { Ref } from 'vue'
 import { isValidLink } from '@avenirs-esr/avenirs-dsav'
+import { useStore } from '@tanstack/vue-form'
 import { isBefore, parse } from 'date-fns'
 import isEmpty from 'lodash-es/isEmpty'
 import { useI18n } from 'vue-i18n'
+
+type AnyFormApi<TFormData extends object> = FormApi<TFormData, any, any, any, any, any, any, any, any, any>
+type TopLevelFieldKey<TFormData extends object> = TFormData extends unknown ? Extract<keyof TFormData, string> : never
 
 export interface validateDateIntervalArgs {
   startDate: string | undefined | null
@@ -22,6 +28,8 @@ export interface UseFormValidatorsReturn {
   validateDateInterval: (args: validateDateIntervalArgs) => string | undefined
   /** Validates that a link is in a valid format */
   validateLink: (link: string | undefined | null, required?: boolean) => string | undefined
+  /** Returns a reactive boolean indicating whether at least one field has errors */
+  hasFieldErrors: <TFormData extends object>(form: AnyFormApi<TFormData>, fieldNames: readonly TopLevelFieldKey<TFormData>[]) => Ref<boolean>
 }
 
 export interface ValidationOptions {
@@ -92,10 +100,19 @@ export function useFormValidators (): UseFormValidatorsReturn {
     }
   }
 
+  function hasFieldErrors<TFormData extends object> (form: AnyFormApi<TFormData>, fieldNames: readonly TopLevelFieldKey<TFormData>[]) {
+    return useStore(form.store, (state) => {
+      return fieldNames.some((fieldName) => {
+        return (state.fieldMeta[fieldName]?.errors?.length ?? 0) > 0
+      })
+    })
+  }
+
   return {
     validateMaxLength,
     validateRequired,
     validateDateInterval,
-    validateLink
+    validateLink,
+    hasFieldErrors
   }
 }

--- a/src/features/student/traces/views/StudentToolsTracesView/components/StudentToolsTracesAddTraceDrawer/StudentToolsTracesAddTraceDrawer.test.ts
+++ b/src/features/student/traces/views/StudentToolsTracesView/components/StudentToolsTracesAddTraceDrawer/StudentToolsTracesAddTraceDrawer.test.ts
@@ -321,10 +321,10 @@ BddTest().given('a student tools traces add trace drawer component', () => {
   })
 
   BddTest().when('save button state', () => {
-    BddTest().then('it should be enabled by default', async () => {
+    BddTest().then('it should be disabled by default', async () => {
       const cancelConfirmButtons = getCancelConfirmButtons()
 
-      expect(cancelConfirmButtons.props('confirmDisabled')).toBe(false)
+      expect(cancelConfirmButtons.props('confirmDisabled')).toBe(true)
     })
   })
 

--- a/src/features/student/traces/views/StudentToolsTracesView/components/StudentToolsTracesAddTraceDrawer/StudentToolsTracesAddTraceDrawer.vue
+++ b/src/features/student/traces/views/StudentToolsTracesView/components/StudentToolsTracesAddTraceDrawer/StudentToolsTracesAddTraceDrawer.vue
@@ -44,7 +44,7 @@ function onTraceCreated () {
   confirmCancel()
 }
 
-const { form, isFormValid, isSubmitting } = useCreateTraceForm(onTraceCreated)
+const { form, isFormValid, isSubmitting, hasDeclarationItemsError, hasDefinitionItemsError } = useCreateTraceForm(onTraceCreated)
 
 const isFormDirty = form.useStore(state => state.isDirty)
 
@@ -182,6 +182,7 @@ const associationSelectionsField = form.useField({ name: 'associationSelections'
             <AvAccordion
               :title="t('student.traces.views.StudentToolsTracesView.studentToolsTracesAddTraceDrawer.accordionItems.addTrace')"
               :icon="MDI_ICONS.IMAGE_OUTLINE"
+              :class="{ 'add-trace-drawer__accordion--error': hasDefinitionItemsError }"
             >
               <CreateTraceFormTraceDefinitionItems :form="form" />
             </AvAccordion>
@@ -189,6 +190,7 @@ const associationSelectionsField = form.useField({ name: 'associationSelections'
             <AvAccordion
               :title="t('student.traces.views.StudentToolsTracesView.studentToolsTracesAddTraceDrawer.accordionItems.declarations')"
               :icon="MDI_ICONS.FILE_DOCUMENT_BOX_MULTIPLE_OUTLINE"
+              :class="{ 'add-trace-drawer__accordion--error': hasDeclarationItemsError }"
             >
               <CreateTraceFormDeclarationItems :form="form" />
             </AvAccordion>
@@ -230,5 +232,12 @@ const associationSelectionsField = form.useField({ name: 'associationSelections'
 <style scoped lang="scss">
 .placeholder-content {
   font-style: italic;
+}
+
+.add-trace-drawer__accordion--error {
+  :deep(.av-accordion__trigger) {
+    border: 1px solid var(--dark-background-error);
+    color: var(--dark-background-error);
+  }
 }
 </style>

--- a/src/features/student/traces/views/StudentToolsTracesView/components/StudentToolsTracesAddTraceDrawer/use-create-tarce-form/use-create-trace-form.test.ts
+++ b/src/features/student/traces/views/StudentToolsTracesView/components/StudentToolsTracesAddTraceDrawer/use-create-tarce-form/use-create-trace-form.test.ts
@@ -44,9 +44,9 @@ BddTest().given('the useCreateTraceForm composable', () => {
       expect(typeof composableResult.form.useStore).toBe('function')
     })
 
-    BddTest().then('it should return isFormValid as true initially', () => {
+    BddTest().then('it should return isFormValid as false initially', () => {
       expect(composableResult.isFormValid).toBeDefined()
-      expect(composableResult.isFormValid.value).toBe(true)
+      expect(composableResult.isFormValid.value).toBe(false)
     })
   })
 

--- a/src/features/student/traces/views/StudentToolsTracesView/components/StudentToolsTracesAddTraceDrawer/use-create-tarce-form/use-create-trace-form.ts
+++ b/src/features/student/traces/views/StudentToolsTracesView/components/StudentToolsTracesAddTraceDrawer/use-create-tarce-form/use-create-trace-form.ts
@@ -4,6 +4,7 @@ import type { ComputedRef } from 'vue'
 import { ELanguage, type TraceAssociationsDTO } from '@/api/avenir-esr'
 import { useFormValidators } from '@/common/composables/use-form-validators/use-form-validators'
 import { useTraceFileValidation } from '@/features/student/traces/composables/use-trace-file/use-trace-file'
+import { TRACE_LINK_MAX_LENGTH, TRACE_NAME_MAX_LENGTH, TRACE_PERSONAL_NOTE_MAX_LENGTH } from '@/features/student/traces/config'
 import {
   useAssociateTraceWithActivitiesMutation,
   useAssociateTraceWithDeclaredSkillsMutation,
@@ -23,7 +24,7 @@ export function useCreateTraceForm (onTraceCreated?: () => void) {
   const { t } = useI18n()
 
   const { addErrorMessage } = useToasterStore()
-  const { validateLink } = useFormValidators()
+  const { validateLink, validateMaxLength, hasFieldErrors } = useFormValidators()
 
   function onCreateTraceError (error: BaseApiException) {
     addErrorMessage({
@@ -143,6 +144,9 @@ export function useCreateTraceForm (onTraceCreated?: () => void) {
       onChange ({ value }: { value: TraceFormData }) {
         return {
           fields: {
+            link: isTraceLinkType(value) ? validateMaxLength(value.link, TRACE_LINK_MAX_LENGTH) : undefined,
+            traceName: validateMaxLength(value.traceName, TRACE_NAME_MAX_LENGTH),
+            personalNote: validateMaxLength(value.personalNote, TRACE_PERSONAL_NOTE_MAX_LENGTH),
             file: isTraceFileType(value) ? validateFile(value.file) : undefined,
           }
         }
@@ -155,8 +159,11 @@ export function useCreateTraceForm (onTraceCreated?: () => void) {
 
   const isFormValid = computed(() => {
     const state = form.useStore(state => state)
-    return state.value.isValid && !state.value.isValidating
+    return state.value.isDirty && state.value.isValid && !state.value.isValidating
   })
+
+  const hasDefinitionItemsError = hasFieldErrors(form, ['traceName', 'personalNote', 'traceType', 'file', 'link'])
+  const hasDeclarationItemsError = hasFieldErrors(form, ['isAuthentic', 'isGroup', 'useIA'])
 
   const isSubmitting: ComputedRef<boolean> = computed(() => {
     return createTraceMutation.isPending.value
@@ -169,6 +176,8 @@ export function useCreateTraceForm (onTraceCreated?: () => void) {
   return {
     form,
     isFormValid,
-    isSubmitting
+    isSubmitting,
+    hasDefinitionItemsError,
+    hasDeclarationItemsError
   }
 }

--- a/src/features/student/traces/views/StudentTraceView/components/UpdateTraceForm/use-update-trace-form/use-update-trace-form.ts
+++ b/src/features/student/traces/views/StudentTraceView/components/UpdateTraceForm/use-update-trace-form/use-update-trace-form.ts
@@ -1,11 +1,13 @@
 import type { BaseApiException } from '@/common/exceptions'
 import type { TraceFormData } from '@/features/student/traces/types/traces.types'
 import { ELanguage, type TraceDetailDTO } from '@/api/avenir-esr'
+import { useFormValidators } from '@/common/composables/use-form-validators/use-form-validators'
 import { useTraceAttachmentFile, useTraceFileValidation } from '@/features/student/traces/composables/use-trace-file/use-trace-file'
+import { TRACE_LINK_MAX_LENGTH, TRACE_NAME_MAX_LENGTH, TRACE_PERSONAL_NOTE_MAX_LENGTH } from '@/features/student/traces/config'
 import { useUpdateTraceMutation, useUploadAttachmentMutation } from '@/features/student/traces/queries/use-traces.query/use-traces.query'
 import { useTracesStore } from '@/features/student/traces/stores/traces.store'
 import { TraceType } from '@/features/student/traces/types/traces.types'
-import { isTraceFileType } from '@/features/student/traces/utils/trace.types-guard'
+import { isTraceFileType, isTraceLinkType } from '@/features/student/traces/utils/trace.types-guard'
 import { useToasterStore } from '@/store'
 import { useForm } from '@tanstack/vue-form'
 import { useI18n } from 'vue-i18n'
@@ -15,6 +17,7 @@ export function useUpdateTraceForm (trace: TraceDetailDTO, onTraceUpdated?: () =
 
   const { addErrorMessage } = useToasterStore()
   const { setUpdateTraceForm, setUpdateTraceFormModified } = useTracesStore()
+  const { validateMaxLength } = useFormValidators()
   const { validateFile } = useTraceFileValidation()
   const { attachmentFile } = useTraceAttachmentFile(trace.attachment)
 
@@ -65,6 +68,9 @@ export function useUpdateTraceForm (trace: TraceDetailDTO, onTraceUpdated?: () =
       onChange ({ value }: { value: TraceFormData }) {
         return {
           fields: {
+            traceName: validateMaxLength(value.traceName, TRACE_NAME_MAX_LENGTH),
+            personalNote: validateMaxLength(value.personalNote, TRACE_PERSONAL_NOTE_MAX_LENGTH),
+            link: isTraceLinkType(value) ? validateMaxLength(value.link, TRACE_LINK_MAX_LENGTH) : undefined,
             file: isTraceFileType(value) ? validateFile(value.file) : undefined,
           }
         }
@@ -117,6 +123,11 @@ export function useUpdateTraceForm (trace: TraceDetailDTO, onTraceUpdated?: () =
     return state.value.isDirty
   })
 
+  const isFormValid = computed(() => {
+    const state = form.useStore(state => state)
+    return state.value.isDirty && state.value.isValid && !state.value.isValidating
+  })
+
   watch(() => form, () => {
     setUpdateTraceForm(form)
   }, { immediate: true })
@@ -126,6 +137,7 @@ export function useUpdateTraceForm (trace: TraceDetailDTO, onTraceUpdated?: () =
   }, { immediate: true })
 
   return {
-    form
+    form,
+    isFormValid
   }
 }


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
This PR fixes maxlength validation behavior and harmonizes section-level error handling in forms.

**Main changes:**
- 🐛 Fixes maxlength validation to run on `onChange` for profile and trace forms
- ♻️ Introduces a generic `hasFieldErrors` helper in form validators and reuses it across composables
- 🏷️ Improves typing to support union-based form data (including `link` in trace forms)
- 💄 Adds accordion error styling for profile sections based on field-level validation state
- ✅ Updates unit tests to match current form validity and save-button behavior

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1557
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1559
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1614
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1555
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1553
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1645

---

### Documentation
- Validation behavior is now explicit between `onChange` and `onSubmit` in the touched composables.
- Tests were updated to reflect current functional behavior:
  - Initial `isFormValid` expectations
  - Default save-button disabled state when form is not dirty

---

### Target Branch
`develop`

---

### Additional Notes
The implementation keeps UI feedback consistent by surfacing per-accordion error state while preserving existing submit-time validations.

---

### Known Limitations or Side Effects
No known side effects. The stricter typing for field keys may require explicit key alignment in future union-based form types.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [x] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [x] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process
