### PR TITLE
fix(1576): always display associate button in trace detail

### DIFF
--- a/src/features/student/traces/components/composites/TraceAssociations/TraceAssociations.stub.ts
+++ b/src/features/student/traces/components/composites/TraceAssociations/TraceAssociations.stub.ts
@@ -1,11 +1,14 @@
 import type { TraceAssociationsDTO } from '@/api/avenir-esr'
+import type { BaseApiException } from '@/common/exceptions/base-api-exception/base-api.exception'
 import type { PropType } from 'vue'
 
 export const TraceAssociationsStub = defineComponent({
   name: 'TraceAssociations',
   props: {
     associations: { type: Object as PropType<TraceAssociationsDTO>, required: true },
-    traceId: { type: String, required: true }
+    traceId: { type: String, required: true },
+    countAssociations: { type: Number, required: false },
+    associationsError: { type: Object as PropType<BaseApiException | null>, required: false }
   },
   template: `<div data-testid="trace-associations-stub"></div>`
 })

--- a/src/features/student/traces/components/composites/TraceAssociations/TraceAssociations.test.ts
+++ b/src/features/student/traces/components/composites/TraceAssociations/TraceAssociations.test.ts
@@ -5,6 +5,7 @@ import {
   mockedTraceDeclaredSkillAssociations
 } from '@/__mocks__/fixtures/student'
 import { type DeclaredActivityAssociationDTO, EActivityThematic, EDeclaredActivityStatus, type TraceAssociationsDTO } from '@/api/avenir-esr'
+import { QuerySuspenseStub } from '@/common/components/QuerySuspense/QuerySuspense.stub'
 import { AssociatedDeclaredActivitiesCard } from '@/features/student/buildProject'
 import { AssociatedDeclaredSkillsCardStub } from '@/features/student/declaredSkills/components/cards/AssociatedDeclaredSkillsCard/AssociatedDeclaredSkillsCard.stub'
 import { AssociatedActivityCardStub } from '@/features/student/global/components/cards/AssociatedActivityCard/AssociatedActivityCard.stub'
@@ -33,6 +34,7 @@ const stubs = {
   AssociateActivitiesToTracesModal: AssociateActivitiesToTracesModalStub,
   AssociatedDeclaredSkillsCard: AssociatedDeclaredSkillsCardStub,
   AssociatedActivityCard: AssociatedActivityCardStub,
+  QuerySuspense: QuerySuspenseStub,
 }
 
 BddTest().given('a student trace associations component', () => {
@@ -44,7 +46,8 @@ BddTest().given('a student trace associations component', () => {
       wrapper = mountComponent(TraceAssociations, {
         props: {
           associations: mockedEmptyTraceAssociations,
-          traceId
+          traceId,
+          countAssociations: 0,
         },
         global: {
           stubs
@@ -52,15 +55,18 @@ BddTest().given('a student trace associations component', () => {
       })
     })
 
+    BddTest().then('it should render the empty state', () => {
+      expect(wrapper.find('[data-testid="query-suspense-empty"]').exists()).toBe(true)
+    })
+
     BddTest().then('it should render no associated activity cards', () => {
       const declaredActivityCards = wrapper.findAllComponents(AssociatedActivityCardStub)
       expect(declaredActivityCards).toHaveLength(0)
     })
 
-    BddTest().then('it should render the associated declared skills card with empty associations', () => {
+    BddTest().then('it should not render the associated declared skills card', () => {
       const declaredSkillsCard = wrapper.findComponent(AssociatedDeclaredSkillsCardStub)
-      expect(declaredSkillsCard.exists()).toBe(true)
-      expect(declaredSkillsCard.props('associatedDeclaredSkills')).toEqual([])
+      expect(declaredSkillsCard.exists()).toBe(false)
     })
 
     BddTest().then('it should not render the declared activity associations container', () => {
@@ -68,11 +74,9 @@ BddTest().given('a student trace associations component', () => {
       expect(declaredActivityContainer.exists()).toBe(false)
     })
 
-    BddTest().then('it should render the delete trace associated elements dropdown with disabled items', () => {
+    BddTest().then('it should render the delete trace associated elements dropdown', () => {
       const dropdown = wrapper.findComponent(DeleteTraceAssociatedElementsDropdownStub)
       expect(dropdown.exists()).toBe(true)
-      expect(dropdown.props().skillsDisabled).toBe(true)
-      expect(dropdown.props().activitiesDisabled).toBe(true)
     })
 
     BddTest().then('it should render the trace associate elements dropdown', () => {
@@ -114,30 +118,6 @@ BddTest().given('a student trace associations component', () => {
       expect(modal.exists()).toBe(true)
       expect(modal.props('show')).toBe(false)
       expect(modal.props('traceId')).toBe(traceId)
-    })
-
-    BddTest().and('the delete trace associated elements dropdown emits skillsSelected', () => {
-      beforeEach(() => {
-        const dropdown = wrapper.findComponent(DeleteTraceAssociatedElementsDropdownStub)
-        dropdown.vm.$emit('skillsSelected')
-      })
-
-      BddTest().then('the delete trace associated skills modal should be shown', () => {
-        const skillsModal = wrapper.findComponent(DeleteTraceAssociatedSkillsModalStub)
-        expect(skillsModal.props('show')).toBe(true)
-      })
-    })
-
-    BddTest().and('the delete trace associated elements dropdown emits activitiesSelected', () => {
-      beforeEach(() => {
-        const dropdown = wrapper.findComponent(DeleteTraceAssociatedElementsDropdownStub)
-        dropdown.vm.$emit('activitiesSelected')
-      })
-
-      BddTest().then('the delete trace associated activities modal should be shown', () => {
-        const activitiesModal = wrapper.findComponent(DeleteTraceAssociatedActivitiesModalStub)
-        expect(activitiesModal.props('show')).toBe(true)
-      })
     })
 
     BddTest().and('the trace associate elements dropdown emits skillsSelected', () => {
@@ -274,12 +254,17 @@ BddTest().given('a student trace associations component', () => {
       wrapper = mountComponent(TraceAssociations, {
         props: {
           associations: associationsProps,
-          traceId
+          traceId,
+          countAssociations: declaredSkillAssociations.length
         },
         global: {
           stubs
         }
       })
+    })
+
+    BddTest().then('it should not render the empty state', () => {
+      expect(wrapper.find('[data-testid="query-suspense-empty"]').exists()).toBe(false)
     })
 
     BddTest().then('it should render the associated declared skills card with the correct associations', () => {
@@ -338,12 +323,17 @@ BddTest().given('a student trace associations component', () => {
       wrapper = mountComponent(TraceAssociations, {
         props: {
           associations: associationsProps,
-          traceId
+          traceId,
+          countAssociations: declaredActivityAssociations.length
         },
         global: {
           stubs
         }
       })
+    })
+
+    BddTest().then('it should not render the empty state', () => {
+      expect(wrapper.find('[data-testid="query-suspense-empty"]').exists()).toBe(false)
     })
 
     BddTest().then('it should render the associated declared skills card with empty associations', () => {

--- a/src/features/student/traces/components/composites/TraceAssociations/TraceAssociations.vue
+++ b/src/features/student/traces/components/composites/TraceAssociations/TraceAssociations.vue
@@ -1,5 +1,8 @@
 <script setup lang="ts">
+import type { BaseApiException } from '@/common/exceptions'
 import { EDeclaredActivityStatus, type TraceAssociationsDTO } from '@/api/avenir-esr'
+import QuerySuspense
+  from '@/common/components/QuerySuspense/QuerySuspense.vue'
 import { useModal } from '@/common/composables'
 import { AssociatedDeclaredActivitiesCard } from '@/features/student/buildProject'
 import { AssociatedDeclaredSkillsCard } from '@/features/student/declaredSkills'
@@ -17,13 +20,18 @@ import DeleteTraceAssociatedActivitiesModal
   from '@/features/student/traces/views/StudentTraceView/components/overlays/modals/DeleteTraceAssociatedActivitiesModal/DeleteTraceAssociatedActivitiesModal.vue'
 import DeleteTraceAssociatedSkillsModal
   from '@/features/student/traces/views/StudentTraceView/components/overlays/modals/DeleteTraceAssociatedSkillsModal/DeleteTraceAssociatedSkillsModal.vue'
+import { useI18n } from 'vue-i18n'
+
+const { associations, traceId, associationsError, countAssociations = 0 } = defineProps<TraceAssociationsProps>()
+
+const { t } = useI18n()
 
 export interface TraceAssociationsProps {
-  associations: TraceAssociationsDTO
+  associations: TraceAssociationsDTO | undefined
   traceId: string
+  associationsError?: BaseApiException | null
+  countAssociations?: number
 }
-
-const { associations, traceId } = defineProps<TraceAssociationsProps>()
 
 const { showModal: showSkillsModal, displayModal: displaySkillsModal, hideModal: hideSkillsModal } = useModal()
 const { showModal: showActivitiesModal, displayModal: displayActivitiesModal, hideModal: hideActivitiesModal } = useModal()
@@ -32,8 +40,8 @@ const { showModal: showAssociateActivitiesModal, displayModal: displayAssociateA
 const { showModal: showAssociationModal, displayModal: displayAssociationModal, hideModal: hideAssociationModal } = useModal()
 const { showModal: showAssociateExperiencesModal, displayModal: displayAssociateExperiencesModal, hideModal: hideAssociateExperiencesModal } = useModal()
 
-const declaredSkillAssociations = computed(() => associations.declaredSkillAssociations ?? [])
-const declaredActivityAssociations = computed(() => associations.declaredActivityAssociations ?? [])
+const declaredSkillAssociations = computed(() => associations?.declaredSkillAssociations ?? [])
+const declaredActivityAssociations = computed(() => associations?.declaredActivityAssociations ?? [])
 
 const deletableDeclaredActivityAssociations = computed(() =>
   declaredActivityAssociations.value.filter(({ declaredActivity }) => declaredActivity.status !== EDeclaredActivityStatus.COMPLETED)
@@ -61,11 +69,15 @@ const deletableDeclaredActivityAssociations = computed(() =>
 
     <slot name="caption" />
 
-    <AssociatedDeclaredSkillsCard
-      :associated-declared-skills="declaredSkillAssociations"
-    />
-
-    <AssociatedDeclaredActivitiesCard :associated-activities="declaredActivityAssociations" />
+    <QuerySuspense
+      :error="associationsError"
+      :error-title="t('student.traces.views.StudentTraceView.errors.fetchAssociations')"
+      :empty-state-message="t('student.traces.views.StudentTraceView.empty.associations')"
+      :is-empty="countAssociations === 0"
+    >
+      <AssociatedDeclaredSkillsCard :associated-declared-skills="declaredSkillAssociations" />
+      <AssociatedDeclaredActivitiesCard :associated-activities="declaredActivityAssociations" />
+    </QuerySuspense>
   </div>
 
   <AssociateActivitiesToTracesModal

--- a/src/features/student/traces/locales/en.json
+++ b/src/features/student/traces/locales/en.json
@@ -257,6 +257,9 @@
             "fetchAssociations": "An error occurred while fetching the trace associations",
             "fetchTrace": "An error occurred while fetching the trace details"
           },
+          "empty": {
+            "associations": "No association for this trace."
+          },
           "settings": {
             "associate": "Associate my trace",
             "delete": "Delete my trace",

--- a/src/features/student/traces/locales/fr.json
+++ b/src/features/student/traces/locales/fr.json
@@ -250,6 +250,9 @@
             "activities": "une/des activité(s) associée(s)",
             "skills": "une/des compétence(s) associée(s)"
           },
+          "empty": {
+            "associations": "Aucune association pour cette trace."
+          },
           "errors": {
             "delete": "Une erreur est survenue lors de la suppression de la trace.",
             "download": "Une erreur est survenue lors du téléchargement de la trace.",

--- a/src/features/student/traces/views/StudentTraceView/StudentTraceView.test.ts
+++ b/src/features/student/traces/views/StudentTraceView/StudentTraceView.test.ts
@@ -155,6 +155,13 @@ BddTest().given('a student trace view', () => {
       expect(tabs[1].props('title')).toBe('Mes éléments associés (5)')
     })
 
+    BddTest().then('it should render TraceAssociations with correct props', async () => {
+      const traceAssociations = wrapper.findComponent(TraceAssociationsStub)
+      expect(traceAssociations.exists()).toBe(true)
+      expect(traceAssociations.props('countAssociations')).toBe(5)
+      expect(traceAssociations.props('associationsError')).toBeNull()
+    })
+
     BddTest().then('it should render StudentTraceDetails component in the first tab', () => {
       const traceDetails = wrapper.findComponent({ name: 'StudentTraceDetails' })
       expect(traceDetails.exists()).toBe(true)

--- a/src/features/student/traces/views/StudentTraceView/StudentTraceView.vue
+++ b/src/features/student/traces/views/StudentTraceView/StudentTraceView.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import type { BaseApiException } from '@/common/exceptions'
 import { useDownloadAttachment } from '@/api/avenir-esr'
-import { QuerySuspense } from '@/common/components'
 import ErrorMessage from '@/common/components/feedback/ErrorMessage/ErrorMessage.vue'
 import Loader from '@/common/components/Loader/Loader.vue'
 import PageTitle from '@/common/components/PageTitle/PageTitle.vue'
@@ -29,7 +28,7 @@ const { traceId } = toRefs(props)
 const { addErrorMessage } = useToasterStore()
 
 const { traceDetailed, error: traceDetailsError, isLoading } = useTraceDetailedQuery(traceId)
-const { traceAssociations, error: associationsError } = useTraceAssociationsQuery(traceId)
+const { traceAssociations, error: associationsError, isLoading: isAssociationsLoading } = useTraceAssociationsQuery(traceId)
 const { navigateToStudentTraces } = useNavigation()
 
 const countAssociations = computed(() => !traceAssociations.value ? 0 : traceAssociations.value.declaredActivityAssociations.length + traceAssociations.value.declaredSkillAssociations.length)
@@ -130,17 +129,14 @@ const breadcrumbLinks = computed(() => [
           :icon="ICONS.ASSOCIATIONS"
           data-testid="associations-tab-item"
         >
-          <QuerySuspense
-            :error="associationsError"
-            :error-title="t('student.traces.views.StudentTraceView.errors.fetchAssociations')"
-            :is-empty="countAssociations === 0"
-          >
+          <Loader :is-loading="isAssociationsLoading">
             <TraceAssociations
-              v-if="traceAssociations"
               :associations="traceAssociations"
               :trace-id="traceDetailed.id"
+              :associations-error="associationsError"
+              :count-associations="countAssociations"
             />
-          </QuerySuspense>
+          </Loader>
         </AvTab>
       </AvTabs>
 


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
Fix the missing "Associer..." button in the trace detail view when no associations exist.

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1576


---

### Target Branch
develop

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and detaiils for the update process

---
