### PR TITLE
fix(1539): DeclaredExperience - add missing NAF information

### DIFF
--- a/src/features/student/declaredSkills/components/interactions/formFields/DeclaredSkillReflectionFormField/DeclaredSkillReflectionFormField.test.ts
+++ b/src/features/student/declaredSkills/components/interactions/formFields/DeclaredSkillReflectionFormField/DeclaredSkillReflectionFormField.test.ts
@@ -126,17 +126,18 @@ BddTest().given('a declared skill reflection form field component', () => {
   })
 
   BddTest().when('the user types a long reflection', () => {
-    BddTest().then('it should respect the maxlength (display truncated to 400)', async () => {
+    BddTest().then('it should allow the maxlength to be exceeded', async () => {
       const avInput = wrapper.findComponent({ name: 'AvInput' })
       const textarea = avInput.find('textarea')
 
-      await textarea.setValue('a'.repeat(DECLARED_SKILL_REFLECTION_MAX_LENGTH + 1))
+      const longReflection = 'a'.repeat(DECLARED_SKILL_REFLECTION_MAX_LENGTH + 1)
+      await textarea.setValue(longReflection)
       await wrapper.vm.$nextTick()
 
       await vi.waitFor(() => {
         const updated = wrapper.findComponent({ name: 'AvInput' })
         const displayed = updated.props('modelValue') as string
-        expect(displayed.length).toBeLessThanOrEqual(DECLARED_SKILL_REFLECTION_MAX_LENGTH)
+        expect(displayed).toBe(longReflection)
       })
     })
   })

--- a/src/features/student/declaredSkills/components/interactions/formFields/DeclaredSkillReflectionFormField/DeclaredSkillReflectionFormField.vue
+++ b/src/features/student/declaredSkills/components/interactions/formFields/DeclaredSkillReflectionFormField/DeclaredSkillReflectionFormField.vue
@@ -22,10 +22,10 @@ const { t } = useI18n()
       <DeclaredSkillReflectionInput
         v-bind="$attrs"
         id="skill-reflection"
-        :model-value="(field.state.value ?? '').slice(0, DECLARED_SKILL_REFLECTION_MAX_LENGTH)"
+        :model-value="(field.state.value ?? '')"
         :error-message="field.state.meta.errors?.join(', ')"
         @blur="field.handleBlur"
-        @update:model-value="(value) => field.handleChange(String(value ?? '').slice(0, DECLARED_SKILL_REFLECTION_MAX_LENGTH))"
+        @update:model-value="(value) => field.handleChange(String(value ?? ''))"
       >
         <template #maxLengthCaption>
           <span class="caption-regular">

--- a/src/features/student/declaredSkills/components/overlays/AddDeclaredSkillDrawer/AddDeclaredSkillDrawer.vue
+++ b/src/features/student/declaredSkills/components/overlays/AddDeclaredSkillDrawer/AddDeclaredSkillDrawer.vue
@@ -21,7 +21,7 @@ const declaredSkillsStore = useDeclaredSkillsStore()
 const { addSuccessMessage } = useToasterStore()
 const showDrawer = toRef(declaredSkillsStore, 'showCreateDeclaredSkillDrawer')
 
-const { form, isFormValid, isSubmitting } = useDeclaredSkillForm(() => {
+const { form, isFormValid, isSubmitting, hasSkillDetailsErrors } = useDeclaredSkillForm(() => {
   addSuccessMessage({
     timeout: 2000,
     description: t('student.declaredSkills.overlays.AddDeclaredSkillDrawer.success')
@@ -87,6 +87,9 @@ async function handleCancel () {
               :title="t('student.declaredSkills.overlays.AddDeclaredSkillDrawer.accordions.addMySkill.title')"
               :icon="ICONS.SKILLS"
               overflow-visible
+              :class="{
+                'accordion--error': hasSkillDetailsErrors,
+              }"
             >
               <div class="av-col av-gap-md">
                 <AddDeclaredSkillAutocompleteField :form="form" />
@@ -133,5 +136,14 @@ async function handleCancel () {
   color: var(--light-foreground-primary1) !important;
   background-color: transparent;
   font-weight: var(--font-weight-bold);
+}
+</style>
+
+<style scoped lang="scss">
+.accordion--error {
+  :deep(.av-accordion__trigger) {
+    border: 1px solid var(--dark-background-error);
+    color: var(--dark-background-error);
+  }
 }
 </style>

--- a/src/features/student/declaredSkills/components/overlays/AddDeclaredSkillDrawer/use-declared-skill-form/use-declared-skill-form.ts
+++ b/src/features/student/declaredSkills/components/overlays/AddDeclaredSkillDrawer/use-declared-skill-form/use-declared-skill-form.ts
@@ -1,7 +1,9 @@
 import type { BaseApiException } from '@/common/exceptions'
 import type { DeclaredSkillFormData } from '@/features/student/declaredSkills/components/overlays/AddDeclaredSkillDrawer/types'
 import { EDeclaredSkillLevel, EErrorCode, invalidateGetDeclaredSkillsProgresses, useCreateDeclaredSkillProgress } from '@/api/avenir-esr'
+import { useFormValidators } from '@/common/composables/use-form-validators/use-form-validators'
 import { useTaskLoading } from '@/common/composables/use-task-loading/use-task-loading'
+import { DECLARED_SKILL_REFLECTION_MAX_LENGTH } from '@/features/student/declaredSkills/config'
 import { useToasterStore } from '@/store'
 import { useForm } from '@tanstack/vue-form'
 import { useQueryClient } from '@tanstack/vue-query'
@@ -12,6 +14,7 @@ export function useDeclaredSkillForm (onSkillAdded?: () => void) {
   const { addErrorMessage } = useToasterStore()
   const queryClient = useQueryClient()
   const { isLoading, withTaskLoading } = useTaskLoading()
+  const { validateRequired, validateMaxLength, hasFieldErrors } = useFormValidators()
 
   const onCreateDeclaredSkillError = (error: BaseApiException) => {
     addErrorMessage({
@@ -46,6 +49,13 @@ export function useDeclaredSkillForm (onSkillAdded?: () => void) {
       level: EDeclaredSkillLevel.BEGINNER
     } as unknown as DeclaredSkillFormData,
     validators: {
+      onChange ({ value }: { value: DeclaredSkillFormData }) {
+        return {
+          fields: {
+            reflection: validateMaxLength(value.reflection, DECLARED_SKILL_REFLECTION_MAX_LENGTH)
+          }
+        }
+      },
       onSubmit ({ value }: { value: DeclaredSkillFormData }) {
         return {
           fields: {
@@ -55,7 +65,7 @@ export function useDeclaredSkillForm (onSkillAdded?: () => void) {
             level: !value.level
               ? t('student.declaredSkills.overlays.AddDeclaredSkillDrawer.validation.levelRequired')
               : undefined,
-            reflection: !value.reflection
+            reflection: validateRequired(value.reflection)
           }
         }
       }
@@ -70,10 +80,13 @@ export function useDeclaredSkillForm (onSkillAdded?: () => void) {
     return state.value.isValid && !state.value.isValidating
   })
 
+  const hasSkillDetailsErrors = hasFieldErrors(form, ['reflection'])
+
   return {
     form,
     isFormValid,
-    isSubmitting: isPending || isLoading.value
+    isSubmitting: isPending || isLoading.value,
+    hasSkillDetailsErrors
   }
 }
 

--- a/src/features/student/personalCareer/components/interactions/inputs/DeclaredExperienceActivitySectorInput/DeclaredExperienceActivitySectorInput.test.ts
+++ b/src/features/student/personalCareer/components/interactions/inputs/DeclaredExperienceActivitySectorInput/DeclaredExperienceActivitySectorInput.test.ts
@@ -63,9 +63,9 @@ BddTest().given('a declared experience activity sector input component', () => {
     })
   })
 
-  BddTest().then('it should NOT display the hint by default', () => {
+  BddTest().then('it should display the classification hint', () => {
     const input = wrapper.findComponent({ name: 'AvInput' })
-    expect(input.props('hint')).toBeUndefined()
+    expect(input.props('hint')).toBe('Pour une classification reconnue, consultez le référentiel NAF (Nomenclature d\'Activités Française)')
   })
 
   BddTest().when('the component is mounted in disabled state', () => {
@@ -80,9 +80,9 @@ BddTest().given('a declared experience activity sector input component', () => {
       })
     })
 
-    BddTest().then('it should display the classification hint', () => {
+    BddTest().then('it should not display the classification hint', () => {
       const input = wrapper.findComponent({ name: 'AvInput' })
-      expect(input.props('hint')).toBe('Pour une classification reconnue, consultez le référentiel NAF (Nomenclature d\'Activités Française)')
+      expect(input.props('hint')).toBeUndefined()
     })
   })
 

--- a/src/features/student/personalCareer/components/interactions/inputs/DeclaredExperienceActivitySectorInput/DeclaredExperienceActivitySectorInput.vue
+++ b/src/features/student/personalCareer/components/interactions/inputs/DeclaredExperienceActivitySectorInput/DeclaredExperienceActivitySectorInput.vue
@@ -21,7 +21,7 @@ const avInputProps = computed(() => ({
   maxlength: DECLARED_EXPERIENCE_ACTIVITY_SECTOR_MAX_LENGTH,
   prefixIcon: MDI_ICONS.BUILDING,
   placeholder: placeholder ?? t('student.personalCareer.interactions.inputs.DeclaredExperienceActivitySectorInput.placeholder'),
-  hint: restProps.disabled ? t('student.personalCareer.interactions.inputs.DeclaredExperienceActivitySectorInput.hint') : undefined
+  hint: !restProps.disabled ? t('student.personalCareer.interactions.inputs.DeclaredExperienceActivitySectorInput.hint') : undefined
 }))
 </script>
 


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
This PR fixes validation and UX issues in declared skill and declared experience forms, including the missing NAF indication behavior.

**Main changes:**
- 🐛 Fixes activity sector hint visibility logic so the NAF indication is shown when the input is enabled
- 🐛 Moves reflection max-length validation into form validators to ensure consistent validation behavior
- 🎨 Adds error styling on the skill details accordion when reflection validation fails
- ♻️ Simplifies reflection field value handling by removing inline manual slicing in the form field component

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1539

---

### Documentation
- Validation logic updated in declared skill form composable
- Drawer UI updated to surface validation error state at accordion level
- Activity sector input hint condition corrected

**Modified files:**
- src/features/student/declaredSkills/components/interactions/formFields/DeclaredSkillReflectionFormField/DeclaredSkillReflectionFormField.vue
- src/features/student/declaredSkills/components/overlays/AddDeclaredSkillDrawer/AddDeclaredSkillDrawer.vue
- src/features/student/declaredSkills/components/overlays/AddDeclaredSkillDrawer/use-declared-skill-form/use-declared-skill-form.ts
- src/features/student/personalCareer/components/interactions/inputs/DeclaredExperienceActivitySectorInput/DeclaredExperienceActivitySectorInput.vue

---

### Target Branch
develop

---

### Additional Notes
Technical alignment was made to keep validation rules centralized in form validators rather than splitting them between UI input handlers and submit-time checks.

---

### Known Limitations or Side Effects
No known limitations or side effects.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [ ] No unnecessary code (e.g., debug logs, commented code)
- [ ] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to CHANGELOG.md file all properties and database change and details for the update process
