### PR TITLE
feat(1493): add staff national activity creation view

### DIFF
--- a/a11y/staff.a11y.test.ts
+++ b/a11y/staff.a11y.test.ts
@@ -14,6 +14,7 @@ const __dirname = dirname(__filename)
 
 const routesToCheck: Array<AvRoute> = [
   ROUTES.STAFF.ACTIVITIES,
+  ROUTES.STAFF.ACTIVITIES_ADD_NATIONAL_ACTIVITY,
 ]
 
 const pathsToTest = [

--- a/src/common/composables/use-navigation/use-navigation.test.ts
+++ b/src/common/composables/use-navigation/use-navigation.test.ts
@@ -335,4 +335,12 @@ BddTest().given('a useNavigation composable', () => {
       expect(pushMock).toHaveBeenCalledWith(ROUTES.STAFF.ACTIVITIES)
     })
   })
+
+  BddTest().when('trying to navigate to staff activities add national activity', () => {
+    BddTest().then('it should navigate to staff activities add national activity', () => {
+      const { navigateToStaffActivitiesAddNationalActivity } = navigation
+      navigateToStaffActivitiesAddNationalActivity()
+      expect(pushMock).toHaveBeenCalledWith(ROUTES.STAFF.ACTIVITIES_ADD_NATIONAL_ACTIVITY)
+    })
+  })
 })

--- a/src/common/composables/use-navigation/use-navigation.ts
+++ b/src/common/composables/use-navigation/use-navigation.ts
@@ -155,6 +155,10 @@ export function useNavigation () {
     return router.push(ROUTES.STAFF.ACTIVITIES)
   }
 
+  const navigateToStaffActivitiesAddNationalActivity = () => {
+    return router.push(ROUTES.STAFF.ACTIVITIES_ADD_NATIONAL_ACTIVITY)
+  }
+
   return {
     navigateToStudentDeclaredSkill,
     navigateToStudentDeclaredExperience,
@@ -180,5 +184,6 @@ export function useNavigation () {
     navigateToStaffHome,
     navigateToActivityDetailed,
     navigateToStaffActivities,
+    navigateToStaffActivitiesAddNationalActivity,
   }
 }

--- a/src/common/constants/route-names.ts
+++ b/src/common/constants/route-names.ts
@@ -2,6 +2,7 @@ export const ROUTES = {
   STAFF: {
     ACCESSIBILITY: { name: 'staff-accessibility', path: 'accessibility' },
     ACTIVITIES: { name: 'staff-activities', path: 'activities' },
+    ACTIVITIES_ADD_NATIONAL_ACTIVITY: { name: 'staff-activities-add-national-activity', path: 'activities/:id/add-national-activity' },
     COOKIES: { name: 'staff-cookies', path: 'cookies' },
     HOME: { name: 'staff-home', path: '' },
     LEGAL: { name: 'staff-legal', path: 'legal' },

--- a/src/features/staff/activities/routes/index.test.ts
+++ b/src/features/staff/activities/routes/index.test.ts
@@ -1,12 +1,17 @@
-import { staffActivitiesRoute } from '@/features/staff/activities/routes'
+import { ROUTES } from '@/common/constants'
+import { staffActivitiesAddNationalActivityRoute, staffActivitiesRoute } from '@/features/staff/activities/routes'
 import ActivitiesView from '@/features/staff/activities/views/ActivitiesView/ActivitiesView.vue'
+import AddNationalActivityView from '@/features/staff/activities/views/AddNationalActivityView/AddNationalActivityView.vue'
 import { testRoute } from 'tests/utils'
 
 testRoute(
   staffActivitiesRoute,
-  {
-    path: 'activities',
-    name: 'staff-activities',
-  },
+  ROUTES.STAFF.ACTIVITIES,
   ActivitiesView
+)
+
+testRoute(
+  staffActivitiesAddNationalActivityRoute,
+  ROUTES.STAFF.ACTIVITIES_ADD_NATIONAL_ACTIVITY,
+  AddNationalActivityView
 )

--- a/src/features/staff/activities/routes/index.ts
+++ b/src/features/staff/activities/routes/index.ts
@@ -6,3 +6,9 @@ export const staffActivitiesRoute: AvRoute = {
   component: () =>
     import('@/features/staff/activities/views/ActivitiesView/ActivitiesView.vue'),
 }
+
+export const staffActivitiesAddNationalActivityRoute: AvRoute = {
+  ...ROUTES.STAFF.ACTIVITIES_ADD_NATIONAL_ACTIVITY,
+  component: () =>
+    import('@/features/staff/activities/views/AddNationalActivityView/AddNationalActivityView.vue'),
+}

--- a/src/features/staff/activities/views/AddNationalActivityView/AddNationalActivityView.test.ts
+++ b/src/features/staff/activities/views/AddNationalActivityView/AddNationalActivityView.test.ts
@@ -1,0 +1,28 @@
+import { PageTitleStub } from '@/common/components/PageTitle/PageTitle.stub'
+import { ROUTES } from '@/common/constants'
+import AddNationalActivityView from '@/features/staff/activities/views/AddNationalActivityView/AddNationalActivityView.vue'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { mount, type VueWrapper } from '@vue/test-utils'
+
+BddTest().given('a student mailbox view', () => {
+  const stubs = { PageTitle: PageTitleStub }
+  let wrapper: VueWrapper<InstanceType<typeof AddNationalActivityView>>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    wrapper = mount(AddNationalActivityView, { global: { stubs } })
+  })
+
+  BddTest().when('the view is mounted', () => {
+    BddTest().then('it should render PageTitle with correct props', () => {
+      const pageTitle = wrapper.findComponent({ name: 'PageTitle' })
+
+      expect(pageTitle.props('title')).toBe('Créer mon activité')
+      expect(pageTitle.props('breadcrumbLinks')).toEqual([
+        { text: 'Accueil', to: ROUTES.STAFF.HOME },
+        { text: 'Bibliothèque des activités', to: ROUTES.STAFF.ACTIVITIES },
+        { text: 'Créer mon activité' }
+      ])
+    })
+  })
+})

--- a/src/features/staff/activities/views/AddNationalActivityView/AddNationalActivityView.vue
+++ b/src/features/staff/activities/views/AddNationalActivityView/AddNationalActivityView.vue
@@ -1,0 +1,21 @@
+<script setup lang="ts">
+import PageTitle from '@/common/components/PageTitle/PageTitle.vue'
+import { ROUTES } from '@/common/constants'
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
+
+const breadcrumbLinks = computed(() => [
+  { text: t('staff.global.navigation.tabs.home'), to: ROUTES.STAFF.HOME },
+  { text: t('staff.global.navigation.tabs.activities.header'), to: ROUTES.STAFF.ACTIVITIES },
+  { text: t('staff.global.navigation.tabs.activities.items.addNationalActivity') }
+])
+</script>
+
+<template>
+  <PageTitle
+    :title="t('staff.global.views.AddNationalActivityView.title')"
+    :breadcrumb-links="breadcrumbLinks"
+    :back="ROUTES.STAFF.ACTIVITIES"
+  />
+</template>

--- a/src/features/staff/global/locales/en.json
+++ b/src/features/staff/global/locales/en.json
@@ -9,7 +9,10 @@
       "navigation": {
         "tabs": {
           "activities": {
-            "header": "Activity library"
+            "header": "Activity library",
+            "items": {
+              "addNationalActivity": "Create my activity"
+            }
           },
           "home": "Home"
         }
@@ -17,6 +20,9 @@
       "views": {
         "ActivitiesView": {
           "title": "My activity library"
+        },
+        "AddNationalActivityView": {
+          "title": "Create my activity"
         },
         "StaffHomeView": {
           "buttons": {

--- a/src/features/staff/global/locales/fr.json
+++ b/src/features/staff/global/locales/fr.json
@@ -9,7 +9,10 @@
       "navigation": {
         "tabs": {
           "activities": {
-            "header": "Bibliothèque des activités"
+            "header": "Bibliothèque des activités",
+            "items": {
+              "addNationalActivity": "Créer mon activité"
+            }
           },
           "home": "Accueil"
         }
@@ -17,6 +20,9 @@
       "views": {
         "ActivitiesView": {
           "title": "Ma bibliothèque d'activités"
+        },
+        "AddNationalActivityView": {
+          "title": "Créer mon activité"
         },
         "StaffHomeView": {
           "buttons": {

--- a/src/features/staff/global/routes/index.ts
+++ b/src/features/staff/global/routes/index.ts
@@ -1,5 +1,5 @@
 import { ROUTES } from '@/common/constants'
-import { staffActivitiesRoute } from '@/features/staff/activities/routes'
+import { staffActivitiesAddNationalActivityRoute, staffActivitiesRoute } from '@/features/staff/activities/routes'
 
 export default [
   {
@@ -32,6 +32,7 @@ export default [
           import('@/common/views/PersonalDataView/PersonalDataView.vue'),
       },
       staffActivitiesRoute,
+      staffActivitiesAddNationalActivityRoute,
     ]
   }
 ]


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
- Added route to the staff national activity creation view
- Added `AddNationalActivityView.vue` to `src/features/staff/activities/views/AddNationalActivityView/`

---

### Reference to an Issue, Feature, Task, User Story or another PR
- Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1493

---

**Modified areas:**
- `a11y/staff.a11y.test.ts`
- `src/common/composables/use-navigation/use-navigation.test.ts`
- `src/common/composables/use-navigation/use-navigation.ts`
- `src/common/constants/route-names.ts`
- `src/features/staff/activities/routes/index.test.ts`
- `src/features/staff/activities/routes/index.ts`
- `src/features/staff/activities/views/AddNationalActivityView/AddNationalActivityView.test.ts`
- `src/features/staff/activities/views/AddNationalActivityView/AddNationalActivityView.vue`
- `src/features/staff/global/locales/en.json`
- `src/features/staff/global/locales/fr.json`
- `src/features/staff/global/routes/index.ts`

---

### Target Branch
`develop`

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [x] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [x] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process