### PR TITLE
fix(1550): SelfKnowledge element details - implement delete action

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "avenirs-cofolio-client",
       "version": "0.0.0",
       "dependencies": {
-        "@avenirs-esr/avenirs-dsav": "^0.1.195",
+        "@avenirs-esr/avenirs-dsav": "^0.1.197",
         "@tanstack/vue-form": "^1.15.0",
         "@tanstack/vue-query": "^5.74.9",
         "@vue-flow/core": "^1.48.0",
@@ -348,10 +348,11 @@
       "license": "ISC"
     },
     "node_modules/@avenirs-esr/avenirs-dsav": {
-      "version": "0.1.195",
-      "resolved": "https://registry.npmjs.org/@avenirs-esr/avenirs-dsav/-/avenirs-dsav-0.1.195.tgz",
-      "integrity": "sha512-JF31L4qzyvlVjWh+cSUTndoiNQZgdUxgcPhPag/rOzZYKFR0DRdKfCoB45T4muQERkF+Fz0pZSScj6nfQgxncA==",
+      "version": "0.1.197",
+      "resolved": "https://registry.npmjs.org/@avenirs-esr/avenirs-dsav/-/avenirs-dsav-0.1.197.tgz",
+      "integrity": "sha512-N2DS3Al4eBpSFR8w74BWpoIHKdlHONG7VPRv/CaYs/2q6a6HEJGhZw2GPFuBBpLdP5Uc6tiSBORH136vyGYg+Q==",
       "dependencies": {
+        "@tanstack/vue-table": "^8.21.3",
         "@tiptap/extension-character-count": "^3.20.2",
         "@tiptap/extension-image": "^3.20.1",
         "@tiptap/extension-link": "^3.20.1",
@@ -4907,6 +4908,19 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
+    "node_modules/@tanstack/table-core": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.21.3.tgz",
+      "integrity": "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
     "node_modules/@tanstack/vue-form": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/@tanstack/vue-form/-/vue-form-1.15.0.tgz",
@@ -4970,6 +4984,25 @@
         "@vue/composition-api": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@tanstack/vue-table": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/vue-table/-/vue-table-8.21.3.tgz",
+      "integrity": "sha512-rusRyd77c5tDPloPskctMyPLFEQUeBzxdQ+2Eow4F7gDPlPOB1UnnhzfpdvqZ8ZyX2rRNGmqNnQWm87OI2OQPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/table-core": "8.21.3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "vue": ">=3.2"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
-    "@avenirs-esr/avenirs-dsav": "^0.1.195",
+    "@avenirs-esr/avenirs-dsav": "^0.1.197",
     "@tanstack/vue-form": "^1.15.0",
     "@tanstack/vue-query": "^5.74.9",
     "@vue-flow/core": "^1.48.0",

--- a/src/common/composables/use-navigation/use-navigation.test.ts
+++ b/src/common/composables/use-navigation/use-navigation.test.ts
@@ -86,6 +86,22 @@ BddTest().given('a useNavigation composable', () => {
     })
   })
 
+  BddTest().when('trying to navigate to student trajectories', () => {
+    BddTest().then('it should navigate to student trajectories', () => {
+      const { navigateToStudentTrajectories } = navigation
+      navigateToStudentTrajectories()
+      expect(pushMock).toHaveBeenCalledWith(ROUTES.STUDENT.PROJECT_TRAJECTORIES)
+    })
+  })
+
+  BddTest().when('trying to navigate to student trajectories with replace', () => {
+    BddTest().then('it should navigate to student trajectories with replace', () => {
+      const { navigateToStudentTrajectories } = navigation
+      navigateToStudentTrajectories(true)
+      expect(replaceMock).toHaveBeenCalledWith(ROUTES.STUDENT.PROJECT_TRAJECTORIES)
+    })
+  })
+
   BddTest().when('trying to navigate to self-knowledge categories', () => {
     BddTest().then('it should navigate to self-knowledge categories', () => {
       const { navigateToStudentSelfKnowledgeCategory } = navigation

--- a/src/common/composables/use-navigation/use-navigation.ts
+++ b/src/common/composables/use-navigation/use-navigation.ts
@@ -55,6 +55,13 @@ export function useNavigation () {
     return router.push(ROUTES.STUDENT.TOOLS_RESUMES)
   }
 
+  const navigateToStudentTrajectories = (replace?: boolean) => {
+    if (replace) {
+      return router.replace(ROUTES.STUDENT.PROJECT_TRAJECTORIES)
+    }
+    return router.push(ROUTES.STUDENT.PROJECT_TRAJECTORIES)
+  }
+
   const navigateToStudentSelfKnowledgeCategory = ({ categoryId, elementId }: { categoryId: string, elementId: string }) => {
     return router.push({
       name: ROUTES.STUDENT.SELFKNOWLEDGE_CATEGORY.name,
@@ -166,6 +173,7 @@ export function useNavigation () {
     navigateToStudentNotifications,
     navigateToStudentPages,
     navigateToStudentResumes,
+    navigateToStudentTrajectories,
     navigateToStudentSelfKnowledgeCategory,
     navigateToStudentSelfKnowledgeElementUpdate,
     navigateToStudentSkills,

--- a/src/features/student/selfKnowledge/views/SelfKnowledgeCategoryView/SelfKnowledgeCategoryView.test.ts
+++ b/src/features/student/selfKnowledge/views/SelfKnowledgeCategoryView/SelfKnowledgeCategoryView.test.ts
@@ -3,6 +3,7 @@ import {
   selfKnowledgeElementDetailsNotFoundHandler
 } from '@/__mocks__/msw/handlers/student/self-knowledge.handlers'
 import { server } from '@/__mocks__/msw/server'
+import { ConfirmationModalStub } from '@/common/components/ConfirmationModal/ConfirmationModal.stub'
 import { DetailedPageTitleStub } from '@/common/components/DetailedPageTitle/DetailedPageTitle.stub'
 import { ErrorMessageStub } from '@/common/components/feedback/ErrorMessage/ErrorMessage.stub'
 import { ROUTES } from '@/common/constants'
@@ -17,7 +18,22 @@ import { beforeEach, expect, vi } from 'vitest'
 import { nextTick } from 'vue'
 
 const navigateToStudentSelfKnowledgeElementUpdate = vi.fn()
+const navigateToStudentTrajectories = vi.fn()
 const mockSelectedElementId = ref('')
+
+const mockAddSuccessMessage = vi.fn()
+const mockAddErrorMessage = vi.fn()
+
+vi.mock('@/store', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/store')>()
+  return {
+    ...actual,
+    useToasterStore: () => ({
+      addSuccessMessage: mockAddSuccessMessage,
+      addErrorMessage: mockAddErrorMessage
+    })
+  }
+})
 
 vi.mock('@vueuse/router', () => ({
   useRouteQuery: vi.fn((key: string, defaultValue: string) => {
@@ -34,6 +50,7 @@ vi.mock('@/common/composables/use-navigation/use-navigation', async (importOrigi
     ...actual,
     useNavigation: () => ({
       navigateToStudentSelfKnowledgeElementUpdate,
+      navigateToStudentTrajectories
     }),
   }
 })
@@ -63,7 +80,8 @@ const stubs = {
   SelfKnowledgeElementDetailsContainer: SelfKnowledgeElementDetailsContainerStub,
   SelfKnowledgeElementDetailsDropdown: SelfKnowledgeElementDetailsDropdownStub,
   SelfKnowledgeElementDetails: SelfKnowledgeElementDetailsStub,
-  SelfKnowledgeElementTabs: SelfKnowledgeElementTabsStub
+  SelfKnowledgeElementTabs: SelfKnowledgeElementTabsStub,
+  ConfirmationModal: ConfirmationModalStub
 }
 
 BddTest().given('a self knowledge category view component', () => {
@@ -213,6 +231,40 @@ BddTest().given('a self knowledge category view component', () => {
         expect(navigateToStudentSelfKnowledgeElementUpdate).toHaveBeenCalledWith({
           categoryId,
           elementId: firstElementId
+        })
+      })
+    })
+
+    BddTest().and('confirming deletion of an element', () => {
+      let firstElementId: string
+
+      beforeEach(async () => {
+        const sideMenu = getSideMenu()
+        const elements = getSideMenuElements()
+        firstElementId = elements[0].id
+
+        sideMenu.vm.$emit('selectElement', firstElementId)
+        await nextTick()
+        await flushPromises()
+
+        const dropdown = wrapper.findComponent(SelfKnowledgeElementDetailsDropdownStub)
+        expect(dropdown.exists()).toBe(true)
+        await dropdown.vm.$emit('deleteSelected')
+
+        const confirmModal = wrapper.findComponent({ name: 'ConfirmationModal' })
+        expect(confirmModal.exists()).toBe(true)
+        await confirmModal.vm.$emit('confirm')
+      })
+
+      BddTest().then('it should call the delete API and show success message', async () => {
+        await vi.waitFor(() => {
+          expect(mockAddSuccessMessage).toHaveBeenCalled()
+        })
+      })
+
+      BddTest().then('it should navigate to the trajectories view', () => {
+        return vi.waitFor(() => {
+          expect(navigateToStudentTrajectories).toHaveBeenCalled()
         })
       })
     })

--- a/src/features/student/selfKnowledge/views/SelfKnowledgeCategoryView/SelfKnowledgeCategoryView.vue
+++ b/src/features/student/selfKnowledge/views/SelfKnowledgeCategoryView/SelfKnowledgeCategoryView.vue
@@ -1,11 +1,13 @@
 <script setup lang="ts">
 import type { Ref } from 'vue'
-import { useGetSelfKnowledgeElementDetails } from '@/api/avenir-esr'
+import { invalidateGetSelfKnowledgeElements, useDeleteSelfKnowledgeElements, useGetSelfKnowledgeElementDetails } from '@/api/avenir-esr'
+import ConfirmationModal from '@/common/components/ConfirmationModal/ConfirmationModal.vue'
 import DetailedPageTitle from '@/common/components/DetailedPageTitle/DetailedPageTitle.vue'
 import ErrorMessage from '@/common/components/feedback/ErrorMessage/ErrorMessage.vue'
 import QuerySuspense from '@/common/components/QuerySuspense/QuerySuspense.vue'
-import { useNavigation } from '@/common/composables'
+import { useModal, useNavigation } from '@/common/composables'
 import { useApiErrors } from '@/common/composables/use-api-errors/use-api-errors'
+import { useTaskLoading } from '@/common/composables/use-task-loading/use-task-loading'
 import { ErrorCodes, ROUTES } from '@/common/constants'
 import SelfKnowledgeElementDetailsContainer from '@/features/student/selfKnowledge/components/containers/SelfKnowledgeElementDetailsContainer/SelfKnowledgeElementDetailsContainer.vue'
 import SelfKnowledgeElementsSideMenu from '@/features/student/selfKnowledge/components/navigation/SelfKnowledgeElementsSideMenu/SelfKnowledgeElementsSideMenu.vue'
@@ -14,6 +16,8 @@ import { useSelfKnowledgeCategory } from '@/features/student/selfKnowledge/compo
 import { useSelfKnowledgePaginatedElements } from '@/features/student/selfKnowledge/composables/use-self-knowledge-paginated-elements/use-self-knowledge-paginated-elements'
 import SelfKnowledgeElementDetails from '@/features/student/selfKnowledge/views/SelfKnowledgeCategoryView/components/SelfKnowledgeElementDetails/SelfKnowledgeElementDetails.vue'
 import SelfKnowledgeElementDetailsDropdown from '@/features/student/selfKnowledge/views/SelfKnowledgeCategoryView/components/SelfKnowledgeElementDetailsDropdown/SelfKnowledgeElementDetailsDropdown.vue'
+import { useToasterStore } from '@/store'
+import { useQueryClient } from '@tanstack/vue-query'
 import { useRouteQuery } from '@vueuse/router'
 import { useI18n } from 'vue-i18n'
 
@@ -24,7 +28,9 @@ interface SelfKnowledgeCategoryViewProps {
 const props = defineProps<SelfKnowledgeCategoryViewProps>()
 
 const { t } = useI18n()
-const { navigateToStudentSelfKnowledgeElementUpdate } = useNavigation()
+const { navigateToStudentSelfKnowledgeElementUpdate, navigateToStudentTrajectories } = useNavigation()
+const { showModal: showConfirmModal, displayModal: displayConfirmModal, hideModal: hideConfirmModal } = useModal()
+const { addErrorMessage, addSuccessMessage } = useToasterStore()
 
 const { categoryType } = useSelfKnowledgeCategory(computed(() => props.categoryId))
 
@@ -36,6 +42,7 @@ const breadcrumbLinks = computed(() => [
 ])
 
 const selectedElementId: Ref<string> = useRouteQuery('elementId', '')
+const queryClient = useQueryClient()
 
 const {
   elements,
@@ -46,6 +53,27 @@ const {
 })
 
 const { data: selectedElementDetails, error } = useGetSelfKnowledgeElementDetails(selectedElementId)
+const { isLoading, withTaskLoading } = useTaskLoading()
+
+const { mutate: mutateDeleteSelfKnowledgeElements } = useDeleteSelfKnowledgeElements()
+
+function deleteSelfKnowledgeElement () {
+  mutateDeleteSelfKnowledgeElements({
+    data: [selectedElementId.value]
+  }, {
+    onError: error => addErrorMessage({
+      title: t('student.selfKnowledge.SelfKnowledgeMainSection.categoryElementsPaginator.modals.deleteElements.error'),
+      description: error.message
+    }),
+    onSuccess: async () => {
+      await withTaskLoading(() => invalidateGetSelfKnowledgeElements(queryClient, props.categoryId))
+      addSuccessMessage(
+        t('student.selfKnowledge.SelfKnowledgeMainSection.categoryElementsPaginator.modals.deleteElements.success', { count: 1 })
+      )
+      navigateToStudentTrajectories(true)
+    }
+  })
+}
 
 const { originalErrorCode, isNotFound } = useApiErrors(error)
 const isSelfKnowledgeNotFound = computed(() => originalErrorCode.value === ErrorCodes.SELF_KNOWLEDGE_ELEMENT_NOT_FOUND || isNotFound.value)
@@ -95,6 +123,7 @@ function onUpdateSelected () {
         <template #title>
           <SelfKnowledgeElementDetailsDropdown
             @update-selected="onUpdateSelected"
+            @delete-selected="displayConfirmModal"
           />
         </template>
 
@@ -109,4 +138,13 @@ function onUpdateSelected () {
       </SelfKnowledgeElementDetailsContainer>
     </div>
   </QuerySuspense>
+
+  <ConfirmationModal
+    :show="showConfirmModal"
+    :title="t('student.selfKnowledge.SelfKnowledgeMainSection.categoryElementsPaginator.modals.confirmDeleteElements.title', { count: 1 })"
+    :description="selectedElementDetails?.title"
+    :is-loading="isLoading"
+    @close="hideConfirmModal"
+    @confirm="deleteSelfKnowledgeElement"
+  />
 </template>


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
This PR implements the delete action for self-knowledge elements from the category details view and stabilizes associated navigation and view tests.

**Main changes:**
- ✨ Adds delete action flow in self-knowledge category details view
- ✅ Updates unit tests for delete behavior and navigation timing
- ♻️ Extends navigation composable coverage and usage for trajectories redirect
- 🔧 Updates project dependencies/lockfile to support the new test/runtime behavior

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1550

---

### Documentation
- Unit tests updated for self-knowledge category behavior and deletion workflow
- Navigation composable tests updated to cover trajectories redirection usage

**Modified files:**
- src/features/student/selfKnowledge/views/SelfKnowledgeCategoryView/SelfKnowledgeCategoryView.vue
- src/features/student/selfKnowledge/views/SelfKnowledgeCategoryView/SelfKnowledgeCategoryView.test.ts
- src/features/student/user/composables/use-navigation/use-navigation.ts
- src/features/student/user/composables/use-navigation/use-navigation.test.ts
- package.json
- package-lock.json

---

### Target Branch
`develop`

---

### Additional Notes
The test suite now stubs modal interactions in the category view tests to avoid coupling with DSAV modal internals and to keep the unit tests deterministic.

---

### Known Limitations or Side Effects
No known functional side effects. Dependency lockfile changed as part of project dependency alignment.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [ ] No unnecessary code (e.g., debug logs, commented code)
- [ ] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process
