### PR TITLE
refactor(1441): add experience type in association search modal

### DIFF
--- a/src/features/student/personalCareer/components/modals/AssociateDeclaredExperiencesModal/AssociateDeclaredExperiencesModal.test.ts
+++ b/src/features/student/personalCareer/components/modals/AssociateDeclaredExperiencesModal/AssociateDeclaredExperiencesModal.test.ts
@@ -1,11 +1,12 @@
-import type { Association } from '@/features/student/global/types/associations.types'
 import type { AvAutocompleteOption } from '@avenirs-esr/avenirs-dsav'
 import type { VueWrapper } from '@vue/test-utils'
+import { EExperienceType } from '@/api/avenir-esr'
 import { SearchAssociationLayoutStub } from '@/features/student/global/components/interaction/SearchAssociationLayout/SearchAssociationLayout.stub'
 import { ConfirmAssociateModalStub } from '@/features/student/global/components/overlays/modals/ConfirmAssociateModal/ConfirmAssociateModal.stub'
 import { DeclaredExperienceCompactCardStub } from '@/features/student/personalCareer/components/cards/DeclaredExperienceCompactCard/DeclaredExperienceCompactCard.stub'
 import AssociateDeclaredExperiencesModal, {
-  type AssociateDeclaredExperiencesModalProps
+  type AssociateDeclaredExperiencesModalProps,
+  type AssociationDeclaredExperiences
 } from '@/features/student/personalCareer/components/modals/AssociateDeclaredExperiencesModal/AssociateDeclaredExperiencesModal.vue'
 import { AvModalStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { flushPromises } from '@vue/test-utils'
@@ -26,16 +27,19 @@ BddTest().given('an associate declared experiences modal', () => {
     {
       id: 'experience-search-1',
       title: 'Définir ses valeurs',
+      experienceType: EExperienceType.PERSONAL,
       disabled: false
     },
     {
       id: 'experience-search-2',
       title: 'Explorer ses pistes d’orientation',
+      experienceType: EExperienceType.PROFESSIONAL,
       disabled: false
     },
     {
       id: 'experience-search-3',
       title: 'Développeur Web Full Stack',
+      experienceType: EExperienceType.PROFESSIONAL,
       disabled: true
     }
 
@@ -58,15 +62,17 @@ BddTest().given('an associate declared experiences modal', () => {
     }
   ]
 
-  const expectedSelectedAssociations: Association[] = [
+  const expectedSelectedAssociations: AssociationDeclaredExperiences[] = [
     {
       id: 'experience-search-1',
       title: 'Définir ses valeurs',
+      experienceType: EExperienceType.PERSONAL,
       disabled: false
     },
     {
       id: 'experience-search-2',
       title: 'Explorer ses pistes d’orientation',
+      experienceType: EExperienceType.PROFESSIONAL,
       disabled: false
     }
   ]
@@ -110,16 +116,19 @@ BddTest().given('an associate declared experiences modal', () => {
         {
           label: 'Définir ses valeurs',
           value: 'experience-search-1',
+          description: 'Expérience personnelle',
           disabled: false
         },
         {
           label: 'Explorer ses pistes d’orientation',
           value: 'experience-search-2',
+          description: 'Expérience professionnelle',
           disabled: false
         },
         {
           label: 'Développeur Web Full Stack',
           value: 'experience-search-3',
+          description: 'Expérience professionnelle',
           disabled: true
         },
       ])
@@ -188,6 +197,7 @@ BddTest().given('an associate declared experiences modal', () => {
             {
               id: 'experience-search-1',
               title: 'Définir ses valeurs',
+              experienceType: EExperienceType.PERSONAL,
               disabled: false
             }
           ])
@@ -199,6 +209,7 @@ BddTest().given('an associate declared experiences modal', () => {
             {
               id: 'experience-search-1',
               title: 'Définir ses valeurs',
+              experienceType: EExperienceType.PERSONAL,
               disabled: false
             }
           ])

--- a/src/features/student/personalCareer/components/modals/AssociateDeclaredExperiencesModal/AssociateDeclaredExperiencesModal.vue
+++ b/src/features/student/personalCareer/components/modals/AssociateDeclaredExperiencesModal/AssociateDeclaredExperiencesModal.vue
@@ -1,4 +1,5 @@
 <script lang="ts" setup>
+import type { EExperienceType } from '@/api/avenir-esr'
 import type { Association } from '@/features/student/global/types/associations.types'
 import type { AvAutocompleteOption } from '@avenirs-esr/avenirs-dsav'
 import { ICONS } from '@/common/constants'
@@ -8,9 +9,13 @@ import DeclaredExperienceCompactCard from '@/features/student/personalCareer/com
 import { AvModal } from '@avenirs-esr/avenirs-dsav'
 import { useI18n } from 'vue-i18n'
 
+export type AssociationDeclaredExperiences = Association & {
+  experienceType: EExperienceType
+}
+
 export interface AssociateDeclaredExperiencesModalProps {
   show: boolean
-  experiences: Association[]
+  experiences: AssociationDeclaredExperiences[]
   isLoading?: boolean
 }
 
@@ -41,11 +46,12 @@ const experienceAutocompleteOptions = computed<AvAutocompleteOption[]>(() =>
     .map(experience => ({
       label: experience.title,
       value: experience.id,
+      description: t(`student.personalCareer.declaredExperienceType.${experience.experienceType}`),
       disabled: experience.disabled
     }))
 )
 
-const selectedAssociations = computed<Association[]>(() =>
+const selectedAssociations = computed<AssociationDeclaredExperiences[]>(() =>
   experiences.filter(experience => selectedExperienceOptions.value.some(option => option.value === experience.id))
 )
 

--- a/src/features/student/traces/views/StudentTraceView/components/overlays/modals/AssociateDeclaredExperiencesToTracesModal/AssociateDeclaredExperiencesToTracesModal.vue
+++ b/src/features/student/traces/views/StudentTraceView/components/overlays/modals/AssociateDeclaredExperiencesToTracesModal/AssociateDeclaredExperiencesToTracesModal.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import type { Association } from '@/features/student/global/types/associations.types'
+import type { AssociationDeclaredExperiences } from '@/features/student/personalCareer/components/modals/AssociateDeclaredExperiencesModal/AssociateDeclaredExperiencesModal.vue'
 import {
   useAssociateTraceWithDeclaredExperiences,
   useSearchDeclaredExperiencesForAssociation,
@@ -39,9 +39,10 @@ const params = computed(() => ({
 
 const { data: associationExperiences, isError: isSearchError, error: searchError, isPending: isLoading } = useSearchDeclaredExperiencesForAssociation(params, {
   query: {
-    select: (response): Association[] => response.data.map(experience => ({
+    select: (response): AssociationDeclaredExperiences[] => response.data.map(experience => ({
       id: experience.id,
       title: experience.title,
+      experienceType: experience.experienceType,
       disabled: experience.disabled
     }))
   }


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
Add experience type display in the association search modal, showing whether
a declared experience is personal or professional when associating it to a trace.

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1441#issue-4274961718

---

### Target Branch
develop

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [ ] No unnecessary code (e.g., debug logs, commented code)
- [ ] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process