### PR TITLE
feat(1490): create MyWorkspaceTab staff component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "avenirs-cofolio-client",
       "version": "0.0.0",
       "dependencies": {
-        "@avenirs-esr/avenirs-dsav": "^0.1.197",
+        "@avenirs-esr/avenirs-dsav": "^0.1.198",
         "@tanstack/vue-form": "^1.15.0",
         "@tanstack/vue-query": "^5.74.9",
         "@vue-flow/core": "^1.48.0",
@@ -348,9 +348,9 @@
       "license": "ISC"
     },
     "node_modules/@avenirs-esr/avenirs-dsav": {
-      "version": "0.1.197",
-      "resolved": "https://registry.npmjs.org/@avenirs-esr/avenirs-dsav/-/avenirs-dsav-0.1.197.tgz",
-      "integrity": "sha512-N2DS3Al4eBpSFR8w74BWpoIHKdlHONG7VPRv/CaYs/2q6a6HEJGhZw2GPFuBBpLdP5Uc6tiSBORH136vyGYg+Q==",
+      "version": "0.1.198",
+      "resolved": "https://registry.npmjs.org/@avenirs-esr/avenirs-dsav/-/avenirs-dsav-0.1.198.tgz",
+      "integrity": "sha512-8uX//oYTnxxy5Y0yoiUdOrLfeDmAWN0/2P262wP7m1oJrT6EXv1o4PGUp+9a6DRWrc88WFL+T9PTjs32dGZAUA==",
       "dependencies": {
         "@tanstack/vue-table": "^8.21.3",
         "@tiptap/extension-character-count": "^3.20.2",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
-    "@avenirs-esr/avenirs-dsav": "^0.1.197",
+    "@avenirs-esr/avenirs-dsav": "^0.1.198",
     "@tanstack/vue-form": "^1.15.0",
     "@tanstack/vue-query": "^5.74.9",
     "@vue-flow/core": "^1.48.0",

--- a/src/common/composables/use-date-utils/use-date-utils.test.ts
+++ b/src/common/composables/use-date-utils/use-date-utils.test.ts
@@ -1,11 +1,14 @@
 import { useDateUtils } from '@/common/composables/use-date-utils/use-date-utils'
 import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { subHours, subMinutes, subSeconds } from 'date-fns'
 import { mountComposable } from 'tests/utils'
+import { beforeEach, expect, vi } from 'vitest'
 
 BddTest().given('a use-date-utils composable', () => {
   let composableResult: ReturnType<typeof useDateUtils>
 
   beforeEach(() => {
+    vi.clearAllMocks()
     const result = mountComposable(() => useDateUtils(), {
       useI18n: true
     })
@@ -41,6 +44,65 @@ BddTest().given('a use-date-utils composable', () => {
 
       expect(formatted).toContain('à')
       expect(formatted).toContain('juin')
+    })
+  })
+
+  BddTest().when('formatting last modified date', () => {
+    BddTest().and('the date is today and modified more than 1 hour ago', () => {
+      BddTest().then('it should return hours ago with date', () => {
+        const twoHoursAgo = subHours(new Date(), 2)
+        const formatted = composableResult.formatLastModified(twoHoursAgo.toISOString())
+        const formattedDate = `${String(twoHoursAgo.getDate()).padStart(2, '0')}/${String(twoHoursAgo.getMonth() + 1).padStart(2, '0')}/${twoHoursAgo.getFullYear()}`
+
+        expect(formatted).toContain('Il y a 2 heures')
+        expect(formatted).toContain(formattedDate)
+      })
+
+      BddTest().then('it should use singular form for exactly 1 hour', () => {
+        const oneHourAgo = subHours(new Date(), 1)
+        const formatted = composableResult.formatLastModified(oneHourAgo.toISOString())
+
+        expect(formatted).toContain('Il y a 1 heure')
+      })
+    })
+
+    BddTest().and('the date is today and modified less than 1 hour ago but more than 1 minute ago', () => {
+      BddTest().then('it should return minutes ago with date', () => {
+        const thirtyMinutesAgo = subMinutes(new Date(), 30)
+        const formatted = composableResult.formatLastModified(thirtyMinutesAgo.toISOString())
+        const formattedDate = `${String(thirtyMinutesAgo.getDate()).padStart(2, '0')}/${String(thirtyMinutesAgo.getMonth() + 1).padStart(2, '0')}/${thirtyMinutesAgo.getFullYear()}`
+
+        expect(formatted).toContain('Il y a 30 minutes')
+        expect(formatted).toContain(formattedDate)
+      })
+
+      BddTest().then('it should use singular form for exactly 1 minute', () => {
+        const oneMinuteAgo = subMinutes(new Date(), 1)
+        const formatted = composableResult.formatLastModified(oneMinuteAgo.toISOString())
+
+        expect(formatted).toContain('Il y a 1 minute')
+      })
+    })
+
+    BddTest().and('the date is today and modified less than 1 minute ago', () => {
+      BddTest().then('it should return "À l\'instant"', () => {
+        const thirtySecondsAgo = subSeconds(new Date(), 30)
+        const formatted = composableResult.formatLastModified(thirtySecondsAgo.toISOString())
+
+        expect(formatted).toBe('À l\'instant')
+      })
+    })
+
+    BddTest().and('the date is not today', () => {
+      BddTest().then('it should use formatTranslatedDateTime', () => {
+        const pastDate = '2024-01-15T14:30:00'
+        const formatted = composableResult.formatLastModified(pastDate)
+
+        expect(formatted).toContain('15')
+        expect(formatted).toContain('janvier')
+        expect(formatted).toContain('2024')
+        expect(formatted).toContain('à')
+      })
     })
   })
 })

--- a/src/common/composables/use-date-utils/use-date-utils.ts
+++ b/src/common/composables/use-date-utils/use-date-utils.ts
@@ -1,11 +1,42 @@
 import type { AvLocale } from '@/types'
 import { formatDateLocalized, formatTimeLocalized } from '@/common/utils'
+import { differenceInHours, differenceInMinutes, format, isToday } from 'date-fns'
 import { useI18n } from 'vue-i18n'
 
 /**
  * Result returned by the useDateUtils composable.
  */
 interface UseDateUtilsReturn {
+  /**
+   * Formats a given ISO date string into a human-readable "last modified" string.
+   * Example for French locale
+   * - If the date is **today** and modified **≥ 1 hour ago**: returns `"Il y a X heure(s) - DD/MM/YYYY"`
+   * - If the date is **today** and modified **≥ 1 minute ago**: returns `"Il y a X minute(s) - DD/MM/YYYY"`
+   * - If the date is **today** and modified **< 1 minute ago**: returns `"À l'instant"`
+   * - If the date is **not today**: delegates to `formatTranslatedDateTime`
+   *
+   * @param date - ISO 8601 date string (e.g. `"2025-10-15T14:32:00Z"`)
+   * @returns Formatted string according to the rules above.
+   *
+   * @example
+   * ```ts
+   * const { formatLastModified } = useDateUtils()
+   *
+   * formatLastModified(subHours(new Date(), 2).toISOString())
+   * // → "Il y a 2 heures - 11/05/2026"
+   *
+   * formatLastModified(subMinutes(new Date(), 30).toISOString())
+   * // → "Il y a 30 minutes - 11/05/2026"
+   *
+   * formatLastModified(subSeconds(new Date(), 30).toISOString())
+   * // → "À l'instant"
+   *
+   * formatLastModified('2024-01-15T14:30:00Z')
+   * // → "15 janvier 2024 à 15:30" (for French locale)
+   * ```
+   */
+  formatLastModified: (date: string) => string
+
   /**
    * Formats a given date string into a localized date and time string,
    * including the translation of the word “at” (e.g., "12 October 2025 at 14:32").
@@ -42,6 +73,7 @@ interface UseDateUtilsReturn {
  * ```
  *
  * @returns {UseDateUtilsReturn} Object containing:
+ *  - `formatLastModified`: function to format a date as a human-readable "last modified" string.
  *  - `formatTranslatedDateTime`: function to format a date string into a localized "date at time" format.
  */
 export function useDateUtils (): UseDateUtilsReturn {
@@ -57,7 +89,28 @@ export function useDateUtils (): UseDateUtilsReturn {
     })
   }
 
+  const formatLastModified = (date: string) => {
+    const parsedDate = new Date(date)
+
+    if (isToday(parsedDate)) {
+      const now = new Date()
+      const formattedDate = format(parsedDate, 'dd/MM/yyyy')
+      const hours = differenceInHours(now, parsedDate)
+      if (hours >= 1) {
+        return `${t('global.dates.hoursAgo', { count: hours }, hours)} - ${formattedDate}`
+      }
+      const minutes = differenceInMinutes(now, parsedDate)
+      if (minutes >= 1) {
+        return `${t('global.dates.minutesAgo', { count: minutes }, minutes)} - ${formattedDate}`
+      }
+      return t('global.dates.justNow')
+    }
+
+    return formatTranslatedDateTime(date)
+  }
+
   return {
+    formatLastModified,
     formatTranslatedDateTime
   }
 }

--- a/src/common/constants/route-names.ts
+++ b/src/common/constants/route-names.ts
@@ -3,6 +3,7 @@ export const ROUTES = {
     ACCESSIBILITY: { name: 'staff-accessibility', path: 'accessibility' },
     ACTIVITIES: { name: 'staff-activities', path: 'activities' },
     ACTIVITIES_ADD_NATIONAL_ACTIVITY: { name: 'staff-activities-add-national-activity', path: 'activities/:id/add-national-activity' },
+    ACTIVITY_DETAILS: { name: 'staff-activity-details', path: 'activities/:status/:id' },
     COOKIES: { name: 'staff-cookies', path: 'cookies' },
     HOME: { name: 'staff-home', path: '' },
     LEGAL: { name: 'staff-legal', path: 'legal' },

--- a/src/features/staff/activities/locales/en.json
+++ b/src/features/staff/activities/locales/en.json
@@ -1,0 +1,19 @@
+{
+  "staff": {
+    "activities": {
+      "views": {
+        "ActivitiesView": {
+          "MyWorkspaceTab": {
+            "columns": {
+              "activityName": "Activity name",
+              "lastModification": "Last modification",
+              "owner": "Owner",
+              "status": "Status"
+            },
+            "title": "All published activities in my institution ({count})"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/features/staff/activities/locales/fr.json
+++ b/src/features/staff/activities/locales/fr.json
@@ -1,0 +1,19 @@
+{
+  "staff": {
+    "activities": {
+      "views": {
+        "ActivitiesView": {
+          "MyWorkspaceTab": {
+            "columns": {
+              "activityName": "Nom de l'activité",
+              "lastModification": "Dernière modification",
+              "owner": "Propriétaire",
+              "status": "Statut"
+            },
+            "title": "Toutes les activités publiées dans mon établissement ({count})"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/features/staff/activities/routes/index.test.ts
+++ b/src/features/staff/activities/routes/index.test.ts
@@ -1,5 +1,5 @@
 import { ROUTES } from '@/common/constants'
-import { staffActivitiesAddNationalActivityRoute, staffActivitiesRoute } from '@/features/staff/activities/routes'
+import { staffActivitiesAddNationalActivityRoute, staffActivitiesRoute, staffActivityDetailsRoute } from '@/features/staff/activities/routes'
 import ActivitiesView from '@/features/staff/activities/views/ActivitiesView/ActivitiesView.vue'
 import AddNationalActivityView from '@/features/staff/activities/views/AddNationalActivityView/AddNationalActivityView.vue'
 import { testRoute } from 'tests/utils'
@@ -14,4 +14,11 @@ testRoute(
   staffActivitiesAddNationalActivityRoute,
   ROUTES.STAFF.ACTIVITIES_ADD_NATIONAL_ACTIVITY,
   AddNationalActivityView
+)
+
+testRoute(
+  staffActivityDetailsRoute,
+  ROUTES.STAFF.ACTIVITY_DETAILS,
+  // TODO: us #1493 update the rendered component
+  ActivitiesView
 )

--- a/src/features/staff/activities/routes/index.ts
+++ b/src/features/staff/activities/routes/index.ts
@@ -12,3 +12,10 @@ export const staffActivitiesAddNationalActivityRoute: AvRoute = {
   component: () =>
     import('@/features/staff/activities/views/AddNationalActivityView/AddNationalActivityView.vue'),
 }
+
+export const staffActivityDetailsRoute: AvRoute = {
+  ...ROUTES.STAFF.ACTIVITY_DETAILS,
+  // TODO: us #1493 update component to load when #1493 is merged
+  component: () =>
+    import('@/features/staff/activities/views/ActivitiesView/ActivitiesView.vue'),
+}

--- a/src/features/staff/activities/views/ActivitiesView/ActivitiesView.test.ts
+++ b/src/features/staff/activities/views/ActivitiesView/ActivitiesView.test.ts
@@ -1,11 +1,15 @@
 import { PageTitleStub } from '@/common/components/PageTitle/PageTitle.stub'
 import { ROUTES } from '@/common/constants'
 import ActivitiesView from '@/features/staff/activities/views/ActivitiesView/ActivitiesView.vue'
+import { MyWorkspaceTabStub } from '@/features/staff/activities/views/ActivitiesView/components/MyWorkspaceTab/MyWorkspaceTab.stub'
 import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { mount, type VueWrapper } from '@vue/test-utils'
 
-BddTest().given('a student mailbox view', () => {
-  const stubs = { PageTitle: PageTitleStub }
+BddTest().given('a staff activities view', () => {
+  const stubs = {
+    PageTitle: PageTitleStub,
+    MyWorkspaceTab: MyWorkspaceTabStub,
+  }
   let wrapper: VueWrapper<InstanceType<typeof ActivitiesView>>
 
   beforeEach(() => {
@@ -22,6 +26,10 @@ BddTest().given('a student mailbox view', () => {
         { text: 'Accueil', to: ROUTES.STAFF.HOME },
         { text: 'Bibliothèque des activités' }
       ])
+    })
+
+    BddTest().then('it should render MyWorkspaceTab', () => {
+      expect(wrapper.findComponent({ name: 'MyWorkspaceTab' }).exists()).toBe(true)
     })
   })
 })

--- a/src/features/staff/activities/views/ActivitiesView/ActivitiesView.types.ts
+++ b/src/features/staff/activities/views/ActivitiesView/ActivitiesView.types.ts
@@ -1,0 +1,10 @@
+import type { EActivityThematic } from '@/api/avenir-esr'
+
+export interface ActivityTableRow {
+  id: string
+  owner: string
+  status: string
+  thematic: EActivityThematic
+  title: string
+  updatedAt: string
+}

--- a/src/features/staff/activities/views/ActivitiesView/ActivitiesView.utils.ts
+++ b/src/features/staff/activities/views/ActivitiesView/ActivitiesView.utils.ts
@@ -1,0 +1,14 @@
+import type { ActivityDetailsDTO } from '@/api/avenir-esr'
+import type { ActivityTableRow } from '@/features/staff/activities/views/ActivitiesView/ActivitiesView.types'
+
+export function mapActivityToActivityTableRow (activity: ActivityDetailsDTO): ActivityTableRow {
+  return {
+    id: activity.id,
+    owner: '',
+    // TODO: #1618 map status when its added to the dto
+    status: 'draft',
+    thematic: activity.thematic,
+    title: activity.title,
+    updatedAt: activity.updatedAt ?? '',
+  }
+}

--- a/src/features/staff/activities/views/ActivitiesView/ActivitiesView.vue
+++ b/src/features/staff/activities/views/ActivitiesView/ActivitiesView.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import PageTitle from '@/common/components/PageTitle/PageTitle.vue'
 import { ROUTES } from '@/common/constants'
+import MyWorkspaceTab from '@/features/staff/activities/views/ActivitiesView/components/MyWorkspaceTab/MyWorkspaceTab.vue'
 import { useI18n } from 'vue-i18n'
 
 const { t } = useI18n()
@@ -17,4 +18,5 @@ const breadcrumbLinks = computed(() => [
     :breadcrumb-links="breadcrumbLinks"
     :back="ROUTES.STAFF.HOME"
   />
+  <MyWorkspaceTab />
 </template>

--- a/src/features/staff/activities/views/ActivitiesView/components/ActivityTableTitle/ActivityTableTitle.stub.ts
+++ b/src/features/staff/activities/views/ActivitiesView/components/ActivityTableTitle/ActivityTableTitle.stub.ts
@@ -1,0 +1,13 @@
+import type { ActivityTableRow } from '@/features/staff/activities/views/ActivitiesView/ActivitiesView.types'
+import type { PropType } from 'vue'
+
+export const ActivityTableTitleStub = defineComponent({
+  name: 'ActivityTableTitle',
+  template: '<div data-testid="activity-table-title-stub"></div>',
+  props: {
+    activity: {
+      type: Object as PropType<ActivityTableRow>,
+      required: true,
+    },
+  },
+})

--- a/src/features/staff/activities/views/ActivitiesView/components/ActivityTableTitle/ActivityTableTitle.test.ts
+++ b/src/features/staff/activities/views/ActivitiesView/components/ActivityTableTitle/ActivityTableTitle.test.ts
@@ -1,0 +1,103 @@
+import type { ActivityTableRow } from '@/features/staff/activities/views/ActivitiesView/ActivitiesView.types'
+import { EActivityThematic } from '@/api/avenir-esr'
+import { ActivityThematicBadgeStub } from '@/common/activities/badges/ActivityThematicBadge/ActivityThematicBadge.stub'
+import { ROUTES } from '@/common/constants'
+import ActivityTableTitle from '@/features/staff/activities/views/ActivitiesView/components/ActivityTableTitle/ActivityTableTitle.vue'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { mount, RouterLinkStub, type VueWrapper } from '@vue/test-utils'
+import { beforeEach, expect, vi } from 'vitest'
+
+BddTest().given('an ActivityTableTitle component', () => {
+  let wrapper: ReturnType<typeof mount<typeof ActivityTableTitle>>
+
+  const stubs = {
+    ActivityThematicBadge: ActivityThematicBadgeStub,
+    RouterLink: RouterLinkStub,
+  }
+
+  const baseActivity: ActivityTableRow = {
+    id: 'activity-1',
+    owner: '',
+    status: 'published',
+    thematic: EActivityThematic.SELF_KNOWLEDGE,
+    title: 'Activité "Connaissance de soi" : Définir ses valeurs',
+    updatedAt: '2025-03-10T14:00:00.000Z',
+  }
+
+  BddTest().when('the component is mounted', () => {
+    let link: VueWrapper<InstanceType<typeof RouterLinkStub>>
+
+    beforeEach(() => {
+      vi.clearAllMocks()
+      wrapper = mount(ActivityTableTitle, {
+        props: { activity: baseActivity },
+        global: { stubs },
+      })
+      link = wrapper.findComponent(RouterLinkStub)
+    })
+
+    BddTest().then('it should render the component', () => {
+      expect(wrapper.exists()).toBe(true)
+    })
+
+    BddTest().then('it should render the activity title inside the link', () => {
+      expect(link.text()).toContain(baseActivity.title)
+    })
+
+    BddTest().then('it should link to the activity details route with correct params', () => {
+      expect(link.props('to')).toEqual({
+        name: ROUTES.STAFF.ACTIVITY_DETAILS.name,
+        params: { id: baseActivity.id, status: baseActivity.status },
+      })
+    })
+
+    BddTest().then('it should render the thematic badge with the correct thematic', () => {
+      expect(wrapper.findComponent({ name: 'ActivityThematicBadge' }).props('thematic')).toBe(EActivityThematic.SELF_KNOWLEDGE)
+    })
+  })
+
+  BddTest().when('the component is mounted with a different thematic', () => {
+    beforeEach(() => {
+      vi.clearAllMocks()
+      wrapper = mount(ActivityTableTitle, {
+        props: {
+          activity: {
+            ...baseActivity,
+            thematic: EActivityThematic.EXPERIENCES,
+          },
+        },
+        global: { stubs },
+      })
+    })
+
+    BddTest().then('it should pass the updated thematic to the badge', () => {
+      expect(wrapper.findComponent({ name: 'ActivityThematicBadge' }).props('thematic')).toBe(EActivityThematic.EXPERIENCES)
+    })
+  })
+
+  BddTest().when('the component is mounted with a different activity id and status', () => {
+    let link: VueWrapper<InstanceType<typeof RouterLinkStub>>
+
+    beforeEach(() => {
+      vi.clearAllMocks()
+      wrapper = mount(ActivityTableTitle, {
+        props: {
+          activity: {
+            ...baseActivity,
+            id: 'activity-42',
+            status: 'draft',
+          },
+        },
+        global: { stubs },
+      })
+      link = wrapper.findComponent(RouterLinkStub)
+    })
+
+    BddTest().then('it should update the route params accordingly', () => {
+      expect(link.props('to')).toEqual({
+        name: ROUTES.STAFF.ACTIVITY_DETAILS.name,
+        params: { id: 'activity-42', status: 'draft' },
+      })
+    })
+  })
+})

--- a/src/features/staff/activities/views/ActivitiesView/components/ActivityTableTitle/ActivityTableTitle.vue
+++ b/src/features/staff/activities/views/ActivitiesView/components/ActivityTableTitle/ActivityTableTitle.vue
@@ -1,0 +1,37 @@
+<script lang="ts" setup>
+import type { ActivityTableRow } from '@/features/staff/activities/views/ActivitiesView/ActivitiesView.types'
+import ActivityThematicBadge from '@/common/activities/badges/ActivityThematicBadge/ActivityThematicBadge.vue'
+import { ROUTES } from '@/common/constants'
+
+export interface ActivityTableTitleProps {
+  activity: ActivityTableRow
+}
+
+const { activity } = defineProps<ActivityTableTitleProps>()
+
+const to = computed(() => ({
+  name: ROUTES.STAFF.ACTIVITY_DETAILS.name,
+  params: { status: activity.status, id: activity.id }
+}))
+</script>
+
+<template>
+  <div class="activity-table-title av-col av-gap-xs">
+    <RouterLink
+      :to
+      class="name b1-bold av-text-text1"
+    >
+      {{ activity.title }}
+    </RouterLink>
+    <ActivityThematicBadge :thematic="activity.thematic" />
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.activity-table-title {
+  > .name:hover {
+    color: var(--light-foreground-primary2);
+    text-decoration: underline;
+  }
+}
+</style>

--- a/src/features/staff/activities/views/ActivitiesView/components/MyWorkspaceTab/MyWorkspaceTab.stub.ts
+++ b/src/features/staff/activities/views/ActivitiesView/components/MyWorkspaceTab/MyWorkspaceTab.stub.ts
@@ -1,0 +1,4 @@
+export const MyWorkspaceTabStub = defineComponent({
+  name: 'MyWorkspaceTab',
+  template: '<div data-testid="my-workspace-tab-stub"></div>',
+})

--- a/src/features/staff/activities/views/ActivitiesView/components/MyWorkspaceTab/MyWorkspaceTab.test.ts
+++ b/src/features/staff/activities/views/ActivitiesView/components/MyWorkspaceTab/MyWorkspaceTab.test.ts
@@ -1,0 +1,89 @@
+import { PaginationStub } from '@/common/components/Pagination/Pagination.stub'
+import { ActivityTableTitleStub } from '@/features/staff/activities/views/ActivitiesView/components/ActivityTableTitle/ActivityTableTitle.stub'
+import MyWorkspaceTab from '@/features/staff/activities/views/ActivitiesView/components/MyWorkspaceTab/MyWorkspaceTab.vue'
+import { AvTableStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { beforeEach, expect, vi } from 'vitest'
+
+BddTest().given('a MyWorkspaceTab component', () => {
+  let wrapper: ReturnType<typeof mount<typeof MyWorkspaceTab>>
+
+  const stubs = {
+    ActivityTableTitle: ActivityTableTitleStub,
+    AvTable: AvTableStub,
+    Pagination: PaginationStub,
+  }
+
+  BddTest().when('the component is mounted', () => {
+    let avTable: VueWrapper<InstanceType<typeof AvTableStub>>
+    let pagination: VueWrapper<InstanceType<typeof PaginationStub>>
+
+    beforeEach(() => {
+      vi.clearAllMocks()
+      wrapper = mount(MyWorkspaceTab, {
+        global: { stubs },
+      })
+      avTable = wrapper.findComponent({ name: 'AvTable' })
+      pagination = wrapper.findComponent(PaginationStub)
+    })
+
+    BddTest().then('it should render the component', () => {
+      expect(wrapper.find('[data-testid="my-workspace-tab"]').exists()).toBe(true)
+    })
+
+    BddTest().then('it should display the title with the placeholder count', () => {
+      expect(wrapper.find('[data-testid="my-workspace-tab-title"]').text()).toContain('Toutes les activités publiées dans mon établissement (3)')
+    })
+
+    BddTest().then('it should render the AvTable', () => {
+      expect(avTable.exists()).toBe(true)
+    })
+
+    BddTest().then('it should pass 4 columns to the table', () => {
+      expect(avTable.props('columns')).toHaveLength(4)
+    })
+
+    BddTest().then('it should pass the placeholder rows to the table', () => {
+      expect(avTable.props('rows')).toHaveLength(3)
+    })
+
+    BddTest().then('it should render the Pagination', () => {
+      expect(pagination.exists()).toBe(true)
+    })
+
+    BddTest().then('it should pass the correct totalElements to Pagination', () => {
+      expect(pagination.props('pageInfo')).toMatchObject({ totalElements: 3 })
+    })
+
+    BddTest().and('the column labels are correct', () => {
+      let columns: { key: string, label: string }[]
+
+      beforeEach(() => {
+        columns = avTable.props('columns') as { key: string, label: string }[]
+      })
+
+      BddTest().then('it should have the activity name column label', () => {
+        expect(columns.find(c => c.key === 'title')?.label).toBe('Nom de l\'activité')
+      })
+
+      BddTest().then('it should have the last modification column label', () => {
+        expect(columns.find(c => c.key === 'updatedAt')?.label).toBe('Dernière modification')
+      })
+
+      BddTest().then('it should have the owner column label', () => {
+        expect(columns.find(c => c.key === 'owner')?.label).toBe('Propriétaire')
+      })
+
+      BddTest().then('it should have the status column label', () => {
+        expect(columns.find(c => c.key === 'status')?.label).toBe('Statut')
+      })
+    })
+
+    BddTest().and('the title column slot is rendered', () => {
+      BddTest().then('it should render one ActivityTableTitle per row', () => {
+        const titles = wrapper.findAllComponents({ name: 'ActivityTableTitle' })
+        expect(titles).toHaveLength(3)
+      })
+    })
+  })
+})

--- a/src/features/staff/activities/views/ActivitiesView/components/MyWorkspaceTab/MyWorkspaceTab.vue
+++ b/src/features/staff/activities/views/ActivitiesView/components/MyWorkspaceTab/MyWorkspaceTab.vue
@@ -1,0 +1,123 @@
+<script lang="ts" setup>
+import type { ActivityDetailsDTO, PageInfoDTO } from '@/api/avenir-esr'
+import type { ActivityTableRow } from '@/features/staff/activities/views/ActivitiesView/ActivitiesView.types'
+import type { AvTableColumn } from '@avenirs-esr/avenirs-dsav'
+import { EActivityThematic } from '@/api/avenir-esr'
+import Pagination from '@/common/components/Pagination/Pagination.vue'
+import { useDateUtils, usePagination } from '@/common/composables'
+import { mapActivityToActivityTableRow } from '@/features/staff/activities/views/ActivitiesView/ActivitiesView.utils'
+import ActivityTableTitle from '@/features/staff/activities/views/ActivitiesView/components/ActivityTableTitle/ActivityTableTitle.vue'
+import { AvTable, PageSizes } from '@avenirs-esr/avenirs-dsav'
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
+const { formatLastModified } = useDateUtils()
+
+const currentPageRef = ref<number>(0)
+const pageSizeRef = ref<PageSizes>(PageSizes.TWELVE)
+
+const { currentPage, pageSizeSelected, onUpdateCurrentPage, onUpdatePageSize } = usePagination(currentPageRef, pageSizeRef)
+
+const placeholderActivities = computed<ActivityDetailsDTO[]>(() => [
+  {
+    id: '1',
+    title: 'Activité "Connaissance de soi" : Définir ses valeurs',
+    thematic: EActivityThematic.SELF_KNOWLEDGE,
+    banner: { id: 'banner-1', name: 'banner.jpg', url: '' },
+    summary: '',
+    description: '',
+    executionPeriodInfo: '',
+    updatedAt: '2025-03-10T14:00:00.000Z',
+  },
+  {
+    id: '2',
+    title: 'Activité "Connaissance de soi" : Définir ses valeurs',
+    thematic: EActivityThematic.SELF_KNOWLEDGE,
+    banner: { id: 'banner-2', name: 'banner.jpg', url: '' },
+    summary: '',
+    description: '',
+    executionPeriodInfo: '',
+    updatedAt: '2025-03-10T14:00:00.000Z',
+  },
+  {
+    id: '3',
+    title: 'Activité "Connaissance de soi" : Définir ses valeurs',
+    thematic: EActivityThematic.SELF_KNOWLEDGE,
+    banner: { id: 'banner-3', name: 'banner.jpg', url: '' },
+    summary: '',
+    description: '',
+    executionPeriodInfo: '',
+    updatedAt: new Date().toISOString(),
+  },
+])
+
+// TODO: #1618 fetch activities from  the api
+const rows = computed<ActivityTableRow[]>(() => placeholderActivities.value.map(mapActivityToActivityTableRow))
+
+// TODO: #1618 compute total elements from api
+const totalElements = computed(() => rows.value.length)
+
+const columns = computed<AvTableColumn<ActivityTableRow>[]>(() => [
+  {
+    key: 'title',
+    label: t('staff.activities.views.ActivitiesView.MyWorkspaceTab.columns.activityName'),
+    width: '40%',
+  },
+  {
+    key: 'updatedAt',
+    label: t('staff.activities.views.ActivitiesView.MyWorkspaceTab.columns.lastModification'),
+  },
+  {
+    key: 'owner',
+    label: t('staff.activities.views.ActivitiesView.MyWorkspaceTab.columns.owner'),
+  },
+  {
+    key: 'status',
+    label: t('staff.activities.views.ActivitiesView.MyWorkspaceTab.columns.status'),
+  },
+])
+
+// TODO: #1618 forward pageInfo from query result
+const pageInfo = computed<PageInfoDTO>(() => ({
+  page: currentPage.value,
+  pageSize: pageSizeSelected.value,
+  totalElements: totalElements.value,
+  totalPages: Math.ceil(totalElements.value / pageSizeSelected.value),
+}))
+</script>
+
+<template>
+  <div
+    class="my-workspace-tab av-flex-col-xl"
+    data-testid="my-workspace-tab"
+  >
+    <h2
+      class="n4"
+      data-testid="my-workspace-tab-title"
+    >
+      {{ t('staff.activities.views.ActivitiesView.MyWorkspaceTab.title', { count: totalElements }) }}
+    </h2>
+
+    <Pagination
+      :page-info="pageInfo"
+      :page-size-selected="pageSizeSelected"
+      :on-update-current-page="onUpdateCurrentPage"
+      :on-update-page-size="onUpdatePageSize"
+    >
+      <AvTable
+        :columns="columns"
+        :rows="rows"
+        row-key="id"
+        data-testid="my-workspace-table"
+      >
+        <template #cell(title)="{ row }">
+          <ActivityTableTitle :activity="row" />
+        </template>
+
+        <template #cell(updatedAt)="{ row }">
+          {{ row.updatedAt ? formatLastModified(row.updatedAt) : '' }}
+        </template>
+      </AvTable>
+    </Pagination>
+  </div>
+</template>

--- a/src/features/staff/global/routes/index.test.ts
+++ b/src/features/staff/global/routes/index.test.ts
@@ -1,4 +1,8 @@
 import { ROUTES } from '@/common/constants'
+import AccessibilityView from '@/common/views/AccessibilityView/AccessibilityView.vue'
+import CookiesView from '@/common/views/CookiesView/CookiesView.vue'
+import LegalView from '@/common/views/LegalView/LegalView.vue'
+import PersonalDataView from '@/common/views/PersonalDataView/PersonalDataView.vue'
 import routes from '@/features/staff/global/routes'
 import StaffHomeView from '@/features/staff/global/views/StaffHomeView/StaffHomeView.vue'
 import { testRoute } from 'tests/utils'
@@ -10,4 +14,28 @@ testRoute(
   children.find(r => r.name === ROUTES.STAFF.HOME.name)!,
   ROUTES.STAFF.HOME,
   StaffHomeView
+)
+
+testRoute(
+  children.find(r => r.name === ROUTES.STAFF.ACCESSIBILITY.name)!,
+  ROUTES.STAFF.ACCESSIBILITY,
+  AccessibilityView
+)
+
+testRoute(
+  children.find(r => r.name === ROUTES.STAFF.COOKIES.name)!,
+  ROUTES.STAFF.COOKIES,
+  CookiesView
+)
+
+testRoute(
+  children.find(r => r.name === ROUTES.STAFF.LEGAL.name)!,
+  ROUTES.STAFF.LEGAL,
+  LegalView
+)
+
+testRoute(
+  children.find(r => r.name === ROUTES.STAFF.PERSONAL_DATA.name)!,
+  ROUTES.STAFF.PERSONAL_DATA,
+  PersonalDataView
 )

--- a/src/features/staff/global/routes/index.ts
+++ b/src/features/staff/global/routes/index.ts
@@ -1,5 +1,5 @@
 import { ROUTES } from '@/common/constants'
-import { staffActivitiesAddNationalActivityRoute, staffActivitiesRoute } from '@/features/staff/activities/routes'
+import { staffActivitiesAddNationalActivityRoute, staffActivitiesRoute, staffActivityDetailsRoute } from '@/features/staff/activities/routes'
 
 export default [
   {
@@ -33,6 +33,7 @@ export default [
       },
       staffActivitiesRoute,
       staffActivitiesAddNationalActivityRoute,
+      staffActivityDetailsRoute
     ]
   }
 ]

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -116,6 +116,10 @@
       "createdAtWithPrefix": "{prefix} created on {date}",
       "dateTimeAt": "{date} at {time}",
       "endDateBeforeStartDate": "End date must be after start date",
+      "hoursAgo": "{count} hour ago | {count} hours ago",
+      "justNow": "Just now",
+      "minutesAgo": "{count} minute ago | {count} minutes ago",
+      "secondsAgo": "{count} second ago | {count} seconds ago",
       "updatedAt": "Updated on {date}"
     },
     "detail": "Detail",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -116,6 +116,10 @@
       "createdAtWithPrefix": "{prefix} créé le {date}",
       "dateTimeAt": "{date} à {time}",
       "endDateBeforeStartDate": "La date de fin doit être postérieure à la date de début",
+      "hoursAgo": "Il y a {count} heure | Il y a {count} heures",
+      "justNow": "À l'instant",
+      "minutesAgo": "Il y a {count} minute | Il y a {count} minutes",
+      "secondsAgo": "Il y a {count} seconde | Il y a {count} secondes",
       "updatedAt": "Modifié le {date}"
     },
     "detail": "Détail",


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
Création du composant `MyWorkspaceTab` pour l'espace de travail du personnel. Ce composant affiche un onglet de zone de travail personnelle avec un tableau d'activités et la gestion des dates.

### Changes
- ✨ Nouveau composant `MyWorkspaceTab` avec interface de zone de travail
- ✨ Nouveau composant `ActivityTableTitle` pour l'en-tête du tableau d'activités
- 🛠 Refactorisation de `use-date-utils` avec des tests complets
- 🗂 Ajout des routes staff pour accéder au composant
- 🌐 Traductions FR/EN pour les nouvelles clés i18n
- 📝 Tests unitaires complets pour les nouveaux composants et composables

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1490

### Target Branch
`develop`

### Additional Notes
- Intégration du composant dans la vue des activités du personnel
- Tests d'intégration pour les routes du personnel
- Conformité avec la structure feature-based et les patterns du projet

---

## ✅ Checklist

- [x] a11y tested (composants sans interactions complexes)
- [x] Tests provided (unit tests pour composants et composables)
- [x] i18n handled (FR/EN translations ajoutées)
- [x] No unnecessary code
- [x] Code style and formatting rules respected
- [x] Semantic Versioning respected