### PR TITLE
fix: declared program form validation

### DIFF
--- a/src/common/composables/use-form-validators/use-form-validators.ts
+++ b/src/common/composables/use-form-validators/use-form-validators.ts
@@ -1,13 +1,10 @@
-import type { FormApi } from '@tanstack/vue-form'
+import type { AnyFormApi, TopLevelFieldKey } from '@/common/types'
 import type { Ref } from 'vue'
 import { isValidLink } from '@avenirs-esr/avenirs-dsav'
 import { useStore } from '@tanstack/vue-form'
 import { isBefore, parse } from 'date-fns'
 import isEmpty from 'lodash-es/isEmpty'
 import { useI18n } from 'vue-i18n'
-
-type AnyFormApi<TFormData extends object> = FormApi<TFormData, any, any, any, any, any, any, any, any, any>
-type TopLevelFieldKey<TFormData extends object> = TFormData extends unknown ? Extract<keyof TFormData, string> : never
 
 export interface validateDateIntervalArgs {
   startDate: string | undefined | null

--- a/src/common/types/forms.types.ts
+++ b/src/common/types/forms.types.ts
@@ -1,0 +1,4 @@
+import type { FormApi } from '@tanstack/vue-form'
+
+export type AnyFormApi<TFormData extends object> = FormApi<TFormData, any, any, any, any, any, any, any, any, any>
+export type TopLevelFieldKey<TFormData extends object> = TFormData extends unknown ? Extract<keyof TFormData, string> : never

--- a/src/common/types/index.ts
+++ b/src/common/types/index.ts
@@ -1,2 +1,3 @@
+export * from './forms.types'
 export * from './router.types'
 export * from './sort-criteria.types'

--- a/src/features/student/personalCareer/components/interactions/formFields/DeclaredProgramDescriptionFormField/DeclaredProgramDescriptionFormField.test.ts
+++ b/src/features/student/personalCareer/components/interactions/formFields/DeclaredProgramDescriptionFormField/DeclaredProgramDescriptionFormField.test.ts
@@ -1,6 +1,5 @@
 import type { AddDeclaredProgramForm, DeclaredProgramFormData } from '@/features/student/personalCareer/types/forms.types'
 import DeclaredProgramDescriptionFormField from '@/features/student/personalCareer/components/interactions/formFields/DeclaredProgramDescriptionFormField/DeclaredProgramDescriptionFormField.vue'
-import { DECLARED_PROGRAM_DESCRIPTION_MAX_LENGTH } from '@/features/student/personalCareer/config'
 import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { useForm } from '@tanstack/vue-form'
 import { mount, type VueWrapper } from '@vue/test-utils'
@@ -92,21 +91,6 @@ BddTest().given('a declared program description form field', () => {
         await vi.waitFor(() => {
           const updated = wrapper.findComponent({ name: 'DeclaredProgramDescriptionTextarea' })
           expect(updated.props('modelValue')).toBe('This is my program description')
-        })
-      })
-    })
-
-    BddTest().and('the user enters a description exceeding max length', () => {
-      BddTest().then('it should truncate the value to max length', async () => {
-        const textarea = wrapper.findComponent({ name: 'DeclaredProgramDescriptionTextarea' })
-        const textareaElement = textarea.find('textarea')
-        const longDescription = 'a'.repeat(DECLARED_PROGRAM_DESCRIPTION_MAX_LENGTH + 20)
-        await textareaElement.setValue(longDescription)
-        await wrapper.vm.$nextTick()
-
-        await vi.waitFor(() => {
-          const updated = wrapper.findComponent({ name: 'DeclaredProgramDescriptionTextarea' })
-          expect(updated.props('modelValue')).toHaveLength(DECLARED_PROGRAM_DESCRIPTION_MAX_LENGTH)
         })
       })
     })

--- a/src/features/student/personalCareer/components/interactions/formFields/DeclaredProgramDescriptionFormField/DeclaredProgramDescriptionFormField.vue
+++ b/src/features/student/personalCareer/components/interactions/formFields/DeclaredProgramDescriptionFormField/DeclaredProgramDescriptionFormField.vue
@@ -1,23 +1,18 @@
 <script setup lang="ts">
 import type { AddDeclaredProgramForm } from '@/features/student/personalCareer/types/forms.types'
 import DeclaredProgramDescriptionTextarea from '@/features/student/personalCareer/components/interactions/inputs/DeclaredProgramDescriptionTextarea/DeclaredProgramDescriptionTextarea.vue'
-import { DECLARED_PROGRAM_DESCRIPTION_MAX_LENGTH } from '@/features/student/personalCareer/config'
 import { markRaw } from 'vue'
 
 interface DeclaredProgramDescriptionFormFieldProps {
   form: AddDeclaredProgramForm
 }
 
-defineOptions({
-  inheritAttrs: false
-})
-
 const { form } = defineProps<DeclaredProgramDescriptionFormFieldProps>()
 const FormField = markRaw(form.Field)
 const descriptionField = form.useField({ name: 'description' })
 
 function onUpdateDescription (value: string | undefined) {
-  descriptionField.api.handleChange(String(value ?? '').slice(0, DECLARED_PROGRAM_DESCRIPTION_MAX_LENGTH))
+  descriptionField.api.handleChange(String(value ?? ''))
 }
 </script>
 
@@ -26,7 +21,7 @@ function onUpdateDescription (value: string | undefined) {
     <template #default="{ field }">
       <DeclaredProgramDescriptionTextarea
         v-bind="$attrs"
-        :model-value="(field.state.value ?? '').slice(0, DECLARED_PROGRAM_DESCRIPTION_MAX_LENGTH)"
+        :model-value="field.state.value ?? ''"
         :error-message="field.state.meta.errors?.join(', ')"
         @blur="field.handleBlur"
         @update:model-value="onUpdateDescription"

--- a/src/features/student/personalCareer/components/interactions/formFields/DeclaredProgramOrganizationFormField/DeclaredProgramOrganizationFormField.test.ts
+++ b/src/features/student/personalCareer/components/interactions/formFields/DeclaredProgramOrganizationFormField/DeclaredProgramOrganizationFormField.test.ts
@@ -1,6 +1,5 @@
 import type { AddDeclaredProgramForm, DeclaredProgramFormData } from '@/features/student/personalCareer/types/forms.types'
 import DeclaredProgramOrganizationFormField from '@/features/student/personalCareer/components/interactions/formFields/DeclaredProgramOrganizationFormField/DeclaredProgramOrganizationFormField.vue'
-import { DECLARED_PROGRAM_ORGANIZATION_MAX_LENGTH } from '@/features/student/personalCareer/config'
 import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { useForm } from '@tanstack/vue-form'
 import { mount, type VueWrapper } from '@vue/test-utils'
@@ -91,21 +90,6 @@ BddTest().given('a declared program institution form field', () => {
         await vi.waitFor(() => {
           const updated = wrapper.findComponent({ name: 'DeclaredProgramOrganizationInput' })
           expect(updated.props('modelValue')).toBe('University of Paris')
-        })
-      })
-    })
-
-    BddTest().and('the user enters an institution name exceeding max length', () => {
-      BddTest().then('it should truncate the value to max length', async () => {
-        const input = wrapper.findComponent({ name: 'DeclaredProgramOrganizationInput' })
-        const textInput = input.find('input')
-        const longInstitution = 'a'.repeat(DECLARED_PROGRAM_ORGANIZATION_MAX_LENGTH + 10)
-        await textInput.setValue(longInstitution)
-        await wrapper.vm.$nextTick()
-
-        await vi.waitFor(() => {
-          const updated = wrapper.findComponent({ name: 'DeclaredProgramOrganizationInput' })
-          expect(updated.props('modelValue')).toHaveLength(DECLARED_PROGRAM_ORGANIZATION_MAX_LENGTH)
         })
       })
     })

--- a/src/features/student/personalCareer/components/interactions/formFields/DeclaredProgramOrganizationFormField/DeclaredProgramOrganizationFormField.vue
+++ b/src/features/student/personalCareer/components/interactions/formFields/DeclaredProgramOrganizationFormField/DeclaredProgramOrganizationFormField.vue
@@ -1,23 +1,18 @@
 <script setup lang="ts">
 import type { AddDeclaredProgramForm } from '@/features/student/personalCareer/types/forms.types'
 import DeclaredProgramOrganizationInput from '@/features/student/personalCareer/components/interactions/inputs/DeclaredProgramOrganizationInput/DeclaredProgramOrganizationInput.vue'
-import { DECLARED_PROGRAM_ORGANIZATION_MAX_LENGTH } from '@/features/student/personalCareer/config'
 import { markRaw } from 'vue'
 
 interface DeclaredProgramInstitutionFormFieldProps {
   form: AddDeclaredProgramForm
 }
 
-defineOptions({
-  inheritAttrs: false
-})
-
 const { form } = defineProps<DeclaredProgramInstitutionFormFieldProps>()
 const FormField = markRaw(form.Field)
 const institutionField = form.useField({ name: 'organization' })
 
 function onUpdateInstitution (value: string | undefined) {
-  institutionField.api.handleChange(String(value ?? '').slice(0, DECLARED_PROGRAM_ORGANIZATION_MAX_LENGTH))
+  institutionField.api.handleChange(String(value ?? ''))
 }
 </script>
 
@@ -26,8 +21,9 @@ function onUpdateInstitution (value: string | undefined) {
     <template #default="{ field }">
       <DeclaredProgramOrganizationInput
         v-bind="$attrs"
-        :model-value="(field.state.value ?? '').slice(0, DECLARED_PROGRAM_ORGANIZATION_MAX_LENGTH)"
+        :model-value="field.state.value ?? ''"
         :error-message="field.state.meta.errors?.join(', ')"
+        required
         @blur="field.handleBlur"
         @update:model-value="onUpdateInstitution"
       />

--- a/src/features/student/personalCareer/components/interactions/formFields/DeclaredProgramPeriodFormField/DeclaredProgramPeriodFormField.vue
+++ b/src/features/student/personalCareer/components/interactions/formFields/DeclaredProgramPeriodFormField/DeclaredProgramPeriodFormField.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { AddDeclaredProgramForm } from '@/features/student/personalCareer/types/forms.types'
 import { AvCheckbox, AvPeriodInput } from '@avenirs-esr/avenirs-dsav'
+import { isBefore, parse } from 'date-fns'
 import { markRaw } from 'vue'
 import { useI18n } from 'vue-i18n'
 
@@ -19,7 +20,16 @@ const startDateField = form.useField({ name: 'startDate' })
 const endDateField = form.useField({ name: 'endDate' })
 const isOngoingField = form.useField({ name: IS_ONGOING })
 
-const isOngoing = computed(() => Boolean(isOngoingField.state.value.value))
+const isOngoingDisabled = computed(() => {
+  const endDate = String(endDateField.state.value.value ?? '')
+  if (!endDate) {
+    return false
+  }
+
+  const parsedEndDate = parse(endDate, 'yyyy-MM', new Date())
+  return isBefore(parsedEndDate, new Date())
+})
+const isOngoing = computed(() => !isOngoingDisabled.value && Boolean(isOngoingField.state.value.value))
 
 function setStartDate (value: string) {
   startDateField.api.handleChange(value)
@@ -56,6 +66,7 @@ function onUpdateIsOngoing (values: (string | number | boolean | undefined)[]) {
             :model-value="field.state.value ? [IS_ONGOING] : []"
             :value="IS_ONGOING"
             :label="t('student.personalCareer.interactions.formFields.DeclaredProgramPeriodFormField.ongoing')"
+            :disabled="isOngoingDisabled"
             @update:model-value="onUpdateIsOngoing"
           />
         </template>

--- a/src/features/student/personalCareer/components/interactions/formFields/DeclaredProgramResultFormField/DeclaredProgramResultFormField.test.ts
+++ b/src/features/student/personalCareer/components/interactions/formFields/DeclaredProgramResultFormField/DeclaredProgramResultFormField.test.ts
@@ -1,6 +1,5 @@
 import type { AddDeclaredProgramForm, DeclaredProgramFormData } from '@/features/student/personalCareer/types/forms.types'
 import DeclaredProgramResultFormField from '@/features/student/personalCareer/components/interactions/formFields/DeclaredProgramResultFormField/DeclaredProgramResultFormField.vue'
-import { DECLARED_PROGRAM_RESULT_MAX_LENGTH } from '@/features/student/personalCareer/config'
 import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { useForm } from '@tanstack/vue-form'
 import { mount, type VueWrapper } from '@vue/test-utils'
@@ -84,21 +83,6 @@ BddTest().given('a declared program result form field', () => {
         await vi.waitFor(() => {
           const updated = wrapper.findComponent({ name: 'DeclaredProgramResultInput' })
           expect(updated.props('modelValue')).toBe('Admis avec mention')
-        })
-      })
-    })
-
-    BddTest().and('the user enters a result exceeding max length', () => {
-      BddTest().then('it should truncate the value to max length', async () => {
-        const input = wrapper.findComponent({ name: 'DeclaredProgramResultInput' })
-        const textInput = input.find('input')
-        const longResult = 'a'.repeat(DECLARED_PROGRAM_RESULT_MAX_LENGTH + 10)
-        await textInput.setValue(longResult)
-        await wrapper.vm.$nextTick()
-
-        await vi.waitFor(() => {
-          const updated = wrapper.findComponent({ name: 'DeclaredProgramResultInput' })
-          expect(updated.props('modelValue')).toHaveLength(DECLARED_PROGRAM_RESULT_MAX_LENGTH)
         })
       })
     })

--- a/src/features/student/personalCareer/components/interactions/formFields/DeclaredProgramResultFormField/DeclaredProgramResultFormField.vue
+++ b/src/features/student/personalCareer/components/interactions/formFields/DeclaredProgramResultFormField/DeclaredProgramResultFormField.vue
@@ -1,23 +1,18 @@
 <script setup lang="ts">
 import type { AddDeclaredProgramForm } from '@/features/student/personalCareer/types/forms.types'
 import DeclaredProgramResultInput from '@/features/student/personalCareer/components/interactions/inputs/DeclaredProgramResultInput/DeclaredProgramResultInput.vue'
-import { DECLARED_PROGRAM_RESULT_MAX_LENGTH } from '@/features/student/personalCareer/config'
 import { markRaw } from 'vue'
 
 interface DeclaredProgramResultFormFieldProps {
   form: AddDeclaredProgramForm
 }
 
-defineOptions({
-  inheritAttrs: false
-})
-
 const { form } = defineProps<DeclaredProgramResultFormFieldProps>()
 const FormField = markRaw(form.Field)
 const resultField = form.useField({ name: 'result' })
 
 function onUpdateResult (value: string | undefined) {
-  resultField.api.handleChange(String(value ?? '').slice(0, DECLARED_PROGRAM_RESULT_MAX_LENGTH))
+  resultField.api.handleChange(String(value ?? ''))
 }
 </script>
 
@@ -26,7 +21,7 @@ function onUpdateResult (value: string | undefined) {
     <template #default="{ field }">
       <DeclaredProgramResultInput
         v-bind="$attrs"
-        :model-value="(field.state.value ?? '').slice(0, DECLARED_PROGRAM_RESULT_MAX_LENGTH)"
+        :model-value="field.state.value ?? ''"
         :error-message="field.state.meta.errors?.join(', ')"
         @blur="field.handleBlur"
         @update:model-value="onUpdateResult"

--- a/src/features/student/personalCareer/components/interactions/formFields/DeclaredProgramSourceOfInformationFormField/DeclaredProgramSourceOfInformationFormField.test.ts
+++ b/src/features/student/personalCareer/components/interactions/formFields/DeclaredProgramSourceOfInformationFormField/DeclaredProgramSourceOfInformationFormField.test.ts
@@ -1,6 +1,5 @@
 import type { AddDeclaredProgramForm, DeclaredProgramFormData } from '@/features/student/personalCareer/types/forms.types'
 import DeclaredProgramSourceOfInformationFormField from '@/features/student/personalCareer/components/interactions/formFields/DeclaredProgramSourceOfInformationFormField/DeclaredProgramSourceOfInformationFormField.vue'
-import { DECLARED_PROGRAM_SOURCE_OF_INFORMATION_MAX_LENGTH } from '@/features/student/personalCareer/config'
 import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { useForm } from '@tanstack/vue-form'
 import { mount, type VueWrapper } from '@vue/test-utils'
@@ -84,21 +83,6 @@ BddTest().given('a declared program source of information form field', () => {
         await vi.waitFor(() => {
           const updated = wrapper.findComponent({ name: 'DeclaredProgramSourceOfInformationInput' })
           expect(updated.props('modelValue')).toBe('Information from university website')
-        })
-      })
-    })
-
-    BddTest().and('the user enters a source of information exceeding max length', () => {
-      BddTest().then('it should truncate the value to max length', async () => {
-        const input = wrapper.findComponent({ name: 'DeclaredProgramSourceOfInformationInput' })
-        const textInput = input.find('input')
-        const longSource = 'a'.repeat(DECLARED_PROGRAM_SOURCE_OF_INFORMATION_MAX_LENGTH + 10)
-        await textInput.setValue(longSource)
-        await wrapper.vm.$nextTick()
-
-        await vi.waitFor(() => {
-          const updated = wrapper.findComponent({ name: 'DeclaredProgramSourceOfInformationInput' })
-          expect(updated.props('modelValue')).toHaveLength(DECLARED_PROGRAM_SOURCE_OF_INFORMATION_MAX_LENGTH)
         })
       })
     })

--- a/src/features/student/personalCareer/components/interactions/formFields/DeclaredProgramSourceOfInformationFormField/DeclaredProgramSourceOfInformationFormField.vue
+++ b/src/features/student/personalCareer/components/interactions/formFields/DeclaredProgramSourceOfInformationFormField/DeclaredProgramSourceOfInformationFormField.vue
@@ -1,23 +1,18 @@
 <script setup lang="ts">
 import type { AddDeclaredProgramForm } from '@/features/student/personalCareer/types/forms.types'
 import DeclaredProgramSourceOfInformationInput from '@/features/student/personalCareer/components/interactions/inputs/DeclaredProgramSourceOfInformationInput/DeclaredProgramSourceOfInformationInput.vue'
-import { DECLARED_PROGRAM_SOURCE_OF_INFORMATION_MAX_LENGTH } from '@/features/student/personalCareer/config'
 import { markRaw } from 'vue'
 
 interface DeclaredProgramSourceOfInformationFormFieldProps {
   form: AddDeclaredProgramForm
 }
 
-defineOptions({
-  inheritAttrs: false
-})
-
 const { form } = defineProps<DeclaredProgramSourceOfInformationFormFieldProps>()
 const FormField = markRaw(form.Field)
 const sourceOfInformationField = form.useField({ name: 'sourceOfInformation' })
 
 function onUpdateSourceOfInformation (value: string | undefined) {
-  sourceOfInformationField.api.handleChange(String(value ?? '').slice(0, DECLARED_PROGRAM_SOURCE_OF_INFORMATION_MAX_LENGTH))
+  sourceOfInformationField.api.handleChange(String(value ?? ''))
 }
 </script>
 
@@ -26,7 +21,7 @@ function onUpdateSourceOfInformation (value: string | undefined) {
     <template #default="{ field }">
       <DeclaredProgramSourceOfInformationInput
         v-bind="$attrs"
-        :model-value="(field.state.value ?? '').slice(0, DECLARED_PROGRAM_SOURCE_OF_INFORMATION_MAX_LENGTH)"
+        :model-value="field.state.value ?? ''"
         :error-message="field.state.meta.errors?.join(', ')"
         @blur="field.handleBlur"
         @update:model-value="onUpdateSourceOfInformation"

--- a/src/features/student/personalCareer/components/interactions/formFields/DeclaredProgramTitleFormField/DeclaredProgramTitleFormField.test.ts
+++ b/src/features/student/personalCareer/components/interactions/formFields/DeclaredProgramTitleFormField/DeclaredProgramTitleFormField.test.ts
@@ -1,6 +1,5 @@
 import type { AddDeclaredProgramForm, DeclaredProgramFormData } from '@/features/student/personalCareer/types/forms.types'
 import DeclaredProgramTitleFormField from '@/features/student/personalCareer/components/interactions/formFields/DeclaredProgramTitleFormField/DeclaredProgramTitleFormField.vue'
-import { DECLARED_PROGRAM_TITLE_MAX_LENGTH } from '@/features/student/personalCareer/config'
 import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { useForm } from '@tanstack/vue-form'
 import { mount, type VueWrapper } from '@vue/test-utils'
@@ -91,21 +90,6 @@ BddTest().given('a declared program title form field', () => {
         await vi.waitFor(() => {
           const updated = wrapper.findComponent({ name: 'DeclaredProgramTitleInput' })
           expect(updated.props('modelValue')).toBe('My Program Title')
-        })
-      })
-    })
-
-    BddTest().and('the user enters a title exceeding max length', () => {
-      BddTest().then('it should truncate the value to max length', async () => {
-        const input = wrapper.findComponent({ name: 'DeclaredProgramTitleInput' })
-        const textInput = input.find('input')
-        const longTitle = 'a'.repeat(DECLARED_PROGRAM_TITLE_MAX_LENGTH + 10)
-        await textInput.setValue(longTitle)
-        await wrapper.vm.$nextTick()
-
-        await vi.waitFor(() => {
-          const updated = wrapper.findComponent({ name: 'DeclaredProgramTitleInput' })
-          expect(updated.props('modelValue')).toHaveLength(DECLARED_PROGRAM_TITLE_MAX_LENGTH)
         })
       })
     })

--- a/src/features/student/personalCareer/components/interactions/formFields/DeclaredProgramTitleFormField/DeclaredProgramTitleFormField.vue
+++ b/src/features/student/personalCareer/components/interactions/formFields/DeclaredProgramTitleFormField/DeclaredProgramTitleFormField.vue
@@ -1,23 +1,18 @@
 <script setup lang="ts">
 import type { AddDeclaredProgramForm } from '@/features/student/personalCareer/types/forms.types'
 import DeclaredProgramTitleInput from '@/features/student/personalCareer/components/interactions/inputs/DeclaredProgramTitleInput/DeclaredProgramTitleInput.vue'
-import { DECLARED_PROGRAM_TITLE_MAX_LENGTH } from '@/features/student/personalCareer/config'
 import { markRaw } from 'vue'
 
 interface DeclaredProgramTitleFormFieldProps {
   form: AddDeclaredProgramForm
 }
 
-defineOptions({
-  inheritAttrs: false
-})
-
 const { form } = defineProps<DeclaredProgramTitleFormFieldProps>()
 const FormField = markRaw(form.Field)
 const titleField = form.useField({ name: 'title' })
 
 function onUpdateTitle (value: string | undefined) {
-  titleField.api.handleChange(String(value ?? '').slice(0, DECLARED_PROGRAM_TITLE_MAX_LENGTH))
+  titleField.api.handleChange(String(value ?? ''))
 }
 </script>
 
@@ -26,8 +21,9 @@ function onUpdateTitle (value: string | undefined) {
     <template #default="{ field }">
       <DeclaredProgramTitleInput
         v-bind="$attrs"
-        :model-value="(field.state.value ?? '').slice(0, DECLARED_PROGRAM_TITLE_MAX_LENGTH)"
+        :model-value="field.state.value ?? ''"
         :error-message="field.state.meta.errors?.join(', ')"
+        required
         @blur="field.handleBlur"
         @update:model-value="onUpdateTitle"
       />

--- a/src/features/student/personalCareer/components/interactions/inputs/DeclaredProgramDescriptionTextarea/DeclaredProgramDescriptionTextarea.test.ts
+++ b/src/features/student/personalCareer/components/interactions/inputs/DeclaredProgramDescriptionTextarea/DeclaredProgramDescriptionTextarea.test.ts
@@ -1,6 +1,7 @@
+import { InputStub } from '@/common/components/interaction/inputs/Input/Input.stub'
 import DeclaredProgramDescriptionTextarea from '@/features/student/personalCareer/components/interactions/inputs/DeclaredProgramDescriptionTextarea/DeclaredProgramDescriptionTextarea.vue'
 import { DECLARED_PROGRAM_DESCRIPTION_MAX_LENGTH } from '@/features/student/personalCareer/config'
-import { AvInputStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { mount, type VueWrapper } from '@vue/test-utils'
 import { beforeEach, expect, vi } from 'vitest'
 
@@ -8,7 +9,7 @@ BddTest().given('a declared program description textarea component', () => {
   let wrapper: VueWrapper<InstanceType<typeof DeclaredProgramDescriptionTextarea>>
 
   const stubs = {
-    AvInput: AvInputStub
+    Input: InputStub
   }
 
   BddTest().when('the component is mounted with model value', () => {
@@ -27,28 +28,28 @@ BddTest().given('a declared program description textarea component', () => {
       expect(wrapper.exists()).toBe(true)
     })
 
-    BddTest().then('it should render the AvInput component', () => {
-      const input = wrapper.findComponent({ name: 'AvInput' })
+    BddTest().then('it should render the Input component', () => {
+      const input = wrapper.findComponent(InputStub)
       expect(input.exists()).toBe(true)
     })
 
     BddTest().then('it should have isTextarea prop set to true', () => {
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
       expect(input.props('isTextarea')).toBe(true)
     })
 
     BddTest().then('it should have maxlength prop set to config value', () => {
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
       expect(input.props('maxlength')).toBe(DECLARED_PROGRAM_DESCRIPTION_MAX_LENGTH)
     })
 
     BddTest().then('it should display the correct French label', () => {
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
       expect(input.props('label')).toBe('Description de ma formation')
     })
 
     BddTest().then('it should have empty initial value', () => {
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
       expect(input.props('modelValue')).toBe('')
     })
 
@@ -70,7 +71,7 @@ BddTest().given('a declared program description textarea component', () => {
     })
 
     BddTest().then('it should display the custom label', () => {
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
       expect(input.props('label')).toBe('Custom Label')
     })
   })
@@ -87,8 +88,8 @@ BddTest().given('a declared program description textarea component', () => {
       })
     })
 
-    BddTest().then('it should pass the error message to AvInput', () => {
-      const input = wrapper.findComponent({ name: 'AvInput' })
+    BddTest().then('it should pass the error message to Input', () => {
+      const input = wrapper.findComponent(InputStub)
       expect(input.props('errorMessage')).toBe('Ce champ est requis')
     })
   })
@@ -102,13 +103,13 @@ BddTest().given('a declared program description textarea component', () => {
         },
         global: { stubs }
       })
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
       await input.vm.$emit('update:modelValue', 'New description text')
       await wrapper.vm.$nextTick()
     })
 
     BddTest().then('it should update the model value', () => {
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
       expect(input.props('modelValue')).toBe('New description text')
     })
   })
@@ -125,7 +126,7 @@ BddTest().given('a declared program description textarea component', () => {
     })
 
     BddTest().then('it should display the initial value', () => {
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
       expect(input.props('modelValue')).toBe('Initial description')
     })
   })
@@ -177,8 +178,8 @@ BddTest().given('a declared program description textarea component', () => {
       })
     })
 
-    BddTest().then('it should pass additional props to AvInput', () => {
-      const input = wrapper.findComponent({ name: 'AvInput' })
+    BddTest().then('it should pass additional props to Input', () => {
+      const input = wrapper.findComponent(InputStub)
       expect(input.props('disabled')).toBe(true)
       expect(input.props('required')).toBe(true)
     })
@@ -193,13 +194,13 @@ BddTest().given('a declared program description textarea component', () => {
         },
         global: { stubs }
       })
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
       await input.vm.$emit('update:modelValue', '')
       await wrapper.vm.$nextTick()
     })
 
     BddTest().then('it should update to empty value', () => {
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
       expect(input.props('modelValue')).toBe('')
     })
 

--- a/src/features/student/personalCareer/components/interactions/inputs/DeclaredProgramDescriptionTextarea/DeclaredProgramDescriptionTextarea.vue
+++ b/src/features/student/personalCareer/components/interactions/inputs/DeclaredProgramDescriptionTextarea/DeclaredProgramDescriptionTextarea.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
+import Input, { type InputProps } from '@/common/components/interaction/inputs/Input/Input.vue'
 import { DECLARED_PROGRAM_DESCRIPTION_MAX_LENGTH } from '@/features/student/personalCareer/config'
-import { AvInput, type AvInputProps } from '@avenirs-esr/avenirs-dsav'
 import { useI18n } from 'vue-i18n'
 
-type DeclaredProgramDescriptionTextareaProps = Omit<AvInputProps, 'maxlength' | 'isTextarea'>
+type DeclaredProgramDescriptionTextareaProps = Omit<InputProps, 'maxlength' | 'isTextarea'>
 
 const {
   label,
@@ -13,7 +13,7 @@ const {
 const modelValue = defineModel<string>()
 const { t } = useI18n()
 
-const avInputProps = computed(() => ({
+const inputProps = computed(() => ({
   ...restProps,
   isTextarea: true,
   labelVisible: true,
@@ -24,19 +24,8 @@ const avInputProps = computed(() => ({
 </script>
 
 <template>
-  <div class="declared-program-description-textarea">
-    <AvInput
-      v-bind="avInputProps"
-      v-model="modelValue"
-    >
-      <template #maxLengthCaption="{ currentValue }">
-        <span class="caption-light">
-          {{ t('global.inputs.textarea.limit', {
-            count: currentValue?.toString().length || 0,
-            maxlength: avInputProps.maxlength,
-          }) }}
-        </span>
-      </template>
-    </AvInput>
-  </div>
+  <Input
+    v-bind="inputProps"
+    v-model="modelValue"
+  />
 </template>

--- a/src/features/student/personalCareer/components/interactions/inputs/DeclaredProgramOrganizationInput/DeclaredProgramOrganizationInput.test.ts
+++ b/src/features/student/personalCareer/components/interactions/inputs/DeclaredProgramOrganizationInput/DeclaredProgramOrganizationInput.test.ts
@@ -1,7 +1,8 @@
+import { InputStub } from '@/common/components/interaction/inputs/Input/Input.stub'
 import DeclaredProgramOrganizationInput from '@/features/student/personalCareer/components/interactions/inputs/DeclaredProgramOrganizationInput/DeclaredProgramOrganizationInput.vue'
 import { DECLARED_PROGRAM_ORGANIZATION_MAX_LENGTH } from '@/features/student/personalCareer/config'
 import { MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
-import { AvInputStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { mount, type VueWrapper } from '@vue/test-utils'
 import { beforeEach, expect, vi } from 'vitest'
 
@@ -9,7 +10,7 @@ BddTest().given('a declared program institution input component', () => {
   let wrapper: VueWrapper<InstanceType<typeof DeclaredProgramOrganizationInput>>
 
   const stubs = {
-    AvInput: AvInputStub
+    Input: InputStub
   }
 
   BddTest().when('the component is mounted', () => {
@@ -27,38 +28,38 @@ BddTest().given('a declared program institution input component', () => {
       expect(wrapper.exists()).toBe(true)
     })
 
-    BddTest().then('it should render the AvInput component', () => {
-      const input = wrapper.findComponent({ name: 'AvInput' })
+    BddTest().then('it should render the Input component', () => {
+      const input = wrapper.findComponent(InputStub)
       expect(input.exists()).toBe(true)
     })
 
     BddTest().then('it should have labelVisible set to true', () => {
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
       expect(input.props('labelVisible')).toBe(true)
     })
 
     BddTest().then('it should have maxlength prop set to config value', () => {
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
       expect(input.props('maxlength')).toBe(DECLARED_PROGRAM_ORGANIZATION_MAX_LENGTH)
     })
 
     BddTest().then('it should display the correct French label', () => {
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
       expect(input.props('label')).toBe('Établissement / Organisme')
     })
 
     BddTest().then('it should display the correct prefix icon', () => {
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
       expect(input.props('prefixIcon')).toBe(MDI_ICONS.BUILDING)
     })
 
     BddTest().then('it should display the correct placeholder', () => {
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
       expect(input.props('placeholder')).toBe('Nom de l\'établissement')
     })
 
     BddTest().then('it should have empty initial value', () => {
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
       expect(input.props('modelValue')).toBe('')
     })
   })
@@ -76,7 +77,7 @@ BddTest().given('a declared program institution input component', () => {
     })
 
     BddTest().then('it should display the custom label', () => {
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
       expect(input.props('label')).toBe('Custom Label')
     })
   })
@@ -94,7 +95,7 @@ BddTest().given('a declared program institution input component', () => {
     })
 
     BddTest().then('it should display the custom placeholder', () => {
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
       expect(input.props('placeholder')).toBe('Custom Placeholder')
     })
   })
@@ -112,7 +113,7 @@ BddTest().given('a declared program institution input component', () => {
     })
 
     BddTest().then('it should display the custom prefix icon', () => {
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
       expect(input.props('prefixIcon')).toBe('mdi:account')
     })
   })
@@ -129,8 +130,8 @@ BddTest().given('a declared program institution input component', () => {
       })
     })
 
-    BddTest().then('it should pass the error message to AvInput', () => {
-      const input = wrapper.findComponent({ name: 'AvInput' })
+    BddTest().then('it should pass the error message to Input', () => {
+      const input = wrapper.findComponent(InputStub)
       expect(input.props('errorMessage')).toBe('Ce champ est requis')
     })
   })
@@ -144,13 +145,13 @@ BddTest().given('a declared program institution input component', () => {
         },
         global: { stubs }
       })
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
       await input.vm.$emit('update:modelValue', 'University Name')
       await wrapper.vm.$nextTick()
     })
 
     BddTest().then('it should update the model value', () => {
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
       expect(input.props('modelValue')).toBe('University Name')
     })
   })
@@ -167,8 +168,24 @@ BddTest().given('a declared program institution input component', () => {
     })
 
     BddTest().then('it should display the initial value', () => {
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
       expect(input.props('modelValue')).toBe('Initial institution')
+    })
+  })
+
+  BddTest().when('the component uses default custom captions template', () => {
+    beforeEach(() => {
+      vi.clearAllMocks()
+      wrapper = mount(DeclaredProgramOrganizationInput, {
+        props: {
+          modelValue: 'Test'
+        },
+        global: { stubs }
+      })
+    })
+
+    BddTest().then('it should display character count', () => {
+      expect(wrapper.text()).toContain('4 / 50')
     })
   })
 
@@ -185,8 +202,8 @@ BddTest().given('a declared program institution input component', () => {
       })
     })
 
-    BddTest().then('it should pass additional props to AvInput', () => {
-      const input = wrapper.findComponent({ name: 'AvInput' })
+    BddTest().then('it should pass additional props to Input', () => {
+      const input = wrapper.findComponent(InputStub)
       expect(input.props('disabled')).toBe(true)
       expect(input.props('required')).toBe(true)
     })
@@ -201,13 +218,13 @@ BddTest().given('a declared program institution input component', () => {
         },
         global: { stubs }
       })
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
       await input.vm.$emit('update:modelValue', '')
       await wrapper.vm.$nextTick()
     })
 
     BddTest().then('it should update to empty value', () => {
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
       expect(input.props('modelValue')).toBe('')
     })
   })

--- a/src/features/student/personalCareer/components/interactions/inputs/DeclaredProgramOrganizationInput/DeclaredProgramOrganizationInput.vue
+++ b/src/features/student/personalCareer/components/interactions/inputs/DeclaredProgramOrganizationInput/DeclaredProgramOrganizationInput.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
+import Input, { type InputProps } from '@/common/components/interaction/inputs/Input/Input.vue'
 import { DECLARED_PROGRAM_ORGANIZATION_MAX_LENGTH } from '@/features/student/personalCareer/config'
-import { AvInput, type AvInputProps, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
+import { MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
 import { useI18n } from 'vue-i18n'
 
-type DeclaredProgramInstitutionInputProps = Omit<AvInputProps, 'maxlength'>
+type DeclaredProgramInstitutionInputProps = Omit<InputProps, 'maxlength'>
 
 const {
   label,
@@ -15,7 +16,7 @@ const {
 const modelValue = defineModel<string>()
 const { t } = useI18n()
 
-const avInputProps = computed(() => ({
+const inputProps = computed(() => ({
   ...restProps,
   labelVisible: true,
   label: label ?? t('student.personalCareer.interactions.inputs.DeclaredProgramOrganizationInput.label'),
@@ -26,8 +27,8 @@ const avInputProps = computed(() => ({
 </script>
 
 <template>
-  <AvInput
-    v-bind="avInputProps"
+  <Input
+    v-bind="inputProps"
     v-model="modelValue"
   />
 </template>

--- a/src/features/student/personalCareer/components/interactions/inputs/DeclaredProgramResultInput/DeclaredProgramResultInput.test.ts
+++ b/src/features/student/personalCareer/components/interactions/inputs/DeclaredProgramResultInput/DeclaredProgramResultInput.test.ts
@@ -1,7 +1,8 @@
+import { InputStub } from '@/common/components/interaction/inputs/Input/Input.stub'
 import DeclaredProgramResultInput from '@/features/student/personalCareer/components/interactions/inputs/DeclaredProgramResultInput/DeclaredProgramResultInput.vue'
 import { DECLARED_PROGRAM_RESULT_MAX_LENGTH } from '@/features/student/personalCareer/config'
 import { RI_ICONS } from '@avenirs-esr/avenirs-dsav'
-import { AvInputStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { mount, type VueWrapper } from '@vue/test-utils'
 import { beforeEach, expect, vi } from 'vitest'
 
@@ -9,7 +10,7 @@ BddTest().given('a declared program result input component', () => {
   let wrapper: VueWrapper<InstanceType<typeof DeclaredProgramResultInput>>
 
   const stubs = {
-    AvInput: AvInputStub
+    Input: InputStub
   }
 
   BddTest().when('the component is mounted', () => {
@@ -27,38 +28,38 @@ BddTest().given('a declared program result input component', () => {
       expect(wrapper.exists()).toBe(true)
     })
 
-    BddTest().then('it should render the AvInput component', () => {
-      const input = wrapper.findComponent({ name: 'AvInput' })
+    BddTest().then('it should render the Input component', () => {
+      const input = wrapper.findComponent(InputStub)
       expect(input.exists()).toBe(true)
     })
 
     BddTest().then('it should have labelVisible set to true', () => {
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
       expect(input.props('labelVisible')).toBe(true)
     })
 
     BddTest().then('it should have maxlength prop set to config value', () => {
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
       expect(input.props('maxlength')).toBe(DECLARED_PROGRAM_RESULT_MAX_LENGTH)
     })
 
     BddTest().then('it should display the correct French label', () => {
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
       expect(input.props('label')).toBe('Résultat obtenu')
     })
 
     BddTest().then('it should display the correct prefix icon', () => {
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
       expect(input.props('prefixIcon')).toBe(RI_ICONS.LAYOUT_6_LINE)
     })
 
     BddTest().then('it should display the correct placeholder', () => {
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
       expect(input.props('placeholder')).toBe('Résultat')
     })
 
     BddTest().then('it should have empty initial value', () => {
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
       expect(input.props('modelValue')).toBe('')
     })
   })
@@ -76,7 +77,7 @@ BddTest().given('a declared program result input component', () => {
     })
 
     BddTest().then('it should display the custom label', () => {
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
       expect(input.props('label')).toBe('Custom Label')
     })
   })
@@ -94,7 +95,7 @@ BddTest().given('a declared program result input component', () => {
     })
 
     BddTest().then('it should display the custom placeholder', () => {
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
       expect(input.props('placeholder')).toBe('Custom Placeholder')
     })
   })
@@ -112,7 +113,7 @@ BddTest().given('a declared program result input component', () => {
     })
 
     BddTest().then('it should display the custom prefix icon', () => {
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
       expect(input.props('prefixIcon')).toBe('mdi:account')
     })
   })
@@ -129,8 +130,8 @@ BddTest().given('a declared program result input component', () => {
       })
     })
 
-    BddTest().then('it should pass the error message to AvInput', () => {
-      const input = wrapper.findComponent({ name: 'AvInput' })
+    BddTest().then('it should pass the error message to Input', () => {
+      const input = wrapper.findComponent(InputStub)
       expect(input.props('errorMessage')).toBe('Ce champ est requis')
     })
   })
@@ -144,13 +145,13 @@ BddTest().given('a declared program result input component', () => {
         },
         global: { stubs }
       })
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
       await input.vm.$emit('update:modelValue', 'Obtained result')
       await wrapper.vm.$nextTick()
     })
 
     BddTest().then('it should update the model value', () => {
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
       expect(input.props('modelValue')).toBe('Obtained result')
     })
   })
@@ -167,8 +168,24 @@ BddTest().given('a declared program result input component', () => {
     })
 
     BddTest().then('it should display the initial value', () => {
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
       expect(input.props('modelValue')).toBe('Initial result')
+    })
+  })
+
+  BddTest().when('the component uses default custom captions template', () => {
+    beforeEach(() => {
+      vi.clearAllMocks()
+      wrapper = mount(DeclaredProgramResultInput, {
+        props: {
+          modelValue: 'Test'
+        },
+        global: { stubs }
+      })
+    })
+
+    BddTest().then('it should display character count', () => {
+      expect(wrapper.text()).toContain('4 / 50')
     })
   })
 
@@ -185,8 +202,8 @@ BddTest().given('a declared program result input component', () => {
       })
     })
 
-    BddTest().then('it should pass additional props to AvInput', () => {
-      const input = wrapper.findComponent({ name: 'AvInput' })
+    BddTest().then('it should pass additional props to Input', () => {
+      const input = wrapper.findComponent(InputStub)
       expect(input.props('disabled')).toBe(true)
       expect(input.props('required')).toBe(true)
     })
@@ -201,13 +218,13 @@ BddTest().given('a declared program result input component', () => {
         },
         global: { stubs }
       })
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
       await input.vm.$emit('update:modelValue', '')
       await wrapper.vm.$nextTick()
     })
 
     BddTest().then('it should update to empty value', () => {
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
       expect(input.props('modelValue')).toBe('')
     })
   })

--- a/src/features/student/personalCareer/components/interactions/inputs/DeclaredProgramResultInput/DeclaredProgramResultInput.vue
+++ b/src/features/student/personalCareer/components/interactions/inputs/DeclaredProgramResultInput/DeclaredProgramResultInput.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
+import Input, { type InputProps } from '@/common/components/interaction/inputs/Input/Input.vue'
 import { DECLARED_PROGRAM_RESULT_MAX_LENGTH } from '@/features/student/personalCareer/config'
-import { AvInput, type AvInputProps, RI_ICONS } from '@avenirs-esr/avenirs-dsav'
+import { RI_ICONS } from '@avenirs-esr/avenirs-dsav'
 import { useI18n } from 'vue-i18n'
 
-type DeclaredProgramResultInputProps = Omit<AvInputProps, 'maxlength'>
+type DeclaredProgramResultInputProps = Omit<InputProps, 'maxlength'>
 
 const {
   label,
@@ -15,7 +16,7 @@ const {
 const modelValue = defineModel<string>()
 const { t } = useI18n()
 
-const avInputProps = computed(() => ({
+const inputProps = computed(() => ({
   ...restProps,
   labelVisible: true,
   maxlength: DECLARED_PROGRAM_RESULT_MAX_LENGTH,
@@ -26,8 +27,8 @@ const avInputProps = computed(() => ({
 </script>
 
 <template>
-  <AvInput
-    v-bind="avInputProps"
+  <Input
+    v-bind="inputProps"
     v-model="modelValue"
   />
 </template>

--- a/src/features/student/personalCareer/components/interactions/inputs/DeclaredProgramSourceOfInformationInput/DeclaredProgramSourceOfInformationInput.test.ts
+++ b/src/features/student/personalCareer/components/interactions/inputs/DeclaredProgramSourceOfInformationInput/DeclaredProgramSourceOfInformationInput.test.ts
@@ -1,7 +1,8 @@
+import { InputStub } from '@/common/components/interaction/inputs/Input/Input.stub'
 import DeclaredProgramSourceOfInformationInput from '@/features/student/personalCareer/components/interactions/inputs/DeclaredProgramSourceOfInformationInput/DeclaredProgramSourceOfInformationInput.vue'
 import { DECLARED_PROGRAM_SOURCE_OF_INFORMATION_MAX_LENGTH } from '@/features/student/personalCareer/config'
 import { MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
-import { AvInputStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { mount, type VueWrapper } from '@vue/test-utils'
 import { beforeEach, expect, vi } from 'vitest'
 
@@ -9,7 +10,7 @@ BddTest().given('a declared program source of information input', () => {
   let wrapper: VueWrapper<InstanceType<typeof DeclaredProgramSourceOfInformationInput>>
 
   const stubs = {
-    AvInput: AvInputStub
+    Input: InputStub
   }
 
   BddTest().when('the component is mounted', () => {
@@ -20,39 +21,39 @@ BddTest().given('a declared program source of information input', () => {
       })
     })
 
-    BddTest().then('it should render the AvInput component', () => {
-      const input = wrapper.findComponent({ name: 'AvInput' })
+    BddTest().then('it should render the Input component', () => {
+      const input = wrapper.findComponent(InputStub)
       expect(input.exists()).toBe(true)
     })
 
     BddTest().then('it should have default label from i18n', () => {
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
       expect(input.props('label')).toBe('Provenance de l\'information')
     })
 
     BddTest().then('it should have default placeholder from i18n', () => {
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
       expect(input.props('placeholder')).toBe('Source de l\'information')
     })
 
     BddTest().then('it should have default prefix icon', () => {
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
       expect(input.props('prefixIcon')).toBe(MDI_ICONS.NEWSPAPER_VARIANT)
     })
 
     BddTest().then('it should have max length from config', () => {
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
       expect(input.props('maxlength')).toBe(DECLARED_PROGRAM_SOURCE_OF_INFORMATION_MAX_LENGTH)
     })
 
     BddTest().then('it should have labelVisible set to true', () => {
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
       expect(input.props('labelVisible')).toBe(true)
     })
 
     BddTest().and('the user enters text', () => {
       BddTest().then('it should update the model value', async () => {
-        const input = wrapper.findComponent({ name: 'AvInput' })
+        const input = wrapper.findComponent(InputStub)
         await input.vm.$emit('update:modelValue', 'University website')
         await wrapper.vm.$nextTick()
 
@@ -74,7 +75,7 @@ BddTest().given('a declared program source of information input', () => {
     })
 
     BddTest().then('it should override default label', () => {
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
       expect(input.props('label')).toBe('Custom Label')
     })
   })
@@ -91,7 +92,7 @@ BddTest().given('a declared program source of information input', () => {
     })
 
     BddTest().then('it should override default prefix icon', () => {
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
       expect(input.props('prefixIcon')).toBe(MDI_ICONS.ATTACH_FILE)
     })
   })
@@ -108,7 +109,7 @@ BddTest().given('a declared program source of information input', () => {
     })
 
     BddTest().then('it should override default placeholder', () => {
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
       expect(input.props('placeholder')).toBe('Custom Placeholder')
     })
   })
@@ -125,8 +126,24 @@ BddTest().given('a declared program source of information input', () => {
     })
 
     BddTest().then('it should display the initial value', () => {
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
       expect(input.props('modelValue')).toBe('Initial source')
+    })
+  })
+
+  BddTest().when('the component uses default custom captions template', () => {
+    beforeEach(() => {
+      vi.clearAllMocks()
+      wrapper = mount(DeclaredProgramSourceOfInformationInput, {
+        props: {
+          modelValue: 'Test'
+        },
+        global: { stubs }
+      })
+    })
+
+    BddTest().then('it should display character count', () => {
+      expect(wrapper.text()).toContain('4 / 200')
     })
   })
 
@@ -141,8 +158,8 @@ BddTest().given('a declared program source of information input', () => {
       })
     })
 
-    BddTest().then('it should pass error message to AvInput', () => {
-      const input = wrapper.findComponent({ name: 'AvInput' })
+    BddTest().then('it should pass error message to Input', () => {
+      const input = wrapper.findComponent(InputStub)
       expect(input.props('errorMessage')).toBe('This field is required')
     })
   })

--- a/src/features/student/personalCareer/components/interactions/inputs/DeclaredProgramSourceOfInformationInput/DeclaredProgramSourceOfInformationInput.vue
+++ b/src/features/student/personalCareer/components/interactions/inputs/DeclaredProgramSourceOfInformationInput/DeclaredProgramSourceOfInformationInput.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
+import Input, { type InputProps } from '@/common/components/interaction/inputs/Input/Input.vue'
 import { DECLARED_PROGRAM_SOURCE_OF_INFORMATION_MAX_LENGTH } from '@/features/student/personalCareer/config'
-import { AvInput, type AvInputProps, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
+import { MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
 import { useI18n } from 'vue-i18n'
 
-type DeclaredProgramSourceOfInformationInputProps = Omit<AvInputProps, 'maxlength'>
+type DeclaredProgramSourceOfInformationInputProps = Omit<InputProps, 'maxlength'>
 
 const {
   label,
@@ -15,7 +16,7 @@ const {
 const modelValue = defineModel<string>()
 const { t } = useI18n()
 
-const avInputProps = computed(() => ({
+const inputProps = computed(() => ({
   ...restProps,
   labelVisible: true,
   maxlength: DECLARED_PROGRAM_SOURCE_OF_INFORMATION_MAX_LENGTH,
@@ -26,8 +27,8 @@ const avInputProps = computed(() => ({
 </script>
 
 <template>
-  <AvInput
-    v-bind="avInputProps"
+  <Input
+    v-bind="inputProps"
     v-model="modelValue"
   />
 </template>

--- a/src/features/student/personalCareer/components/interactions/inputs/DeclaredProgramTitleInput/DeclaredProgramTitleInput.test.ts
+++ b/src/features/student/personalCareer/components/interactions/inputs/DeclaredProgramTitleInput/DeclaredProgramTitleInput.test.ts
@@ -1,7 +1,8 @@
+import { InputStub } from '@/common/components/interaction/inputs/Input/Input.stub'
 import DeclaredProgramTitleInput from '@/features/student/personalCareer/components/interactions/inputs/DeclaredProgramTitleInput/DeclaredProgramTitleInput.vue'
 import { DECLARED_PROGRAM_TITLE_MAX_LENGTH } from '@/features/student/personalCareer/config'
 import { MDI_ICONS, RI_ICONS } from '@avenirs-esr/avenirs-dsav'
-import { AvInputStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { mount, type VueWrapper } from '@vue/test-utils'
 import { beforeEach, expect, vi } from 'vitest'
 
@@ -9,7 +10,7 @@ BddTest().given('a declared program title input component', () => {
   let wrapper: VueWrapper<InstanceType<typeof DeclaredProgramTitleInput>>
 
   const stubs = {
-    AvInput: AvInputStub
+    Input: InputStub
   }
 
   BddTest().when('the component is mounted', () => {
@@ -27,38 +28,38 @@ BddTest().given('a declared program title input component', () => {
       expect(wrapper.exists()).toBe(true)
     })
 
-    BddTest().then('it should render the AvInput component', () => {
-      const input = wrapper.findComponent({ name: 'AvInput' })
+    BddTest().then('it should render the Input component', () => {
+      const input = wrapper.findComponent(InputStub)
       expect(input.exists()).toBe(true)
     })
 
     BddTest().then('it should have labelVisible set to true', () => {
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
       expect(input.props('labelVisible')).toBe(true)
     })
 
     BddTest().then('it should have maxlength prop set to config value', () => {
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
       expect(input.props('maxlength')).toBe(DECLARED_PROGRAM_TITLE_MAX_LENGTH)
     })
 
     BddTest().then('it should display the correct French label', () => {
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
       expect(input.props('label')).toBe('Intitulé de ma formation')
     })
 
     BddTest().then('it should display the correct prefix icon', () => {
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
       expect(input.props('prefixIcon')).toBe(RI_ICONS.LOADER_LINE)
     })
 
     BddTest().then('it should display the correct placeholder', () => {
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
       expect(input.props('placeholder')).toBe('Nom de ma formation')
     })
 
     BddTest().then('it should have empty initial value', () => {
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
       expect(input.props('modelValue')).toBe('')
     })
   })
@@ -76,7 +77,7 @@ BddTest().given('a declared program title input component', () => {
     })
 
     BddTest().then('it should display the custom label', () => {
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
       expect(input.props('label')).toBe('Custom Label')
     })
   })
@@ -94,7 +95,7 @@ BddTest().given('a declared program title input component', () => {
     })
 
     BddTest().then('it should display the custom placeholder', () => {
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
       expect(input.props('placeholder')).toBe('Custom Placeholder')
     })
   })
@@ -112,7 +113,7 @@ BddTest().given('a declared program title input component', () => {
     })
 
     BddTest().then('it should display the custom prefix icon', () => {
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
       expect(input.props('prefixIcon')).toBe(MDI_ICONS.LINK)
     })
   })
@@ -129,8 +130,8 @@ BddTest().given('a declared program title input component', () => {
       })
     })
 
-    BddTest().then('it should pass the error message to AvInput', () => {
-      const input = wrapper.findComponent({ name: 'AvInput' })
+    BddTest().then('it should pass the error message to Input', () => {
+      const input = wrapper.findComponent(InputStub)
       expect(input.props('errorMessage')).toBe('Ce champ est requis')
     })
   })
@@ -144,13 +145,13 @@ BddTest().given('a declared program title input component', () => {
         },
         global: { stubs }
       })
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
       await input.vm.$emit('update:modelValue', 'New title')
       await wrapper.vm.$nextTick()
     })
 
     BddTest().then('it should update the model value', () => {
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
       expect(input.props('modelValue')).toBe('New title')
     })
   })
@@ -167,8 +168,24 @@ BddTest().given('a declared program title input component', () => {
     })
 
     BddTest().then('it should display the initial value', () => {
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
       expect(input.props('modelValue')).toBe('Initial title')
+    })
+  })
+
+  BddTest().when('the component uses default custom captions template', () => {
+    beforeEach(() => {
+      vi.clearAllMocks()
+      wrapper = mount(DeclaredProgramTitleInput, {
+        props: {
+          modelValue: 'Test'
+        },
+        global: { stubs }
+      })
+    })
+
+    BddTest().then('it should display character count', () => {
+      expect(wrapper.text()).toContain('4 / 80')
     })
   })
 
@@ -185,8 +202,8 @@ BddTest().given('a declared program title input component', () => {
       })
     })
 
-    BddTest().then('it should pass additional props to AvInput', () => {
-      const input = wrapper.findComponent({ name: 'AvInput' })
+    BddTest().then('it should pass additional props to Input', () => {
+      const input = wrapper.findComponent(InputStub)
       expect(input.props('disabled')).toBe(true)
       expect(input.props('required')).toBe(true)
     })
@@ -201,13 +218,13 @@ BddTest().given('a declared program title input component', () => {
         },
         global: { stubs }
       })
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
       await input.vm.$emit('update:modelValue', '')
       await wrapper.vm.$nextTick()
     })
 
     BddTest().then('it should update to empty value', () => {
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
       expect(input.props('modelValue')).toBe('')
     })
   })

--- a/src/features/student/personalCareer/components/interactions/inputs/DeclaredProgramTitleInput/DeclaredProgramTitleInput.vue
+++ b/src/features/student/personalCareer/components/interactions/inputs/DeclaredProgramTitleInput/DeclaredProgramTitleInput.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
+import Input, { type InputProps } from '@/common/components/interaction/inputs/Input/Input.vue'
 import { DECLARED_PROGRAM_TITLE_MAX_LENGTH } from '@/features/student/personalCareer/config'
-import { AvInput, type AvInputProps, RI_ICONS } from '@avenirs-esr/avenirs-dsav'
+import { RI_ICONS } from '@avenirs-esr/avenirs-dsav'
 import { useI18n } from 'vue-i18n'
 
-type DeclaredProgramTitleInputProps = Omit<AvInputProps, 'maxlength'>
+type DeclaredProgramTitleInputProps = Omit<InputProps, 'maxlength'>
 
 const {
   label,
@@ -15,7 +16,7 @@ const {
 const modelValue = defineModel<string>()
 const { t } = useI18n()
 
-const avInputProps = computed(() => ({
+const inputProps = computed(() => ({
   ...restProps,
   labelVisible: true,
   maxlength: DECLARED_PROGRAM_TITLE_MAX_LENGTH,
@@ -26,8 +27,8 @@ const avInputProps = computed(() => ({
 </script>
 
 <template>
-  <AvInput
-    v-bind="avInputProps"
+  <Input
+    v-bind="inputProps"
     v-model="modelValue"
   />
 </template>

--- a/src/features/student/personalCareer/components/overlays/AddDeclaredProgramDrawer/AddDeclaredProgramDrawer.vue
+++ b/src/features/student/personalCareer/components/overlays/AddDeclaredProgramDrawer/AddDeclaredProgramDrawer.vue
@@ -19,7 +19,7 @@ const declaredProgramsStore = usePersonalCareerStore()
 const { addSuccessMessage } = useToasterStore()
 const showDrawer = toRef(declaredProgramsStore, 'showAddDeclaredProgramDrawer')
 
-const { form, isFormValid, isSubmitting } = useAddDeclaredProgramForm(() => {
+const { form, isFormValid, isSubmitting, hasDefinitionItemsError } = useAddDeclaredProgramForm(() => {
   addSuccessMessage({
     timeout: 2000,
     description: t('student.personalCareer.overlays.AddDeclaredProgramDrawer.success')
@@ -74,6 +74,7 @@ const isDemo = __DEMO_MODE__
             <AvAccordion
               :title="t('student.personalCareer.overlays.AddDeclaredProgramDrawer.sections.addProgram')"
               :icon="MDI_ICONS.PENCIL_OUTLINE"
+              :trigger-border-color="hasDefinitionItemsError ? 'var(--dark-background-error)' : undefined"
             >
               <div class="av-col av-gap-md">
                 <DeclaredProgramTitleFormField :form="form" />

--- a/src/features/student/personalCareer/components/overlays/AddDeclaredProgramDrawer/use-add-declared-program-form/use-add-declared-program-form.ts
+++ b/src/features/student/personalCareer/components/overlays/AddDeclaredProgramDrawer/use-add-declared-program-form/use-add-declared-program-form.ts
@@ -1,6 +1,7 @@
 import type { BaseApiException } from '@/common/exceptions'
-import type { DeclaredProgramFormData } from '@/features/student/personalCareer/types/forms.types'
+import type { DeclaredProgramFormApi, DeclaredProgramFormData } from '@/features/student/personalCareer/types/forms.types'
 import { type DeclaredProgramRequestDTO, invalidateGetDeclaredPrograms, useCreateDeclaredProgram } from '@/api/avenir-esr'
+import { useFormValidators } from '@/common/composables/use-form-validators/use-form-validators'
 import { useTaskLoading } from '@/common/composables/use-task-loading/use-task-loading'
 import { formatYearMonthToDate } from '@/common/utils'
 import { useDeclaredProgramFormValidators } from '@/features/student/personalCareer/composables/use-declared-program-form-validators/use-declared-program-form-validators'
@@ -11,7 +12,10 @@ import { useI18n } from 'vue-i18n'
 
 export function useAddDeclaredProgramForm (onProgramAdded?: () => void) {
   const { t } = useI18n()
+
   const { addErrorMessage } = useToasterStore()
+  const { hasFieldErrors } = useFormValidators()
+
   const queryClient = useQueryClient()
   const { isLoading, withTaskLoading } = useTaskLoading()
   const onCreateDeclaredProgramError = (error: BaseApiException) => {
@@ -59,6 +63,24 @@ export function useAddDeclaredProgramForm (onProgramAdded?: () => void) {
             endDate: validators.validateEndDate(value.endDate, value.startDate, { isRequired: !value.isOngoing }),
           }
         }
+      },
+      onChange ({ value, formApi }: { value: DeclaredProgramFormData, formApi: DeclaredProgramFormApi }) {
+        const isTouched = (field: keyof DeclaredProgramFormData) => formApi.getFieldMeta(field)?.isTouched ?? true
+        const isValid = (field: keyof DeclaredProgramFormData) => formApi.getFieldMeta(field)?.isValid ?? true
+        return {
+          fields: {
+            title: isTouched('title') ? validators.validateTitle(value.title) : undefined,
+            description: isTouched('description') ? validators.validateDescription(value.description) : undefined,
+            organization: isTouched('organization') ? validators.validateOrganization(value.organization) : undefined,
+            result: isTouched('result') ? validators.validateResult(value.result) : undefined,
+            sourceOfInformation: isTouched('sourceOfInformation') ? validators.validateSourceOfInformation(value.sourceOfInformation) : undefined,
+            startDate: isTouched('startDate') ? validators.validateStartDate(value.startDate) : undefined,
+            endDate: isTouched('startDate') && isValid('startDate') ? validators.validateEndDate(value.endDate, value.startDate, { isRequired: !value.isOngoing }) : undefined,
+          }
+        }
+      },
+      onBlur ({ formApi }: { formApi: DeclaredProgramFormApi }) {
+        formApi.validate('change')
       }
     },
     onSubmit: ({ value }: { value: DeclaredProgramFormData }) => {
@@ -74,6 +96,8 @@ export function useAddDeclaredProgramForm (onProgramAdded?: () => void) {
     }
   })
 
+  const hasDefinitionItemsError = hasFieldErrors(form, ['title', 'description', 'organization', 'result', 'sourceOfInformation', 'startDate', 'endDate'])
+
   const isFormValid = computed(() => {
     const state = form.useStore(state => state)
     return state.value.isValid && !state.value.isValidating && state.value.isDirty
@@ -82,6 +106,7 @@ export function useAddDeclaredProgramForm (onProgramAdded?: () => void) {
   return {
     form,
     isFormValid,
-    isSubmitting: isPending || isLoading.value
+    isSubmitting: isPending || isLoading.value,
+    hasDefinitionItemsError
   }
 }

--- a/src/features/student/personalCareer/types/forms.types.ts
+++ b/src/features/student/personalCareer/types/forms.types.ts
@@ -1,3 +1,4 @@
+import type { AnyFormApi } from '@/common/types'
 import type {
   useAddDeclaredExperienceForm
 } from '@/features/student/personalCareer/components/overlays/AddDeclaredExperienceDrawer/use-add-declared-experience-form/use-add-declared-experience-form'
@@ -20,6 +21,7 @@ export interface DeclaredProgramFormData {
   endDate: string
   isOngoing: boolean
 }
+export type DeclaredProgramFormApi = AnyFormApi<DeclaredProgramFormData>
 
 export interface DeclaredExperienceFormData {
   title: string

--- a/src/features/student/personalCareer/views/DeclaredProgramUpdateView/components/use-update-declared-program-form/use-update-declared-program-form.ts
+++ b/src/features/student/personalCareer/views/DeclaredProgramUpdateView/components/use-update-declared-program-form/use-update-declared-program-form.ts
@@ -1,5 +1,5 @@
 import type { BaseApiException } from '@/common/exceptions'
-import type { DeclaredProgramFormData } from '@/features/student/personalCareer/types/forms.types'
+import type { DeclaredProgramFormApi, DeclaredProgramFormData } from '@/features/student/personalCareer/types/forms.types'
 import { type DeclaredProgramDetailedDTO, type DeclaredProgramRequestDTO, invalidateGetDeclaredPrograms, useUpdateDeclaredProgram } from '@/api/avenir-esr'
 import { useTaskLoading } from '@/common/composables/use-task-loading/use-task-loading'
 import { formatDateToYearMonth, formatYearMonthToDate } from '@/common/utils'
@@ -83,9 +83,27 @@ export function useUpdateDeclaredProgramForm (
             result: validators.validateResult(value.result),
             sourceOfInformation: validators.validateSourceOfInformation(value.sourceOfInformation),
             startDate: validators.validateStartDate(value.startDate),
-            endDate: validators.validateEndDate(value.endDate, value.startDate, { isRequired: !value.isOngoing })
+            endDate: validators.validateEndDate(value.endDate, value.startDate, { isRequired: !value.isOngoing }),
           }
         }
+      },
+      onChange ({ value, formApi }: { value: DeclaredProgramFormData, formApi: DeclaredProgramFormApi }) {
+        const isTouched = (field: keyof DeclaredProgramFormData) => formApi.getFieldMeta(field)?.isTouched ?? true
+        const isValid = (field: keyof DeclaredProgramFormData) => formApi.getFieldMeta(field)?.isValid ?? true
+        return {
+          fields: {
+            title: isTouched('title') ? validators.validateTitle(value.title) : undefined,
+            description: isTouched('description') ? validators.validateDescription(value.description) : undefined,
+            organization: isTouched('organization') ? validators.validateOrganization(value.organization) : undefined,
+            result: isTouched('result') ? validators.validateResult(value.result) : undefined,
+            sourceOfInformation: isTouched('sourceOfInformation') ? validators.validateSourceOfInformation(value.sourceOfInformation) : undefined,
+            startDate: isTouched('startDate') ? validators.validateStartDate(value.startDate) : undefined,
+            endDate: isTouched('startDate') && isValid('startDate') ? validators.validateEndDate(value.endDate, value.startDate, { isRequired: !value.isOngoing }) : undefined,
+          }
+        }
+      },
+      onBlur ({ formApi }: { formApi: DeclaredProgramFormApi }) {
+        formApi.validate('change')
       }
     },
     onSubmit: ({ value }: { value: DeclaredProgramFormData }) => {


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
- Fixed form validation in `AddDeclaredProgramDrawer` to correctly enforce required fields and length constraints, and ensured the accordion containing invalid fields is focused/highlighted when validation fails
- Fixed form validation in `DeclaredProgramUpdateView` to correctly enforce required fields and length constraints

---

### Reference to an Issue, Feature, Task, User Story or another PR
- Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1622
- Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1623
- Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1624
- Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1625
- Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1626
- Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1629
- Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1635
- Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1636
- Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1637
- Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1638
- Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1639
- Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1640

---

**Modified areas:**
- `src/common/composables/use-form-validators/use-form-validators.ts`
- `src/common/types/forms.types.ts`
- `src/common/types/index.ts`
- `src/features/student/personalCareer/components/interactions/formFields/DeclaredProgramDescriptionFormField/DeclaredProgramDescriptionFormField.test.ts`
- `src/features/student/personalCareer/components/interactions/formFields/DeclaredProgramDescriptionFormField/DeclaredProgramDescriptionFormField.vue`
- `src/features/student/personalCareer/components/interactions/formFields/DeclaredProgramOrganizationFormField/DeclaredProgramOrganizationFormField.test.ts`
- `src/features/student/personalCareer/components/interactions/formFields/DeclaredProgramOrganizationFormField/DeclaredProgramOrganizationFormField.vue`
- `src/features/student/personalCareer/components/interactions/formFields/DeclaredProgramPeriodFormField/DeclaredProgramPeriodFormField.vue`
- `src/features/student/personalCareer/components/interactions/formFields/DeclaredProgramResultFormField/DeclaredProgramResultFormField.test.ts`
- `src/features/student/personalCareer/components/interactions/formFields/DeclaredProgramResultFormField/DeclaredProgramResultFormField.vue`
- `src/features/student/personalCareer/components/interactions/formFields/DeclaredProgramSourceOfInformationFormField/DeclaredProgramSourceOfInformationFormField.test.ts`
- `src/features/student/personalCareer/components/interactions/formFields/DeclaredProgramSourceOfInformationFormField/DeclaredProgramSourceOfInformationFormField.vue`
- `src/features/student/personalCareer/components/interactions/formFields/DeclaredProgramTitleFormField/DeclaredProgramTitleFormField.test.ts`
- `src/features/student/personalCareer/components/interactions/formFields/DeclaredProgramTitleFormField/DeclaredProgramTitleFormField.vue`
- `src/features/student/personalCareer/components/interactions/inputs/DeclaredProgramOrganizationInput/DeclaredProgramOrganizationInput.test.ts`
- `src/features/student/personalCareer/components/interactions/inputs/DeclaredProgramOrganizationInput/DeclaredProgramOrganizationInput.vue`
- `src/features/student/personalCareer/components/interactions/inputs/DeclaredProgramResultInput/DeclaredProgramResultInput.test.ts`
- `src/features/student/personalCareer/components/interactions/inputs/DeclaredProgramResultInput/DeclaredProgramResultInput.vue`
- `src/features/student/personalCareer/components/interactions/inputs/DeclaredProgramSourceOfInformationInput/DeclaredProgramSourceOfInformationInput.test.ts`
- `src/features/student/personalCareer/components/interactions/inputs/DeclaredProgramSourceOfInformationInput/DeclaredProgramSourceOfInformationInput.vue`
- `src/features/student/personalCareer/components/interactions/inputs/DeclaredProgramTitleInput/DeclaredProgramTitleInput.test.ts`
- `src/features/student/personalCareer/components/interactions/inputs/DeclaredProgramTitleInput/DeclaredProgramTitleInput.vue`
- `src/features/student/personalCareer/components/overlays/AddDeclaredProgramDrawer/AddDeclaredProgramDrawer.vue`
- `src/features/student/personalCareer/components/overlays/AddDeclaredProgramDrawer/use-add-declared-program-form/use-add-declared-program-form.ts`
- `src/features/student/personalCareer/types/forms.types.ts`
- `src/features/student/personalCareer/views/DeclaredProgramUpdateView/components/use-update-declared-program-form/use-update-declared-program-form.ts`

---

### Target Branch
`develop`

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process