### PR TITLE
fix(1569): SelfKnowledgeElementTabs - fix locales

### DIFF
--- a/src/features/student/selfKnowledge/locales/en.json
+++ b/src/features/student/selfKnowledge/locales/en.json
@@ -105,10 +105,10 @@
           "category": {
             "titles": {
               "ASPIRATIONS": "My aspiration",
-              "IMPROVEMENT_AREAS": "My area for improvement",
+              "IMPROVEMENT": "My area for improvement",
               "INSPIRATIONS": "My inspiration",
               "INTERESTS": "My area of interest",
-              "MOTIVATIONS": "My professional motivation",
+              "MOTIVATION": "My professional motivation",
               "OBLIGATIONS": "My obligation",
               "STRENGTHS": "My strength",
               "TESTIMONIALS": "My testimonial",

--- a/src/features/student/selfKnowledge/locales/fr.json
+++ b/src/features/student/selfKnowledge/locales/fr.json
@@ -104,10 +104,10 @@
           "category": {
             "titles": {
               "ASPIRATIONS": "Mon envie",
-              "IMPROVEMENT_AREAS": "Mon axe d'amélioration",
+              "IMPROVEMENT": "Mon axe d'amélioration",
               "INSPIRATIONS": "Mon inspiration",
               "INTERESTS": "Mon centre d'intérêt",
-              "MOTIVATIONS": "Ma motivation professionnelle",
+              "MOTIVATION": "Ma motivation professionnelle",
               "OBLIGATIONS": "Mon obligation",
               "STRENGTHS": "Mon point fort",
               "TESTIMONIALS": "Mon témoignage",


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
This PR fixes missing locale keys used by SelfKnowledge element category details so labels are resolved correctly in both English and French.

**Main changes:**
- 🐛 Replaces incorrect category keys in English translations
- 🐛 Replaces incorrect category keys in French translations
- 🏷️ Aligns i18n keys with expected enum-like category values used by the UI

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1569

---

### Documentation
- Updated locale mappings in:
  - `src/features/student/selfKnowledge/locales/en.json`
  - `src/features/student/selfKnowledge/locales/fr.json`
- No additional configuration or technical spec changes required.

---

### Target Branch
`develop`

---

### Additional Notes
The keys `IMPROVEMENT_AREAS` and `MOTIVATIONS` were replaced by `IMPROVEMENT` and `MOTIVATION` to match the category keys expected by the feature.

---

### Known Limitations or Side Effects
No known limitations or side effects.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [ ] No unnecessary code (e.g., debug logs, commented code)
- [ ] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process
