### PR TITLE
fix(1603): DeclaredExperienceCard - replace location badge with organization

### DIFF
--- a/src/features/student/personalCareer/components/cards/DeclaredExperienceCard/DeclaredExperienceCard.test.ts
+++ b/src/features/student/personalCareer/components/cards/DeclaredExperienceCard/DeclaredExperienceCard.test.ts
@@ -37,7 +37,7 @@ BddTest().given('a declared experience card', () => {
           declaredExperience: {
             ...baseDeclaredExperience,
             experienceType: EExperienceType.PROFESSIONAL,
-            location: 'Paris, France'
+            organization: 'AVENIR(S)'
           }
         },
         global: { stubs }
@@ -106,32 +106,32 @@ BddTest().given('a declared experience card', () => {
       })
     })
 
-    BddTest().and('the location badge is rendered', () => {
-      let locationBadge: VueWrapper<InstanceType<typeof AvBadgeStub>> | undefined
+    BddTest().and('the organization badge is rendered', () => {
+      let organizationBadge: VueWrapper<InstanceType<typeof AvBadgeStub>> | undefined
 
       beforeEach(() => {
         const badges = wrapper.findAllComponents({ name: 'AvBadge' })
-        locationBadge = badges.find(badge => badge.props('label') === 'Paris, France') as VueWrapper<InstanceType<typeof AvBadgeStub>>
+        organizationBadge = badges.find(badge => badge.props('label') === 'AVENIR(S)') as VueWrapper<InstanceType<typeof AvBadgeStub>>
       })
 
       BddTest().then('it should exist', () => {
-        expect(locationBadge).toBeDefined()
+        expect(organizationBadge).toBeDefined()
       })
 
       BddTest().then('it should have map marker outline icon', () => {
-        expect(locationBadge?.props('icon')).toBe(MDI_ICONS.MAP_MARKER_OUTLINE)
+        expect(organizationBadge?.props('icon')).toBe(MDI_ICONS.MAP_MARKER_OUTLINE)
       })
 
       BddTest().then('it should have text2 color', () => {
-        expect(locationBadge?.props('color')).toBe('var(--text2)')
+        expect(organizationBadge?.props('color')).toBe('var(--text2)')
       })
 
       BddTest().then('it should have transparent background', () => {
-        expect(locationBadge?.props('backgroundColor')).toBe('transparent')
+        expect(organizationBadge?.props('backgroundColor')).toBe('transparent')
       })
 
       BddTest().then('it should have ellipsis enabled', () => {
-        expect(locationBadge?.props('ellipsis')).toBe(true)
+        expect(organizationBadge?.props('ellipsis')).toBe(true)
       })
     })
   })
@@ -209,26 +209,6 @@ BddTest().given('a declared experience card', () => {
     })
   })
 
-  BddTest().when('the component is mounted without location', () => {
-    beforeEach(() => {
-      wrapper = mount(DeclaredExperienceCard, {
-        props: {
-          declaredExperience: {
-            ...baseDeclaredExperience,
-            location: undefined
-          }
-        },
-        global: { stubs }
-      })
-    })
-
-    BddTest().then('it should not render location badge', () => {
-      const badges = wrapper.findAllComponents({ name: 'AvBadge' })
-      const locationBadge = badges.find(badge => badge.props('icon') === MDI_ICONS.MAP_MARKER_OUTLINE)
-      expect(locationBadge).toBeUndefined()
-    })
-  })
-
   BddTest().when('the component is mounted with only required fields', () => {
     beforeEach(() => {
       wrapper = mount(DeclaredExperienceCard, {
@@ -244,9 +224,9 @@ BddTest().given('a declared experience card', () => {
       expect(floatingCard.exists()).toBe(true)
     })
 
-    BddTest().then('it should not render any badges', () => {
+    BddTest().then('it should only render the organization badge', () => {
       const badges = wrapper.findAllComponents({ name: 'AvBadge' })
-      expect(badges.length).toBe(0)
+      expect(badges.length).toBe(1)
     })
   })
 })

--- a/src/features/student/personalCareer/components/cards/DeclaredExperienceCard/DeclaredExperienceCard.vue
+++ b/src/features/student/personalCareer/components/cards/DeclaredExperienceCard/DeclaredExperienceCard.vue
@@ -51,8 +51,7 @@ const experienceTypeColorMap: Record<EExperienceType, string> = {
               ellipsis
             />
             <AvBadge
-              v-if="declaredExperience.location"
-              :label="declaredExperience.location"
+              :label="declaredExperience.organization"
               :icon="MDI_ICONS.MAP_MARKER_OUTLINE"
               color="var(--text2)"
               background-color="transparent"


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
This PR replaces the declared experience location badge with an organization badge in `DeclaredExperienceCard`, so professional experiences now display the organization name instead of a location label.

**Main changes:**
- ✨ Shows `declaredExperience.organization` in the badge
- 🐛 Removes the conditional rendering that depended on `declaredExperience.location`
- ✅ Updates the component test suite to match the new badge behavior

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1603

---

### Documentation
No documentation or configuration updates were required for this change.

---

### Target Branch
`develop`

---

### Additional Notes
This change is limited to the declared experience card display logic and its corresponding unit test coverage. The badge still uses the same visual treatment and icon, but now reflects the organization field instead of the location field.

---

### Known Limitations or Side Effects
No known limitations or side effects.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [x] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process
