### PR TITLE
fix(1604-1633): DeclaredExperience and DeclaredProgram periods - add in progress status

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "avenirs-cofolio-client",
       "version": "0.0.0",
       "dependencies": {
-        "@avenirs-esr/avenirs-dsav": "^0.1.200",
+        "@avenirs-esr/avenirs-dsav": "^0.1.201",
         "@tanstack/vue-form": "^1.15.0",
         "@tanstack/vue-query": "^5.74.9",
         "@vue-flow/core": "^1.48.0",
@@ -348,9 +348,9 @@
       "license": "ISC"
     },
     "node_modules/@avenirs-esr/avenirs-dsav": {
-      "version": "0.1.200",
-      "resolved": "https://registry.npmjs.org/@avenirs-esr/avenirs-dsav/-/avenirs-dsav-0.1.200.tgz",
-      "integrity": "sha512-EBPmLQwC7gPdyOvQHY0MxU0ehXkH0LGxhKe2vKyqZtGDPlWSlft4AdATUqiRkNxy6MVWvzFnwHCXIDyYUe+41Q==",
+      "version": "0.1.201",
+      "resolved": "https://registry.npmjs.org/@avenirs-esr/avenirs-dsav/-/avenirs-dsav-0.1.201.tgz",
+      "integrity": "sha512-cU/F9F+fehASNTl7XQ5Bemi6iyULqrgzA865/VzH983wy02GQGH1Y/iy3pqNN06OncXQqb72eixzH9POjccpYQ==",
       "dependencies": {
         "@tanstack/vue-table": "^8.21.3",
         "@tiptap/extension-character-count": "^3.20.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "avenirs-cofolio-client",
       "version": "0.0.0",
       "dependencies": {
-        "@avenirs-esr/avenirs-dsav": "^0.1.199",
+        "@avenirs-esr/avenirs-dsav": "^0.1.200",
         "@tanstack/vue-form": "^1.15.0",
         "@tanstack/vue-query": "^5.74.9",
         "@vue-flow/core": "^1.48.0",
@@ -348,9 +348,9 @@
       "license": "ISC"
     },
     "node_modules/@avenirs-esr/avenirs-dsav": {
-      "version": "0.1.199",
-      "resolved": "https://registry.npmjs.org/@avenirs-esr/avenirs-dsav/-/avenirs-dsav-0.1.199.tgz",
-      "integrity": "sha512-owCxh34IXZjtj3NOn9AsEq6jUUb8eqm6bXbIsmo17qJ8QSWsGwCVq2ByzfSeAaTqyUMu3SPa4JU0FG5X91a3mA==",
+      "version": "0.1.200",
+      "resolved": "https://registry.npmjs.org/@avenirs-esr/avenirs-dsav/-/avenirs-dsav-0.1.200.tgz",
+      "integrity": "sha512-EBPmLQwC7gPdyOvQHY0MxU0ehXkH0LGxhKe2vKyqZtGDPlWSlft4AdATUqiRkNxy6MVWvzFnwHCXIDyYUe+41Q==",
       "dependencies": {
         "@tanstack/vue-table": "^8.21.3",
         "@tiptap/extension-character-count": "^3.20.2",
@@ -7518,13 +7518,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
       }
@@ -10703,9 +10703,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
-      "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {
@@ -15795,9 +15795,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.3",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
-      "integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "funding": [
         {
           "type": "opencollective",
@@ -15814,7 +15814,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.8",
+        "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
-    "@avenirs-esr/avenirs-dsav": "^0.1.200",
+    "@avenirs-esr/avenirs-dsav": "^0.1.201",
     "@tanstack/vue-form": "^1.15.0",
     "@tanstack/vue-query": "^5.74.9",
     "@vue-flow/core": "^1.48.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
-    "@avenirs-esr/avenirs-dsav": "^0.1.199",
+    "@avenirs-esr/avenirs-dsav": "^0.1.200",
     "@tanstack/vue-form": "^1.15.0",
     "@tanstack/vue-query": "^5.74.9",
     "@vue-flow/core": "^1.48.0",

--- a/src/features/student/personalCareer/components/interactions/formFields/DeclaredProgramPeriodFormField/DeclaredProgramPeriodFormField.vue
+++ b/src/features/student/personalCareer/components/interactions/formFields/DeclaredProgramPeriodFormField/DeclaredProgramPeriodFormField.vue
@@ -55,7 +55,7 @@ function onUpdateIsOngoing (values: (string | number | boolean | undefined)[]) {
             :name="IS_ONGOING"
             :model-value="field.state.value ? [IS_ONGOING] : []"
             :value="IS_ONGOING"
-            label="En cours"
+            :label="t('student.personalCareer.interactions.formFields.DeclaredProgramPeriodFormField.ongoing')"
             @update:model-value="onUpdateIsOngoing"
           />
         </template>
@@ -68,7 +68,7 @@ function onUpdateIsOngoing (values: (string | number | boolean | undefined)[]) {
         label-class="av-hidden"
         :start-label="t('student.personalCareer.interactions.formFields.DeclaredProgramPeriodFormField.startDate')"
         :end-label="t('student.personalCareer.interactions.formFields.DeclaredProgramPeriodFormField.endDate')"
-        :in-progress-label="t('student.personalCareer.interactions.formFields.DeclaredProgramPeriodFormField.ongoing')"
+        :ongoing-label="t('student.personalCareer.interactions.formFields.DeclaredProgramPeriodFormField.ongoing')"
         :start-model-value="String(startDateField.state.value.value ?? '')"
         :end-model-value="String(endDateField.state.value.value ?? '')"
         :end-date-disabled="isOngoing"

--- a/src/features/student/personalCareer/components/interactions/formFields/DeclaredProgramPeriodFormField/DeclaredProgramPeriodFormField.vue
+++ b/src/features/student/personalCareer/components/interactions/formFields/DeclaredProgramPeriodFormField/DeclaredProgramPeriodFormField.vue
@@ -68,6 +68,7 @@ function onUpdateIsOngoing (values: (string | number | boolean | undefined)[]) {
         label-class="av-hidden"
         :start-label="t('student.personalCareer.interactions.formFields.DeclaredProgramPeriodFormField.startDate')"
         :end-label="t('student.personalCareer.interactions.formFields.DeclaredProgramPeriodFormField.endDate')"
+        :in-progress-label="t('student.personalCareer.interactions.formFields.DeclaredProgramPeriodFormField.ongoing')"
         :start-model-value="String(startDateField.state.value.value ?? '')"
         :end-model-value="String(endDateField.state.value.value ?? '')"
         :end-date-disabled="isOngoing"

--- a/src/features/student/personalCareer/components/interactions/inputs/DeclaredExperiencePeriodInput/DeclaredExperiencePeriodInput.vue
+++ b/src/features/student/personalCareer/components/interactions/inputs/DeclaredExperiencePeriodInput/DeclaredExperiencePeriodInput.vue
@@ -21,7 +21,7 @@ const avPeriodInputProps = computed<AvPeriodInputProps>(() => ({
   stacked: isMobile.value,
   separatorSpacing: 'var(--spacing-sm)',
   width: '10rem',
-  inProgressLabel: t('student.personalCareer.interactions.formFields.DeclaredExperiencePeriodFormField.ongoing'),
+  ongoingLabel: t('student.personalCareer.interactions.formFields.DeclaredExperiencePeriodFormField.ongoing'),
 }))
 </script>
 

--- a/src/features/student/personalCareer/components/interactions/inputs/DeclaredExperiencePeriodInput/DeclaredExperiencePeriodInput.vue
+++ b/src/features/student/personalCareer/components/interactions/inputs/DeclaredExperiencePeriodInput/DeclaredExperiencePeriodInput.vue
@@ -20,7 +20,8 @@ const avPeriodInputProps = computed<AvPeriodInputProps>(() => ({
   endLabel: t('student.personalCareer.interactions.inputs.DeclaredExperiencePeriodInput.endLabel'),
   stacked: isMobile.value,
   separatorSpacing: 'var(--spacing-sm)',
-  width: '10rem'
+  width: '10rem',
+  inProgressLabel: t('student.personalCareer.interactions.formFields.DeclaredExperiencePeriodFormField.ongoing'),
 }))
 </script>
 

--- a/src/features/student/personalCareer/views/DeclaredProgramDetailedView/components/DeclaredProgramDetailed/DeclaredProgramDetailed.vue
+++ b/src/features/student/personalCareer/views/DeclaredProgramDetailedView/components/DeclaredProgramDetailed/DeclaredProgramDetailed.vue
@@ -68,6 +68,7 @@ const createdAtPrefix = computed(() =>
         label-class="caption-regular"
         :start-label="t('student.personalCareer.interactions.formFields.DeclaredProgramPeriodFormField.startDate')"
         :end-label="t('student.personalCareer.interactions.formFields.DeclaredProgramPeriodFormField.endDate')"
+        :in-progress-label="t('student.personalCareer.interactions.formFields.DeclaredProgramPeriodFormField.ongoing')"
         :start-model-value="startDate ?? ''"
         :end-model-value="endDate ?? ''"
         start-date-disabled

--- a/src/features/student/personalCareer/views/DeclaredProgramDetailedView/components/DeclaredProgramDetailed/DeclaredProgramDetailed.vue
+++ b/src/features/student/personalCareer/views/DeclaredProgramDetailedView/components/DeclaredProgramDetailed/DeclaredProgramDetailed.vue
@@ -68,7 +68,7 @@ const createdAtPrefix = computed(() =>
         label-class="caption-regular"
         :start-label="t('student.personalCareer.interactions.formFields.DeclaredProgramPeriodFormField.startDate')"
         :end-label="t('student.personalCareer.interactions.formFields.DeclaredProgramPeriodFormField.endDate')"
-        :in-progress-label="t('student.personalCareer.interactions.formFields.DeclaredProgramPeriodFormField.ongoing')"
+        :ongoing-label="t('student.personalCareer.interactions.formFields.DeclaredProgramPeriodFormField.ongoing')"
         :start-model-value="startDate ?? ''"
         :end-model-value="endDate ?? ''"
         start-date-disabled


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
This PR aligns personal career period displays with the updated DSAV period input behavior by handling the "in progress" state consistently in cofolio screens.

**Main changes:**
- 🐛 Fix declared experience period rendering for ongoing/in-progress status
- ♻️ Refactor declared program period integration after AvPeriodInput API update
- ⬆️ Update DSAV package version and lockfile to consume the new input behavior
- ✅ Keep UI integration aligned in detailed declared program view

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1604
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1633

---

### Documentation
- Updated integration points in student personal career components to use the ongoing status behavior.
- Dependency update reflected in package manifests.

**Modified files:**
- `package.json`
- `package-lock.json`
- `src/features/student/personalCareer/components/interactions/formFields/DeclaredProgramPeriodFormField/DeclaredProgramPeriodFormField.vue`
- `src/features/student/personalCareer/components/interactions/inputs/DeclaredExperiencePeriodInput/DeclaredExperiencePeriodInput.vue`
- `src/features/student/personalCareer/views/DeclaredProgramDetailedView/components/DeclaredProgramDetailed/DeclaredProgramDetailed.vue`

---

### Target Branch
`develop`

---

### Additional Notes
This branch contains three commits related to issue #1604 and follow-up adaptation after the AvPeriodInput change in DSAV.

---

### Known Limitations or Side Effects
No known side effects beyond the intended display change for ongoing periods.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [ ] No unnecessary code (e.g., debug logs, commented code)
- [ ] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process
