### PR TITLE
fix(1605): Declared experiences and programs - preserve scroll on side nav

### DIFF
--- a/src/features/student/personalCareer/views/DeclaredExperienceUpdateView/DeclaredExperienceUpdateView.vue
+++ b/src/features/student/personalCareer/views/DeclaredExperienceUpdateView/DeclaredExperienceUpdateView.vue
@@ -34,7 +34,7 @@ const isDirty = ref(false)
 const { showModal, displayModal, hideModal } = useModal()
 
 const { declaredExperiences, pageInfo, loadMoreDeclaredExperiences } = usePaginatedDeclaredExperiences({})
-const { data: declaredExperience, isLoading, isError } = useGetDeclaredExperience(selectedExperienceId.value)
+const { data: declaredExperience, isLoading, isError } = useGetDeclaredExperience(selectedExperienceId)
 
 const declaredExperienceTitle = computed(() => declaredExperience.value?.title ?? '')
 
@@ -61,7 +61,8 @@ async function onSelectExperience (experienceId: string) {
   if (await canLeave()) {
     router.replace({
       name: ROUTES.STUDENT.UPDATE_DECLARED_EXPERIENCE.name,
-      params: { id: experienceId }
+      params: { id: experienceId },
+      state: { preserveScroll: true }
     })
   }
 }

--- a/src/features/student/personalCareer/views/DeclaredExperienceView/DeclaredExperienceView.test.ts
+++ b/src/features/student/personalCareer/views/DeclaredExperienceView/DeclaredExperienceView.test.ts
@@ -227,7 +227,8 @@ BddTest().given('a declared experience view component', () => {
       BddTest().then('it should navigate to the declared experience route', () => {
         expect(routerReplace).toHaveBeenCalledWith({
           name: 'student-declared-experience',
-          params: { id: experienceId }
+          params: { id: experienceId },
+          state: { preserveScroll: true }
         })
       })
     })

--- a/src/features/student/personalCareer/views/DeclaredExperienceView/DeclaredExperienceView.vue
+++ b/src/features/student/personalCareer/views/DeclaredExperienceView/DeclaredExperienceView.vue
@@ -64,7 +64,11 @@ const countAssociations = computed(() => (associations.value?.traceAssociations.
 const traceAssociations = computed(() => associations.value?.traceAssociations ?? [])
 
 function onSelectExperience (experienceId: string) {
-  router.replace({ name: ROUTES.STUDENT.DECLARED_EXPERIENCE.name, params: { id: experienceId } })
+  router.replace({
+    name: ROUTES.STUDENT.DECLARED_EXPERIENCE.name,
+    params: { id: experienceId },
+    state: { preserveScroll: true }
+  })
 }
 
 function handleUpdateSelected () {

--- a/src/features/student/personalCareer/views/DeclaredProgramDetailedView/DeclaredProgramDetailedView.test.ts
+++ b/src/features/student/personalCareer/views/DeclaredProgramDetailedView/DeclaredProgramDetailedView.test.ts
@@ -251,7 +251,8 @@ BddTest().given('a declared program detailed view component', () => {
       BddTest().then('it should navigate to the route with the selected id', () => {
         expect(routerReplace).toHaveBeenCalledWith({
           name: ROUTES.STUDENT.PERSONAL_CAREER_DECLARED_PROGRAM_DETAILED.name,
-          params: { id: secondProgramId }
+          params: { id: secondProgramId },
+          state: { preserveScroll: true }
         })
       })
 

--- a/src/features/student/personalCareer/views/DeclaredProgramDetailedView/DeclaredProgramDetailedView.vue
+++ b/src/features/student/personalCareer/views/DeclaredProgramDetailedView/DeclaredProgramDetailedView.vue
@@ -35,7 +35,11 @@ const breadcrumbLinks = computed(() => [
 ])
 
 function onSelectProgram (programId: string) {
-  router.replace({ name: ROUTES.STUDENT.PERSONAL_CAREER_DECLARED_PROGRAM_DETAILED.name, params: { id: programId } })
+  router.replace({
+    name: ROUTES.STUDENT.PERSONAL_CAREER_DECLARED_PROGRAM_DETAILED.name,
+    params: { id: programId },
+    state: { preserveScroll: true }
+  })
 }
 
 function handleConfirmDelete () {

--- a/src/features/student/personalCareer/views/DeclaredProgramUpdateView/DeclaredProgramUpdateView.test.ts
+++ b/src/features/student/personalCareer/views/DeclaredProgramUpdateView/DeclaredProgramUpdateView.test.ts
@@ -222,7 +222,8 @@ BddTest().given('a declared program update view component', () => {
       BddTest().then('it should navigate immediately and not open the modal', () => {
         expect(routerReplace).toHaveBeenCalledWith({
           name: ROUTES.STUDENT.PERSONAL_CAREER_UPDATE_DECLARED_PROGRAM.name,
-          params: { id: secondProgramId }
+          params: { id: secondProgramId },
+          state: { preserveScroll: true }
         })
         expect(displayConfirmationModal).not.toHaveBeenCalled()
       })

--- a/src/features/student/personalCareer/views/DeclaredProgramUpdateView/DeclaredProgramUpdateView.vue
+++ b/src/features/student/personalCareer/views/DeclaredProgramUpdateView/DeclaredProgramUpdateView.vue
@@ -49,7 +49,8 @@ async function onSelectProgram (programId: string) {
   if (await canLeave()) {
     router.replace({
       name: ROUTES.STUDENT.PERSONAL_CAREER_UPDATE_DECLARED_PROGRAM.name,
-      params: { id: programId }
+      params: { id: programId },
+      state: { preserveScroll: true }
     })
   }
 }

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -28,7 +28,15 @@ const routes = [
 const router = createRouter({
   history: createWebHistory(import.meta.env?.BASE_URL || ''),
   routes,
-  scrollBehavior: () => {
+  scrollBehavior: (_to, _from, savedPosition) => {
+    if (savedPosition) {
+      return savedPosition
+    }
+
+    if (window.history.state?.preserveScroll) {
+      return false
+    }
+
     return { top: 0 }
   }
 })


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
This PR fixes scroll reset behavior when navigating between declared experience and declared program details/edition pages via side navigation.

**Main changes:**
- 🐛 Preserve current scroll position when switching items from side navigation
- ♻️ Update navigation calls to pass router state (`preserveScroll`) on detail/update views
- ♻️ Enhance router `scrollBehavior` to keep position when requested and still honor browser saved positions
- 🐛 Fix declared experience query call to use reactive route-based id source

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1605

---

### Documentation
No documentation updates required.

**Modified files:**
- `src/features/student/personalCareer/views/DeclaredExperienceUpdateView/DeclaredExperienceUpdateView.vue` - pass `preserveScroll` state and fix query argument
- `src/features/student/personalCareer/views/DeclaredExperienceView/DeclaredExperienceView.vue` - preserve scroll when selecting another experience
- `src/features/student/personalCareer/views/DeclaredProgramDetailedView/DeclaredProgramDetailedView.vue` - preserve scroll when selecting another program
- `src/features/student/personalCareer/views/DeclaredProgramUpdateView/DeclaredProgramUpdateView.vue` - preserve scroll when selecting another program in update flow
- `src/router/index.ts` - update `scrollBehavior` to support preserve-scroll state

---

### Target Branch
`develop`

---

### Additional Notes
The implementation keeps native browser restoration behavior by returning `savedPosition` first. The `preserveScroll` behavior is only applied on explicit in-app navigations where state is set.

---

### Known Limitations or Side Effects
No known limitations or side effects.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [ ] No unnecessary code (e.g., debug logs, commented code)
- [ ] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process
