### PR TITLE
feat(1523): create ToggleParameterCard component

### DIFF
--- a/src/features/staff/global/components/cards/FormFieldCardContainer/FormFieldCardContainer.stub.ts
+++ b/src/features/staff/global/components/cards/FormFieldCardContainer/FormFieldCardContainer.stub.ts
@@ -1,6 +1,10 @@
-export const FormFieldCardContainerStub = defineComponent({ name: 'FormFieldCardContainer', props: {
-  orientation: {
-    type: String,
-    required: false
-  }
-}, template: `<div data-testid="form-field-card-container"></div>` })
+export const FormFieldCardContainerStub = defineComponent({
+  name: 'FormFieldCardContainer',
+  props: ['title', 'titleIcon', 'backgroundColor', 'collapsible', 'collapsed', 'titleOnly'],
+  template: `
+    <div data-testid="form-field-card-container">
+      <slot name="title" />
+      <slot />
+    </div>
+  `,
+})

--- a/src/features/staff/global/components/cards/FormFieldCardContainer/FormFieldCardContainer.test.ts
+++ b/src/features/staff/global/components/cards/FormFieldCardContainer/FormFieldCardContainer.test.ts
@@ -1,41 +1,76 @@
-import type { VueWrapper } from '@vue/test-utils'
+import type { FormFieldCardContainerProps } from '@/features/staff/global/components/cards/FormFieldCardContainer/FormFieldCardContainer.vue'
 import FormFieldCardContainer from '@/features/staff/global/components/cards/FormFieldCardContainer/FormFieldCardContainer.vue'
-import { AvCardStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
-import { mount } from '@vue/test-utils'
-import { beforeEach, expect, vi } from 'vitest'
+import { AvCardStub, AvIconTextStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { beforeEach, expect } from 'vitest'
 
 BddTest().given('a form field card container', () => {
   let wrapper: VueWrapper<InstanceType<typeof FormFieldCardContainer>>
+
   const stubs = {
-    AvCard: AvCardStub
+    AvCard: AvCardStub,
+    AvIconText: AvIconTextStub
   }
 
-  BddTest().when('component is mounted', () => {
+  const props: FormFieldCardContainerProps = {
+    title: 'Mon titre',
+    titleIcon: 'mdi:attach-file',
+  }
+
+  BddTest().when('the component is mounted', () => {
     beforeEach(() => {
-      vi.clearAllMocks()
+      wrapper = mount(FormFieldCardContainer, { props, global: { stubs } })
+    })
+
+    BddTest().then('it should render the card', () => {
+      const card = wrapper.findComponent(AvCardStub)
+      expect(card.exists()).toBe(true)
+    })
+
+    BddTest().then('it should render the title', () => {
+      const title = wrapper.findComponent(AvIconTextStub)
+      expect(title.exists()).toBe(true)
+      expect(title.props('text')).toBe(props.title)
+    })
+
+    BddTest().then('it should render the icon', () => {
+      const title = wrapper.findComponent(AvIconTextStub)
+      expect(title.props('icon')).toBe(props.titleIcon)
+    })
+
+    BddTest().then('it should render the card with collapsible false by default', () => {
+      const card = wrapper.findComponent(AvCardStub)
+      expect(card.props('collapsible')).toBe(false)
+    })
+
+    BddTest().then('it should render the card with collapsed false by default', () => {
+      const card = wrapper.findComponent(AvCardStub)
+      expect(card.props('collapsed')).toBe(false)
+    })
+
+    BddTest().then('it should render the card with titleOnly false by default', () => {
+      const card = wrapper.findComponent(AvCardStub)
+      expect(card.props('titleOnly')).toBe(false)
+    })
+
+    BddTest().then('it should render the slot content', () => {
       wrapper = mount(FormFieldCardContainer, {
-        global: { stubs }
+        props,
+        global: { stubs },
+        slots: { default: '<p data-testid="slot-content">Contenu</p>' },
       })
+      const slot = wrapper.find('[data-testid="slot-content"]')
+      expect(slot.exists()).toBe(true)
     })
 
-    BddTest().then('it should render vertical orientation by default', () => {
-      expect(wrapper.find('[data-testid="vertical-container"]').exists()).toBe(true)
-    })
-  })
-
-  BddTest().when('orientation is horizontal', () => {
-    beforeEach(() => {
-      vi.clearAllMocks()
+    BddTest().then('it should render the title slot content', () => {
       wrapper = mount(FormFieldCardContainer, {
-        props: {
-          orientation: 'horizontal'
-        },
-        global: { stubs }
+        props,
+        global: { stubs },
+        slots: { title: '<button data-testid="title-slot-content">Action</button>' },
       })
-    })
-
-    BddTest().then('it should render horizontal layout', () => {
-      expect(wrapper.find('[data-testid="horizontal-container"]').exists()).toBe(true)
+      const slot = wrapper.find('[data-testid="title-slot-content"]')
+      expect(slot.exists()).toBe(true)
     })
   })
 })

--- a/src/features/staff/global/components/cards/FormFieldCardContainer/FormFieldCardContainer.vue
+++ b/src/features/staff/global/components/cards/FormFieldCardContainer/FormFieldCardContainer.vue
@@ -1,11 +1,20 @@
 <script setup lang="ts">
 import type { Slot } from 'vue'
+import { AvCard, type AvCardProps, AvIconText } from '@avenirs-esr/avenirs-dsav'
 
-export interface FormFieldCardContainerProps {
-  orientation?: 'vertical' | 'horizontal'
+export interface FormFieldCardContainerProps extends Pick<AvCardProps, 'collapsible' | 'collapsed' | 'titleOnly'> {
+  title: string
+  titleIcon: string
+  backgroundColor?: 'var(--card2)' | 'var(--other-background-base)'
 }
 
-const { orientation = 'vertical' } = defineProps<FormFieldCardContainerProps>()
+const {
+  backgroundColor = 'var(--card2)',
+  collapsible = false,
+  collapsed = false,
+  titleOnly = false
+} = defineProps<FormFieldCardContainerProps>()
+
 defineSlots<{
   title?: Slot
   default?: Slot
@@ -13,13 +22,28 @@ defineSlots<{
 </script>
 
 <template>
-  <AvCard>
-    <div
-      :class="orientation === 'horizontal' ? 'av-row' : 'av-col'"
-      :data-testid="`${orientation}-container`"
-    >
-      <slot name="title" />
-      <slot />
-    </div>
+  <AvCard
+    :background-color="backgroundColor"
+    :title-background="backgroundColor"
+    border-color="var(--light-background-neutral)"
+    :collapsible="collapsible"
+    :collapsed="collapsed"
+    :title-only="titleOnly"
+  >
+    <template #title>
+      <div class="av-row av-w-full av-gap-md av-align-center av-justify-between">
+        <AvIconText
+          :icon="titleIcon"
+          :text="title"
+          icon-color="var(--dark-background-primary1)"
+          text-color="var(--text1)"
+          typography-class="s1-regular"
+          gap="var(--spacing-xs)"
+        />
+        <slot name="title" />
+      </div>
+    </template>
+
+    <slot />
   </AvCard>
 </template>

--- a/src/features/staff/global/components/cards/ToggleParameterCard/ToggleParameterCard.stub.ts
+++ b/src/features/staff/global/components/cards/ToggleParameterCard/ToggleParameterCard.stub.ts
@@ -1,0 +1,5 @@
+export const ToggleParameterCardStub = defineComponent({
+  name: 'ToggleParameterCard',
+  props: ['title', 'icon'],
+  template: '<div class="toggle-parameter-card" />',
+})

--- a/src/features/staff/global/components/cards/ToggleParameterCard/ToggleParameterCard.test.ts
+++ b/src/features/staff/global/components/cards/ToggleParameterCard/ToggleParameterCard.test.ts
@@ -1,0 +1,60 @@
+import type { ToggleParameterCardProps } from '@/features/staff/global/components/cards/ToggleParameterCard/ToggleParameterCard.vue'
+import { ToggleStub } from '@/common/components/Toggle/Toggle.stub'
+import { FormFieldCardContainerStub } from '@/features/staff/global/components/cards/FormFieldCardContainer/FormFieldCardContainer.stub'
+import ToggleParameterCard from '@/features/staff/global/components/cards/ToggleParameterCard/ToggleParameterCard.vue'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { beforeEach, expect } from 'vitest'
+
+BddTest().given('a toggle parameter card', () => {
+  let wrapper: VueWrapper<InstanceType<typeof ToggleParameterCard>>
+
+  const stubs = {
+    FormFieldCardContainer: FormFieldCardContainerStub,
+    Toggle: ToggleStub,
+  }
+
+  const props: ToggleParameterCardProps = {
+    title: 'Association de traces',
+    icon: 'mdi:attach-file',
+  }
+
+  BddTest().when('the component is mounted', () => {
+    beforeEach(() => {
+      wrapper = mount(ToggleParameterCard, { props, global: { stubs } })
+    })
+
+    BddTest().then('it should render the card', () => {
+      const card = wrapper.find('[data-testid="toggle-parameter-card"]')
+      expect(card.exists()).toBe(true)
+    })
+
+    BddTest().then('it should render the toggle enabled by default', () => {
+      const toggle = wrapper.findComponent(ToggleStub)
+      expect(toggle.exists()).toBe(true)
+      expect(toggle.props('modelValue')).toBe(true)
+    })
+
+    BddTest().then('it should render the slot content', () => {
+      wrapper = mount(ToggleParameterCard, {
+        props,
+        global: { stubs },
+        slots: { default: '<p data-testid="slot-content">Contenu</p>' },
+      })
+      const slot = wrapper.find('[data-testid="slot-content"]')
+      expect(slot.exists()).toBe(true)
+    })
+
+    BddTest().and('the user clicks the toggle', () => {
+      beforeEach(() => {
+        const toggle = wrapper.findComponent(ToggleStub)
+        toggle.vm.$emit('update:modelValue', false)
+      })
+
+      BddTest().then('the toggle value should be false', () => {
+        const toggle = wrapper.findComponent(ToggleStub)
+        expect(toggle.props('modelValue')).toBe(false)
+      })
+    })
+  })
+})

--- a/src/features/staff/global/components/cards/ToggleParameterCard/ToggleParameterCard.vue
+++ b/src/features/staff/global/components/cards/ToggleParameterCard/ToggleParameterCard.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import type { Slot } from 'vue'
+import Toggle from '@/common/components/Toggle/Toggle.vue'
+import FormFieldCardContainer from '@/features/staff/global/components/cards/FormFieldCardContainer/FormFieldCardContainer.vue'
+
+export interface ToggleParameterCardProps {
+  title: string
+  icon: string
+}
+
+defineProps<ToggleParameterCardProps>()
+defineSlots<{
+  default?: Slot
+}>()
+
+const model = defineModel<boolean>({ default: true })
+</script>
+
+<template>
+  <FormFieldCardContainer
+    :title="title"
+    :title-icon="icon"
+    data-testid="toggle-parameter-card"
+  >
+    <template #title>
+      <Toggle
+        v-model="model"
+        description=""
+      />
+    </template>
+
+    <slot />
+  </FormFieldCardContainer>
+</template>


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
Add a reusable `ToggleParameterCard` component allowing staff to enable or disable parameters for a national activity, starting with the trace association setting.

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1523

---

### Target Branch
develop

---

### Additional Notes
- Added `ToggleParameterCard` component with title, icon and toggle
- Updated `FormFieldCardContainer` base card component
- Added unit tests and stubs for  `ToggleParameterCard` component 

The screenshot below shows the newly added `ToggleParameterCard` component:

<img width="1281" height="170" alt="Capture d’écran du 2026-05-12 16-11-40" src="https://github.com/user-attachments/assets/2aa4c56c-bae4-43f1-84d3-ff113d3fac42" />

> ⚠️ The text *"L'apprenant peut associer jusqu'à 10 traces maximum."* is injected via a slot — shown here for illustration purposes only.


---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [ ] No unnecessary code (e.g., debug logs, commented code)
- [ ] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process