### PR TITLE
feat: add Input component

### DIFF
--- a/src/common/components/interaction/inputs/Input/Input.stub.ts
+++ b/src/common/components/interaction/inputs/Input/Input.stub.ts
@@ -1,0 +1,19 @@
+export const InputStub = defineComponent({
+  name: 'Input',
+  props: ['modelValue', 'label', 'placeholder', 'maxlength', 'prefixIcon', 'isValid', 'isTextarea', 'labelVisible', 'disabled', 'required', 'errorMessage'],
+  emits: ['update:modelValue'],
+  template: `
+    <div>
+      <label v-if="labelVisible">{{ label }}</label>
+      <input
+        :value="modelValue"
+        :placeholder="placeholder"
+        :maxlength="maxlength"
+        :disabled="disabled"
+        :required="required"
+        @input="$emit('update:modelValue', $event.target.value)"
+      />
+      <span data-testid="maxlength-caption">{{ modelValue?.length || 0 }} / {{ maxlength }} caractères (espaces compris)</span>
+    </div>
+  `
+})

--- a/src/common/components/interaction/inputs/Input/Input.test.ts
+++ b/src/common/components/interaction/inputs/Input/Input.test.ts
@@ -1,0 +1,47 @@
+import type { VueWrapper } from '@vue/test-utils'
+import Input, { type InputProps } from '@/common/components/interaction/inputs/Input/Input.vue'
+import { AvInputStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { mount } from '@vue/test-utils'
+import { expect } from 'vitest'
+
+BddTest().given('an Input component', () => {
+  let wrapper: VueWrapper<InstanceType<typeof Input>>
+
+  const stubs = { AvInput: AvInputStub }
+
+  BddTest().when('the component is mounted without a maxlength prop', () => {
+    const props: InputProps = { modelValue: 'test' }
+
+    beforeEach(() => {
+      wrapper = mount(Input, { props, global: { stubs } })
+    })
+
+    BddTest().then('it should not render the maxLengthCaption slot', () => {
+      expect(wrapper.find('[data-testid="maxlength-caption"]').exists()).toBe(false)
+    })
+  })
+
+  BddTest().when('the component is mounted with a maxlength prop', () => {
+    const props: InputProps = { modelValue: 'test', maxlength: 100 }
+
+    beforeEach(() => {
+      wrapper = mount(Input, { props, global: { stubs } })
+    })
+
+    BddTest().then('it should render the maxLengthCaption slot', () => {
+      expect(wrapper.find('[data-testid="maxlength-caption"]').exists()).toBe(true)
+    })
+  })
+
+  BddTest().when('the component is mounted with a maxlength prop and a model value exceeding the maxlength', () => {
+    const props: InputProps = { modelValue: 'a'.repeat(101), maxlength: 100 }
+
+    beforeEach(() => {
+      wrapper = mount(Input, { props, global: { stubs } })
+    })
+
+    BddTest().then('it should render the maxlength error slot', () => {
+      expect(wrapper.find('.maxlength-error').exists()).toBe(true)
+    })
+  })
+})

--- a/src/common/components/interaction/inputs/Input/Input.vue
+++ b/src/common/components/interaction/inputs/Input/Input.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+import { AvInput, type AvInputProps } from '@avenirs-esr/avenirs-dsav'
+import { type ComputedRef, useAttrs } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+export interface InputProps extends AvInputProps { }
+
+const props = defineProps<InputProps>()
+const { t } = useI18n()
+const attrs = useAttrs()
+
+const avInputProps: ComputedRef<AvInputProps> = computed(() => ({
+  ...attrs,
+  ...props,
+}))
+</script>
+
+<template>
+  <AvInput v-bind="avInputProps">
+    <template
+      v-if="avInputProps.maxlength"
+      #maxLengthCaption="{ currentValue }"
+    >
+      <span
+        class="caption-light"
+        :class="{ 'maxlength-error': (currentValue?.toString().length || 0) > avInputProps.maxlength }"
+        data-testid="maxlength-caption"
+      >
+        {{ t('global.inputs.textarea.limit', {
+          count: currentValue?.toString().length || 0,
+          maxlength: avInputProps.maxlength,
+        }) }}
+      </span>
+    </template>
+  </AvInput>
+</template>
+
+<style lang="scss" scoped>
+.maxlength-error {
+  color: var(--dark-background-error);
+}
+</style>

--- a/src/features/student/traces/components/interactions/inputs/TraceNameInput/TraceNameInput.test.ts
+++ b/src/features/student/traces/components/interactions/inputs/TraceNameInput/TraceNameInput.test.ts
@@ -1,3 +1,4 @@
+import { InputStub } from '@/common/components/interaction/inputs/Input/Input.stub'
 import TraceNameInput from '@/features/student/traces/components/interactions/inputs/TraceNameInput/TraceNameInput.vue'
 import { TRACE_NAME_MAX_LENGTH } from '@/features/student/traces/config'
 import { MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
@@ -5,28 +6,8 @@ import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { mount, type VueWrapper } from '@vue/test-utils'
 import { beforeEach, expect } from 'vitest'
 
-const AvInputStub = {
-  name: 'AvInput',
-  props: ['modelValue', 'label', 'placeholder', 'maxlength', 'prefixIcon', 'isValid', 'isTextarea', 'labelVisible', 'disabled', 'required', 'errorMessage'],
-  emits: ['update:modelValue'],
-  template: `
-    <div>
-      <label v-if="labelVisible">{{ label }}</label>
-      <input
-        :value="modelValue"
-        :placeholder="placeholder"
-        :maxlength="maxlength"
-        :disabled="disabled"
-        :required="required"
-        @input="$emit('update:modelValue', $event.target.value)"
-      />
-      <slot name="maxLengthCaption" :current-value="modelValue" :maxlength="maxlength" />
-    </div>
-  `
-}
-
 const stubs = {
-  AvInput: AvInputStub
+  Input: InputStub
 }
 
 BddTest().given('a trace name input component', () => {
@@ -41,8 +22,8 @@ BddTest().given('a trace name input component', () => {
   })
 
   BddTest().when('the component is mounted', () => {
-    BddTest().then('it should render AvInput with default props', () => {
-      const input = wrapper.findComponent({ name: 'AvInput' })
+    BddTest().then('it should render Input with default props', () => {
+      const input = wrapper.findComponent(InputStub)
 
       expect(input.exists()).toBe(true)
       expect(input.props('label')).toBe('Nom de ma trace')
@@ -56,7 +37,7 @@ BddTest().given('a trace name input component', () => {
     })
 
     BddTest().then('it should render character count hint', () => {
-      const hint = wrapper.find('.caption-light')
+      const hint = wrapper.find('[data-testid="maxlength-caption"]')
 
       expect(hint.exists()).toBe(true)
       expect(hint.text()).toBe(`0 / ${TRACE_NAME_MAX_LENGTH} caractères (espaces compris)`)
@@ -74,7 +55,7 @@ BddTest().given('a trace name input component', () => {
         }
       })
 
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
 
       expect(input.props('label')).toBe('Custom Label')
     })
@@ -91,7 +72,7 @@ BddTest().given('a trace name input component', () => {
         }
       })
 
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
 
       expect(input.props('placeholder')).toBe('Custom placeholder text')
     })
@@ -108,7 +89,7 @@ BddTest().given('a trace name input component', () => {
         }
       })
 
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
 
       expect(input.props('maxlength')).toBe(200)
     })
@@ -125,14 +106,14 @@ BddTest().given('a trace name input component', () => {
         }
       })
 
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
 
       expect(input.props('prefixIcon')).toBe(MDI_ICONS.ACCOUNT_CIRCLE_OUTLINE)
     })
   })
 
   BddTest().when('the component is disabled', () => {
-    BddTest().then('it should pass disabled state to AvInput', () => {
+    BddTest().then('it should pass disabled state to Input', () => {
       wrapper = mount(TraceNameInput, {
         props: {
           disabled: true
@@ -142,14 +123,14 @@ BddTest().given('a trace name input component', () => {
         }
       })
 
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
 
       expect(input.props('disabled')).toBe(true)
     })
   })
 
   BddTest().when('required is false', () => {
-    BddTest().then('it should pass required state to AvInput', () => {
+    BddTest().then('it should pass required state to Input', () => {
       wrapper = mount(TraceNameInput, {
         props: {
           required: false
@@ -159,7 +140,7 @@ BddTest().given('a trace name input component', () => {
         }
       })
 
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
 
       expect(input.props('required')).toBe(false)
     })
@@ -176,14 +157,14 @@ BddTest().given('a trace name input component', () => {
         }
       })
 
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
 
       expect(input.props('labelVisible')).toBe(false)
     })
   })
 
   BddTest().when('isValid is true', () => {
-    BddTest().then('it should pass valid state to AvInput', () => {
+    BddTest().then('it should pass valid state to Input', () => {
       wrapper = mount(TraceNameInput, {
         props: {
           isValid: true
@@ -193,7 +174,7 @@ BddTest().given('a trace name input component', () => {
         }
       })
 
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
 
       expect(input.props('isValid')).toBe(true)
     })
@@ -201,7 +182,7 @@ BddTest().given('a trace name input component', () => {
 
   BddTest().when('text is entered', () => {
     BddTest().then('it should update the model value', async () => {
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
       await input.vm.$emit('update:modelValue', 'My trace name')
       await wrapper.vm.$nextTick()
 
@@ -218,14 +199,14 @@ BddTest().given('a trace name input component', () => {
         }
       })
 
-      const hint = wrapper.find('.caption-light')
+      const hint = wrapper.find('[data-testid="maxlength-caption"]')
 
       expect(hint.text()).toBe(`12 / ${TRACE_NAME_MAX_LENGTH} caractères (espaces compris)`)
     })
   })
 
   BddTest().when('a value is provided via v-model', () => {
-    BddTest().then('it should pass the value to AvInput', () => {
+    BddTest().then('it should pass the value to Input', () => {
       const testValue = 'Test trace name'
 
       wrapper = mount(TraceNameInput, {
@@ -237,14 +218,14 @@ BddTest().given('a trace name input component', () => {
         }
       })
 
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
 
       expect(input.props('modelValue')).toBe(testValue)
     })
   })
 
   BddTest().when('errorMessage is provided', () => {
-    BddTest().then('it should pass the error message to AvInput', () => {
+    BddTest().then('it should pass the error message to Input', () => {
       wrapper = mount(TraceNameInput, {
         props: {
           errorMessage: 'Ce champ est requis'
@@ -254,14 +235,14 @@ BddTest().given('a trace name input component', () => {
         }
       })
 
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
 
       expect(input.props('errorMessage')).toBe('Ce champ est requis')
     })
   })
 
   BddTest().when('isTextarea is true', () => {
-    BddTest().then('it should pass textarea state to AvInput', () => {
+    BddTest().then('it should pass textarea state to Input', () => {
       wrapper = mount(TraceNameInput, {
         props: {
           isTextarea: true
@@ -271,7 +252,7 @@ BddTest().given('a trace name input component', () => {
         }
       })
 
-      const input = wrapper.findComponent({ name: 'AvInput' })
+      const input = wrapper.findComponent(InputStub)
 
       expect(input.props('isTextarea')).toBe(true)
     })
@@ -290,7 +271,7 @@ BddTest().given('a trace name input component', () => {
         }
       })
 
-      const hint = wrapper.find('.caption-light')
+      const hint = wrapper.find('[data-testid="maxlength-caption"]')
 
       expect(hint.text()).toBe(`${TRACE_NAME_MAX_LENGTH} / ${TRACE_NAME_MAX_LENGTH} caractères (espaces compris)`)
     })

--- a/src/features/student/traces/components/interactions/inputs/TraceNameInput/TraceNameInput.vue
+++ b/src/features/student/traces/components/interactions/inputs/TraceNameInput/TraceNameInput.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
+import Input from '@/common/components/interaction/inputs/Input/Input.vue'
 import { TRACE_NAME_MAX_LENGTH } from '@/features/student/traces/config'
-import { AvInput, type AvInputProps, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
+import { type AvInputProps, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
 import { useAttrs } from 'vue'
 import { useI18n } from 'vue-i18n'
 
@@ -44,20 +45,8 @@ const avInputProps = computed(() => ({
 </script>
 
 <template>
-  <AvInput
+  <Input
     v-bind="avInputProps"
     v-model="modelValue"
-  >
-    <template
-      v-if="!$slots.maxLengthCaption"
-      #maxLengthCaption="{ currentValue }"
-    >
-      <span class="caption-light">
-        {{ t('global.inputs.textarea.limit', {
-          count: currentValue?.toString().length || 0,
-          maxlength,
-        }) }}
-      </span>
-    </template>
-  </AvInput>
+  />
 </template>


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
This PR introduces a new generic `Input` wrapper component around `AvInput` from the design system. It centralises the `maxLengthCaption` slot logic (character counter with error styling) in a single reusable component, and refactors `TraceNameInput` to use it.

**Main changes:**
- ✨ Add `Input` component wrapping `AvInput` with `maxLengthCaption` slot and error colour when limit is exceeded
- 🏷️ Export `InputProps` interface
- ✅ Add unit tests for `Input` component (no maxlength, with maxlength, value exceeding maxlength)
- 🎨 Add `InputStub` for tests
- ♻️ Refactor `TraceNameInput` to delegate to `Input` instead of `AvInput` directly
- ✅ Update `TraceNameInput` tests to use `InputStub`

---

### Reference to an Issue, Feature, Task, User Story or another PR
No linked issue (technical component addition).

---

### Documentation
- Unit tests added for `Input` component covering three cases: no maxlength, maxlength present, value exceeding maxlength
- `InputStub` added to ease testing of parent components

**Modified files:**
- `src/common/components/interaction/inputs/Input/Input.vue` — New `Input` wrapper component
- `src/common/components/interaction/inputs/Input/Input.test.ts` — Unit tests for `Input`
- `src/common/components/interaction/inputs/Input/Input.stub.ts` — Test stub for `Input`
- `src/features/student/traces/components/interactions/inputs/TraceNameInput/TraceNameInput.vue` — Refactored to use `Input`
- `src/features/student/traces/components/interactions/inputs/TraceNameInput/TraceNameInput.test.ts` — Updated to use `InputStub`

---

### Target Branch
`develop`

---

### Additional Notes
The `Input` component follows the same pattern as the existing `Toggle` wrapper: it extends `AvInputProps` and passes all props/attrs through to the underlying design system component. The `maxLengthCaption` slot adds a character counter that turns red when the value exceeds `maxlength`.

---

### Known Limitations or Side Effects
No known limitations or side effects.

---

## ✅ Checklist

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (unit tests added for `Input`, `TraceNameInput` tests updated)
- [ ] i18n handled (uses existing `global.inputs.textarea.limit` translation key)
- [ ] Performance tests (no significant performance changes)
- [ ] No unnecessary code (no debug logs or commented code)
- [ ] Code style and formatting rules respected (linting conventions followed)
- [ ] Semantic Versioning respected (conventional commit used)
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process (no database or property changes)