### PR TITLE
fix(1611): DeleteDeclaredExperiencesModal - update close label

### DIFF
--- a/src/features/student/personalCareer/views/PersonalCareerView/sections/ExperiencesSection/components/DeleteDeclaredExperiencesModal/DeleteDeclaredExperiencesModal.vue
+++ b/src/features/student/personalCareer/views/PersonalCareerView/sections/ExperiencesSection/components/DeleteDeclaredExperiencesModal/DeleteDeclaredExperiencesModal.vue
@@ -55,7 +55,7 @@ function onConfirm () {
 <template>
   <AvModal
     :opened="show"
-    :close-button-label="t('global.buttons.close')"
+    :close-button-label="t('global.buttons.cancel')"
     :confirm-button-disabled="selectedExperienceIds.length === 0"
     :confirm-button-label="t('student.personalCareer.views.PersonalCareerView.ExperiencesSection.DeleteDeclaredExperiencesModal.confirm', { count: selectedExperienceIds.length })"
     @close="onCancel"


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
This PR updates the close label used in `DeleteDeclaredExperiencesModal` to improve wording consistency in the declared experiences deletion flow.

**Main changes:**
- 🐛 Fixes the close label text in the delete declared experiences modal
- 💬 Aligns displayed wording with the expected UX copy in the personal career section

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1611

---

### Documentation
No additional technical documentation changes were required.

**Modified files:**
- `src/features/student/personalCareer/views/PersonalCareerView/sections/ExperiencesSection/components/DeleteDeclaredExperiencesModal/DeleteDeclaredExperiencesModal.vue`

---

### Target Branch
`develop`

---

### Additional Notes
Scope is intentionally minimal: one UI copy update in a single component.

---

### Known Limitations or Side Effects
No known limitations or side effects.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [ ] No unnecessary code (e.g., debug logs, commented code)
- [ ] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process
