### PR TITLE
fix(1641): reset my career delete program modal selection on reopen

### DIFF
--- a/src/features/student/personalCareer/views/PersonalCareerView/sections/ProgramsSection/components/DeleteDeclaredProgramsModal/DeleteDeclaredProgramsModal.test.ts
+++ b/src/features/student/personalCareer/views/PersonalCareerView/sections/ProgramsSection/components/DeleteDeclaredProgramsModal/DeleteDeclaredProgramsModal.test.ts
@@ -120,6 +120,11 @@ BddTest().given('a delete declared programs modal', () => {
         BddTest().then('it should emit confirm with the selected ids', () => {
           expect(wrapper.emitted('confirm')).toBeTruthy()
         })
+
+        BddTest().then('it should reset the selected program ids', () => {
+          const modal = wrapper.findComponent(AvModalStub)
+          expect(modal.props('confirmButtonLabel')).toContain('(0)')
+        })
       })
     })
   })

--- a/src/features/student/personalCareer/views/PersonalCareerView/sections/ProgramsSection/components/DeleteDeclaredProgramsModal/DeleteDeclaredProgramsModal.vue
+++ b/src/features/student/personalCareer/views/PersonalCareerView/sections/ProgramsSection/components/DeleteDeclaredProgramsModal/DeleteDeclaredProgramsModal.vue
@@ -47,6 +47,7 @@ function onClose () {
 }
 
 function onconfirm () {
+  selectedProgramIds.value = []
   emit('confirm')
   hideModal()
 }


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
Fix the delete modal not resetting the selected programs count after a successful deletion. The selected program IDs are now cleared after confirmation.

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1641

---

### Target Branch
develop

---

### Additional Notes
* Fixed onconfirm in DeleteDeclaredProgramsModal to reset selectedProgramIds after confirmation
* Added unit test to verify the reset behaviour after confirm

---

### QUALIF


https://github.com/user-attachments/assets/581f6a54-54da-4ab8-8944-ac3d274d2cfb


---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and detaiils for the update process