### PR TITLE
fix(1631-1632): set default page size and make pagination reactive for declared programs list

### DIFF
--- a/src/features/student/personalCareer/composables/use-paginated-declared-programs/use-paginated-declared-programs.test.ts
+++ b/src/features/student/personalCareer/composables/use-paginated-declared-programs/use-paginated-declared-programs.test.ts
@@ -101,7 +101,7 @@ BddTest().given('the usePaginatedDeclaredProgram composable', () => {
     BddTest().then('it should load the first page into elements with default page size', () => {
       const elements = composableResult.declaredPrograms.value
 
-      expect(elements.length).toBe(4)
+      expect(elements.length).toBe(8)
       expect(elements[0]).toHaveProperty('id')
       expect(elements[0]).toHaveProperty('title')
       expect(composableResult.page.value).toBe(0)
@@ -111,7 +111,7 @@ BddTest().given('the usePaginatedDeclaredProgram composable', () => {
       const pageInfo = composableResult.pageInfo.value
 
       expect(pageInfo.page).toBe(0)
-      expect(pageInfo.pageSize).toBe(4)
+      expect(pageInfo.pageSize).toBe(8)
       expect(pageInfo.totalElements).toBeGreaterThan(0)
       expect(pageInfo.totalPages).toBeGreaterThan(0)
     })

--- a/src/features/student/personalCareer/stores/personalCareer.store.test.ts
+++ b/src/features/student/personalCareer/stores/personalCareer.store.test.ts
@@ -34,7 +34,7 @@ BddTest().given('a personal career store', () => {
 
     BddTest().then('it should have default declared programs pagination values', () => {
       expect(store.declaredProgramsCurrentPage).toBe(0)
-      expect(store.declaredProgramsPageSizeSelected).toBe(PageSizes.FOUR)
+      expect(store.declaredProgramsPageSizeSelected).toBe(PageSizes.EIGHT)
     })
 
     BddTest().then('it should provide declared experiences pagination state', () => {

--- a/src/features/student/personalCareer/stores/personalCareer.store.ts
+++ b/src/features/student/personalCareer/stores/personalCareer.store.ts
@@ -2,8 +2,6 @@ import { useDrawer } from '@/common/composables'
 import { PageSizes } from '@avenirs-esr/avenirs-dsav'
 import { defineStore } from 'pinia'
 
-const DEFAULT_PAGE_SIZE = PageSizes.FOUR
-
 export const usePersonalCareerStore = defineStore('personalCareer', () => {
   const {
     showDrawer: showAddDeclaredProgramDrawer,
@@ -17,10 +15,10 @@ export const usePersonalCareerStore = defineStore('personalCareer', () => {
     hideDrawer: hideAddDeclaredExperienceDrawer
   } = useDrawer()
 
-  const declaredProgramsPageSizeSelected = ref<PageSizes>(DEFAULT_PAGE_SIZE)
+  const declaredProgramsPageSizeSelected = ref<PageSizes>(PageSizes.EIGHT)
   const declaredProgramsCurrentPage = ref(0)
 
-  const declaredExperiencesPageSizeSelected = ref<PageSizes>(DEFAULT_PAGE_SIZE)
+  const declaredExperiencesPageSizeSelected = ref<PageSizes>(PageSizes.FOUR)
   const declaredExperiencesCurrentPage = ref(0)
 
   return {

--- a/src/features/student/personalCareer/views/DeclaredProgramDetailedView/DeclaredProgramDetailedView.test.ts
+++ b/src/features/student/personalCareer/views/DeclaredProgramDetailedView/DeclaredProgramDetailedView.test.ts
@@ -154,11 +154,15 @@ BddTest().given('a declared program detailed view component', () => {
       expect(sideMenu.props('selectedProgramId')).toBe('declared-program-1')
       expect(sideMenu.props('countPrograms')).toBe(60)
 
-      expect(programs).toHaveLength(4)
+      expect(programs).toHaveLength(8)
       expect(programs[0].title).toBe('Formation déclarée 1')
       expect(programs[1].title).toBe('Formation déclarée 2')
       expect(programs[2].title).toBe('Formation déclarée 3')
       expect(programs[3].title).toBe('Formation déclarée 4')
+      expect(programs[4].title).toBe('Formation déclarée 5')
+      expect(programs[5].title).toBe('Formation déclarée 6')
+      expect(programs[6].title).toBe('Formation déclarée 7')
+      expect(programs[7].title).toBe('Formation déclarée 8')
     })
 
     BddTest().then('it should render program details when a program is selected', async () => {

--- a/src/features/student/personalCareer/views/PersonalCareerView/sections/ProgramsSection/components/DeclaredProgramsTab/DeclaredProgramsTab.vue
+++ b/src/features/student/personalCareer/views/PersonalCareerView/sections/ProgramsSection/components/DeclaredProgramsTab/DeclaredProgramsTab.vue
@@ -27,20 +27,18 @@ const {
   toRef(personalCareerStore, 'declaredProgramsPageSizeSelected')
 )
 
-const { data, error, isFetching } = useGetDeclaredPrograms({
+const params = computed(() => ({
   page: currentPage.value,
   pageSize: pageSizeSelected.value
-}, {
-  query: { placeholderData: keepPreviousData }
-})
+}))
 
+const { data, error, isFetching } = useGetDeclaredPrograms(params, { query: { placeholderData: keepPreviousData } })
 const declaredPrograms = computed(() => data.value?.data ?? [])
 const pageInfo = computed(() => data.value?.page)
 
 const { showModal, displayModal, hideModal } = useModal()
 
-const countDeclaredPrograms = computed(() => pageInfo.value?.totalElements ?? 0)
-const titleWithCount = computed(() => t('student.personalCareer.views.PersonalCareerView.ProgramsSection.DeclaredProgramsTab.title').concat(` (${countDeclaredPrograms.value})`))
+const titleWithCount = computed(() => t('student.personalCareer.views.PersonalCareerView.ProgramsSection.DeclaredProgramsTab.title').concat(` (${pageInfo.value?.totalElements ?? 0})`))
 
 useBaseApiExceptionToast(error)
 </script>


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
- Set default page size to 8
- Make pagination reactive to enable navigation between pages

---

### Reference to an Issue, Feature, Task, User Story or another PR
- Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1631
- Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1632

---

**Modified areas:**
- `src/features/student/personalCareer/composables/use-paginated-declared-programs/use-paginated-declared-programs.test.ts`
- `src/features/student/personalCareer/stores/personalCareer.store.test.ts`
- `src/features/student/personalCareer/stores/personalCareer.store.ts`
- `src/features/student/personalCareer/views/DeclaredProgramDetailedView/DeclaredProgramDetailedView.test.ts`
- `src/features/student/personalCareer/views/PersonalCareerView/sections/ProgramsSection/components/DeclaredProgramsTab/DeclaredProgramsTab.vue`

---

### Target Branch
`develop`

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process