### PR TITLE
fix(1642): rename cancel button label in my career delete program modal

### DIFF
--- a/src/features/student/personalCareer/views/PersonalCareerView/sections/ProgramsSection/components/DeleteDeclaredProgramsModal/DeleteDeclaredProgramsModal.vue
+++ b/src/features/student/personalCareer/views/PersonalCareerView/sections/ProgramsSection/components/DeleteDeclaredProgramsModal/DeleteDeclaredProgramsModal.vue
@@ -55,7 +55,7 @@ function onconfirm () {
 <template>
   <AvModal
     :opened="show"
-    :close-button-label="t('global.buttons.close')"
+    :close-button-label="t('global.buttons.cancel')"
     :confirm-button-disabled="selectedProgramIds.length === 0"
     :confirm-button-label="t('student.personalCareer.views.PersonalCareerView.ProgramsSection.DeleteDeclaredProgramsModal.confirm', { count: selectedProgramIds.length })"
     @close="onClose"


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
Fix incorrect button label in the multiple deletion modal: replaced `"Fermer"` with `"Annuler"` by using the shared translation key `global.buttons.cancel`.


---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1642#issue-4430446768

---

### Target Branch
develop

---

### QUALIF

<img width="1232" height="1244" alt="Capture d’écran du 2026-05-18 10-28-08" src="https://github.com/user-attachments/assets/4b6b2905-552d-4110-a3f9-89ca98661566" />


## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [x] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [x] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [x] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process