### PR TITLE
feat(1253): add draft activity

### DIFF
--- a/api-specs/avenir-esr.swagger.json
+++ b/api-specs/avenir-esr.swagger.json
@@ -1550,6 +1550,55 @@
         }
       }
     },
+    "/me/activities/{activityStatus}/{activityId}": {
+      "patch": {
+        "tags": [
+          "activity-controller"
+        ],
+        "operationId": "updateActivity",
+        "parameters": [
+          {
+            "name": "activityStatus",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/EActivityStatus"
+            }
+          },
+          {
+            "name": "activityId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ActivityDraftUpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivityDraftUpdateResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/storage/users/{fileId}": {
       "get": {
         "tags": [
@@ -2843,14 +2892,8 @@
             "name": "activityStatus",
             "in": "path",
             "required": true,
-            "$ref": "#/components/schemas/EActivityStatus",
             "schema": {
-              "type": "string",
-              "$ref": "#/components/schemas/EActivityStatus",
-              "enum": [
-                "PUBLISHED",
-                "DRAFT"
-              ]
+              "$ref": "#/components/schemas/EActivityStatus"
             }
           },
           {
@@ -2888,14 +2931,8 @@
             "name": "activityStatus",
             "in": "path",
             "required": true,
-            "$ref": "#/components/schemas/EActivityStatus",
             "schema": {
-              "type": "string",
-              "$ref": "#/components/schemas/EActivityStatus",
-              "enum": [
-                "PUBLISHED",
-                "DRAFT"
-              ]
+              "$ref": "#/components/schemas/EActivityStatus"
             }
           },
           {
@@ -4767,6 +4804,62 @@
           "draftId"
         ]
       },
+      "ActivityDraftUpdateRequest": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "thematic": {
+            "type": "string",
+            "$ref": "#/components/schemas/EActivityThematic",
+            "enum": [
+              "SELF_KNOWLEDGE",
+              "FUTURE_PLANS",
+              "PROGRAMS",
+              "EXPERIENCES",
+              "TRAJECTORIES",
+              "RESUMES",
+              "TRANSVERSAL"
+            ]
+          },
+          "summary": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "executionPeriodInfo": {
+            "type": "string"
+          },
+          "executionPeriodInfoSummary": {
+            "type": "string"
+          },
+          "traceAllowedAssociations": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "feedbackAllowedIterations": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "enableReflection": {
+            "type": "boolean"
+          }
+        }
+      },
+      "ActivityDraftUpdateResponse": {
+        "type": "object",
+        "properties": {
+          "draftId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "draftId"
+        ]
+      },
       "FileDTO": {
         "type": "object",
         "properties": {
@@ -5628,6 +5721,9 @@
             "type": "string",
             "format": "uuid"
           },
+          "author": {
+            "$ref": "#/components/schemas/AuthorDTO"
+          },
           "title": {
             "type": "string"
           },
@@ -5669,6 +5765,26 @@
           "summary",
           "thematic",
           "title"
+        ]
+      },
+      "AuthorDTO": {
+        "type": "object",
+        "properties": {
+          "userId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "firstName": {
+            "type": "string"
+          },
+          "lastName": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "firstName",
+          "lastName",
+          "userId"
         ]
       },
       "PagedResponseActivityOverviewDTO": {
@@ -5974,10 +6090,12 @@
           "DECLARED_PROGRAM_NOT_FOUND",
           "INSTITUTION_CONFIG_NOT_FOUND",
           "ACTIVITY_NOT_FOUND",
+          "ACTIVITY_DRAFT_NOT_FOUND",
           "DECLARED_ACTIVITY_NOT_FOUND",
           "USER_NOT_AUTHORIZED",
           "USER_IS_NOT_STUDENT_EXCEPTION",
           "USER_IS_NOT_STAFF_EXCEPTION",
+          "MAXIMUM_ALLOWED_ASSOCIATIONS_REACHED",
           "USER_ALREADY_EXISTS",
           "STUDENT_DECLARED_ALREADY_EXIST",
           "DECLARED_ACTIVITY_ALREADY_EXIST",

--- a/api-specs/avenir-esr.swagger.json
+++ b/api-specs/avenir-esr.swagger.json
@@ -1490,6 +1490,36 @@
         }
       }
     },
+    "/me/activities/draft": {
+      "post": {
+        "tags": [
+          "activity-controller"
+        ],
+        "operationId": "createActivityDraft",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ActivityDraftCreationRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivityDraftCreationResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/admin/seeding/run": {
       "post": {
         "tags": [
@@ -4713,6 +4743,29 @@
             "$ref": "#/components/schemas/DeclaredActivityPeriodDTO"
           }
         }
+      },
+      "ActivityDraftCreationRequest": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "title"
+        ]
+      },
+      "ActivityDraftCreationResponse": {
+        "type": "object",
+        "properties": {
+          "draftId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "draftId"
+        ]
       },
       "FileDTO": {
         "type": "object",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "preview:development": "vite preview -m development",
     "test": "npm run test:unit",
     "test:coverage": "vitest run --pool.threads.maxThreads=6 --coverage",
+    "test:coverage:shard": "vitest run --reporter=blob --coverage.enabled=true --coverage.provider=v8 --coverage.reporter=json --coverage.thresholds.lines=0 --coverage.thresholds.branches=0 --coverage.thresholds.functions=0 --coverage.thresholds.statements=0",
     "test:unit": "vitest run --pool.threads.maxThreads=6",
     "test:a11y": "run-s -c test:a11y:run test:a11y:cleanup",
     "test:a11y:run": "playwright test --config=a11y/playwright.a11y.config.ts",

--- a/src/__mocks__/fixtures/staffs/activities.fixtures.ts
+++ b/src/__mocks__/fixtures/staffs/activities.fixtures.ts
@@ -1,0 +1,5 @@
+import type { ActivityDraftCreationResponse } from '@/api/avenir-esr'
+
+export const mockedActivityDraftCreationResponse: ActivityDraftCreationResponse = {
+  draftId: '5046ec1c-c8f3-4d06-abf3-71ba4a73643c',
+}

--- a/src/__mocks__/msw/handlers/index.ts
+++ b/src/__mocks__/msw/handlers/index.ts
@@ -1,3 +1,4 @@
+import { staffsActivitiesHandlers } from '@/__mocks__/msw/handlers/staffs/activities.handlers'
 import { staffsUserHandlers } from '@/__mocks__/msw/handlers/staffs/user.handlers'
 import { activitiesHandlers } from '@/__mocks__/msw/handlers/student/activities.handlers'
 import { backOfficeHandlers } from '@/__mocks__/msw/handlers/student/back-office.handlers'
@@ -20,4 +21,5 @@ export const handlers = [
   ...selfKnowledgeHandlers,
   ...skillsHandlers,
   ...staffsUserHandlers,
+  ...staffsActivitiesHandlers,
 ]

--- a/src/__mocks__/msw/handlers/staffs/activities.handlers.ts
+++ b/src/__mocks__/msw/handlers/staffs/activities.handlers.ts
@@ -1,0 +1,20 @@
+import type { ActivityDraftCreationResponse } from '@/api/avenir-esr'
+import { mockedActivityDraftCreationResponse } from '@/__mocks__/fixtures/staffs/activities.fixtures'
+import { getCreateActivityDraftUrl } from '@/api/avenir-esr'
+import { http, HttpResponse } from 'msw'
+
+export const createActivityDraftErrorHandler = http.post(`*${getCreateActivityDraftUrl()}`, () => {
+  return HttpResponse.json(
+    { message: 'Erreur interne du serveur' },
+    { status: 500, headers: { 'Content-Type': 'application/json' } }
+  )
+})
+
+export const staffsActivitiesHandlers = [
+  http.post(`*${getCreateActivityDraftUrl()}`, () => {
+    return HttpResponse.json<ActivityDraftCreationResponse>(mockedActivityDraftCreationResponse, {
+      status: 201,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }),
+]

--- a/src/__mocks__/msw/handlers/student/activities.handlers.ts
+++ b/src/__mocks__/msw/handlers/student/activities.handlers.ts
@@ -18,6 +18,7 @@ import {
   type AssociationsCreationRequest,
   type DeclaredActivityAssociationsDTO,
   type DeclaredActivityDetailsDTO,
+  EActivityStatus,
   EErrorCode,
   getAssociateActivityWithDeclaredSkillsUrl,
   getAssociateActivityWithTracesUrl,
@@ -46,7 +47,7 @@ import { delay, http, HttpResponse, type PathParams } from 'msw'
 const subscribedActivities = new Set<string>()
 const declaredActivityDetailsOverrides = new Map<string, Partial<DeclaredActivityDetailsDTO>>()
 
-export const activityDetailsErrorHandler = http.get(`*${getGetActivityPresentationUrl('PUBLISHED', ':activityId')}`, () => {
+export const activityDetailsErrorHandler = http.get(`*${getGetActivityPresentationUrl(EActivityStatus.PUBLISHED, ':activityId')}`, () => {
   return HttpResponse.json(
     { message: 'Internal Server Error' },
     {
@@ -133,8 +134,7 @@ export const largeLibraryActivitiesHandler = http.get(`*${getGetDeclaredActiviti
     }
   })
 })
-
-export const activityDetailHandler = http.get(`*${getGetActivityPresentationUrl('PUBLISHED', ':activityId')}`, async ({ params }) => {
+export const activityDetailHandler = http.get(`*${getGetActivityPresentationUrl(EActivityStatus.PUBLISHED, ':activityId')}`, async ({ params }) => {
   const { activityId } = params
   if (activityId === 'INVALID_ACTIVITY_ID') {
     return HttpResponse.json(

--- a/src/common/types/forms.types.ts
+++ b/src/common/types/forms.types.ts
@@ -1,4 +1,5 @@
-import type { FormApi } from '@tanstack/vue-form'
+import type { FormApi, VueFormApi } from '@tanstack/vue-form'
 
 export type AnyFormApi<TFormData extends object> = FormApi<TFormData, any, any, any, any, any, any, any, any, any>
+export type AnyVueFormApi<TFormData extends object> = AnyFormApi<TFormData> & VueFormApi<TFormData, any, any, any, any, any, any, any, any, any>
 export type TopLevelFieldKey<TFormData extends object> = TFormData extends unknown ? Extract<keyof TFormData, string> : never

--- a/src/features/staff/activities/components/interactions/formFields/ActivityTitleFormField/ActivityTitleFormField.test.ts
+++ b/src/features/staff/activities/components/interactions/formFields/ActivityTitleFormField/ActivityTitleFormField.test.ts
@@ -1,0 +1,92 @@
+import type { ActivityDraftCreationForm } from '@/features/staff/activities/types/forms.types'
+import ActivityTitleFormField from '@/features/staff/activities/components/interactions/formFields/ActivityTitleFormField/ActivityTitleFormField.vue'
+import { ActivityTitleInputStub } from '@/features/staff/activities/components/interactions/inputs/ActivityTitleInput/ActivityTitleInput.stub'
+import { ACTIVITY_TITLE_MAX_LENGTH } from '@/features/staff/activities/config'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { useForm } from '@tanstack/vue-form'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { beforeEach, expect, vi } from 'vitest'
+
+const TestWrapper = defineComponent({
+  components: { ActivityTitleFormField },
+  setup () {
+    const form = useForm({
+      defaultValues: { title: '' },
+    }) satisfies ActivityDraftCreationForm
+    return { form }
+  },
+  template: '<form @submit.prevent="form.handleSubmit()"><ActivityTitleFormField :form="form" /></form>',
+})
+
+BddTest().given('an ActivityTitleFormField component', () => {
+  let wrapper: VueWrapper<InstanceType<typeof TestWrapper>>
+
+  const stubs = { ActivityTitleInput: ActivityTitleInputStub }
+
+  const getInput = () => wrapper.findComponent(ActivityTitleInputStub) as VueWrapper<InstanceType<typeof ActivityTitleInputStub>>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    wrapper = mount(TestWrapper, { global: { stubs } })
+  })
+
+  BddTest().when('the component is mounted', () => {
+    BddTest().then('it should render the ActivityTitleInput', () => {
+      expect(getInput().exists()).toBe(true)
+    })
+
+    BddTest().then('it should have an empty initial model value', () => {
+      expect(getInput().props('modelValue')).toBe('')
+    })
+
+    BddTest().then('it should have no initial error message', () => {
+      expect(getInput().props('errorMessage')).toBeFalsy()
+    })
+  })
+
+  BddTest().when('the input emits a valid title', () => {
+    beforeEach(async () => {
+      await getInput().vm.$emit('update:modelValue', 'Mon activité nationale')
+    })
+
+    BddTest().then('it should update the model value', async () => {
+      await vi.waitFor(() => expect(getInput().props('modelValue')).toBe('Mon activité nationale'))
+    })
+
+    BddTest().then('it should not show an error message', async () => {
+      await vi.waitFor(() => expect(getInput().props('errorMessage')).toBeFalsy())
+    })
+  })
+
+  BddTest().when('the input emits an empty value', () => {
+    beforeEach(async () => {
+      await getInput().vm.$emit('update:modelValue', '')
+    })
+
+    BddTest().then('it should show a required error message', async () => {
+      await vi.waitFor(() => expect(getInput().props('errorMessage')).toBe('Ce champ est requis.'))
+    })
+  })
+
+  BddTest().when('the input emits a title exceeding the max length', () => {
+    beforeEach(async () => {
+      await getInput().vm.$emit('update:modelValue', 'a'.repeat(ACTIVITY_TITLE_MAX_LENGTH + 1))
+    })
+
+    BddTest().then('it should show a max length error message', async () => {
+      await vi.waitFor(() => {
+        expect(getInput().props('errorMessage')).toBe(`Veuillez limiter votre saisie à ${ACTIVITY_TITLE_MAX_LENGTH} caractères`)
+      })
+    })
+  })
+
+  BddTest().when('the input emits blur', () => {
+    beforeEach(async () => {
+      await getInput().vm.$emit('blur')
+    })
+
+    BddTest().then('it should propagate the blur event', () => {
+      expect(getInput().emitted('blur')).toBeTruthy()
+    })
+  })
+})

--- a/src/features/staff/activities/components/interactions/formFields/ActivityTitleFormField/ActivityTitleFormField.vue
+++ b/src/features/staff/activities/components/interactions/formFields/ActivityTitleFormField/ActivityTitleFormField.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+import type { ActivityDraftCreationForm } from '@/features/staff/activities/types/forms.types'
+import { useFormValidators } from '@/common/composables/use-form-validators/use-form-validators'
+import ActivityTitleInput from '@/features/staff/activities/components/interactions/inputs/ActivityTitleInput/ActivityTitleInput.vue'
+import { ACTIVITY_TITLE_MAX_LENGTH } from '@/features/staff/activities/config'
+import { markRaw } from 'vue'
+
+interface ActivityTitleFormFieldProps {
+  form: ActivityDraftCreationForm
+}
+
+defineOptions({
+  inheritAttrs: false
+})
+
+const { form } = defineProps<ActivityTitleFormFieldProps>()
+
+const { validateRequired, validateMaxLength } = useFormValidators()
+const FormField = markRaw(form.Field)
+
+const titleValidators = {
+  onChange: ({ value }: { value: string }) => validateRequired(value) || validateMaxLength(value, ACTIVITY_TITLE_MAX_LENGTH),
+}
+</script>
+
+<template>
+  <FormField
+    name="title"
+    :validators="titleValidators"
+  >
+    <template #default="{ field }">
+      <ActivityTitleInput
+        v-bind="$attrs"
+        :model-value="field.state.value"
+        :error-message="field.state.meta.errors?.join(', ')"
+        @blur="field.handleBlur"
+        @update:model-value="(value) => field.handleChange(value ?? '')"
+      />
+    </template>
+  </FormField>
+</template>

--- a/src/features/staff/activities/components/interactions/inputs/ActivityTitleInput/ActivityTitleInput.stub.ts
+++ b/src/features/staff/activities/components/interactions/inputs/ActivityTitleInput/ActivityTitleInput.stub.ts
@@ -1,0 +1,9 @@
+export const ActivityTitleInputStub = defineComponent({
+  name: 'ActivityTitleInput',
+  props: {
+    modelValue: { type: String },
+    errorMessage: { type: String },
+  },
+  emits: ['update:modelValue', 'blur'],
+  template: '<div data-testid="activity-title-input-stub"></div>',
+})

--- a/src/features/staff/activities/components/interactions/inputs/ActivityTitleInput/ActivityTitleInput.test.ts
+++ b/src/features/staff/activities/components/interactions/inputs/ActivityTitleInput/ActivityTitleInput.test.ts
@@ -1,0 +1,163 @@
+import { InputStub } from '@/common/components/interaction/inputs/Input/Input.stub'
+import ActivityTitleInput from '@/features/staff/activities/components/interactions/inputs/ActivityTitleInput/ActivityTitleInput.vue'
+import { ACTIVITY_TITLE_MAX_LENGTH } from '@/features/staff/activities/config'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { beforeEach, expect, vi } from 'vitest'
+
+BddTest().given('ActivityTitleInput component', () => {
+  let wrapper: VueWrapper
+
+  const stubs = {
+    Input: InputStub,
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  BddTest().when('mounted with default props', () => {
+    let inputStub: VueWrapper<InstanceType<typeof InputStub>>
+
+    beforeEach(() => {
+      wrapper = mount(ActivityTitleInput, {
+        global: { stubs },
+      })
+      inputStub = wrapper.findComponent(InputStub) as VueWrapper<InstanceType<typeof InputStub>>
+    })
+
+    BddTest().then('it should render the Input component', () => {
+      expect(inputStub.exists()).toBe(true)
+    })
+
+    BddTest().then('it should always pass ACTIVITY_TITLE_MAX_LENGTH as maxlength', () => {
+      expect(inputStub.props('maxlength')).toBe(ACTIVITY_TITLE_MAX_LENGTH)
+    })
+
+    BddTest().then('it should use the default i18n label', () => {
+      expect(inputStub.props('label')).toBe('Titre de l\'activité')
+    })
+
+    BddTest().then('it should set labelVisible to true', () => {
+      expect(inputStub.props('labelVisible')).toBe(true)
+    })
+
+    BddTest().then('it should set required to true', () => {
+      expect(inputStub.props('required')).toBe(true)
+    })
+
+    BddTest().then('it should set isTextarea to false', () => {
+      expect(inputStub.props('isTextarea')).toBe(false)
+    })
+
+    BddTest().then('it should generate an id prefixed with activity-title-input', () => {
+      expect(inputStub.attributes('id')).toMatch(/^activity-title-input-/)
+    })
+
+    BddTest().then('it should not apply the n4 class', () => {
+      expect(inputStub.classes()).not.toContain('n4')
+    })
+  })
+
+  BddTest().when('mounted with a custom label', () => {
+    const customLabel = 'Mon titre personnalisé'
+
+    beforeEach(() => {
+      wrapper = mount(ActivityTitleInput, {
+        props: { label: customLabel },
+        global: { stubs },
+      })
+    })
+
+    BddTest().then('it should pass the custom label to Input', () => {
+      expect(wrapper.findComponent(InputStub).props('label')).toBe(customLabel)
+    })
+  })
+
+  BddTest().when('mounted with a custom id', () => {
+    const customId = 'custom-activity-id'
+
+    beforeEach(() => {
+      wrapper = mount(ActivityTitleInput, {
+        props: { id: customId },
+        global: { stubs },
+      })
+    })
+
+    BddTest().then('it should pass the custom id to Input', () => {
+      expect(wrapper.findComponent(InputStub).attributes('id')).toBe(customId)
+    })
+  })
+
+  BddTest().when('mounted with isTextarea set to true', () => {
+    beforeEach(() => {
+      wrapper = mount(ActivityTitleInput, {
+        props: { isTextarea: true },
+        global: { stubs },
+      })
+    })
+
+    BddTest().then('it should pass isTextarea true to Input', () => {
+      expect(wrapper.findComponent(InputStub).props('isTextarea')).toBe(true)
+    })
+
+    BddTest().then('it should apply the n4 class', () => {
+      expect(wrapper.findComponent(InputStub).classes()).toContain('n4')
+    })
+  })
+
+  BddTest().when('mounted with an errorMessage', () => {
+    const errorMessage = 'Le titre est requis'
+
+    beforeEach(() => {
+      wrapper = mount(ActivityTitleInput, {
+        props: { errorMessage },
+        global: { stubs },
+      })
+    })
+
+    BddTest().then('it should pass the errorMessage to Input', () => {
+      expect(wrapper.findComponent(InputStub).props('errorMessage')).toBe(errorMessage)
+    })
+  })
+
+  BddTest().when('mounted with labelVisible set to false', () => {
+    beforeEach(() => {
+      wrapper = mount(ActivityTitleInput, {
+        props: { labelVisible: false },
+        global: { stubs },
+      })
+    })
+
+    BddTest().then('it should pass labelVisible false to Input', () => {
+      expect(wrapper.findComponent(InputStub).props('labelVisible')).toBe(false)
+    })
+  })
+
+  BddTest().when('a model value is provided', () => {
+    beforeEach(() => {
+      wrapper = mount(ActivityTitleInput, {
+        props: { modelValue: 'Mon activité' },
+        global: { stubs },
+      })
+    })
+
+    BddTest().then('it should pass the model value to Input', () => {
+      expect(wrapper.findComponent(InputStub).props('modelValue')).toBe('Mon activité')
+    })
+  })
+
+  BddTest().when('the Input emits an update:modelValue event', () => {
+    beforeEach(() => {
+      wrapper = mount(ActivityTitleInput, {
+        props: { modelValue: '' },
+        global: { stubs },
+      })
+    })
+
+    BddTest().then('it should emit the updated value upward', () => {
+      wrapper.findComponent(InputStub).vm.$emit('update:modelValue', 'nouvelle valeur')
+      expect(wrapper.emitted('update:modelValue')?.[0]).toEqual(['nouvelle valeur'])
+    })
+  })
+})

--- a/src/features/staff/activities/components/interactions/inputs/ActivityTitleInput/ActivityTitleInput.vue
+++ b/src/features/staff/activities/components/interactions/inputs/ActivityTitleInput/ActivityTitleInput.vue
@@ -1,0 +1,40 @@
+<script setup lang="ts">
+import Input, { type InputProps } from '@/common/components/interaction/inputs/Input/Input.vue'
+import { ACTIVITY_TITLE_MAX_LENGTH } from '@/features/staff/activities/config'
+import { useAttrs } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+type ActivityTitleInputProps = Omit<InputProps, 'maxlength'>
+
+const {
+  isTextarea = false,
+  labelVisible = true,
+  required = true,
+  id,
+  label,
+  errorMessage,
+} = defineProps<ActivityTitleInputProps>()
+
+const modelValue = defineModel<string>()
+const { t } = useI18n()
+const attr = useAttrs()
+
+const inputProps = computed(() => ({
+  ...attr,
+  isTextarea,
+  labelVisible,
+  required,
+  errorMessage,
+  class: isTextarea ? 'n4' : undefined,
+  maxlength: ACTIVITY_TITLE_MAX_LENGTH,
+  id: id ?? `activity-title-input-${crypto.randomUUID()}`,
+  label: label ?? t('staff.activities.interactions.inputs.ActivityTitleInput.label'),
+}))
+</script>
+
+<template>
+  <Input
+    v-bind="inputProps"
+    v-model="modelValue"
+  />
+</template>

--- a/src/features/staff/activities/config.ts
+++ b/src/features/staff/activities/config.ts
@@ -1,0 +1,1 @@
+export const ACTIVITY_TITLE_MAX_LENGTH = 80

--- a/src/features/staff/activities/locales/en.json
+++ b/src/features/staff/activities/locales/en.json
@@ -1,8 +1,21 @@
 {
   "staff": {
     "activities": {
+      "interactions": {
+        "inputs": {
+          "ActivityTitleInput": {
+            "label": "Activity title"
+          }
+        }
+      },
       "views": {
         "ActivitiesView": {
+          "ActivityDraftCreationModal": {
+            "closeButtonLabel": "Cancel",
+            "confirmButtonLabel": "Create",
+            "error": "An error occurred while creating the activity",
+            "title": "Create an activity"
+          },
           "MyWorkspaceTab": {
             "columns": {
               "activityName": "Activity name",
@@ -10,6 +23,7 @@
               "owner": "Owner",
               "status": "Status"
             },
+            "createActivity": "Create an activity",
             "title": "All published activities in my institution ({count})"
           }
         }

--- a/src/features/staff/activities/locales/fr.json
+++ b/src/features/staff/activities/locales/fr.json
@@ -1,8 +1,21 @@
 {
   "staff": {
     "activities": {
+      "interactions": {
+        "inputs": {
+          "ActivityTitleInput": {
+            "label": "Titre de l'activité"
+          }
+        }
+      },
       "views": {
         "ActivitiesView": {
+          "ActivityDraftCreationModal": {
+            "closeButtonLabel": "Annuler",
+            "confirmButtonLabel": "Créer",
+            "error": "Une erreur est survenue lors de la création de l'activité",
+            "title": "Créer une activité"
+          },
           "MyWorkspaceTab": {
             "columns": {
               "activityName": "Nom de l'activité",
@@ -10,6 +23,7 @@
               "owner": "Propriétaire",
               "status": "Statut"
             },
+            "createActivity": "Créer une activité",
             "title": "Toutes les activités publiées dans mon établissement ({count})"
           }
         }

--- a/src/features/staff/activities/types/forms.types.ts
+++ b/src/features/staff/activities/types/forms.types.ts
@@ -1,0 +1,7 @@
+import type { AnyVueFormApi } from '@/common/types'
+
+export interface ActivityDraftCreationFormData {
+  title: string
+}
+
+export type ActivityDraftCreationForm = AnyVueFormApi<ActivityDraftCreationFormData>

--- a/src/features/staff/activities/views/ActivitiesView/components/ActivityDraftCreationModal/ActivityDraftCreationModal.stub.ts
+++ b/src/features/staff/activities/views/ActivitiesView/components/ActivityDraftCreationModal/ActivityDraftCreationModal.stub.ts
@@ -1,0 +1,10 @@
+export const ActivityDraftCreationModalStub = defineComponent({
+  name: 'ActivityDraftCreationModal',
+  props: {
+    opened: {
+      type: Boolean,
+    },
+  },
+  emits: ['close'],
+  template: '<div data-testid="activity-draft-creation-modal-stub"></div>',
+})

--- a/src/features/staff/activities/views/ActivitiesView/components/ActivityDraftCreationModal/ActivityDraftCreationModal.test.ts
+++ b/src/features/staff/activities/views/ActivitiesView/components/ActivityDraftCreationModal/ActivityDraftCreationModal.test.ts
@@ -1,0 +1,162 @@
+import type { VueWrapper } from '@vue/test-utils'
+import { mockedActivityDraftCreationResponse } from '@/__mocks__/fixtures/staffs/activities.fixtures'
+import { createActivityDraftErrorHandler } from '@/__mocks__/msw/handlers/staffs/activities.handlers'
+import { server } from '@/__mocks__/msw/server'
+import { ActivityTitleInputStub } from '@/features/staff/activities/components/interactions/inputs/ActivityTitleInput/ActivityTitleInput.stub'
+import ActivityDraftCreationModal from '@/features/staff/activities/views/ActivitiesView/components/ActivityDraftCreationModal/ActivityDraftCreationModal.vue'
+import { AvModalStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { mountComponent } from 'tests/utils'
+import { beforeEach, expect, vi } from 'vitest'
+
+const mockNavigateToEdit = vi.fn()
+
+vi.mock('@/common/composables', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/common/composables')>()
+  return {
+    ...actual,
+    useNavigation: () => ({
+      navigateToStaffActivitiesEditNationalActivity: mockNavigateToEdit,
+    }),
+  }
+})
+
+const mockAddErrorMessage = vi.fn()
+
+vi.mock('@/store', async () => {
+  const actual = await vi.importActual<typeof import('@/store')>('@/store')
+  return {
+    ...actual,
+    useToasterStore: vi.fn(() => ({
+      addErrorMessage: mockAddErrorMessage,
+    })),
+  }
+})
+
+BddTest().given('ActivityDraftCreationModal component', () => {
+  let wrapper: VueWrapper<InstanceType<typeof ActivityDraftCreationModal>>
+
+  const stubs = {
+    AvModal: AvModalStub,
+    ActivityTitleInput: ActivityTitleInputStub,
+  }
+
+  const getModal = () => wrapper.findComponent(AvModalStub) as VueWrapper<InstanceType<typeof AvModalStub>>
+  const getTitleInput = () => wrapper.findComponent(ActivityTitleInputStub) as VueWrapper<InstanceType<typeof ActivityTitleInputStub>>
+
+  const fillValidTitle = async () => {
+    await getTitleInput().vm.$emit('update:modelValue', 'Mon activité nationale')
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    wrapper = mountComponent(ActivityDraftCreationModal, {
+      props: { opened: true },
+      global: { stubs },
+    })
+  })
+
+  BddTest().when('the modal is mounted with opened=true', () => {
+    BddTest().then('it should render the AvModal component', () => {
+      expect(getModal().exists()).toBe(true)
+    })
+
+    BddTest().then('it should pass opened=true to AvModal', () => {
+      expect(getModal().props('opened')).toBe(true)
+    })
+
+    BddTest().then('it should pass the correct close button label', () => {
+      expect(getModal().props('closeButtonLabel')).toBe('Annuler')
+    })
+
+    BddTest().then('it should pass the correct confirm button label', () => {
+      expect(getModal().props('confirmButtonLabel')).toBe('Créer')
+    })
+
+    BddTest().then('it should render the modal title', () => {
+      expect(wrapper.text()).toContain('Créer une activité')
+    })
+
+    BddTest().then('it should render the ActivityTitleInput', () => {
+      expect(getTitleInput().exists()).toBe(true)
+    })
+
+    BddTest().then('it should have the confirm button disabled initially', () => {
+      expect(getModal().props('confirmButtonDisabled')).toBe(true)
+    })
+  })
+
+  BddTest().when('mounted with opened=false', () => {
+    beforeEach(() => {
+      wrapper = mountComponent(ActivityDraftCreationModal, {
+        props: { opened: false },
+        global: { stubs },
+      })
+    })
+
+    BddTest().then('it should pass opened=false to AvModal', () => {
+      expect(getModal().props('opened')).toBe(false)
+    })
+  })
+
+  BddTest().when('the title input is filled with a valid value', () => {
+    beforeEach(async () => {
+      await fillValidTitle()
+    })
+
+    BddTest().then('it should enable the confirm button', async () => {
+      await vi.waitFor(() => expect(getModal().props('confirmButtonDisabled')).toBe(false))
+    })
+  })
+
+  BddTest().when('the close button is clicked', () => {
+    beforeEach(async () => {
+      await getModal().vm.$emit('close')
+    })
+
+    BddTest().then('it should emit the close event', () => {
+      expect(wrapper.emitted('close')).toBeTruthy()
+    })
+  })
+
+  BddTest().when('the form is submitted with a valid title and the API succeeds', () => {
+    beforeEach(async () => {
+      await fillValidTitle()
+      await getModal().vm.$emit('confirm')
+    })
+
+    BddTest().then('it should emit the close event', async () => {
+      await vi.waitFor(() => expect(wrapper.emitted('close')).toBeTruthy())
+    })
+
+    BddTest().then('it should navigate to the edit page with the draft id', async () => {
+      await vi.waitFor(() => {
+        expect(mockNavigateToEdit).toHaveBeenCalledWith({
+          id: mockedActivityDraftCreationResponse.draftId,
+          mode: 'add',
+        })
+      })
+    })
+  })
+
+  BddTest().when('the form is submitted with a valid title and the API returns an error', () => {
+    beforeEach(async () => {
+      server.use(createActivityDraftErrorHandler)
+      await fillValidTitle()
+      await getModal().vm.$emit('confirm')
+    })
+
+    BddTest().then('it should call addErrorMessage', async () => {
+      await vi.waitFor(() => expect(mockAddErrorMessage).toHaveBeenCalledTimes(1))
+    })
+
+    BddTest().then('it should call addErrorMessage with the correct error title', async () => {
+      await vi.waitFor(() => {
+        expect(mockAddErrorMessage).toHaveBeenCalledWith(
+          expect.objectContaining({
+            title: 'Une erreur est survenue lors de la création de l\'activité',
+          })
+        )
+      })
+    })
+  })
+})

--- a/src/features/staff/activities/views/ActivitiesView/components/ActivityDraftCreationModal/ActivityDraftCreationModal.vue
+++ b/src/features/staff/activities/views/ActivitiesView/components/ActivityDraftCreationModal/ActivityDraftCreationModal.vue
@@ -1,0 +1,76 @@
+<script setup lang="ts">
+import type { BaseApiException } from '@/common/exceptions'
+import type { ActivityDraftCreationFormData } from '@/features/staff/activities/types/forms.types'
+import { useCreateActivityDraft } from '@/api/avenir-esr'
+import { useNavigation } from '@/common/composables'
+import ActivityTitleFormField from '@/features/staff/activities/components/interactions/formFields/ActivityTitleFormField/ActivityTitleFormField.vue'
+import { useToasterStore } from '@/store'
+import { AvModal, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
+import { useForm } from '@tanstack/vue-form'
+import { useI18n } from 'vue-i18n'
+
+interface ActivityDraftCreationModalProps {
+  opened: boolean
+}
+
+defineProps<ActivityDraftCreationModalProps>()
+
+const emit = defineEmits<{ close: [] }>()
+
+const CREATE_ACTIVITY_FORM_DEFAULT_VALUES = { title: '' }
+
+const { t } = useI18n()
+const { navigateToStaffActivitiesEditNationalActivity } = useNavigation()
+const { mutate, isPending } = useCreateActivityDraft()
+const { addErrorMessage } = useToasterStore()
+
+const form = useForm({
+  defaultValues: {
+    ...CREATE_ACTIVITY_FORM_DEFAULT_VALUES,
+  } satisfies ActivityDraftCreationFormData,
+  onSubmit: ({ value }) => {
+    mutate({ data: { title: value.title } }, {
+      onSuccess: (response) => {
+        emit('close')
+        navigateToStaffActivitiesEditNationalActivity({ id: response.draftId, mode: 'add' })
+      },
+      onError: (error: BaseApiException) => {
+        addErrorMessage({ title: t('staff.activities.views.ActivitiesView.ActivityDraftCreationModal.error'), description: error.message })
+      },
+    })
+  },
+})
+
+const isFormValid = computed(() => form.useStore(s => s.isValid && !s.isValidating && s.isDirty).value)
+
+function onClose () {
+  form.reset({ ...CREATE_ACTIVITY_FORM_DEFAULT_VALUES })
+  emit('close')
+}
+</script>
+
+<template>
+  <AvModal
+    :opened="opened"
+    :close-button-label="t('staff.activities.views.ActivitiesView.ActivityDraftCreationModal.closeButtonLabel')"
+    :confirm-button-label="t('staff.activities.views.ActivitiesView.ActivityDraftCreationModal.confirmButtonLabel')"
+    :confirm-button-disabled="!isFormValid"
+    :confirm-button-icon="MDI_ICONS.ARROW_RIGHT"
+    :is-loading="isPending"
+    @close="onClose"
+    @confirm="form.handleSubmit()"
+  >
+    <template #header>
+      <span class="b2-bold av-pt-md">
+        {{ t('staff.activities.views.ActivitiesView.ActivityDraftCreationModal.title') }}
+      </span>
+    </template>
+
+    <form
+      novalidate
+      @submit.prevent="form.handleSubmit()"
+    >
+      <ActivityTitleFormField :form="form" />
+    </form>
+  </AvModal>
+</template>

--- a/src/features/staff/activities/views/ActivitiesView/components/MyWorkspaceTab/MyWorkspaceTab.test.ts
+++ b/src/features/staff/activities/views/ActivitiesView/components/MyWorkspaceTab/MyWorkspaceTab.test.ts
@@ -1,7 +1,8 @@
 import { PaginationStub } from '@/common/components/Pagination/Pagination.stub'
+import { ActivityDraftCreationModalStub } from '@/features/staff/activities/views/ActivitiesView/components/ActivityDraftCreationModal/ActivityDraftCreationModal.stub'
 import { ActivityTableTitleStub } from '@/features/staff/activities/views/ActivitiesView/components/ActivityTableTitle/ActivityTableTitle.stub'
 import MyWorkspaceTab from '@/features/staff/activities/views/ActivitiesView/components/MyWorkspaceTab/MyWorkspaceTab.vue'
-import { AvTableStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { AvButtonStub, AvTableStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { mount, type VueWrapper } from '@vue/test-utils'
 import { beforeEach, expect, vi } from 'vitest'
 
@@ -9,22 +10,29 @@ BddTest().given('a MyWorkspaceTab component', () => {
   let wrapper: ReturnType<typeof mount<typeof MyWorkspaceTab>>
 
   const stubs = {
+    ActivityDraftCreationModal: ActivityDraftCreationModalStub,
     ActivityTableTitle: ActivityTableTitleStub,
+    AvButton: AvButtonStub,
     AvTable: AvTableStub,
     Pagination: PaginationStub,
   }
+
+  const getModal = () => wrapper.findComponent(ActivityDraftCreationModalStub) as VueWrapper<InstanceType<typeof ActivityDraftCreationModalStub>>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    wrapper = mount(MyWorkspaceTab, {
+      global: { stubs },
+    })
+  })
 
   BddTest().when('the component is mounted', () => {
     let avTable: VueWrapper<InstanceType<typeof AvTableStub>>
     let pagination: VueWrapper<InstanceType<typeof PaginationStub>>
 
     beforeEach(() => {
-      vi.clearAllMocks()
-      wrapper = mount(MyWorkspaceTab, {
-        global: { stubs },
-      })
-      avTable = wrapper.findComponent({ name: 'AvTable' })
-      pagination = wrapper.findComponent(PaginationStub)
+      avTable = wrapper.findComponent({ name: 'AvTable' }) as VueWrapper<InstanceType<typeof AvTableStub>>
+      pagination = wrapper.findComponent(PaginationStub) as VueWrapper<InstanceType<typeof PaginationStub>>
     })
 
     BddTest().then('it should render the component', () => {
@@ -55,6 +63,10 @@ BddTest().given('a MyWorkspaceTab component', () => {
       expect(pagination.props('pageInfo')).toMatchObject({ totalElements: 3 })
     })
 
+    BddTest().then('it should render the modal closed', () => {
+      expect(getModal().props('opened')).toBe(false)
+    })
+
     BddTest().and('the column labels are correct', () => {
       let columns: { key: string, label: string }[]
 
@@ -83,6 +95,26 @@ BddTest().given('a MyWorkspaceTab component', () => {
       BddTest().then('it should render one ActivityTableTitle per row', () => {
         const titles = wrapper.findAllComponents({ name: 'ActivityTableTitle' })
         expect(titles).toHaveLength(3)
+      })
+    })
+  })
+
+  BddTest().when('the create activity button is clicked', () => {
+    beforeEach(async () => {
+      await wrapper.find('#create-activity-button').trigger('click')
+    })
+
+    BddTest().then('it should open the modal', () => {
+      expect(getModal().props('opened')).toBe(true)
+    })
+
+    BddTest().and('the modal emits close', () => {
+      beforeEach(() => {
+        getModal().vm.$emit('close')
+      })
+
+      BddTest().then('it should close the modal', () => {
+        expect(getModal().props('opened')).toBe(false)
       })
     })
   })

--- a/src/features/staff/activities/views/ActivitiesView/components/MyWorkspaceTab/MyWorkspaceTab.vue
+++ b/src/features/staff/activities/views/ActivitiesView/components/MyWorkspaceTab/MyWorkspaceTab.vue
@@ -4,14 +4,16 @@ import type { ActivityTableRow } from '@/features/staff/activities/views/Activit
 import type { AvTableColumn } from '@avenirs-esr/avenirs-dsav'
 import { EActivityThematic } from '@/api/avenir-esr'
 import Pagination from '@/common/components/Pagination/Pagination.vue'
-import { useDateUtils, usePagination } from '@/common/composables'
+import { useDateUtils, useModal, usePagination } from '@/common/composables'
 import { mapActivityToActivityTableRow } from '@/features/staff/activities/views/ActivitiesView/ActivitiesView.utils'
+import ActivityDraftCreationModal from '@/features/staff/activities/views/ActivitiesView/components/ActivityDraftCreationModal/ActivityDraftCreationModal.vue'
 import ActivityTableTitle from '@/features/staff/activities/views/ActivitiesView/components/ActivityTableTitle/ActivityTableTitle.vue'
-import { AvTable, PageSizes } from '@avenirs-esr/avenirs-dsav'
+import { AvButton, AvTable, MDI_ICONS, PageSizes } from '@avenirs-esr/avenirs-dsav'
 import { useI18n } from 'vue-i18n'
 
 const { t } = useI18n()
 const { formatLastModified } = useDateUtils()
+const { showModal: showAddActivityModal, displayModal: displayAddActivityModal, hideModal: hideAddActivityModal } = useModal()
 
 const currentPageRef = ref<number>(0)
 const pageSizeRef = ref<PageSizes>(PageSizes.TWELVE)
@@ -98,6 +100,17 @@ const pageInfo = computed<PageInfoDTO>(() => ({
       {{ t('staff.activities.views.ActivitiesView.MyWorkspaceTab.title', { count: totalElements }) }}
     </h2>
 
+    <div class="av-row av-justify-end av-py-md">
+      <AvButton
+        id="create-activity-button"
+        :label="t('staff.activities.views.ActivitiesView.MyWorkspaceTab.createActivity')"
+        variant="FLAT"
+        :icon="MDI_ICONS.PLUS_CIRCLE_OUTLINE"
+        theme="PRIMARY"
+        @click="displayAddActivityModal"
+      />
+    </div>
+
     <Pagination
       :page-info="pageInfo"
       :page-size-selected="pageSizeSelected"
@@ -120,4 +133,9 @@ const pageInfo = computed<PageInfoDTO>(() => ({
       </AvTable>
     </Pagination>
   </div>
+
+  <ActivityDraftCreationModal
+    :opened="showAddActivityModal"
+    @close="hideAddActivityModal"
+  />
 </template>


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
This PR introduces the draft activity feature for the staff/activities module. It includes new form components for activity creation (title input and form field), a draft creation modal, and the necessary API specifications and test fixtures.

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1616
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1514
---

### Documentation
- Added i18n translations for activity-related strings (en/fr)
- Added MSW mock handlers for activities API endpoints
- Updated API specs with new activity endpoints

---

### Target Branch
`develop`

---

### Additional Notes
- Created reusable form components: ActivityTitleInput and ActivityTitleFormField
- Integrated draft creation modal into MyWorkspaceTab component
- Set up test fixtures and MSW handlers for local development and testing

---

### Known Limitations or Side Effects
None identified at this time.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [x] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [x] i18n handled (texts are translated)
- [x] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [x] Semantic Versioning respected
- [x] Add to `CHANGELOG.md` file all properties and database change and detaiils for the update process