### PR TITLE
fix(1651): display published badge instead of raw status value

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "avenirs-cofolio-client",
       "version": "0.0.0",
       "dependencies": {
-        "@avenirs-esr/avenirs-dsav": "^0.1.201",
+        "@avenirs-esr/avenirs-dsav": "^0.1.203",
         "@tanstack/vue-form": "^1.15.0",
         "@tanstack/vue-query": "^5.74.9",
         "@vue-flow/core": "^1.48.0",
@@ -348,9 +348,9 @@
       "license": "ISC"
     },
     "node_modules/@avenirs-esr/avenirs-dsav": {
-      "version": "0.1.201",
-      "resolved": "https://registry.npmjs.org/@avenirs-esr/avenirs-dsav/-/avenirs-dsav-0.1.201.tgz",
-      "integrity": "sha512-cU/F9F+fehASNTl7XQ5Bemi6iyULqrgzA865/VzH983wy02GQGH1Y/iy3pqNN06OncXQqb72eixzH9POjccpYQ==",
+      "version": "0.1.203",
+      "resolved": "https://registry.npmjs.org/@avenirs-esr/avenirs-dsav/-/avenirs-dsav-0.1.203.tgz",
+      "integrity": "sha512-Mr3kZjzXfJF367ektcH+t2vZW0OViCJ3gYutYlPWNHFfrmqmUTjyusMedOA2VCpcAThjKJaVq+gwUPV7vl/K4w==",
       "dependencies": {
         "@tanstack/vue-table": "^8.21.3",
         "@tiptap/extension-character-count": "^3.20.2",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
-    "@avenirs-esr/avenirs-dsav": "^0.1.201",
+    "@avenirs-esr/avenirs-dsav": "^0.1.203",
     "@tanstack/vue-form": "^1.15.0",
     "@tanstack/vue-query": "^5.74.9",
     "@vue-flow/core": "^1.48.0",

--- a/src/common/activities/badges/ActivityStatusBadge/ActivityStatusBadge.stub.ts
+++ b/src/common/activities/badges/ActivityStatusBadge/ActivityStatusBadge.stub.ts
@@ -1,0 +1,10 @@
+export const ActivityStatusBadgeStub = defineComponent({
+  name: 'ActivityStatusBadge',
+  props: {
+    status: {
+      type: String,
+      required: true
+    }
+  },
+  template: `<div data-testid="activity-status-badge">{{ status }}</div>`
+})

--- a/src/common/activities/badges/ActivityStatusBadge/ActivityStatusBadge.test.ts
+++ b/src/common/activities/badges/ActivityStatusBadge/ActivityStatusBadge.test.ts
@@ -1,0 +1,40 @@
+import type { ActivityStatusBadgeProps } from '@/common/activities/badges/ActivityStatusBadge/ActivityStatusBadge.vue'
+import { EActivityStatus } from '@/api/avenir-esr'
+import ActivityStatusBadge from '@/common/activities/badges/ActivityStatusBadge/ActivityStatusBadge.vue'
+import { MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
+import { AvBadgeStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { mount, type VueWrapper } from '@vue/test-utils'
+
+BddTest().given('an activity status badge', () => {
+  let wrapper: VueWrapper<InstanceType<typeof ActivityStatusBadge>>
+
+  const stubs = { AvBadge: AvBadgeStub }
+
+  const scenario: Array<{ props: ActivityStatusBadgeProps, label: string, icon: string }> = [
+    { props: { status: EActivityStatus.DRAFT }, label: 'non publiée', icon: MDI_ICONS.TEXT_BOX_EDIT_OUTLINE },
+    { props: { status: EActivityStatus.PUBLISHED }, label: 'publiée', icon: MDI_ICONS.TEXT_BOX_CHECK_OUTLINE },
+  ]
+
+  scenario.forEach(({ props, label, icon }) => {
+    BddTest().when(`the badge is rendered with status ${props.status}`, () => {
+      beforeEach(() => {
+        wrapper = mount(ActivityStatusBadge, { props, global: { stubs } })
+      })
+
+      BddTest().then('it should render the badge', () => {
+        const badge = wrapper.findComponent(AvBadgeStub)
+        expect(badge.exists()).toBe(true)
+      })
+
+      BddTest().then('it should render the badge label', () => {
+        const badge = wrapper.findComponent(AvBadgeStub)
+        expect(badge.props('label')).toBe(label)
+      })
+
+      BddTest().then('it should render the badge icon', () => {
+        const badge = wrapper.findComponent(AvBadgeStub)
+        expect(badge.props('icon')).toBe(icon)
+      })
+    })
+  })
+})

--- a/src/common/activities/badges/ActivityStatusBadge/ActivityStatusBadge.vue
+++ b/src/common/activities/badges/ActivityStatusBadge/ActivityStatusBadge.vue
@@ -1,0 +1,35 @@
+<script lang="ts" setup>
+import { EActivityStatus } from '@/api/avenir-esr'
+import { AvBadge, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
+import { useI18n } from 'vue-i18n'
+
+export interface ActivityStatusBadgeProps {
+  status: EActivityStatus
+}
+
+const { status } = defineProps<ActivityStatusBadgeProps>()
+
+const { t } = useI18n()
+
+const label = computed(() => t(`global.activities.badges.statuses.${status}`))
+
+const icon = computed(() => {
+  switch (status) {
+    case EActivityStatus.DRAFT:
+      return MDI_ICONS.TEXT_BOX_EDIT_OUTLINE
+    case EActivityStatus.PUBLISHED:
+    default:
+      return MDI_ICONS.TEXT_BOX_CHECK_OUTLINE
+  }
+})
+</script>
+
+<template>
+  <AvBadge
+    :label="label"
+    :icon="icon"
+    color="var(--text1)"
+    background-color="var(--surface-background)"
+    border-color="var(--stroke)"
+  />
+</template>

--- a/src/features/staff/activities/views/ActivitiesView/ActivitiesView.types.ts
+++ b/src/features/staff/activities/views/ActivitiesView/ActivitiesView.types.ts
@@ -1,9 +1,9 @@
-import type { EActivityThematic } from '@/api/avenir-esr'
+import type { EActivityStatus, EActivityThematic } from '@/api/avenir-esr'
 
 export interface ActivityTableRow {
   id: string
   owner: string
-  status: string
+  status: EActivityStatus
   thematic: EActivityThematic
   title: string
   updatedAt: string

--- a/src/features/staff/activities/views/ActivitiesView/components/ActivityTableTitle/ActivityTableTitle.test.ts
+++ b/src/features/staff/activities/views/ActivitiesView/components/ActivityTableTitle/ActivityTableTitle.test.ts
@@ -1,5 +1,5 @@
 import type { ActivityTableRow } from '@/features/staff/activities/views/ActivitiesView/ActivitiesView.types'
-import { EActivityThematic } from '@/api/avenir-esr'
+import { EActivityStatus, EActivityThematic } from '@/api/avenir-esr'
 import { ActivityThematicBadgeStub } from '@/common/activities/badges/ActivityThematicBadge/ActivityThematicBadge.stub'
 import { ROUTES } from '@/common/constants'
 import ActivityTableTitle from '@/features/staff/activities/views/ActivitiesView/components/ActivityTableTitle/ActivityTableTitle.vue'
@@ -18,7 +18,7 @@ BddTest().given('an ActivityTableTitle component', () => {
   const baseActivity: ActivityTableRow = {
     id: 'activity-1',
     owner: '',
-    status: 'published',
+    status: EActivityStatus.PUBLISHED,
     thematic: EActivityThematic.SELF_KNOWLEDGE,
     title: 'Activité "Connaissance de soi" : Définir ses valeurs',
     updatedAt: '2025-03-10T14:00:00.000Z',
@@ -85,7 +85,7 @@ BddTest().given('an ActivityTableTitle component', () => {
           activity: {
             ...baseActivity,
             id: 'activity-42',
-            status: 'draft',
+            status: EActivityStatus.DRAFT,
           },
         },
         global: { stubs },
@@ -96,7 +96,7 @@ BddTest().given('an ActivityTableTitle component', () => {
     BddTest().then('it should update the route params accordingly', () => {
       expect(link.props('to')).toEqual({
         name: ROUTES.STAFF.ACTIVITY_DETAILS.name,
-        params: { id: 'activity-42', status: 'draft' },
+        params: { id: 'activity-42', status: EActivityStatus.DRAFT },
       })
     })
   })

--- a/src/features/staff/activities/views/ActivitiesView/components/MyWorkspaceTab/MyWorkspaceTab.test.ts
+++ b/src/features/staff/activities/views/ActivitiesView/components/MyWorkspaceTab/MyWorkspaceTab.test.ts
@@ -1,4 +1,5 @@
 import type { mount, VueWrapper } from '@vue/test-utils'
+import { ActivityStatusBadgeStub } from '@/common/activities/badges/ActivityStatusBadge/ActivityStatusBadge.stub'
 import { PaginationStub } from '@/common/components/Pagination/Pagination.stub'
 import { QuerySuspenseStub } from '@/common/components/QuerySuspense/QuerySuspense.stub'
 import { ActivityDraftCreationModalStub } from '@/features/staff/activities/views/ActivitiesView/components/ActivityDraftCreationModal/ActivityDraftCreationModal.stub'
@@ -15,6 +16,7 @@ BddTest().given('a MyWorkspaceTab component', () => {
   const stubs = {
     ActivityDraftCreationModal: ActivityDraftCreationModalStub,
     ActivityTableTitle: ActivityTableTitleStub,
+    ActivityStatusBadge: ActivityStatusBadgeStub,
     AvButton: AvButtonStub,
     AvTable: AvTableStub,
     Pagination: PaginationStub,
@@ -97,6 +99,13 @@ BddTest().given('a MyWorkspaceTab component', () => {
     BddTest().and('the title column slot is rendered', () => {
       BddTest().then('it should render one ActivityTableTitle per row', () => {
         const titles = wrapper.findAllComponents({ name: 'ActivityTableTitle' })
+        expect(titles).toHaveLength(6)
+      })
+    })
+
+    BddTest().and('the status column slot is rendered', () => {
+      BddTest().then('it should render one ActivityStatusBadge per row', () => {
+        const titles = wrapper.findAllComponents(ActivityStatusBadgeStub)
         expect(titles).toHaveLength(6)
       })
     })

--- a/src/features/staff/activities/views/ActivitiesView/components/MyWorkspaceTab/MyWorkspaceTab.vue
+++ b/src/features/staff/activities/views/ActivitiesView/components/MyWorkspaceTab/MyWorkspaceTab.vue
@@ -2,6 +2,7 @@
 import type { ActivityTableRow } from '@/features/staff/activities/views/ActivitiesView/ActivitiesView.types'
 import type { AvTableColumn } from '@avenirs-esr/avenirs-dsav'
 import { useGetStaffActivityWorkingSpace } from '@/api/avenir-esr'
+import ActivityStatusBadge from '@/common/activities/badges/ActivityStatusBadge/ActivityStatusBadge.vue'
 import Pagination from '@/common/components/Pagination/Pagination.vue'
 import { useDateUtils, usePagination } from '@/common/composables'
 import { useStaffActivitiesStore } from '@/features/staff/activities/stores/activities.store'
@@ -106,6 +107,10 @@ const columns = computed<AvTableColumn<ActivityTableRow>[]>(() => [
 
           <template #cell(updatedAt)="{ row }">
             {{ row.updatedAt ? formatLastModified(row.updatedAt) : '' }}
+          </template>
+
+          <template #cell(status)="{ row }">
+            <ActivityStatusBadge :status="row.status" />
           </template>
         </AvTable>
       </Pagination>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -10,6 +10,10 @@
           "SELF_KNOWLEDGE": "Self-knowledge",
           "TRAJECTORIES": "My trajectories",
           "TRANSVERSAL": "Transversal"
+        },
+        "statuses": {
+          "DRAFT": "unpublished",
+          "PUBLISHED": "published"
         }
       }
     },

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -10,6 +10,10 @@
           "SELF_KNOWLEDGE": "Me connaître",
           "TRAJECTORIES": "Mes trajectoires",
           "TRANSVERSAL": "Transverse"
+        },
+        "statuses": {
+          "DRAFT": "non publiée",
+          "PUBLISHED": "publiée"
         }
       }
     },


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
- In `MyWorkspaceTab`, replace the plain-text status display with a badge when the activity status is `published`

---

### Reference to an Issue, Feature, Task, User Story or another PR
- Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1651

---

**Modified areas:**
- `src/common/activities/badges/ActivityStatusBadge/ActivityStatusBadge.stub.ts`
- `src/common/activities/badges/ActivityStatusBadge/ActivityStatusBadge.test.ts`
- `src/common/activities/badges/ActivityStatusBadge/ActivityStatusBadge.vue`
- `src/features/staff/activities/views/ActivitiesView/ActivitiesView.types.ts`
- `src/features/staff/activities/views/ActivitiesView/components/ActivityTableTitle/ActivityTableTitle.test.ts`
- `src/features/staff/activities/views/ActivitiesView/components/MyWorkspaceTab/MyWorkspaceTab.test.ts`
- `src/features/staff/activities/views/ActivitiesView/components/MyWorkspaceTab/MyWorkspaceTab.vue`
- `src/features/staff/activities/views/ActivitiesView/ActivitiesView.types.ts`
- `src/locales/en.json`
- `src/locales/fr.json`
- `package.json`

---

### Target Branch
`develop`

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [x] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process