### PR TITLE
feat(1515): create AddNationalActivitySideNavigation component

### DIFF
--- a/src/common/composables/use-scroll-spy/use-scroll-spy.test.ts
+++ b/src/common/composables/use-scroll-spy/use-scroll-spy.test.ts
@@ -1,0 +1,79 @@
+import { useScrollSpy } from '@/common/composables/use-scroll-spy/use-scroll-spy'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { mountComposable } from 'tests/utils'
+import { beforeEach, vi } from 'vitest'
+import { nextTick } from 'vue'
+
+BddTest().given('a useScrollSpy composable', () => {
+  let result: ReturnType<typeof useScrollSpy>
+
+  beforeEach(() => {
+    vi.spyOn(window, 'addEventListener')
+    vi.spyOn(window, 'removeEventListener')
+  })
+
+  BddTest().when('mounted with element ids', () => {
+    beforeEach(() => {
+      const el1 = document.createElement('div')
+      el1.id = 'TITLE'
+      const el2 = document.createElement('div')
+      el2.id = 'THEMATIC'
+      document.body.appendChild(el1)
+      document.body.appendChild(el2)
+
+      const { result: composableResult } = mountComposable(
+        () => useScrollSpy(['TITLE', 'THEMATIC']),
+        {}
+      )
+      result = composableResult
+    })
+
+    BddTest().then('it should add a scroll listener', () => {
+      expect(window.addEventListener).toHaveBeenCalledWith('scroll', expect.any(Function), { passive: true })
+    })
+
+    BddTest().then('it should initialize activeElementId', () => {
+      expect(result.activeElementId.value).toBeDefined()
+    })
+  })
+
+  BddTest().when('unmounted', () => {
+    BddTest().then('it should remove the scroll listener', () => {
+      const { unmount } = mountComposable(
+        () => useScrollSpy(['TITLE', 'THEMATIC']),
+        {}
+      )
+      unmount()
+      expect(window.removeEventListener).toHaveBeenCalledWith('scroll', expect.any(Function))
+    })
+  })
+
+  BddTest().when('scrolling to a section', () => {
+    BddTest().then('it should update activeElementId to the closest element', async () => {
+      const el = document.createElement('div')
+      el.id = 'TITLE'
+      document.body.appendChild(el)
+
+      vi.spyOn(el, 'getBoundingClientRect').mockReturnValue({
+        top: 100,
+        bottom: 200,
+        left: 0,
+        right: 0,
+        width: 0,
+        height: 0,
+        x: 0,
+        y: 0,
+        toJSON: () => {},
+      })
+
+      const { result: composableResult } = mountComposable(
+        () => useScrollSpy(['TITLE']),
+        {}
+      )
+
+      await nextTick()
+      expect(composableResult.activeElementId.value).toBe('TITLE')
+      document.body.removeChild(el)
+    })
+  })
+})

--- a/src/common/composables/use-scroll-spy/use-scroll-spy.ts
+++ b/src/common/composables/use-scroll-spy/use-scroll-spy.ts
@@ -1,0 +1,66 @@
+/**
+ * A composable function that tracks the currently visible element from a list of element IDs.
+ * @param elementIds - An array of element IDs to observe.
+ * @returns An object { activeElementId } containing the ID of the currently active element or an empty string if no element is active.
+ *
+ * @example
+ * const { activeElementId } = useScrollSpy(['element1', 'element2', 'element3'])
+ * const isManualNavigation = ref(false)
+ *
+ * function navigateToSelectedItem (item: AvSideNavigationSelectedItem) {
+ *   isManualNavigation.value = true
+ *   selectedItem.value = item
+ *   scrollToElement(item.itemId)
+ *   window.setTimeout(() => {
+ *     isManualNavigation.value = false
+ *   }, 500)
+ * }
+ *
+ * watch(activeElementId, () => {
+ *   if (!isManualNavigation.value) {
+ *     selectedItem.value = { itemId: activeElementId.value ?? '' }
+ *   }
+ * })
+ */
+export function useScrollSpy (elementIds: string[]) {
+  const activeElementId = ref<string>()
+
+  const updateActiveElementId = () => {
+    const elements = elementIds
+      .map(id => document.getElementById(id))
+      .filter(Boolean) as HTMLElement[]
+
+    const closestElement = elements.reduce((closest, element) => {
+      const rect = element.getBoundingClientRect()
+
+      const distanceToTop = Math.abs(rect.top - 120)
+
+      if (!closest || distanceToTop < closest.distance) {
+        return {
+          id: element.id,
+          distance: distanceToTop,
+        }
+      }
+
+      return closest
+    }, null as { id: string, distance: number } | null)
+
+    activeElementId.value = closestElement?.id ?? ''
+  }
+
+  onMounted(() => {
+    updateActiveElementId()
+
+    window.addEventListener('scroll', updateActiveElementId, {
+      passive: true,
+    })
+  })
+
+  onUnmounted(() => {
+    window.removeEventListener('scroll', updateActiveElementId)
+  })
+
+  return {
+    activeElementId,
+  }
+}

--- a/src/common/utils/scroll/scroll-to-element.test.ts
+++ b/src/common/utils/scroll/scroll-to-element.test.ts
@@ -1,0 +1,25 @@
+import { scrollToElement } from '@/common/utils/scroll/scroll-to-element'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { vi } from 'vitest'
+
+BddTest().given('scrollToElement function', () => {
+  BddTest().when('called with an existing element id', () => {
+    BddTest().then('it should scroll to the element', () => {
+      const el = document.createElement('div')
+      el.id = 'TITLE'
+      el.scrollIntoView = vi.fn()
+      document.body.appendChild(el)
+
+      scrollToElement('TITLE')
+
+      expect(el.scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth' })
+      document.body.removeChild(el)
+    })
+  })
+
+  BddTest().when('called with a non existing element id', () => {
+    BddTest().then('it should not throw', () => {
+      expect(() => scrollToElement('NON_EXISTING')).not.toThrow()
+    })
+  })
+})

--- a/src/common/utils/scroll/scroll-to-element.ts
+++ b/src/common/utils/scroll/scroll-to-element.ts
@@ -1,0 +1,4 @@
+export function scrollToElement (elementId: string) {
+  const element = document.getElementById(elementId)
+  element?.scrollIntoView({ behavior: 'smooth' })
+}

--- a/src/features/staff/activities/components/navigation/AddNationalActivitySideNavigation/AddNationalActivitySideNavigation.stub.ts
+++ b/src/features/staff/activities/components/navigation/AddNationalActivitySideNavigation/AddNationalActivitySideNavigation.stub.ts
@@ -1,0 +1,10 @@
+import type { EditActivityTabIndex } from '@/features/staff/activities/editActivity.constants'
+import type { PropType } from 'vue'
+
+export const AddNationalActivitySideNavigationStub = defineComponent({
+  name: 'AddNationalActivitySideNavigation',
+  props: {
+    activeTab: { type: Number as PropType<EditActivityTabIndex> },
+  },
+  template: '<div data-testid="add-national-activity-side-navigation-stub"></div>',
+})

--- a/src/features/staff/activities/components/navigation/AddNationalActivitySideNavigation/AddNationalActivitySideNavigation.test.ts
+++ b/src/features/staff/activities/components/navigation/AddNationalActivitySideNavigation/AddNationalActivitySideNavigation.test.ts
@@ -1,0 +1,122 @@
+import AddNationalActivitySideNavigation from '@/features/staff/activities/components/navigation/AddNationalActivitySideNavigation/AddNationalActivitySideNavigation.vue'
+import { ContentSectionId, EditActivityTabIndex, PublicationSectionId } from '@/features/staff/activities/editActivity.constants'
+import { AvSideNavigationStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { beforeEach, vi } from 'vitest'
+
+BddTest().given('AddNationalActivitySideNavigation component', () => {
+  let wrapper: VueWrapper<InstanceType<typeof AddNationalActivitySideNavigation>>
+
+  BddTest().when('mounted with content tab', () => {
+    beforeEach(() => {
+      wrapper = mount(AddNationalActivitySideNavigation, {
+        props: { activeTab: EditActivityTabIndex.CONTENT },
+        global: {
+          stubs: {
+            AvSideNavigation: AvSideNavigationStub,
+          }
+        }
+      })
+    })
+
+    BddTest().then('it should render the component', () => {
+      expect(wrapper.exists()).toBe(true)
+    })
+
+    BddTest().then('it should render AvSideNavigation', () => {
+      expect(wrapper.findComponent({ name: 'AvSideNavigation' }).exists()).toBe(true)
+    })
+
+    BddTest().then('it should pass content items to AvSideNavigation', () => {
+      const items = wrapper.findComponent({ name: 'AvSideNavigation' }).props('items')
+      expect(items[0].id).toBe('CONTENT')
+      expect(items[0].children).toHaveLength(Object.values(ContentSectionId).length)
+    })
+  })
+
+  BddTest().when('mounted with publication tab', () => {
+    beforeEach(() => {
+      wrapper = mount(AddNationalActivitySideNavigation, {
+        props: { activeTab: EditActivityTabIndex.PUBLICATION },
+        global: {
+          stubs: {
+            AvSideNavigation: AvSideNavigationStub,
+          }
+        }
+      })
+    })
+
+    BddTest().then('it should pass publication items to AvSideNavigation', () => {
+      const items = wrapper.findComponent({ name: 'AvSideNavigation' }).props('items')
+      expect(items[0].id).toBe('PUBLICATION')
+      expect(items[0].children).toHaveLength(Object.values(PublicationSectionId).length)
+    })
+  })
+
+  BddTest().when('an item is clicked', () => {
+    beforeEach(() => {
+      wrapper = mount(AddNationalActivitySideNavigation, {
+        props: { activeTab: EditActivityTabIndex.CONTENT },
+        attachTo: document.body,
+        global: {
+          stubs: {
+            AvSideNavigation: AvSideNavigationStub,
+          }
+        }
+      })
+    })
+
+    BddTest().then('it should scroll to the corresponding section', () => {
+      const mockScrollIntoView = vi.fn()
+      const el = document.createElement('div')
+      el.id = ContentSectionId.TITLE
+      el.scrollIntoView = mockScrollIntoView
+      document.body.appendChild(el)
+
+      wrapper.findComponent({ name: 'AvSideNavigation' }).vm.$emit('update:selectedItem', {
+        itemId: ContentSectionId.TITLE,
+        parentId: 'CONTENT',
+      })
+
+      expect(mockScrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth' })
+      document.body.removeChild(el)
+    })
+  })
+
+  BddTest().when('activeTab changes to publication', () => {
+    beforeEach(async () => {
+      wrapper = mount(AddNationalActivitySideNavigation, {
+        props: { activeTab: EditActivityTabIndex.CONTENT },
+        global: {
+          stubs: {
+            AvSideNavigation: AvSideNavigationStub,
+          }
+        }
+      })
+      await wrapper.setProps({ activeTab: EditActivityTabIndex.PUBLICATION })
+    })
+
+    BddTest().then('it should update items to publication', () => {
+      const items = wrapper.findComponent({ name: 'AvSideNavigation' }).props('items')
+      expect(items[0].id).toBe('PUBLICATION')
+    })
+  })
+
+  BddTest().when('mounted', () => {
+    beforeEach(() => {
+      wrapper = mount(AddNationalActivitySideNavigation, {
+        props: { activeTab: EditActivityTabIndex.CONTENT },
+        global: {
+          stubs: {
+            AvSideNavigation: AvSideNavigationStub,
+          }
+        }
+      })
+    })
+
+    BddTest().then('it should initialize selectedItem as empty', () => {
+      const selectedItem = wrapper.findComponent({ name: 'AvSideNavigation' }).props('selectedItem')
+      expect(selectedItem.itemId).toBe('')
+    })
+  })
+})

--- a/src/features/staff/activities/components/navigation/AddNationalActivitySideNavigation/AddNationalActivitySideNavigation.vue
+++ b/src/features/staff/activities/components/navigation/AddNationalActivitySideNavigation/AddNationalActivitySideNavigation.vue
@@ -1,0 +1,84 @@
+<script setup lang="ts">
+import { useScrollSpy } from '@/common/composables/use-scroll-spy/use-scroll-spy'
+import { scrollToElement } from '@/common/utils/scroll/scroll-to-element'
+import { ContentSectionId, EditActivityTabIndex, PublicationSectionId } from '@/features/staff/activities/editActivity.constants'
+import { AvSideNavigation, type AvSideNavigationMenuItem, type AvSideNavigationSelectedItem, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
+import { useI18n } from 'vue-i18n'
+
+const { activeTab } = defineProps<AddNationalActivitySideNavigationProps>()
+
+const { t } = useI18n()
+
+interface AddNationalActivitySideNavigationProps {
+  activeTab: EditActivityTabIndex
+}
+const { activeElementId } = useScrollSpy([
+  ContentSectionId.TITLE,
+  ContentSectionId.THEMATIC,
+  ContentSectionId.INSTRUCTIONS,
+  ContentSectionId.CONTEXT,
+  ContentSectionId.DOCUMENTS,
+  ContentSectionId.SCHEDULE,
+  ContentSectionId.MODALITIES
+])
+
+const isManualNavigation = ref(false)
+const isSideMenuCollapsed = ref<boolean>(false)
+const selectedItem = ref<AvSideNavigationSelectedItem>({ itemId: '' })
+
+const contentItems = computed<AvSideNavigationMenuItem[]>(() => [
+  {
+    id: 'CONTENT',
+    label: t('staff.activities.views.AddNationalActivityView.sideNavigation.contentHeader'),
+    icon: MDI_ICONS.PENCIL_OUTLINE,
+    expanded: true,
+    children: Object.values(ContentSectionId).map(id => ({
+      id,
+      label: t(`staff.activities.views.AddNationalActivityView.sideNavigation.content.${id}`),
+    })),
+  },
+])
+
+const publicationItems = computed<AvSideNavigationMenuItem[]>(() => [
+  {
+    id: 'PUBLICATION',
+    label: t('staff.activities.views.AddNationalActivityView.sideNavigation.publicationHeader'),
+    icon: MDI_ICONS.PENCIL_OUTLINE,
+    expanded: true,
+    children: Object.values(PublicationSectionId).map(id => ({
+      id,
+      label: t(`staff.activities.views.AddNationalActivityView.sideNavigation.publication.${id}`),
+    })),
+  },
+])
+
+const items = computed<AvSideNavigationMenuItem[]>(() => {
+  return activeTab === EditActivityTabIndex.PUBLICATION ? publicationItems.value : contentItems.value
+})
+
+function navigateToSelectedItem (item: AvSideNavigationSelectedItem) {
+  isManualNavigation.value = true
+  selectedItem.value = item
+  scrollToElement(item.itemId)
+  window.setTimeout(() => {
+    isManualNavigation.value = false
+  }, 500)
+}
+
+watch(activeElementId, () => {
+  if (!isManualNavigation.value) {
+    selectedItem.value = { itemId: activeElementId.value ?? '' }
+  }
+})
+</script>
+
+<template>
+  <AvSideNavigation
+    v-model:selected-item="selectedItem"
+    v-model:is-side-menu-collapsed="isSideMenuCollapsed"
+    hide-content-when-collapsed
+    :items="items"
+    sticky
+    @update:selected-item="navigateToSelectedItem"
+  />
+</template>

--- a/src/features/staff/activities/editActivity.constants.ts
+++ b/src/features/staff/activities/editActivity.constants.ts
@@ -1,0 +1,22 @@
+export enum ContentSectionId {
+  TITLE = 'TITLE',
+  THEMATIC = 'THEMATIC',
+  INSTRUCTIONS = 'INSTRUCTIONS',
+  CONTEXT = 'CONTEXT',
+  DOCUMENTS = 'DOCUMENTS',
+  SCHEDULE = 'SCHEDULE',
+  MODALITIES = 'MODALITIES',
+}
+
+export enum PublicationSectionId {
+  ACTIVITY_TITLE = 'ACTIVITY_TITLE',
+  TARGET_GROUPS = 'TARGET_GROUPS',
+  IMAGE = 'IMAGE',
+  EXCERPT = 'EXCERPT',
+  CONTEXT = 'CONTEXT',
+}
+
+export enum EditActivityTabIndex {
+  CONTENT = 0,
+  PUBLICATION = 1,
+}

--- a/src/features/staff/activities/locales/en.json
+++ b/src/features/staff/activities/locales/en.json
@@ -33,6 +33,28 @@
             "title": "All published activities in my institution ({count})"
           }
         },
+        "AddNationalActivityView": {
+          "sideNavigation": {
+            "content": {
+              "CONTEXT": "Recommended completion context(s)",
+              "DOCUMENTS": "Documents and useful links",
+              "INSTRUCTIONS": "Instructions",
+              "MODALITIES": "Modalities",
+              "SCHEDULE": "Schedule",
+              "THEMATIC": "Theme",
+              "TITLE": "Title"
+            },
+            "contentHeader": "Activity content",
+            "publication": {
+              "ACTIVITY_TITLE": "Activity title",
+              "CONTEXT": "Recommended completion context(s)",
+              "EXCERPT": "Excerpt",
+              "IMAGE": "Add an image",
+              "TARGET_GROUPS": "Target group(s)"
+            },
+            "publicationHeader": "Prepare publication"
+          }
+        },
         "EditNationalActivityView": {
           "ActivityContentTab": {
             "nextStepLabel": "Next step"

--- a/src/features/staff/activities/locales/fr.json
+++ b/src/features/staff/activities/locales/fr.json
@@ -33,6 +33,28 @@
             "title": "Toutes les activités publiées dans mon établissement ({count})"
           }
         },
+        "AddNationalActivityView": {
+          "sideNavigation": {
+            "content": {
+              "CONTEXT": "Contexte(s) de réalisation conseillé(s)",
+              "DOCUMENTS": "Documents et liens utiles",
+              "INSTRUCTIONS": "Consigne",
+              "MODALITIES": "Modalités",
+              "SCHEDULE": "Déroulé",
+              "THEMATIC": "Thématique",
+              "TITLE": "Titre"
+            },
+            "contentHeader": "Contenu de l'activité",
+            "publication": {
+              "ACTIVITY_TITLE": "Titre de l'activité",
+              "CONTEXT": "Contexte(s) de réalisation conseillé(s)",
+              "EXCERPT": "Extrait",
+              "IMAGE": "Ajouter une image",
+              "TARGET_GROUPS": "Groupe(s) Cible(s)"
+            },
+            "publicationHeader": "Publication de l'activité"
+          }
+        },
         "EditNationalActivityView": {
           "ActivityContentTab": {
             "nextStepLabel": "Étape suivante"

--- a/src/features/staff/activities/views/EditNationalActivityView/EditNationalActivityView.test.ts
+++ b/src/features/staff/activities/views/EditNationalActivityView/EditNationalActivityView.test.ts
@@ -5,6 +5,8 @@ import { server } from '@/__mocks__/msw/server'
 import { PageTitleStub } from '@/common/components/PageTitle/PageTitle.stub'
 import { QuerySuspenseStub } from '@/common/components/QuerySuspense/QuerySuspense.stub'
 import { ROUTES } from '@/common/constants'
+import { AddNationalActivitySideNavigationStub } from '@/features/staff/activities/components/navigation/AddNationalActivitySideNavigation/AddNationalActivitySideNavigation.stub'
+import { EditActivityTabIndex } from '@/features/staff/activities/editActivity.constants'
 import { ActivityContentTabStub } from '@/features/staff/activities/views/EditNationalActivityView/components/ActivityContentTab/ActivityContentTab.stub'
 import EditNationalActivityView from '@/features/staff/activities/views/EditNationalActivityView/EditNationalActivityView.vue'
 import { type EditNationalActivityViewContext, editNationalActivityViewContextKey } from '@/features/staff/activities/views/EditNationalActivityView/EditNationalActivityViewContext'
@@ -37,6 +39,17 @@ vi.mock('@/store', async () => {
   }
 })
 
+export const mockIsMobile = ref(false)
+vi.mock('@avenirs-esr/avenirs-dsav', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@avenirs-esr/avenirs-dsav')>()
+  return {
+    ...actual,
+    useAvBreakpoints: () => ({
+      isMobile: mockIsMobile,
+    })
+  }
+})
+
 function getContext (wrapper: VueWrapper<InstanceType<typeof EditNationalActivityView>>): EditNationalActivityViewContext {
   const internalInstance = wrapper.vm as unknown as ExposedComponentInstance
   return internalInstance.$.provides[editNationalActivityViewContextKey] as EditNationalActivityViewContext
@@ -49,6 +62,7 @@ BddTest().given('a national activity view', () => {
     PageTitle: PageTitleStub,
     QuerySuspense: QuerySuspenseStub,
     ActivityContentTab: ActivityContentTabStub,
+    AddNationalActivitySideNavigation: AddNationalActivitySideNavigationStub,
   }
 
   const mountView = () => mountComponent(EditNationalActivityView, {
@@ -58,6 +72,7 @@ BddTest().given('a national activity view', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    mockIsMobile.value = false
   })
 
   BddTest().when('the view is mounted in add mode', () => {
@@ -143,6 +158,35 @@ BddTest().given('a national activity view', () => {
           )
         })
       })
+    })
+  })
+
+  BddTest().when('the view is mounted on desktop', () => {
+    beforeEach(async () => {
+      mockMode.value = 'edit'
+      wrapper = mountView()
+      await vi.waitFor(() => {
+        expect(wrapper.findComponent({ name: 'QuerySuspense' }).props('isLoading')).toBe(false)
+      })
+    })
+
+    BddTest().then('it should render AddNationalActivitySideNavigation', () => {
+      expect(wrapper.findComponent(AddNationalActivitySideNavigationStub).exists()).toBe(true)
+    })
+
+    BddTest().then('it should pass the correct activeTab prop', () => {
+      expect(wrapper.findComponent(AddNationalActivitySideNavigationStub).props('activeTab')).toBe(EditActivityTabIndex.CONTENT)
+    })
+  })
+
+  BddTest().when('the view is mounted on mobile', () => {
+    beforeEach(() => {
+      mockIsMobile.value = true
+      wrapper = mountView()
+    })
+
+    BddTest().then('it should not render AddNationalActivitySideNavigation', () => {
+      expect(wrapper.findComponent(AddNationalActivitySideNavigationStub).exists()).toBe(false)
     })
   })
 })

--- a/src/features/staff/activities/views/EditNationalActivityView/EditNationalActivityView.vue
+++ b/src/features/staff/activities/views/EditNationalActivityView/EditNationalActivityView.vue
@@ -11,10 +11,14 @@ import {
 } from '@/api/avenir-esr'
 import { QuerySuspense } from '@/common/components'
 import PageTitle from '@/common/components/PageTitle/PageTitle.vue'
+import { useEnumRouteQuery } from '@/common/composables/use-enum-route-query/use-enum-route-query'
 import { ROUTES } from '@/common/constants'
+import AddNationalActivitySideNavigation from '@/features/staff/activities/components/navigation/AddNationalActivitySideNavigation/AddNationalActivitySideNavigation.vue'
+import { EditActivityTabIndex } from '@/features/staff/activities/editActivity.constants'
 import ActivityContentTab from '@/features/staff/activities/views/EditNationalActivityView/components/ActivityContentTab/ActivityContentTab.vue'
 import { provideEditNationalActivityViewContext } from '@/features/staff/activities/views/EditNationalActivityView/EditNationalActivityViewContext'
 import { useToasterStore } from '@/store'
+import { useAvBreakpoints } from '@avenirs-esr/avenirs-dsav'
 import { useForm } from '@tanstack/vue-form'
 import { useQueryClient } from '@tanstack/vue-query'
 import { useRouteQuery } from '@vueuse/router'
@@ -26,7 +30,10 @@ interface EditNationalActivityViewProps {
 
 const { id } = defineProps<EditNationalActivityViewProps>()
 
+const { isMobile } = useAvBreakpoints()
+
 const { t } = useI18n()
+const activeTab = useEnumRouteQuery('tab', EditActivityTabIndex, EditActivityTabIndex.CONTENT)
 const { addSuccessMessage, addErrorMessage } = useToasterStore()
 
 const mode: Ref<string> = useRouteQuery('mode', 'edit')
@@ -104,6 +111,17 @@ provideEditNationalActivityViewContext({ form, save, cancel })
     :error="error"
     :error-title="t('staff.activities.views.EditNationalActivityView.errors.fetchActivityContent')"
   >
-    <ActivityContentTab :activity="activity!" />
+    <div class="av-row av-w-full av-gap-xl">
+      <AddNationalActivitySideNavigation
+        v-if="!isMobile"
+        :active-tab="activeTab"
+      />
+      <div class="av-col av-flex-fill">
+        <ActivityContentTab
+          v-if="activeTab === EditActivityTabIndex.CONTENT"
+          :activity="activity!"
+        />
+      </div>
+    </div>
   </QuerySuspense>
 </template>

--- a/src/features/staff/activities/views/EditNationalActivityView/components/ActivityContentTab/ActivityContentTab.test.ts
+++ b/src/features/staff/activities/views/EditNationalActivityView/components/ActivityContentTab/ActivityContentTab.test.ts
@@ -1,6 +1,7 @@
 import { mockedActivityContent } from '@/__mocks__/fixtures/staffs/activities.fixtures'
 import { ActivityConsignFormFieldStub } from '@/features/staff/activities/components/interactions/formFields/ActivityConsignFormField/ActivityConsignFormField.stub'
 import { ActivityTitleFormFieldStub } from '@/features/staff/activities/components/interactions/formFields/ActivityTitleFormField/ActivityTitleFormField.stub'
+import { ContentSectionId } from '@/features/staff/activities/editActivity.constants'
 import ActivityContentTab from '@/features/staff/activities/views/EditNationalActivityView/components/ActivityContentTab/ActivityContentTab.vue'
 import { EditNationalActivityViewTabActionsStub } from '@/features/staff/activities/views/EditNationalActivityView/components/EditNationalActivityViewTabActions/EditNationalActivityViewTabActions.stub'
 import { EditNationalActivityViewFormWrapper } from '@/features/staff/activities/views/EditNationalActivityView/EditNationalActivityView.stub'
@@ -40,8 +41,12 @@ BddTest().given('an ActivityContentTab component', () => {
       expect(tab.findComponent({ name: 'ActivityTitleFormField' }).exists()).toBe(true)
     })
 
-    BddTest().then('it should render ActivityConsignFormField', () => {
-      expect(tab.findComponent({ name: 'ActivityConsignFormField' }).exists()).toBe(true)
+    BddTest().then('it should render the TITLE section anchor', () => {
+      expect(tab.find(`#${ContentSectionId.TITLE}`).exists()).toBe(true)
+    })
+
+    BddTest().then('it should render the INSTRUCTIONS section anchor', () => {
+      expect(tab.find(`#${ContentSectionId.INSTRUCTIONS}`).exists()).toBe(true)
     })
 
     BddTest().then('it should render EditNationalActivityViewTabActions', () => {

--- a/src/features/staff/activities/views/EditNationalActivityView/components/ActivityContentTab/ActivityContentTab.vue
+++ b/src/features/staff/activities/views/EditNationalActivityView/components/ActivityContentTab/ActivityContentTab.vue
@@ -3,6 +3,7 @@ import type { ActivityContentDTO } from '@/api/avenir-esr'
 import { ICONS } from '@/common/constants'
 import ActivityConsignFormField from '@/features/staff/activities/components/interactions/formFields/ActivityConsignFormField/ActivityConsignFormField.vue'
 import ActivityTitleFormField from '@/features/staff/activities/components/interactions/formFields/ActivityTitleFormField/ActivityTitleFormField.vue'
+import { ContentSectionId } from '@/features/staff/activities/editActivity.constants'
 import EditNationalActivityViewTabActions from '@/features/staff/activities/views/EditNationalActivityView/components/EditNationalActivityViewTabActions/EditNationalActivityViewTabActions.vue'
 import { useEditNationalActivityViewContext } from '@/features/staff/activities/views/EditNationalActivityView/EditNationalActivityViewContext'
 import FormFieldCardContainer from '@/features/staff/global/components/cards/FormFieldCardContainer/FormFieldCardContainer.vue'
@@ -25,24 +26,27 @@ const { t } = useI18n()
 
 <template>
   <div class="av-col av-gap-xl">
-    <FormFieldCardContainer
-      :title="t('staff.activities.interactions.inputs.ActivityTitleInput.label')"
-      :title-icon="ICONS.ACTIVITY"
-    >
-      <ActivityTitleFormField
-        :form="form"
-        is-textarea
-      />
-    </FormFieldCardContainer>
-    <FormFieldCardContainer
-      :title="t('staff.activities.interactions.formFields.ActivityConsignFormField.label')"
-      :title-icon="MDI_ICONS.TEXT_BOX_EDIT_OUTLINE"
-    >
-      <ActivityConsignFormField
-        :form="form"
-        @autosave="save"
-      />
-    </FormFieldCardContainer>
+    <div :id="ContentSectionId.TITLE">
+      <FormFieldCardContainer
+        :title="t('staff.activities.views.AddNationalActivityView.sideNavigation.content.TITLE')"
+        :title-icon="ICONS.ACTIVITY"
+      >
+        <ActivityTitleFormField :form="form" />
+      </FormFieldCardContainer>
+    </div>
+
+    <div :id="ContentSectionId.INSTRUCTIONS">
+      <FormFieldCardContainer
+        :title="t('staff.activities.views.AddNationalActivityView.sideNavigation.content.INSTRUCTIONS')"
+        :title-icon="MDI_ICONS.TEXT_BOX_EDIT_OUTLINE"
+      >
+        <ActivityConsignFormField
+          :form="form"
+          @autosave="save"
+        />
+      </FormFieldCardContainer>
+    </div>
+
     <div class="av-row av-gap-sm av-justify-end">
       <EditNationalActivityViewTabActions />
       <AvButton


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
Create the AddNationalActivitySideNavigation component using AvSideNavigation and integrate it into EditNationalActivityView. The navigation allows accessing the different sections of the activity creation form via HTML anchors (#), without page reload.

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1515

---

### Target Branch
develop

---

### Additional Notes
The images represent the component developed.
<img width="1256" height="1105" alt="Capture d’écran du 2026-05-18 15-42-35" src="https://github.com/user-attachments/assets/439f1c28-2007-46f5-a3cc-2534c56259c1" />

<img width="1256" height="1105" alt="Capture d’écran du 2026-05-18 15-42-42" src="https://github.com/user-attachments/assets/9298cd15-cc2c-459c-acc4-7a4a183cf4d8" />

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [x] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [x] i18n handled (texts are translated)
- [ ] Performance tests
- [ ] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [x] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change anddetailss for the update process