### PR TITLE
feat: add useEnumRouteQuery composable

### DIFF
--- a/src/common/composables/use-enum-route-query/use-enum-route-query.test.ts
+++ b/src/common/composables/use-enum-route-query/use-enum-route-query.test.ts
@@ -36,7 +36,7 @@ BddTest().given('a useEnumRouteQuery composable', () => {
 
   BddTest().when('the composable is initialized with the default key', () => {
     beforeEach(() => {
-      result = mountComposable(() => useEnumRouteQuery('tab', TestEnum, 'TEST_1'), {}).result
+      result = mountComposable(() => useEnumRouteQuery('tab', TestEnum, TestEnum.TEST_1), {}).result
     })
 
     BddTest().then('it should return the enum value corresponding to the default key', () => {
@@ -47,7 +47,7 @@ BddTest().given('a useEnumRouteQuery composable', () => {
   BddTest().when('the query param holds a valid enum key', () => {
     beforeEach(() => {
       routeQueryValue.value = 'TEST_2'
-      result = mountComposable(() => useEnumRouteQuery('tab', TestEnum, 'TEST_1'), {}).result
+      result = mountComposable(() => useEnumRouteQuery('tab', TestEnum, TestEnum.TEST_1), {}).result
     })
 
     BddTest().then('it should return the enum value corresponding to that key', () => {
@@ -58,7 +58,7 @@ BddTest().given('a useEnumRouteQuery composable', () => {
   BddTest().when('the query param holds an invalid / unknown key', () => {
     beforeEach(() => {
       routeQueryValue.value = 'UNKNOWN'
-      result = mountComposable(() => useEnumRouteQuery('tab', TestEnum, 'TEST_1'), {}).result
+      result = mountComposable(() => useEnumRouteQuery('tab', TestEnum, TestEnum.TEST_1), {}).result
     })
 
     BddTest().then('it should fall back to the default enum value', () => {
@@ -68,7 +68,7 @@ BddTest().given('a useEnumRouteQuery composable', () => {
 
   BddTest().when('the query param changes to another valid key', () => {
     beforeEach(async () => {
-      result = mountComposable(() => useEnumRouteQuery('tab', TestEnum, 'TEST_1'), {}).result
+      result = mountComposable(() => useEnumRouteQuery('tab', TestEnum, TestEnum.TEST_1), {}).result
       expect(result.value).toBe(TestEnum.TEST_1)
 
       routeQueryValue.value = 'TEST_3'
@@ -83,7 +83,7 @@ BddTest().given('a useEnumRouteQuery composable', () => {
   BddTest().when('the query param changes to an invalid key', () => {
     beforeEach(async () => {
       routeQueryValue.value = 'TEST_2'
-      result = mountComposable(() => useEnumRouteQuery('tab', TestEnum, 'TEST_1'), {}).result
+      result = mountComposable(() => useEnumRouteQuery('tab', TestEnum, TestEnum.TEST_1), {}).result
       expect(result.value).toBe(TestEnum.TEST_2)
 
       routeQueryValue.value = 'INVALID'
@@ -97,7 +97,7 @@ BddTest().given('a useEnumRouteQuery composable', () => {
 
   BddTest().when('the setter is called with a valid enum value', () => {
     beforeEach(() => {
-      result = mountComposable(() => useEnumRouteQuery('tab', TestEnum, 'TEST_1'), {}).result
+      result = mountComposable(() => useEnumRouteQuery('tab', TestEnum, TestEnum.TEST_1), {}).result
       result.value = TestEnum.TEST_3
     })
 
@@ -109,7 +109,7 @@ BddTest().given('a useEnumRouteQuery composable', () => {
   BddTest().when('the setter is called with the default enum value', () => {
     beforeEach(() => {
       routeQueryValue.value = 'TEST_2'
-      result = mountComposable(() => useEnumRouteQuery('tab', TestEnum, 'TEST_1'), {}).result
+      result = mountComposable(() => useEnumRouteQuery('tab', TestEnum, TestEnum.TEST_1), {}).result
       result.value = TestEnum.TEST_1
     })
 
@@ -120,7 +120,7 @@ BddTest().given('a useEnumRouteQuery composable', () => {
 
   BddTest().when('the setter is called with a value that has no matching key', () => {
     beforeEach(() => {
-      result = mountComposable(() => useEnumRouteQuery('tab', TestEnum, 'TEST_1'), {}).result
+      result = mountComposable(() => useEnumRouteQuery('tab', TestEnum, TestEnum.TEST_1), {}).result
       result.value = 'not-a-valid-enum-value' as unknown as TestEnum
     })
 
@@ -132,7 +132,7 @@ BddTest().given('a useEnumRouteQuery composable', () => {
   BddTest().when('the composable is used with a numeric enum', () => {
     beforeEach(() => {
       routeQueryValue.value = 'SECOND'
-      result = mountComposable(() => useEnumRouteQuery('tab', TestNumericEnum, 'FIRST'), {}).result
+      result = mountComposable(() => useEnumRouteQuery('tab', TestNumericEnum, TestNumericEnum.FIRST), {}).result
     })
 
     BddTest().then('it should resolve a query key to a numeric enum value', () => {
@@ -147,6 +147,16 @@ BddTest().given('a useEnumRouteQuery composable', () => {
       BddTest().then('it should update the query key', () => {
         expect(routeQueryValue.value).toBe('FIRST')
       })
+    })
+  })
+
+  BddTest().when('initialized with a defaultValue that does not exist in the enum', () => {
+    beforeEach(() => {
+      result = mountComposable(() => useEnumRouteQuery('tab', TestEnum, 'invalid-value' as unknown as TestEnum), {}).result
+    })
+
+    BddTest().then('it should fall back to the first enum key', () => {
+      expect(result.value).toBe(TestEnum.TEST_1)
     })
   })
 })

--- a/src/common/composables/use-enum-route-query/use-enum-route-query.test.ts
+++ b/src/common/composables/use-enum-route-query/use-enum-route-query.test.ts
@@ -1,0 +1,152 @@
+import { useEnumRouteQuery } from '@/common/composables/use-enum-route-query/use-enum-route-query'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { mountComposable } from 'tests/utils'
+import { beforeEach, expect, vi } from 'vitest'
+import { nextTick } from 'vue'
+
+enum TestEnum {
+  TEST_1 = 'test-1',
+  TEST_2 = 'test-2',
+  TEST_3 = 'test-3',
+}
+
+enum TestNumericEnum {
+  FIRST = 0,
+  SECOND = 1,
+}
+
+const routeQueryValue = ref<string>('TEST_1')
+
+vi.mock('@vueuse/router', () => ({
+  useRouteQuery: (_queryName: string, defaultValue: string) => {
+    if (routeQueryValue.value === undefined) {
+      routeQueryValue.value = defaultValue
+    }
+    return routeQueryValue
+  },
+}))
+
+BddTest().given('a useEnumRouteQuery composable', () => {
+  let result: ReturnType<typeof useEnumRouteQuery>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    routeQueryValue.value = 'TEST_1'
+  })
+
+  BddTest().when('the composable is initialized with the default key', () => {
+    beforeEach(() => {
+      result = mountComposable(() => useEnumRouteQuery('tab', TestEnum, 'TEST_1'), {}).result
+    })
+
+    BddTest().then('it should return the enum value corresponding to the default key', () => {
+      expect(result.value).toBe(TestEnum.TEST_1)
+    })
+  })
+
+  BddTest().when('the query param holds a valid enum key', () => {
+    beforeEach(() => {
+      routeQueryValue.value = 'TEST_2'
+      result = mountComposable(() => useEnumRouteQuery('tab', TestEnum, 'TEST_1'), {}).result
+    })
+
+    BddTest().then('it should return the enum value corresponding to that key', () => {
+      expect(result.value).toBe(TestEnum.TEST_2)
+    })
+  })
+
+  BddTest().when('the query param holds an invalid / unknown key', () => {
+    beforeEach(() => {
+      routeQueryValue.value = 'UNKNOWN'
+      result = mountComposable(() => useEnumRouteQuery('tab', TestEnum, 'TEST_1'), {}).result
+    })
+
+    BddTest().then('it should fall back to the default enum value', () => {
+      expect(result.value).toBe(TestEnum.TEST_1)
+    })
+  })
+
+  BddTest().when('the query param changes to another valid key', () => {
+    beforeEach(async () => {
+      result = mountComposable(() => useEnumRouteQuery('tab', TestEnum, 'TEST_1'), {}).result
+      expect(result.value).toBe(TestEnum.TEST_1)
+
+      routeQueryValue.value = 'TEST_3'
+      await nextTick()
+    })
+
+    BddTest().then('the computed value should update reactively', () => {
+      expect(result.value).toBe(TestEnum.TEST_3)
+    })
+  })
+
+  BddTest().when('the query param changes to an invalid key', () => {
+    beforeEach(async () => {
+      routeQueryValue.value = 'TEST_2'
+      result = mountComposable(() => useEnumRouteQuery('tab', TestEnum, 'TEST_1'), {}).result
+      expect(result.value).toBe(TestEnum.TEST_2)
+
+      routeQueryValue.value = 'INVALID'
+      await nextTick()
+    })
+
+    BddTest().then('the computed value should fall back to the default value', () => {
+      expect(result.value).toBe(TestEnum.TEST_1)
+    })
+  })
+
+  BddTest().when('the setter is called with a valid enum value', () => {
+    beforeEach(() => {
+      result = mountComposable(() => useEnumRouteQuery('tab', TestEnum, 'TEST_1'), {}).result
+      result.value = TestEnum.TEST_3
+    })
+
+    BddTest().then('it should update the route query to the corresponding key', () => {
+      expect(routeQueryValue.value).toBe('TEST_3')
+    })
+  })
+
+  BddTest().when('the setter is called with the default enum value', () => {
+    beforeEach(() => {
+      routeQueryValue.value = 'TEST_2'
+      result = mountComposable(() => useEnumRouteQuery('tab', TestEnum, 'TEST_1'), {}).result
+      result.value = TestEnum.TEST_1
+    })
+
+    BddTest().then('it should set the route query to the default key', () => {
+      expect(routeQueryValue.value).toBe('TEST_1')
+    })
+  })
+
+  BddTest().when('the setter is called with a value that has no matching key', () => {
+    beforeEach(() => {
+      result = mountComposable(() => useEnumRouteQuery('tab', TestEnum, 'TEST_1'), {}).result
+      result.value = 'not-a-valid-enum-value' as unknown as TestEnum
+    })
+
+    BddTest().then('it should fall back to the default key in the route query', () => {
+      expect(routeQueryValue.value).toBe('TEST_1')
+    })
+  })
+
+  BddTest().when('the composable is used with a numeric enum', () => {
+    beforeEach(() => {
+      routeQueryValue.value = 'SECOND'
+      result = mountComposable(() => useEnumRouteQuery('tab', TestNumericEnum, 'FIRST'), {}).result
+    })
+
+    BddTest().then('it should resolve a query key to a numeric enum value', () => {
+      expect(result.value).toBe(TestNumericEnum.SECOND)
+    })
+
+    BddTest().and('a numeric value is set', () => {
+      beforeEach(() => {
+        result.value = TestNumericEnum.FIRST
+      })
+
+      BddTest().then('it should update the query key', () => {
+        expect(routeQueryValue.value).toBe('FIRST')
+      })
+    })
+  })
+})

--- a/src/common/composables/use-enum-route-query/use-enum-route-query.ts
+++ b/src/common/composables/use-enum-route-query/use-enum-route-query.ts
@@ -3,13 +3,12 @@ import { useRouteQuery } from '@vueuse/router'
 
 type EnumLike = Record<string, string | number>
 type EnumKeys<TEnum extends EnumLike> = Extract<keyof TEnum, string>
-type EnumRouteQueryModelValue<T> = T extends number ? number : string
 
 /**
  * Composable for handling enum values in route query parameters.
  * @param queryName - The name of the query parameter in the URL.
  * @param enumObject - The enum object to use for conversion.
- * @param defaultKey - The default key to use if the query parameter is not present or invalid.
+ * @param defaultValue - The default enum value to use if the query parameter is not present or invalid.
  * @returns A WritableComputedRef representing the enum value.
  *
  * @example
@@ -18,7 +17,7 @@ type EnumRouteQueryModelValue<T> = T extends number ? number : string
  *   OPTION_2 = 'option-2',
  * }
  *
- * const selectedOption = useEnumRouteQuery('option', MyEnum, 'OPTION_1')
+ * const selectedOption = useEnumRouteQuery('option', MyEnum, MyEnum.OPTION_1)
  *
  * // If the URL is /my-route?option=OPTION_2, then selectedOption.value will be MyEnum.OPTION_2
  * // If the URL is /my-route?option=INVALID, then selectedOption.value will be MyEnum.OPTION_1 (default)
@@ -31,51 +30,53 @@ type EnumRouteQueryModelValue<T> = T extends number ? number : string
  *   SECOND = 1,
  * }
  *
- * const selectedNumericOption = useEnumRouteQuery('numOption', MyNumericEnum, 'FIRST')
+ * const selectedNumericOption = useEnumRouteQuery('numOption', MyNumericEnum, MyNumericEnum.FIRST)
  *
  * // If the URL is /my-route?numOption=SECOND, then selectedNumericOption.value will be MyNumericEnum.SECOND (1)
  * // If the URL is /my-route?numOption=INVALID, then selectedNumericOption.value will be MyNumericEnum.FIRST (0) (default)
  * // If the URL is /my-route (no numOption query), then selectedNumericOption.value will be MyNumericEnum.FIRST (0) (default)
  *
  * @example
- * // === WITH AV_TABS (which are numeric enums with string keys) ===
- * enum AvTabs {
+ * // === WITH AvTabs (which are numeric enums with string keys) ===
+ * enum TabIndex {
  *   FIRST_TAB = 0,
  *   SECOND_TAB = 1,
  * }
  *
- * const activeTab = useEnumRouteQuery('tab', AvTabs, 'FIRST_TAB')
+ * const activeTab = useEnumRouteQuery('tab', TabIndex, TabIndex.FIRST_TAB)
  *
- * // If the URL is /my-route?tab=SECOND_TAB, then activeTab.value will be AvTabs.SECOND_TAB (1)
- * // If the URL is /my-route?tab=INVALID, then activeTab.value will be AvTabs.FIRST_TAB (0) (default)
- * // If the URL is /my-route (no tab query), then activeTab.value will be AvTabs.FIRST_TAB (0) (default)
+ * // If the URL is /my-route?tab=SECOND_TAB, then activeTab.value will be TabIndex.SECOND_TAB (1)
+ * // If the URL is /my-route?tab=INVALID, then activeTab.value will be TabIndex.FIRST_TAB (0) (default)
+ * // If the URL is /my-route (no tab query), then activeTab.value will be TabIndex.FIRST_TAB (0) (default)
  *
  * // In template:
  * // <AvTabs v-model="activeTab">
  */
 export function useEnumRouteQuery<
   TEnum extends EnumLike,
-  TDefaultKey extends EnumKeys<TEnum>,
+  TDefaultValue extends TEnum[EnumKeys<TEnum>],
 > (
   queryName: string,
   enumObject: TEnum,
-  defaultKey: TDefaultKey,
-): WritableComputedRef<EnumRouteQueryModelValue<TEnum[TDefaultKey]>> {
-  const routeQuery = useRouteQuery<string>(queryName, defaultKey)
-
+  defaultValue: TDefaultValue,
+): WritableComputedRef<TDefaultValue> {
   const enumKeys = Object.keys(enumObject)
     .filter(key => Number.isNaN(Number(key))) as EnumKeys<TEnum>[]
 
-  return computed<EnumRouteQueryModelValue<TEnum[TDefaultKey]>>({
+  const defaultKey = enumKeys.find(key => enumObject[key] === defaultValue) || enumKeys[0]
+
+  const routeQuery = useRouteQuery<string>(queryName, defaultKey)
+
+  return computed<TDefaultValue>({
     get () {
       const key = enumKeys.includes(routeQuery.value as EnumKeys<TEnum>)
         ? routeQuery.value as EnumKeys<TEnum>
         : defaultKey
 
-      return enumObject[key] as unknown as EnumRouteQueryModelValue<TEnum[TDefaultKey]>
+      return enumObject[key] as unknown as TDefaultValue
     },
     set (enumValue) {
-      const key = enumKeys.find(key => enumObject[key] === enumValue) ?? defaultKey
+      const key = enumKeys.find(key => enumObject[key] === enumValue) || defaultKey
       routeQuery.value = key
     }
   })

--- a/src/common/composables/use-enum-route-query/use-enum-route-query.ts
+++ b/src/common/composables/use-enum-route-query/use-enum-route-query.ts
@@ -1,0 +1,82 @@
+import type { WritableComputedRef } from 'vue'
+import { useRouteQuery } from '@vueuse/router'
+
+type EnumLike = Record<string, string | number>
+type EnumKeys<TEnum extends EnumLike> = Extract<keyof TEnum, string>
+type EnumRouteQueryModelValue<T> = T extends number ? number : string
+
+/**
+ * Composable for handling enum values in route query parameters.
+ * @param queryName - The name of the query parameter in the URL.
+ * @param enumObject - The enum object to use for conversion.
+ * @param defaultKey - The default key to use if the query parameter is not present or invalid.
+ * @returns A WritableComputedRef representing the enum value.
+ *
+ * @example
+ * enum MyEnum {
+ *   OPTION_1 = 'option-1',
+ *   OPTION_2 = 'option-2',
+ * }
+ *
+ * const selectedOption = useEnumRouteQuery('option', MyEnum, 'OPTION_1')
+ *
+ * // If the URL is /my-route?option=OPTION_2, then selectedOption.value will be MyEnum.OPTION_2
+ * // If the URL is /my-route?option=INVALID, then selectedOption.value will be MyEnum.OPTION_1 (default)
+ * // If the URL is /my-route (no option query), then selectedOption.value will be MyEnum.OPTION_1 (default)
+ *
+ * @example
+ * // === WITH NUMERIC ENUMS ===
+ * enum MyNumericEnum {
+ *   FIRST = 0,
+ *   SECOND = 1,
+ * }
+ *
+ * const selectedNumericOption = useEnumRouteQuery('numOption', MyNumericEnum, 'FIRST')
+ *
+ * // If the URL is /my-route?numOption=SECOND, then selectedNumericOption.value will be MyNumericEnum.SECOND (1)
+ * // If the URL is /my-route?numOption=INVALID, then selectedNumericOption.value will be MyNumericEnum.FIRST (0) (default)
+ * // If the URL is /my-route (no numOption query), then selectedNumericOption.value will be MyNumericEnum.FIRST (0) (default)
+ *
+ * @example
+ * // === WITH AV_TABS (which are numeric enums with string keys) ===
+ * enum AvTabs {
+ *   FIRST_TAB = 0,
+ *   SECOND_TAB = 1,
+ * }
+ *
+ * const activeTab = useEnumRouteQuery('tab', AvTabs, 'FIRST_TAB')
+ *
+ * // If the URL is /my-route?tab=SECOND_TAB, then activeTab.value will be AvTabs.SECOND_TAB (1)
+ * // If the URL is /my-route?tab=INVALID, then activeTab.value will be AvTabs.FIRST_TAB (0) (default)
+ * // If the URL is /my-route (no tab query), then activeTab.value will be AvTabs.FIRST_TAB (0) (default)
+ *
+ * // In template:
+ * // <AvTabs v-model="activeTab">
+ */
+export function useEnumRouteQuery<
+  TEnum extends EnumLike,
+  TDefaultKey extends EnumKeys<TEnum>,
+> (
+  queryName: string,
+  enumObject: TEnum,
+  defaultKey: TDefaultKey,
+): WritableComputedRef<EnumRouteQueryModelValue<TEnum[TDefaultKey]>> {
+  const routeQuery = useRouteQuery<string>(queryName, defaultKey)
+
+  const enumKeys = Object.keys(enumObject)
+    .filter(key => Number.isNaN(Number(key))) as EnumKeys<TEnum>[]
+
+  return computed<EnumRouteQueryModelValue<TEnum[TDefaultKey]>>({
+    get () {
+      const key = enumKeys.includes(routeQuery.value as EnumKeys<TEnum>)
+        ? routeQuery.value as EnumKeys<TEnum>
+        : defaultKey
+
+      return enumObject[key] as unknown as EnumRouteQueryModelValue<TEnum[TDefaultKey]>
+    },
+    set (enumValue) {
+      const key = enumKeys.find(key => enumObject[key] === enumValue) ?? defaultKey
+      routeQuery.value = key
+    }
+  })
+}

--- a/src/features/student/buildProject/views/ProjectActivitiesView/ProjectActivitiesView.test.ts
+++ b/src/features/student/buildProject/views/ProjectActivitiesView/ProjectActivitiesView.test.ts
@@ -8,6 +8,17 @@ import { AvTabsStub, AvTabStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-u
 import { mountComponent } from 'tests/utils'
 import { beforeEach, expect, vi } from 'vitest'
 
+const routeQueryValue = ref<string>('ALL_ACTIVITIES')
+
+vi.mock('@vueuse/router', () => ({
+  useRouteQuery: (_queryName: string, defaultValue: string) => {
+    if (routeQueryValue.value === undefined) {
+      routeQueryValue.value = defaultValue
+    }
+    return routeQueryValue
+  },
+}))
+
 BddTest().given('a project activities view', () => {
   let wrapper: VueWrapper<InstanceType<typeof ProjectActivitiesView>>
 
@@ -21,6 +32,7 @@ BddTest().given('a project activities view', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    routeQueryValue.value = 'ALL_ACTIVITIES'
     wrapper = mountComponent(ProjectActivitiesView, {
       global: { stubs }
     })

--- a/src/features/student/buildProject/views/ProjectActivitiesView/ProjectActivitiesView.vue
+++ b/src/features/student/buildProject/views/ProjectActivitiesView/ProjectActivitiesView.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { useGetActivitiesView, useGetDeclaredActivitiesView } from '@/api/avenir-esr'
 import PageTitle from '@/common/components/PageTitle/PageTitle.vue'
+import { useEnumRouteQuery } from '@/common/composables/use-enum-route-query/use-enum-route-query'
 import { ROUTES } from '@/common/constants'
 import { useProjectActivitiesStore } from '@/features/student/buildProject/stores/activities.store'
 import ActivityLibraryTab from '@/features/student/buildProject/views/ProjectActivitiesView/components/ActivityLibraryTab/ActivityLibraryTab.vue'
@@ -10,7 +11,12 @@ import { useI18n } from 'vue-i18n'
 
 const { t } = useI18n()
 
-const activeTab = ref(0)
+enum ProjectActivitiesTab {
+  ALL_ACTIVITIES = 0,
+  ACTIVITY_LIBRARY = 1,
+}
+
+const activeTab = useEnumRouteQuery('tab', ProjectActivitiesTab, 'ALL_ACTIVITIES')
 
 const activitiesStore = useProjectActivitiesStore()
 

--- a/src/features/student/buildProject/views/ProjectActivitiesView/ProjectActivitiesView.vue
+++ b/src/features/student/buildProject/views/ProjectActivitiesView/ProjectActivitiesView.vue
@@ -16,7 +16,7 @@ enum ProjectActivitiesTab {
   ACTIVITY_LIBRARY = 1,
 }
 
-const activeTab = useEnumRouteQuery('tab', ProjectActivitiesTab, 'ALL_ACTIVITIES')
+const activeTab = useEnumRouteQuery('tab', ProjectActivitiesTab, ProjectActivitiesTab.ALL_ACTIVITIES)
 
 const activitiesStore = useProjectActivitiesStore()
 


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
This PR introduces a reusable `useEnumRouteQuery` composable to keep enum-based UI state synchronized with route query parameters, and integrates it into the project activities view.

**Main changes:**
- ✨ Adds `useEnumRouteQuery` composable for enum/query synchronization
- ✅ Adds unit tests for `useEnumRouteQuery`
- ♻️ Refactors `ProjectActivitiesView` to use the new composable for tab persistence
- ✅ Updates `ProjectActivitiesView` tests to mock `useRouteQuery`

---

### Reference to an Issue, Feature, Task, User Story or another PR
Linked to https://github.com/avenirs-esr/AVENIRS-Project/issues/1515

---

### Documentation
- Added unit tests for the new composable
- Updated view tests to reflect route-query-driven tab state

**Modified files:**
- `src/common/composables/use-enum-route-query/use-enum-route-query.ts`
- `src/common/composables/use-enum-route-query/use-enum-route-query.test.ts`
- `src/features/student/buildProject/views/ProjectActivitiesView/ProjectActivitiesView.vue`
- `src/features/student/buildProject/views/ProjectActivitiesView/ProjectActivitiesView.test.ts`

---

### Target Branch
`develop`

---

### Additional Notes
The new composable centralizes query-state logic and avoids duplicating route query handling in feature views. In `ProjectActivitiesView`, selected tab state now survives reload/share through URL query params.

---

### Known Limitations or Side Effects
No known limitations or side effects.

---

## ✅ Checklist

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [ ] No unnecessary code (e.g., debug logs, commented code)
- [ ] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process
