### PR TITLE
fix(1661): update date format in formatLastModified function

### DIFF
--- a/src/common/composables/use-date-utils/use-date-utils.test.ts
+++ b/src/common/composables/use-date-utils/use-date-utils.test.ts
@@ -49,38 +49,34 @@ BddTest().given('a use-date-utils composable', () => {
 
   BddTest().when('formatting last modified date', () => {
     BddTest().and('the date is today and modified more than 1 hour ago', () => {
-      BddTest().then('it should return hours ago with date', () => {
+      BddTest().then('it should return hours ago', () => {
         const twoHoursAgo = subHours(new Date(), 2)
         const formatted = composableResult.formatLastModified(twoHoursAgo.toISOString())
-        const formattedDate = `${String(twoHoursAgo.getDate()).padStart(2, '0')}/${String(twoHoursAgo.getMonth() + 1).padStart(2, '0')}/${twoHoursAgo.getFullYear()}`
 
-        expect(formatted).toContain('Il y a 2 heures')
-        expect(formatted).toContain(formattedDate)
+        expect(formatted).toBe('Il y a 2 heures')
       })
 
       BddTest().then('it should use singular form for exactly 1 hour', () => {
         const oneHourAgo = subHours(new Date(), 1)
         const formatted = composableResult.formatLastModified(oneHourAgo.toISOString())
 
-        expect(formatted).toContain('Il y a 1 heure')
+        expect(formatted).toBe('Il y a 1 heure')
       })
     })
 
     BddTest().and('the date is today and modified less than 1 hour ago but more than 1 minute ago', () => {
-      BddTest().then('it should return minutes ago with date', () => {
+      BddTest().then('it should return minutes ago', () => {
         const thirtyMinutesAgo = subMinutes(new Date(), 30)
         const formatted = composableResult.formatLastModified(thirtyMinutesAgo.toISOString())
-        const formattedDate = `${String(thirtyMinutesAgo.getDate()).padStart(2, '0')}/${String(thirtyMinutesAgo.getMonth() + 1).padStart(2, '0')}/${thirtyMinutesAgo.getFullYear()}`
 
-        expect(formatted).toContain('Il y a 30 minutes')
-        expect(formatted).toContain(formattedDate)
+        expect(formatted).toBe('Il y a 30 minutes')
       })
 
       BddTest().then('it should use singular form for exactly 1 minute', () => {
         const oneMinuteAgo = subMinutes(new Date(), 1)
         const formatted = composableResult.formatLastModified(oneMinuteAgo.toISOString())
 
-        expect(formatted).toContain('Il y a 1 minute')
+        expect(formatted).toBe('Il y a 1 minute')
       })
     })
 
@@ -94,14 +90,11 @@ BddTest().given('a use-date-utils composable', () => {
     })
 
     BddTest().and('the date is not today', () => {
-      BddTest().then('it should use formatTranslatedDateTime', () => {
+      BddTest().then('it should return date in jj/mm/aaaa format', () => {
         const pastDate = '2024-01-15T14:30:00'
         const formatted = composableResult.formatLastModified(pastDate)
 
-        expect(formatted).toContain('15')
-        expect(formatted).toContain('janvier')
-        expect(formatted).toContain('2024')
-        expect(formatted).toContain('à')
+        expect(formatted).toBe('15/01/2024')
       })
     })
   })

--- a/src/common/composables/use-date-utils/use-date-utils.ts
+++ b/src/common/composables/use-date-utils/use-date-utils.ts
@@ -10,10 +10,10 @@ interface UseDateUtilsReturn {
   /**
    * Formats a given ISO date string into a human-readable "last modified" string.
    * Example for French locale
-   * - If the date is **today** and modified **≥ 1 hour ago**: returns `"Il y a X heure(s) - DD/MM/YYYY"`
-   * - If the date is **today** and modified **≥ 1 minute ago**: returns `"Il y a X minute(s) - DD/MM/YYYY"`
+   * - If the date is **today** and modified **≥ 1 hour ago**: returns `"Il y a X heure(s)"`
+   * - If the date is **today** and modified **≥ 1 minute ago**: returns `"Il y a X minute(s)"`
    * - If the date is **today** and modified **< 1 minute ago**: returns `"À l'instant"`
-   * - If the date is **not today**: delegates to `formatTranslatedDateTime`
+   * - If the date is **not today**: returns `"JJ/MM/YYYY"`
    *
    * @param date - ISO 8601 date string (e.g. `"2025-10-15T14:32:00Z"`)
    * @returns Formatted string according to the rules above.
@@ -23,16 +23,16 @@ interface UseDateUtilsReturn {
    * const { formatLastModified } = useDateUtils()
    *
    * formatLastModified(subHours(new Date(), 2).toISOString())
-   * // → "Il y a 2 heures - 11/05/2026"
+   * // → "Il y a 2 heures"
    *
    * formatLastModified(subMinutes(new Date(), 30).toISOString())
-   * // → "Il y a 30 minutes - 11/05/2026"
+   * // → "Il y a 30 minutes"
    *
    * formatLastModified(subSeconds(new Date(), 30).toISOString())
    * // → "À l'instant"
    *
    * formatLastModified('2024-01-15T14:30:00Z')
-   * // → "15 janvier 2024 à 15:30" (for French locale)
+   * // → "15/01/2024"
    * ```
    */
   formatLastModified: (date: string) => string
@@ -94,19 +94,18 @@ export function useDateUtils (): UseDateUtilsReturn {
 
     if (isToday(parsedDate)) {
       const now = new Date()
-      const formattedDate = format(parsedDate, 'dd/MM/yyyy')
       const hours = differenceInHours(now, parsedDate)
       if (hours >= 1) {
-        return `${t('global.dates.hoursAgo', { count: hours }, hours)} - ${formattedDate}`
+        return t('global.dates.hoursAgo', { count: hours }, hours)
       }
       const minutes = differenceInMinutes(now, parsedDate)
       if (minutes >= 1) {
-        return `${t('global.dates.minutesAgo', { count: minutes }, minutes)} - ${formattedDate}`
+        return t('global.dates.minutesAgo', { count: minutes }, minutes)
       }
       return t('global.dates.justNow')
     }
 
-    return formatTranslatedDateTime(date)
+    return format(parsedDate, 'dd/MM/yyyy')
   }
 
   return {


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
Updated the `formatLastModified` function in the `useDateUtils` composable to follow new business rules for date/time formatting:
- Removed date display from hours/minutes ago format
- Changed past-date format from localized datetime to simple `jj/mm/aaaa` format
- Updated JSDoc documentation with new formatting rules

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1661

### Documentation
Updated JSDoc comments in the composable with new formatting rules and examples:
- Today + ≥1 hour: `"Il y a X heures"` (no date)
- Today + ≥1 minute: `"Il y a X minutes"` (no date)
- Today + <1 minute: `"À l'instant"`
- Not today: `"jj/mm/aaaa"` format

### Target Branch
develop

### Additional Notes
All 9 unit tests updated and passing. The function now returns simpler, cleaner output aligned with user expectations for last modified timestamps.

### Known Limitations or Side Effects
None

## ✅ Checklist

- [x] Tests provided (all 9 unit tests updated and passing)
- [x] No unnecessary code
- [x] Code style and formatting rules respected

---

<img width="1539" height="1231" alt="image" src="https://github.com/user-attachments/assets/cfd5592c-0ac6-4190-835a-917ce5039c7b" />