### PR TITLE
fix(1660): MyWorkspaceTab - replace table with ActivityCard in mobile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "avenirs-cofolio-client",
       "version": "0.0.0",
       "dependencies": {
-        "@avenirs-esr/avenirs-dsav": "^0.1.205",
+        "@avenirs-esr/avenirs-dsav": "^0.1.207",
         "@tanstack/vue-form": "^1.15.0",
         "@tanstack/vue-query": "^5.74.9",
         "@vue-flow/core": "^1.48.0",
@@ -348,9 +348,9 @@
       "license": "ISC"
     },
     "node_modules/@avenirs-esr/avenirs-dsav": {
-      "version": "0.1.205",
-      "resolved": "https://registry.npmjs.org/@avenirs-esr/avenirs-dsav/-/avenirs-dsav-0.1.205.tgz",
-      "integrity": "sha512-eAKeBcNrsJ3rFxyk/N5ZxGj4KjdCcQ08EnxseOnHqKP+ZV+jPK7iKjBis01kU4NLJoxI6PoycQmZGuCvj+ng/g==",
+      "version": "0.1.207",
+      "resolved": "https://registry.npmjs.org/@avenirs-esr/avenirs-dsav/-/avenirs-dsav-0.1.207.tgz",
+      "integrity": "sha512-0kvEytXmFjOXT7eV/MKs2p5pah+A7enFxX9KmJNyXI/A0BsYL3NTHJDzNJ/msatP97SvBtnhVHm4raw+greI1g==",
       "dependencies": {
         "@tanstack/vue-table": "^8.21.3",
         "@tiptap/extension-character-count": "^3.20.2",
@@ -18791,9 +18791,9 @@
       }
     },
     "node_modules/typedoc/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -20236,9 +20236,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.18.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
-      "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
-    "@avenirs-esr/avenirs-dsav": "^0.1.205",
+    "@avenirs-esr/avenirs-dsav": "^0.1.207",
     "@tanstack/vue-form": "^1.15.0",
     "@tanstack/vue-query": "^5.74.9",
     "@vue-flow/core": "^1.48.0",

--- a/src/features/staff/activities/views/ActivitiesView/components/ActivityCard/ActivityCard.stub.ts
+++ b/src/features/staff/activities/views/ActivitiesView/components/ActivityCard/ActivityCard.stub.ts
@@ -1,0 +1,13 @@
+import type { ActivityTableRow } from '@/features/staff/activities/views/ActivitiesView/ActivitiesView.types'
+import type { PropType } from 'vue'
+
+export const ActivityCardStub = defineComponent({
+  name: 'ActivityCard',
+  template: '<div data-testid="activity-card-stub"></div>',
+  props: {
+    activity: {
+      type: Object as PropType<ActivityTableRow>,
+      required: true,
+    },
+  },
+})

--- a/src/features/staff/activities/views/ActivitiesView/components/ActivityCard/ActivityCard.test.ts
+++ b/src/features/staff/activities/views/ActivitiesView/components/ActivityCard/ActivityCard.test.ts
@@ -1,0 +1,133 @@
+import type { ActivityTableRow } from '@/features/staff/activities/views/ActivitiesView/ActivitiesView.types'
+import { EActivityStatus, EActivityThematic } from '@/api/avenir-esr'
+import { ActivityStatusBadgeStub } from '@/common/activities/badges/ActivityStatusBadge/ActivityStatusBadge.stub'
+import { ActivityThematicBadgeStub } from '@/common/activities/badges/ActivityThematicBadge/ActivityThematicBadge.stub'
+import { ROUTES } from '@/common/constants'
+import ActivityCard from '@/features/staff/activities/views/ActivitiesView/components/ActivityCard/ActivityCard.vue'
+import { MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
+import { AvCardStub, AvIconStub, AvIconTextStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { RouterLinkStub } from '@vue/test-utils'
+import { mountComponent } from 'tests/utils'
+import { beforeEach, expect, vi } from 'vitest'
+
+const mockFormatLastModified = vi.fn((value: string) => `formatted-${value}`)
+
+vi.mock('@/common/composables', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/common/composables')>()
+  return {
+    ...actual,
+    useDateUtils: () => ({
+      formatLastModified: mockFormatLastModified,
+    }),
+  }
+})
+
+BddTest().given('an ActivityCard component', () => {
+  let wrapper: ReturnType<typeof mountComponent<typeof ActivityCard>>
+
+  const stubs = {
+    AvCard: AvCardStub,
+    AvIcon: AvIconStub,
+    AvIconText: AvIconTextStub,
+    ActivityThematicBadge: ActivityThematicBadgeStub,
+    ActivityStatusBadge: ActivityStatusBadgeStub,
+    RouterLink: RouterLinkStub,
+  }
+
+  const baseActivity: ActivityTableRow = {
+    id: 'activity-1',
+    owner: 'Marie Curie',
+    status: EActivityStatus.PUBLISHED,
+    thematic: EActivityThematic.SELF_KNOWLEDGE,
+    title: 'Activite de test tres longue pour verifier le rendu du titre',
+    updatedAt: '2025-03-10T14:00:00.000Z',
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  BddTest().when('the component is mounted', () => {
+    beforeEach(() => {
+      wrapper = mountComponent(ActivityCard, {
+        props: { activity: baseActivity },
+        global: { stubs },
+      })
+    })
+
+    BddTest().then('it should render the card component', () => {
+      const card = wrapper.findComponent(AvCardStub)
+      expect(card.exists()).toBe(true)
+      expect(card.props('backgroundColor')).toBe('var(--card)')
+      expect(card.props('titleBackground')).toBe('var(--card)')
+    })
+
+    BddTest().then('it should render the title link to the activity details route', () => {
+      const link = wrapper.findComponent(RouterLinkStub)
+      expect(link.exists()).toBe(true)
+      expect(link.text()).toContain(baseActivity.title)
+      expect(link.props('to')).toEqual({
+        name: ROUTES.STAFF.ACTIVITY_DETAILS.name,
+        params: { id: baseActivity.id, status: baseActivity.status },
+      })
+    })
+
+    BddTest().then('it should render thematic and status badges with the activity values', () => {
+      const thematic = wrapper.findComponent(ActivityThematicBadgeStub)
+      const status = wrapper.findComponent(ActivityStatusBadgeStub)
+
+      expect(thematic.exists()).toBe(true)
+      expect(thematic.props('thematic')).toBe(baseActivity.thematic)
+      expect(status.exists()).toBe(true)
+      expect(status.props('status')).toBe(baseActivity.status)
+    })
+
+    BddTest().then('it should render owner and updated labels', () => {
+      const iconTexts = wrapper.findAllComponents(AvIconTextStub)
+
+      expect(iconTexts).toHaveLength(2)
+      expect(iconTexts[0].props('icon')).toBe(MDI_ICONS.PERSON_OUTLINE)
+      expect(iconTexts[0].props('text')).toContain(baseActivity.owner)
+      expect(iconTexts[1].props('icon')).toBe(MDI_ICONS.CLOCK_ARROW)
+      expect(iconTexts[1].props('text')).toContain(`formatted-${baseActivity.updatedAt}`)
+      expect(mockFormatLastModified).toHaveBeenCalledWith(baseActivity.updatedAt)
+    })
+  })
+
+  BddTest().when('the component is mounted with a different activity', () => {
+    const otherActivity: ActivityTableRow = {
+      id: 'activity-42',
+      owner: 'Ada Lovelace',
+      status: EActivityStatus.DRAFT,
+      thematic: EActivityThematic.EXPERIENCES,
+      title: 'Autre activite',
+      updatedAt: '2024-01-02T10:30:00.000Z',
+    }
+
+    beforeEach(() => {
+      wrapper = mountComponent(ActivityCard, {
+        props: { activity: otherActivity },
+        global: { stubs },
+      })
+    })
+
+    BddTest().then('it should update route and badges accordingly', () => {
+      const link = wrapper.findComponent(RouterLinkStub)
+      const thematic = wrapper.findComponent(ActivityThematicBadgeStub)
+      const status = wrapper.findComponent(ActivityStatusBadgeStub)
+
+      expect(link.props('to')).toEqual({
+        name: ROUTES.STAFF.ACTIVITY_DETAILS.name,
+        params: { id: otherActivity.id, status: otherActivity.status },
+      })
+      expect(thematic.props('thematic')).toBe(otherActivity.thematic)
+      expect(status.props('status')).toBe(otherActivity.status)
+    })
+
+    BddTest().then('it should use the updated date for formatting', () => {
+      const iconTexts = wrapper.findAllComponents(AvIconTextStub)
+      expect(iconTexts[1].props('text')).toContain(`formatted-${otherActivity.updatedAt}`)
+      expect(mockFormatLastModified).toHaveBeenCalledWith(otherActivity.updatedAt)
+    })
+  })
+})

--- a/src/features/staff/activities/views/ActivitiesView/components/ActivityCard/ActivityCard.vue
+++ b/src/features/staff/activities/views/ActivitiesView/components/ActivityCard/ActivityCard.vue
@@ -1,0 +1,96 @@
+<script lang="ts" setup>
+import type { ActivityTableRow } from '@/features/staff/activities/views/ActivitiesView/ActivitiesView.types'
+import ActivityStatusBadge from '@/common/activities/badges/ActivityStatusBadge/ActivityStatusBadge.vue'
+import ActivityThematicBadge from '@/common/activities/badges/ActivityThematicBadge/ActivityThematicBadge.vue'
+import { useDateUtils } from '@/common/composables'
+import { ICONS, ROUTES } from '@/common/constants'
+import { AvCard, AvIcon, AvIconText, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
+import { useI18n } from 'vue-i18n'
+
+export interface ActivityCardProps {
+  activity: ActivityTableRow
+}
+
+const { activity } = defineProps<ActivityCardProps>()
+
+const { t } = useI18n()
+
+const { formatLastModified } = useDateUtils()
+
+const ownerLabel = computed(() => `${t('global.colon', { before: t('staff.activities.views.ActivitiesView.MyWorkspaceTab.columns.owner') })} ${activity.owner}`)
+const updatedAtLabel = computed(() => `${t('global.colon', { before: t('global.updated') })} ${formatLastModified(activity.updatedAt)}`)
+const to = computed(() => ({
+  name: ROUTES.STAFF.ACTIVITY_DETAILS.name,
+  params: { status: activity.status, id: activity.id }
+}))
+</script>
+
+<template>
+  <RouterLink
+    :to="to"
+    :title="activity.title"
+    class="av-max-lines b1-regular av-text-text1"
+  >
+    <AvCard
+      background-color="var(--card)"
+      title-background="var(--card)"
+      class="activity-card"
+    >
+      <template #title>
+        <div class="av-row av-w-full av-gap-sm av-align-center">
+          <div class="av-flex-fill">
+            <span class="av-max-lines b1-regular av-text-text1">
+              {{ activity.title }}
+            </span>
+          </div>
+          <div class="icon-container av-col av-align-center av-justify-center av-p-xs av-radius-lg">
+            <AvIcon
+              :size="2.1875"
+              :name="ICONS.ACTIVITY"
+              color="var(--icon)"
+            />
+          </div>
+        </div>
+      </template>
+
+      <div class="details av-col av-gap-sm av-pb-xs av--mt-sm">
+        <div class="av-row av-w-full av-gap-xs av-wrap av-align-center">
+          <ActivityThematicBadge :thematic="activity.thematic" />
+          <ActivityStatusBadge :status="activity.status" />
+        </div>
+
+        <AvIconText
+          :icon="MDI_ICONS.PERSON_OUTLINE"
+          icon-color="var(--icon)"
+          :text="ownerLabel"
+          text-color="var(--text2)"
+          typography-class="b2-regular"
+        />
+      </div>
+
+      <div class="av-row av-w-full">
+        <AvIconText
+          :icon="MDI_ICONS.CLOCK_ARROW"
+          icon-color="var(--icon)"
+          :text="updatedAtLabel"
+          text-color="var(--text2)"
+          typography-class="b2-regular"
+        />
+      </div>
+    </AvCard>
+  </RouterLink>
+</template>
+
+<style lang="scss" scoped>
+.activity-card {
+  --max-lines: 2;
+
+  .details {
+    border-bottom: 1px solid var(--stroke);
+  }
+
+  .icon-container {
+    background-color: var(--light-background-neutral);
+  }
+}
+</style>

--- a/src/features/staff/activities/views/ActivitiesView/components/MyWorkspaceTab/MyWorkspaceTab.test.ts
+++ b/src/features/staff/activities/views/ActivitiesView/components/MyWorkspaceTab/MyWorkspaceTab.test.ts
@@ -2,6 +2,7 @@ import type { mount, VueWrapper } from '@vue/test-utils'
 import { ActivityStatusBadgeStub } from '@/common/activities/badges/ActivityStatusBadge/ActivityStatusBadge.stub'
 import { PaginationStub } from '@/common/components/Pagination/Pagination.stub'
 import { QuerySuspenseStub } from '@/common/components/QuerySuspense/QuerySuspense.stub'
+import { ActivityCardStub } from '@/features/staff/activities/views/ActivitiesView/components/ActivityCard/ActivityCard.stub'
 import { ActivityDraftCreationModalStub } from '@/features/staff/activities/views/ActivitiesView/components/ActivityDraftCreationModal/ActivityDraftCreationModal.stub'
 import { ActivityTableTitleStub } from '@/features/staff/activities/views/ActivitiesView/components/ActivityTableTitle/ActivityTableTitle.stub'
 import MyWorkspaceTab from '@/features/staff/activities/views/ActivitiesView/components/MyWorkspaceTab/MyWorkspaceTab.vue'
@@ -10,10 +11,23 @@ import { flushPromises } from '@vue/test-utils'
 import { mountComponent } from 'tests/utils'
 import { beforeEach, expect, vi } from 'vitest'
 
+const mockIsMobile = ref(false)
+
+vi.mock('@avenirs-esr/avenirs-dsav', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@avenirs-esr/avenirs-dsav')>()
+  return {
+    ...actual,
+    useAvBreakpoints: () => ({
+      isMobile: mockIsMobile,
+    }),
+  }
+})
+
 BddTest().given('a MyWorkspaceTab component', () => {
   let wrapper: ReturnType<typeof mount<typeof MyWorkspaceTab>>
 
   const stubs = {
+    ActivityCard: ActivityCardStub,
     ActivityDraftCreationModal: ActivityDraftCreationModalStub,
     ActivityTableTitle: ActivityTableTitleStub,
     ActivityStatusBadge: ActivityStatusBadgeStub,
@@ -27,6 +41,7 @@ BddTest().given('a MyWorkspaceTab component', () => {
 
   beforeEach(async () => {
     vi.clearAllMocks()
+    mockIsMobile.value = false
     wrapper = mountComponent(MyWorkspaceTab, { global: { stubs } })
     await flushPromises()
   })
@@ -128,6 +143,39 @@ BddTest().given('a MyWorkspaceTab component', () => {
       BddTest().then('it should close the modal', () => {
         expect(getModal().props('opened')).toBe(false)
       })
+    })
+  })
+
+  BddTest().when('the component is mounted in mobile view', () => {
+    beforeEach(async () => {
+      mockIsMobile.value = true
+      wrapper = mountComponent(MyWorkspaceTab, { global: { stubs } })
+      await flushPromises()
+    })
+
+    BddTest().then('it should render one ActivityCard per row', () => {
+      const cards = wrapper.findAllComponents(ActivityCardStub)
+      expect(cards).toHaveLength(6)
+    })
+
+    BddTest().then('it should not render the AvTable', () => {
+      expect(wrapper.findComponent(AvTableStub).exists()).toBe(false)
+    })
+  })
+
+  BddTest().when('the component is mounted in desktop view', () => {
+    beforeEach(async () => {
+      mockIsMobile.value = false
+      wrapper = mountComponent(MyWorkspaceTab, { global: { stubs } })
+      await flushPromises()
+    })
+
+    BddTest().then('it should render the AvTable', () => {
+      expect(wrapper.findComponent(AvTableStub).exists()).toBe(true)
+    })
+
+    BddTest().then('it should not render ActivityCard', () => {
+      expect(wrapper.findAllComponents(ActivityCardStub)).toHaveLength(0)
     })
   })
 })

--- a/src/features/staff/activities/views/ActivitiesView/components/MyWorkspaceTab/MyWorkspaceTab.vue
+++ b/src/features/staff/activities/views/ActivitiesView/components/MyWorkspaceTab/MyWorkspaceTab.vue
@@ -7,14 +7,16 @@ import Pagination from '@/common/components/Pagination/Pagination.vue'
 import { useDateUtils, usePagination } from '@/common/composables'
 import { useStaffActivitiesStore } from '@/features/staff/activities/stores/activities.store'
 import { mapActivityToActivityTableRow } from '@/features/staff/activities/views/ActivitiesView/ActivitiesView.utils'
+import ActivityCard from '@/features/staff/activities/views/ActivitiesView/components/ActivityCard/ActivityCard.vue'
 import ActivityDraftCreationModal from '@/features/staff/activities/views/ActivitiesView/components/ActivityDraftCreationModal/ActivityDraftCreationModal.vue'
 import ActivityTableTitle from '@/features/staff/activities/views/ActivitiesView/components/ActivityTableTitle/ActivityTableTitle.vue'
-import { AvButton, AvTable, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
+import { AvButton, AvTable, MDI_ICONS, useAvBreakpoints } from '@avenirs-esr/avenirs-dsav'
 import { keepPreviousData } from '@tanstack/vue-query'
 import { useI18n } from 'vue-i18n'
 
 const { t } = useI18n()
 const { formatLastModified } = useDateUtils()
+const { isMobile } = useAvBreakpoints()
 
 const staffActivitiesStore = useStaffActivitiesStore()
 
@@ -95,7 +97,18 @@ const columns = computed<AvTableColumn<ActivityTableRow>[]>(() => [
         :on-update-current-page="onUpdateCurrentPage"
         :on-update-page-size="onUpdatePageSize"
       >
+        <div
+          v-if="isMobile"
+          class="av-col av-gap-sm"
+        >
+          <ActivityCard
+            v-for="activity in rows"
+            :key="activity.id"
+            :activity="activity"
+          />
+        </div>
         <AvTable
+          v-else
           :columns="columns"
           :rows="rows"
           row-key="id"

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -257,6 +257,7 @@
       }
     },
     "text": "Text",
+    "updated": "Updated",
     "valorized": "Valorized in my resumes",
     "video": "Video",
     "views": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -261,6 +261,7 @@
       }
     },
     "text": "Texte",
+    "updated": "Modifié",
     "valorized": "Valoriser dans mes CV",
     "video": "Vidéo",
     "views": {


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
This PR introduces a mobile card-based rendering for activities in `MyWorkspaceTab` and adds dedicated `ActivityCard` coverage with tests/stubs.

**Main changes:**
- ✨ Adds a new `ActivityCard` component for mobile rendering
- ✅ Adds `ActivityCard` unit tests and stub
- ✅ Updates `MyWorkspaceTab` tests to validate mobile (`ActivityCard`) vs desktop (`AvTable`) rendering
- 🌐 Updates i18n entries (`fr`/`en`) required by the new rendering flow
- 🔧 Updates dependencies/lockfile context used during implementation

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1660

---

### Documentation
- Added tests for `ActivityCard` component behavior
- Added responsive rendering tests in `MyWorkspaceTab`

**Modified files:**
- \`src/features/staff/activities/views/ActivitiesView/components/ActivityCard/ActivityCard.vue\`
- \`src/features/staff/activities/views/ActivitiesView/components/ActivityCard/ActivityCard.test.ts\`
- \`src/features/staff/activities/views/ActivitiesView/components/ActivityCard/ActivityCard.stub.ts\`
- \`src/features/staff/activities/views/ActivitiesView/components/MyWorkspaceTab/MyWorkspaceTab.vue\`
- \`src/features/staff/activities/views/ActivitiesView/components/MyWorkspaceTab/MyWorkspaceTab.test.ts\`
- \`src/locales/fr.json\`
- \`src/locales/en.json\`
- \`package.json\`
- \`package-lock.json\`

---

### Target Branch
\`develop\`

---

### Additional Notes
Desktop behavior remains table-based (\`AvTable\`) while mobile now displays one \`ActivityCard\` per activity row. Tests were aligned with existing BDD-style patterns used in the codebase.

<img width="409" height="685" alt="image" src="https://github.com/user-attachments/assets/57dc20e2-d60a-41f1-ad11-1600163b8a74" />

<img width="409" height="685" alt="image" src="https://github.com/user-attachments/assets/1087fb1b-f84f-4839-aa0e-09f19a58afc4" />

---

### Known Limitations or Side Effects
No known side effects. The mobile layout relies on breakpoint detection from DSAV (\`useAvBreakpoints\`).

---

## ✅ Checklist

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [ ] No unnecessary code (e.g., debug logs, commented code)
- [ ] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to \`CHANGELOG.md\` file all properties and database change and details for the update process
