### PR TITLE
feat: add eslint rule for undef components

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,17 @@
 {
+  "eslint.useFlatConfig": true,
+  "eslint.validate": [
+    "javascript",
+    "javascriptreact",
+    "typescript",
+    "typescriptreact",
+    "vue"
+  ],
+  "eslint.workingDirectories": [
+    {
+      "mode": "auto"
+    }
+  ],
   "editor.codeActionsOnSave": {
     "source.fixAll": "explicit"
   },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,4 +1,4 @@
-import antfu from '@antfu/eslint-config'
+import antfu from '@antfu/eslint-config';
 import autoImportConfig from "./auto-import-config.json" with { type: 'json' };
 
 export default antfu({
@@ -9,7 +9,7 @@ export default antfu({
     '.vscode/',
     'eslint.config.js',
     'public/**/*',
-    'e2e/.features-gen/**/*'
+    'e2e/.features-gen/**/*',
   ],
 }, {
   rules: {
@@ -65,6 +65,18 @@ export default antfu({
     'import/no-relative-packages': 'error',
     'import/no-relative-parent-imports': 'error',
 
+  },
+}, {
+  files: ['**/*.vue'],
+  rules: {
+    'vue/no-undef-components': ['error', {
+      ignorePatterns: ['RouterLink', 'RouterView'],
+    }],
+  },
+}, {
+  files: ['**/*.md', '**/*.md/**'],
+  rules: {
+    'vue/no-undef-components': 'off',
   },
 }, {
   files: ['**/index.ts', '**/index.js'],


### PR DESCRIPTION
### Description
This PR adds the `vue/no-undef-components` ESLint rule and updates VS Code settings to improve IDE visibility for missing imports. This ensures that any undefined components are flagged both during development in the IDE and during linting.

### Reference
No issue number detected from branch name (chore/add-eslint-rule-for-undef-components).

### Documentation
- `.vscode/settings.json`: Updated ESLint and editor settings.
- `eslint.config.js`: Added `vue/no-undef-components` rule.

### Target Branch
develop

### Additional Notes
**Commits:**
```
22727b38 feat: add eslint rule for undef components
```

**Diffstat:**
```
 .vscode/settings.json | 13 +++++++++++++
 eslint.config.js      |  7 +++++--
 2 files changed, 18 insertions(+), 2 deletions(-)
```

### Known Limitations
Global components might need to be added to `ignorePatterns` if they are not detected.

### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
