### PR TITLE
feat(1567): add E2E tests for national activity edit page

### DIFF
--- a/e2e/framework/shared/constants/routes.ts
+++ b/e2e/framework/shared/constants/routes.ts
@@ -1,6 +1,7 @@
 export const STAFF_ROUTES = {
   HOME: '/cofolio/staff',
   ACTIVITIES: '/cofolio/staff/activities',
+  ACTIVITIES_EDIT_NATIONAL_CONTENT: '/cofolio/staff/activities/:id/edit',
 }
 
 export const STUDENT_ROUTES = {

--- a/e2e/framework/shared/fixtures/fixtures.ts
+++ b/e2e/framework/shared/fixtures/fixtures.ts
@@ -2,6 +2,7 @@ import { FooterSteps } from '@e2e/framework/shared/steps/FooterSteps'
 import { PageTitleSteps } from '@e2e/framework/shared/steps/PageTitleSteps'
 import { PaginationSteps } from '@e2e/framework/shared/steps/PaginationSteps'
 import { setLocaleFromPage } from '@e2e/framework/shared/utils/i18n'
+import { EditNationalActivityContentPage } from '@e2e/framework/staff/activities/EditNationalActivityContentPage'
 import { StaffActivitiesPage } from '@e2e/framework/staff/activities/StaffActivitiesPage'
 import { StaffHomePage } from '@e2e/framework/staff/home/StaffHomePage'
 import { StaffGlobalSteps } from '@e2e/framework/staff/shared/steps/StaffGlobalSteps'
@@ -23,6 +24,7 @@ interface Fixtures {
   staffGlobalSteps: StaffGlobalSteps
   staffHomePage: StaffHomePage
   staffActivitiesPage: StaffActivitiesPage
+  editNationalActivityContentPage: EditNationalActivityContentPage
   studentGlobalSteps: StudentGlobalSteps
   studentHomePage: StudentHomePage
   studentDeclaredSkillDetailPage: StudentDeclaredSkillDetailPage
@@ -57,6 +59,10 @@ export const test = base.extend<Fixtures>({
   staffActivitiesPage: async ({ page }, use) => {
     await setLocaleFromPage(page)
     await use(new StaffActivitiesPage(page))
+  },
+  editNationalActivityContentPage: async ({ page }, use) => {
+    await setLocaleFromPage(page)
+    await use(new EditNationalActivityContentPage(page))
   },
   studentGlobalSteps: async ({ page }, use) => {
     await setLocaleFromPage(page)

--- a/e2e/framework/staff/activities/EditNationalActivityContentPage.ts
+++ b/e2e/framework/staff/activities/EditNationalActivityContentPage.ts
@@ -1,0 +1,179 @@
+import type { test } from '@e2e/framework/shared/fixtures/fixtures'
+import { BasePage } from '@e2e/framework/shared/base/BasePage'
+import { STAFF_ROUTES } from '@e2e/framework/shared/constants/routes'
+import { clickOnElement } from '@e2e/framework/shared/utils/click'
+import { waitForPageLoad } from '@e2e/framework/shared/utils/waits'
+import { expect, type Page } from '@playwright/test'
+import { Fixture, Given, Then } from 'playwright-bdd/decorators'
+
+@Fixture<typeof test>('editNationalActivityContentPage')
+export class EditNationalActivityContentPage extends BasePage {
+  constructor (public page: Page) {
+    super(page)
+  }
+
+  getPageTitle () {
+    return this.page.getByTestId('page-title')
+  }
+
+  getBackButton () {
+    return this.page
+      .locator('button')
+      .filter({ hasText: /retour|back/i })
+      .first()
+  }
+
+  getBreadcrumbLinks () {
+    return this.page.locator('[role="navigation"] a, [class*="breadcrumb"] a')
+  }
+
+  getActivityTitleFormField () {
+    return this.page.locator('input[type="text"]').first()
+  }
+
+  getActivityConsignFormField () {
+    return this.page.locator('[contenteditable="true"]').first()
+  }
+
+  getNextStepButton () {
+    return this.page.getByRole('button', { name: /étape suivante/i })
+  }
+
+  getSideNavigationMenu () {
+    return this.page.locator('[class*="side-navigation"], [class*="sidenav"]').first()
+  }
+
+  getActivityContentForm () {
+    return this.page.locator('[class*="av-col"][class*="av-gap"]').first()
+  }
+
+  @Given('the staff creates a test national activity')
+  async createTestNationalActivity () {
+    const createButton = this.page.getByTestId('create-activity-button')
+    if (await createButton.isVisible()) {
+      await clickOnElement(createButton)
+
+      const modal = this.page.getByTestId('activity-draft-creation-modal')
+      await expect(modal).toBeVisible()
+
+      const titleInput = modal.getByTestId('activity-title-form-field')
+      if (await titleInput.isVisible()) {
+        await titleInput.fill('Test National Activity')
+      }
+
+      const confirmButton = modal.getByTestId('confirm-button')
+      if (await confirmButton.isVisible()) {
+        await clickOnElement(confirmButton)
+
+        await waitForPageLoad(this.page)
+      }
+    }
+  }
+
+  @Then('the edit national activity content page is displayed')
+  async verifyPageLoaded () {
+    await expect(this.page).toHaveURL(/\/cofolio\/staff\/activities\/.*\/edit/)
+  }
+
+  @Then('the page title is correct for edit national activity content')
+  async verifyPageTitleCorrect () {
+    const pageTitle = this.getPageTitle()
+    await expect(pageTitle).toBeVisible()
+    const heading = pageTitle.getByRole('heading')
+    await expect(heading).toBeVisible()
+    const titleText = await heading.textContent()
+    expect(titleText).toMatch(/Créer|Modifier/)
+  }
+
+  @Then('the page navigates to staff home page')
+  async verifyNavigateToStaffHomePage () {
+    await expect(this.page).toHaveURL(STAFF_ROUTES.HOME)
+  }
+
+  @Given('the activity content form is visible')
+  async verifyActivityContentFormVisible () {
+    const form = this.getActivityContentForm()
+    await expect(form).toBeVisible()
+  }
+
+  @Then('the activity title form field is visible')
+  async verifyActivityTitleFormFieldVisible () {
+    await expect(this.getActivityTitleFormField()).toBeVisible()
+  }
+
+  @Then('the activity title form field has a label')
+  async verifyActivityTitleFormFieldHasLabel () {
+    const titleField = this.getActivityTitleFormField()
+    const label = titleField.locator('xpath=preceding::label[1]')
+    await expect(label).toBeVisible()
+  }
+
+  @Then('the activity consign form field is visible')
+  async verifyActivityConsignFormFieldVisible () {
+    await expect(this.getActivityConsignFormField()).toBeVisible()
+  }
+
+  @Then('the activity consign form field has a label')
+  async verifyActivityConsignFormFieldHasLabel () {
+    const consignField = this.getActivityConsignFormField()
+    const label = consignField.locator('xpath=preceding::label[1]')
+    await expect(label).toBeVisible()
+  }
+
+  @Then('the next step button is visible')
+  async verifyNextStepButtonVisible () {
+    await expect(this.getNextStepButton()).toBeVisible()
+  }
+
+  @Then('the next step button has correct label')
+  async verifyNextStepButtonHasCorrectLabel () {
+    const button = this.getNextStepButton()
+    await expect(button).toContainText(/étape suivante/i)
+  }
+
+  @Then('the side navigation menu is visible')
+  async verifySideNavigationMenuVisible () {
+    const sideNav = this.getSideNavigationMenu()
+    await expect(sideNav).toBeVisible()
+  }
+
+  @Then('the side navigation has TITLE section')
+  async verifySideNavigationHasTitleSection () {
+    await expect(this.page.getByTestId('menu-CONTENT-TITLE')).toBeVisible()
+  }
+
+  @Then('the side navigation has INSTRUCTIONS section')
+  async verifySideNavigationHasInstructionsSection () {
+    await expect(this.page.getByTestId('menu-CONTENT-INSTRUCTIONS')).toBeVisible()
+  }
+
+  @Then('the side navigation has CONTEXT section')
+  async verifySideNavigationHasContextSection () {
+    await expect(this.page.getByTestId('menu-CONTENT-CONTEXT')).toBeVisible()
+  }
+
+  @Then('the side navigation has DOCUMENTS section')
+  async verifySideNavigationHasDocumentsSection () {
+    await expect(this.page.getByTestId('menu-CONTENT-DOCUMENTS')).toBeVisible()
+  }
+
+  @Then('the side navigation has SCHEDULE section')
+  async verifySideNavigationHasScheduleSection () {
+    await expect(this.page.getByTestId('menu-CONTENT-SCHEDULE')).toBeVisible()
+  }
+
+  @Then('the side navigation has MODALITIES section')
+  async verifySideNavigationHasModalitiesSection () {
+    await expect(this.page.getByTestId('menu-CONTENT-MODALITIES')).toBeVisible()
+  }
+
+  @Then('the side navigation has THEMATIC section')
+  async verifySideNavigationHasThematicSection () {
+    await expect(this.page.getByTestId('menu-CONTENT-THEMATIC')).toBeVisible()
+  }
+
+  @Then('the side navigation menu is not visible')
+  async verifySideNavigationMenuNotVisible () {
+    await expect(this.getSideNavigationMenu()).not.toBeVisible()
+  }
+}

--- a/e2e/tests/staff/activities/edit-national-activity-content.feature
+++ b/e2e/tests/staff/activities/edit-national-activity-content.feature
@@ -1,0 +1,68 @@
+@staff @activities @edit-national-activity-content @dataset-full
+Feature: Staff Edit National Activity Content Page
+
+  Background:
+    Given the staff opens the activities page
+    And the staff creates a test national activity
+
+  Rule: Page Load and Basic Display
+
+    @high
+    Scenario: Staff can load edit national activity content page successfully
+      Then the edit national activity content page is displayed
+      And the URL contains "/cofolio/staff/activities"
+      And the URL contains "/edit"
+
+  Rule: Page Title and Navigation
+
+    Background:
+      Given the page title is visible
+
+    @high @page-title
+    Scenario: Staff can see the page title for edit mode
+      Then the page title is correct for edit national activity content
+      And the breadcrumb items are visible
+      And the back button is correct
+
+    @high @page-title @navigation
+    Scenario: Staff can interact with the page title back button
+      When the user clicks the back button
+      Then the page navigates to activities page
+
+    @high @page-title @navigation
+    Scenario: Staff can interact with the first breadcrumb link
+      When the user clicks the first breadcrumb link
+      Then the page navigates to staff home page
+
+  Rule: Activity Content Form Elements
+
+    Background:
+      Given the activity content form is visible
+
+    @high @form-elements
+    Scenario: Staff can see the title form field
+      Then the activity title form field is visible
+      And the activity title form field has a label
+
+    @high @form-elements
+    Scenario: Staff can see the consign form field
+      Then the activity consign form field is visible
+      And the activity consign form field has a label
+
+    @high @form-elements
+    Scenario: Staff can see the next step button
+      Then the next step button is visible
+      And the next step button has correct label
+
+  Rule: Side Navigation
+
+    @high @side-navigation
+    Scenario: Staff can see the side navigation menu with content sections
+      Then the side navigation menu is visible
+      And the side navigation has TITLE section
+      And the side navigation has INSTRUCTIONS section
+      And the side navigation has CONTEXT section
+      And the side navigation has DOCUMENTS section
+      And the side navigation has SCHEDULE section
+      And the side navigation has MODALITIES section
+      And the side navigation has THEMATIC section

--- a/e2e/tests/staff/activities/edit-national-activity-content.mobile.feature
+++ b/e2e/tests/staff/activities/edit-national-activity-content.mobile.feature
@@ -1,0 +1,13 @@
+@staff @activities @edit-national-activity-content @dataset-full @mobile
+Feature: Staff Edit National Activity Content Page - Mobile
+
+  Background:
+    Given the staff opens the activities page
+    And the staff creates a test national activity
+    And the page is displayed on mobile viewport
+
+  Rule: Side Navigation
+
+    @medium @responsive @side-navigation
+    Scenario: Staff cannot see the side navigation on mobile
+      Then the side navigation menu is not visible


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
Add E2E tests for the national activity edit page, covering page load, navigation, form elements, side navigation, and responsive behavior.

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1567
---

### Documentation
<!-- Detail any updates made to documentation, configuration steps, or technical specs. -->

---

### Target Branch
develop

---

### Additional Notes
- Added `EditNationalActivityContentPage` fixture with BDD steps
- Added `edit-national-activity-content.feature` for desktop scenarios
- Added `edit-national-activity-content.mobile.feature` for mobile responsive scenarios
- Registered fixture in `fixtures.ts`
- Tests cover: page load, page title, breadcrumb, back button navigation, form fields (title + consign), side navigation sections, and mobile side nav visibility

---

### Known Limitations or Side Effects
<!-- List any limitations, known bugs, or side effects this PR may introduce. -->

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process
