### PR TITLE
test(1567): implement e2e tests for edit national activity side navigation

### DIFF
--- a/e2e/framework/shared/constants/routes.ts
+++ b/e2e/framework/shared/constants/routes.ts
@@ -1,6 +1,7 @@
 export const STAFF_ROUTES = {
   HOME: '/cofolio/staff',
   ACTIVITIES: '/cofolio/staff/activities',
+  ACTIVITIES_EDIT_NATIONAL_ACTIVITY: '/cofolio/staff/activities/:id/edit',
 }
 
 export const STUDENT_ROUTES = {

--- a/e2e/framework/shared/fixtures/fixtures.ts
+++ b/e2e/framework/shared/fixtures/fixtures.ts
@@ -2,6 +2,7 @@ import { FooterSteps } from '@e2e/framework/shared/steps/FooterSteps'
 import { PageTitleSteps } from '@e2e/framework/shared/steps/PageTitleSteps'
 import { PaginationSteps } from '@e2e/framework/shared/steps/PaginationSteps'
 import { setLocaleFromPage } from '@e2e/framework/shared/utils/i18n'
+import { EditNationalActivityPage } from '@e2e/framework/staff/activities/EditNationalActivityPage'
 import { StaffActivitiesPage } from '@e2e/framework/staff/activities/StaffActivitiesPage'
 import { StaffHomePage } from '@e2e/framework/staff/home/StaffHomePage'
 import { StaffGlobalSteps } from '@e2e/framework/staff/shared/steps/StaffGlobalSteps'
@@ -23,6 +24,7 @@ interface Fixtures {
   staffGlobalSteps: StaffGlobalSteps
   staffHomePage: StaffHomePage
   staffActivitiesPage: StaffActivitiesPage
+  editNationalActivityPage: EditNationalActivityPage
   studentGlobalSteps: StudentGlobalSteps
   studentHomePage: StudentHomePage
   studentDeclaredSkillDetailPage: StudentDeclaredSkillDetailPage
@@ -57,6 +59,10 @@ export const test = base.extend<Fixtures>({
   staffActivitiesPage: async ({ page }, use) => {
     await setLocaleFromPage(page)
     await use(new StaffActivitiesPage(page))
+  },
+  editNationalActivityPage: async ({ page }, use) => {
+    await setLocaleFromPage(page)
+    await use(new EditNationalActivityPage(page))
   },
   studentGlobalSteps: async ({ page }, use) => {
     await setLocaleFromPage(page)

--- a/e2e/framework/staff/activities/EditNationalActivityPage.ts
+++ b/e2e/framework/staff/activities/EditNationalActivityPage.ts
@@ -1,0 +1,82 @@
+import type { test } from '@e2e/framework/shared/fixtures/fixtures'
+import { BasePage } from '@e2e/framework/shared/base/BasePage'
+import { STAFF_ROUTES } from '@e2e/framework/shared/constants/routes'
+import { clickOnElement } from '@e2e/framework/shared/utils/click'
+import { waitForPageLoad } from '@e2e/framework/shared/utils/waits'
+import { expect, type Page } from '@playwright/test'
+import { Fixture, Given, Then, When } from 'playwright-bdd/decorators'
+
+@Fixture<typeof test>('editNationalActivityPage')
+export class EditNationalActivityPage extends BasePage {
+  constructor (public page: Page) {
+    super(page)
+  }
+
+  getSideNavigation () {
+    return this.page.getByTestId('add-national-activity-side-navigation')
+  }
+
+  @Given('the staff navigates to the first activity edit page')
+  async navigateToEditNationalActivity () {
+    const activityId = await this.page
+      .locator('[data-testid="activity-table-title"][data-activity-status="DRAFT"], [data-testid="activity-card-title"][data-activity-status="DRAFT"]')
+      .first()
+      .getAttribute('data-activity-id')
+
+    if (!activityId) {
+      throw new Error('No draft activity found')
+    }
+
+    await this.page.goto(
+      `${STAFF_ROUTES.ACTIVITIES_EDIT_NATIONAL_ACTIVITY.replace(':id', activityId)}?mode=add`
+    )
+    await waitForPageLoad(this.page)
+  }
+
+  @Then('the edit national activity page is displayed')
+  async verifyPageDisplayed () {
+    await expect(this.getSideNavigation()).toBeVisible()
+  }
+
+  @Then('the side navigation menu is visible')
+  async verifySideNavigationMenuVisible () {
+    const sideNav = this.getSideNavigation()
+    await expect(sideNav).toBeVisible()
+  }
+
+  @Then('the side navigation has {string} content section')
+  async verifySideNavHasContentSection (section: string) {
+    await expect(this.page.getByTestId(`menu-CONTENT-${section}`)).toBeVisible()
+  }
+
+  @Then('the activity title form field is visible')
+  async verifyActivityTitleFormFieldVisible () {
+    await expect(this.page.getByTestId('activity-title-form-field')).toBeVisible()
+  }
+
+  @Then('the side navigation menu is not visible')
+  async verifySideNavigationMenuNotVisible () {
+    await expect(this.getSideNavigation()).not.toBeVisible()
+  }
+
+  @When('the user clicks on the side navigation {string} content item')
+  async clickSideNavContentItem (item: string) {
+    await clickOnElement(this.page.getByTestId(`menu-CONTENT-${item}`))
+  }
+
+  @Given('the staff navigates to the publication tab')
+  async navigateToPublicationTab () {
+    await clickOnElement(this.page.getByTestId('activity-publication-tab'))
+    await this.page.waitForURL('**tab=PUBLICATION**')
+  }
+
+  @When('the user clicks on the side navigation {string} publication item')
+  async clickSideNavPublicationItem (item: string) {
+    await clickOnElement(this.page.getByTestId(`menu-PUBLICATION-${item}`))
+  }
+
+  @Then('the side navigation has {string} publication section')
+  async verifySideNavHasPublicationSection (section: string) {
+    await expect(this.page.getByTestId(`menu-PUBLICATION-${section}`)).toBeVisible()
+  }
+}

--- a/e2e/tests/staff/activities/edit-national-activity.feature
+++ b/e2e/tests/staff/activities/edit-national-activity.feature
@@ -1,0 +1,104 @@
+@staff @activities @edit-national-activity @dataset-full
+Feature: Staff Edit National Activity Page
+
+  Background:
+    Given the staff opens the activities page
+    And the staff navigates to the first activity edit page
+
+  Rule: Page Load and Basic Display
+
+    @high
+    Scenario: Staff can load edit national activity page successfully
+      Then the edit national activity page is displayed
+      And the URL contains "/cofolio/staff/activities"
+      And the URL contains "/edit"
+
+  Rule: Side Navigation - Content tab
+
+    @high @side-navigation
+    Scenario: Staff can see the side navigation menu with content sections
+      Then the side navigation menu is visible
+      And the side navigation has "TITLE" content section
+      And the side navigation has "INSTRUCTIONS" content section
+      And the side navigation has "CONTEXT" content section
+      And the side navigation has "DOCUMENTS" content section
+      And the side navigation has "SCHEDULE" content section
+      And the side navigation has "MODALITIES" content section
+      And the side navigation has "THEMATIC" content section
+
+    @high @side-navigation
+    Scenario: Staff can navigate to TITLE section via side navigation
+      When the user clicks on the side navigation "TITLE" content item
+      Then the URL contains "#TITLE"
+
+    @high @side-navigation
+    Scenario: Staff can navigate to INSTRUCTIONS section via side navigation
+      When the user clicks on the side navigation "INSTRUCTIONS" content item
+      Then the URL contains "#INSTRUCTIONS"
+
+    @high @side-navigation
+    Scenario: Staff can navigate to CONTEXT section via side navigation
+      When the user clicks on the side navigation "CONTEXT" content item
+      Then the URL contains "#CONTEXT"
+
+    @high @side-navigation
+    Scenario: Staff can navigate to DOCUMENTS section via side navigation
+      When the user clicks on the side navigation "DOCUMENTS" content item
+      Then the URL contains "#DOCUMENTS"
+
+    @high @side-navigation
+    Scenario: Staff can navigate to SCHEDULE section via side navigation
+      When the user clicks on the side navigation "SCHEDULE" content item
+      Then the URL contains "#SCHEDULE"
+
+    @high @side-navigation
+    Scenario: Staff can navigate to MODALITIES section via side navigation
+      When the user clicks on the side navigation "MODALITIES" content item
+      Then the URL contains "#MODALITIES"
+
+    @high @side-navigation
+    Scenario: Staff can navigate to THEMATIC section via side navigation
+      When the user clicks on the side navigation "THEMATIC" content item
+      Then the URL contains "#THEMATIC"
+
+  Rule: Side Navigation - Publication tab
+
+    Background:
+      Given the staff navigates to the publication tab
+
+    @high @side-navigation
+    Scenario: Staff can see the side navigation menu with publication sections
+      Then the side navigation has "ACTIVITY_TITLE" publication section
+      And the side navigation has "TARGET_GROUPS" publication section
+      And the side navigation has "IMAGE" publication section
+      And the side navigation has "SUMMARY_CONTEXT" publication section
+
+
+    @high @side-navigation
+    Scenario: Staff can navigate to ACTIVITY_TITLE section via side navigation
+      When the user clicks on the side navigation "ACTIVITY_TITLE" publication item
+      Then the URL contains "#ACTIVITY_TITLE"
+
+    @high @side-navigation
+    Scenario: Staff can navigate to TARGET_GROUPS section via side navigation
+      When the user clicks on the side navigation "TARGET_GROUPS" publication item
+      Then the URL contains "#TARGET_GROUPS"
+
+    @high @side-navigation
+    Scenario: Staff can navigate to IMAGE section via side navigation
+      When the user clicks on the side navigation "IMAGE" publication item
+      Then the URL contains "#IMAGE"
+
+    @high @side-navigation
+    Scenario: Staff can navigate to SUMMARY_CONTEXT section via side navigation
+      When the user clicks on the side navigation "SUMMARY_CONTEXT" publication item
+      Then the URL contains "#SUMMARY_CONTEXT"
+
+  Rule: Side Navigation - Content tab sections visibility
+
+    @high @side-navigation
+    Scenario: Staff can see the title form field after clicking TITLE content section
+      When the user clicks on the side navigation "TITLE" content item
+      Then the URL contains "#TITLE"
+      And the activity title form field is visible
+      

--- a/e2e/tests/staff/activities/edit-national-activity.mobile.feature
+++ b/e2e/tests/staff/activities/edit-national-activity.mobile.feature
@@ -1,0 +1,14 @@
+@staff @activities @edit-national-activity @dataset-full @mobile
+Feature: Staff Edit National Activity Page - Mobile
+
+  Background:
+    Given the staff opens the activities page
+    And the staff navigates to the first activity edit page
+    And the page is displayed on mobile viewport
+
+  Rule: Side Navigation
+
+    @medium @responsive @side-navigation
+    Scenario: Staff cannot see the side navigation on mobile
+      Then the side navigation menu is not visible
+      

--- a/src/features/staff/activities/components/interactions/formFields/ActivityConsignFormField/ActivityConsignFormField.vue
+++ b/src/features/staff/activities/components/interactions/formFields/ActivityConsignFormField/ActivityConsignFormField.vue
@@ -40,6 +40,7 @@ const debouncedAutosave = debounce((value: string, hasErrors: boolean) => {
   >
     <template #default="{ field }">
       <RichTextEditor
+        data-testid="activity-consign-form-field"
         :model-value="field.state.value"
         :maxlength="ACTIVITY_CONSIGN_MAX_LENGTH"
         :error-message="field.state.meta.errors?.join(', ')"

--- a/src/features/staff/activities/components/interactions/formFields/ActivityTitleFormField/ActivityTitleFormField.vue
+++ b/src/features/staff/activities/components/interactions/formFields/ActivityTitleFormField/ActivityTitleFormField.vue
@@ -31,6 +31,7 @@ const titleValidators = {
     <template #default="{ field }">
       <ActivityTitleInput
         v-bind="$attrs"
+        data-testid="activity-title-form-field"
         :model-value="field.state.value"
         :error-message="field.state.meta.errors?.join(', ')"
         @blur="field.handleBlur"

--- a/src/features/staff/activities/components/navigation/AddNationalActivitySideNavigation/AddNationalActivitySideNavigation.vue
+++ b/src/features/staff/activities/components/navigation/AddNationalActivitySideNavigation/AddNationalActivitySideNavigation.vue
@@ -102,6 +102,7 @@ watch(activeTab, (newValue) => {
     hide-content-when-collapsed
     :items="items"
     sticky
+    data-testid="add-national-activity-side-navigation"
     @update:selected-item="navigateToSelectedItem"
   />
 </template>

--- a/src/features/staff/activities/locales/en.json
+++ b/src/features/staff/activities/locales/en.json
@@ -14,6 +14,10 @@
           "ActivityTitleInput": {
             "label": "Activity title"
           }
+        },
+        "ThematicSelect": {
+          "label": "Thematic",
+          "placeholder": "Choose a thematic"
         }
       },
       "views": {

--- a/src/features/staff/activities/views/ActivitiesView/components/ActivityCard/ActivityCard.vue
+++ b/src/features/staff/activities/views/ActivitiesView/components/ActivityCard/ActivityCard.vue
@@ -35,6 +35,9 @@ const to = computed(() => ({
       background-color="var(--card)"
       title-background="var(--card)"
       class="activity-card"
+      data-testid="activity-card-title"
+      :data-activity-id="activity.id"
+      :data-activity-status="activity.status"
     >
       <template #title>
         <div class="av-row av-w-full av-gap-sm av-align-center">

--- a/src/features/staff/activities/views/ActivitiesView/components/ActivityTableTitle/ActivityTableTitle.vue
+++ b/src/features/staff/activities/views/ActivitiesView/components/ActivityTableTitle/ActivityTableTitle.vue
@@ -19,6 +19,8 @@ const to = computed(() => ({
   <div
     class="activity-table-title av-col av-gap-xs"
     data-testid="activity-table-title"
+    :data-activity-id="activity.id"
+    :data-activity-status="activity.status"
   >
     <RouterLink
       :to

--- a/src/features/staff/activities/views/ActivitiesView/components/tabs/NationalActivityContentTab/interactions/inputs/ThematicSelect/ThematicSelect.vue
+++ b/src/features/staff/activities/views/ActivitiesView/components/tabs/NationalActivityContentTab/interactions/inputs/ThematicSelect/ThematicSelect.vue
@@ -8,36 +8,12 @@ type ThematicSelectProps = Omit<AvSelectProps, 'options' | 'placeholder' | 'pref
 const { label, ...restProps } = defineProps<ThematicSelectProps>()
 const selectedItem = defineModel<{ itemId: EActivityThematic }>()
 const { t } = useI18n()
-const options = computed(() => [
-  {
-    id: EActivityThematic.SELF_KNOWLEDGE,
-    label: t('global.activities.badges.thematics.SELF_KNOWLEDGE'),
-  },
-  {
-    id: EActivityThematic.FUTURE_PLANS,
-    label: t('global.activities.badges.thematics.FUTURE_PLANS'),
-  },
-  {
-    id: EActivityThematic.PROGRAMS,
-    label: t('global.activities.badges.thematics.PROGRAMS'),
-  },
-  {
-    id: EActivityThematic.EXPERIENCES,
-    label: t('global.activities.badges.thematics.EXPERIENCES'),
-  },
-  {
-    id: EActivityThematic.TRAJECTORIES,
-    label: t('global.activities.badges.thematics.TRAJECTORIES'),
-  },
-  {
-    id: EActivityThematic.RESUMES,
-    label: t('global.activities.badges.thematics.RESUMES'),
-  },
-  {
-    id: EActivityThematic.TRANSVERSAL,
-    label: t('global.activities.badges.thematics.TRANSVERSAL'),
-  },
-])
+const options = computed(() =>
+  Object.values(EActivityThematic).map(thematic => ({
+    id: thematic,
+    label: t(`global.activities.badges.thematics.${thematic}`),
+  })),
+)
 
 const avSelectProps = computed<AvSelectProps>(() => ({
   ...restProps,

--- a/src/features/staff/activities/views/EditNationalActivityView/EditNationalActivityView.stub.ts
+++ b/src/features/staff/activities/views/EditNationalActivityView/EditNationalActivityView.stub.ts
@@ -1,7 +1,7 @@
 import type { EditActivityFormData } from '@/features/staff/activities/types/forms.types'
 import type { SlotsType } from 'vue'
-import { ACTIVITY_TRACE_SETTING_INFINITY_VALUE } from '@/features/staff/activities/config'
 import { EActivityThematic } from '@/api/avenir-esr'
+import { ACTIVITY_TRACE_SETTING_INFINITY_VALUE } from '@/features/staff/activities/config'
 import { provideEditNationalActivityViewContext } from '@/features/staff/activities/views/EditNationalActivityView/EditNationalActivityViewContext'
 import { useForm } from '@tanstack/vue-form'
 import { vi } from 'vitest'

--- a/src/features/staff/activities/views/EditNationalActivityView/EditNationalActivityView.vue
+++ b/src/features/staff/activities/views/EditNationalActivityView/EditNationalActivityView.vue
@@ -139,12 +139,14 @@ provideEditNationalActivityViewContext({ form, save, cancel })
           <AvTab
             :title="t('staff.activities.views.EditNationalActivityView.ActivityContentTab.title')"
             :icon="MDI_ICONS.PENCIL_OUTLINE"
+            data-testid="activity-content-tab"
           >
             <ActivityContentTab :activity="activity!" />
           </AvTab>
           <AvTab
             :title="t('staff.activities.views.EditNationalActivityView.ActivityPublicationTab.title')"
             :icon="RI_ICONS.SEND_PLANE_LINE"
+            data-testid="activity-publication-tab"
           >
             <ActivityPublicationTab :activity="activity!" />
           </AvTab>

--- a/src/features/staff/activities/views/EditNationalActivityView/components/ActivityContentTab/ActivityContentTab.vue
+++ b/src/features/staff/activities/views/EditNationalActivityView/components/ActivityContentTab/ActivityContentTab.vue
@@ -31,7 +31,10 @@ const { t } = useI18n()
 </script>
 
 <template>
-  <div class="av-col av-gap-xl">
+  <div
+    class="av-col av-gap-xl"
+    data-testid="activity-content-tab"
+  >
     <div :id="ContentSectionId.TITLE">
       <FormFieldCardContainer
         :title="t('staff.activities.views.AddNationalActivityView.sideNavigation.content.TITLE')"

--- a/src/features/staff/activities/views/EditNationalActivityView/components/ActivityPublicationTab/ActivityPublicationTab.vue
+++ b/src/features/staff/activities/views/EditNationalActivityView/components/ActivityPublicationTab/ActivityPublicationTab.vue
@@ -20,7 +20,10 @@ const { form, save } = useEditNationalActivityViewContext()
 </script>
 
 <template>
-  <div class="av-col av-gap-xl">
+  <div
+    class="av-col av-gap-xl"
+    data-testid="activity-publication-tab-content"
+  >
     <div
       :id="PublicationSectionId.SUMMARY_CONTEXT"
       class="av-row av-w-full av-gap-sm"


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
Add E2E tests for the national activity edit page, covering page load, navigation, form elements, side navigation, and responsive behavior.

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1567

---

### Documentation
<!-- Detail any updates made to documentation, configuration steps, or technical specs. -->

---

### Target Branch
develop

---

### Additional Notes
- Added `EditNationalActivityContentPage` fixture with BDD steps
- Added `edit-national-activity-content.feature` for desktop scenarios
- Added `edit-national-activity-content.mobile.feature` for mobile responsive scenarios
- Registered fixture in `fixtures.ts`
- Tests cover: page load, page title, breadcrumb, back button navigation, form fields (title + consign), side navigation sections, and mobile side nav visibility

---

### Known Limitations or Side Effects
<!-- List any limitations, known bugs, or side effects this PR may introduce. -->

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process