### PR TITLE
feat(1525): introduce activity reflection setting

### DIFF
--- a/src/features/staff/activities/components/interactions/formFields/ActivityReflectionFormField/ActivityReflectionFormField.stub.ts
+++ b/src/features/staff/activities/components/interactions/formFields/ActivityReflectionFormField/ActivityReflectionFormField.stub.ts
@@ -1,0 +1,12 @@
+import type { EditActivityForm } from '@/features/staff/activities/types/forms.types'
+import type { PropType } from 'vue'
+
+export const ActivityReflectionFormFieldStub = defineComponent({
+  name: 'ActivityReflectionFormField',
+  props: {
+    form: {
+      type: Object as PropType<EditActivityForm>,
+    },
+  },
+  template: '<div data-testid="activity-reflection-form-field-stub"></div>',
+})

--- a/src/features/staff/activities/components/interactions/formFields/ActivityReflectionFormField/ActivityReflectionFormField.test.ts
+++ b/src/features/staff/activities/components/interactions/formFields/ActivityReflectionFormField/ActivityReflectionFormField.test.ts
@@ -1,0 +1,58 @@
+import type { EditActivityFormData } from '@/features/staff/activities/types/forms.types'
+import { ToggleStub } from '@/common/components/Toggle/Toggle.stub'
+import ActivityReflectionFormField from '@/features/staff/activities/components/interactions/formFields/ActivityReflectionFormField/ActivityReflectionFormField.vue'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { createFormFieldTestWrapper } from 'tests/utils'
+import { beforeEach, expect, vi } from 'vitest'
+
+const TestWrapper = createFormFieldTestWrapper<EditActivityFormData, EditActivityFormData, 'enableReflection'>({
+  formFieldComponent: ActivityReflectionFormField,
+  fieldName: 'enableReflection',
+  defaultValue: true,
+  useValidator: () => () => undefined,
+})
+
+BddTest().given('an ActivityReflectionFormField component', () => {
+  let wrapper: VueWrapper<InstanceType<typeof TestWrapper>>
+
+  const stubs = { Toggle: ToggleStub }
+
+  const getToggle = () => wrapper.findComponent(ToggleStub) as VueWrapper<InstanceType<typeof ToggleStub>>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    wrapper = mount(TestWrapper, { global: { stubs } })
+  })
+
+  BddTest().when('the component is mounted', () => {
+    BddTest().then('it should render the toggle', () => {
+      expect(getToggle().exists()).toBe(true)
+    })
+
+    BddTest().then('it should have the toggle enabled by default', () => {
+      expect(getToggle().props('modelValue')).toBe(true)
+    })
+  })
+
+  BddTest().when('the toggle is disabled', () => {
+    beforeEach(async () => {
+      await getToggle().find('input').setValue(false)
+    })
+
+    BddTest().then('it should set the toggle to unchecked', async () => {
+      await vi.waitFor(() => expect(getToggle().props('modelValue')).toBe(false))
+    })
+  })
+
+  BddTest().when('the toggle is enabled after being disabled', () => {
+    beforeEach(async () => {
+      await getToggle().find('input').setValue(false)
+      await getToggle().find('input').setValue(true)
+    })
+
+    BddTest().then('it should set the toggle back to checked', async () => {
+      await vi.waitFor(() => expect(getToggle().props('modelValue')).toBe(true))
+    })
+  })
+})

--- a/src/features/staff/activities/components/interactions/formFields/ActivityReflectionFormField/ActivityReflectionFormField.vue
+++ b/src/features/staff/activities/components/interactions/formFields/ActivityReflectionFormField/ActivityReflectionFormField.vue
@@ -1,0 +1,55 @@
+<script setup lang="ts">
+import type { ActivityDraftUpdateRequest } from '@/api/avenir-esr'
+import type { EditActivityForm } from '@/features/staff/activities/types/forms.types'
+import { ACTIVITY_AUTO_SAVE_DEBOUNCE, ACTIVITY_TRACE_SETTING_DISABLED_VALUE } from '@/features/staff/activities/config'
+import ToggleParameterCard from '@/features/staff/global/components/cards/ToggleParameterCard/ToggleParameterCard.vue'
+import { MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
+import { debounce } from 'lodash-es'
+import { useI18n } from 'vue-i18n'
+
+interface ActivityReflectionFormFieldProps {
+  form: EditActivityForm
+}
+
+defineOptions({ inheritAttrs: false })
+
+const { form } = defineProps<ActivityReflectionFormFieldProps>()
+
+const emit = defineEmits<{
+  autosave: [value: ActivityDraftUpdateRequest]
+}>()
+
+const { t } = useI18n()
+
+const reflectionField = form.useField({ name: 'enableReflection' })
+const isFormDirty = form.useStore(state => state.isDirty)
+
+const debouncedAutosave = debounce((data: ActivityDraftUpdateRequest) => {
+  if (isFormDirty.value) {
+    emit('autosave', data)
+  }
+}, ACTIVITY_AUTO_SAVE_DEBOUNCE)
+
+const inputEnabled = computed({
+  get: () => reflectionField.state.value.value !== false,
+  set: (newValue: boolean) => {
+    form.setFieldValue('enableReflection', newValue)
+    const autosaveData: ActivityDraftUpdateRequest = { enableReflection: newValue }
+    if (!newValue) {
+      form.setFieldValue('traceAllowedAssociations', ACTIVITY_TRACE_SETTING_DISABLED_VALUE)
+      autosaveData.traceAllowedAssociations = ACTIVITY_TRACE_SETTING_DISABLED_VALUE
+    }
+    debouncedAutosave(autosaveData)
+  },
+})
+</script>
+
+<template>
+  <ToggleParameterCard
+    v-model="inputEnabled"
+    :title="t('staff.activities.views.EditNationalActivityView.ActivityReflectionFormField.title')"
+    :icon="MDI_ICONS.TEXT_BOX_EDIT_OUTLINE"
+  >
+    <span class="b2-regular av-text-text1">{{ t('staff.activities.views.EditNationalActivityView.ActivityReflectionFormField.description') }}</span>
+  </ToggleParameterCard>
+</template>

--- a/src/features/staff/activities/components/interactions/formFields/ActivityTraceFormField/ActivityTraceFormField.vue
+++ b/src/features/staff/activities/components/interactions/formFields/ActivityTraceFormField/ActivityTraceFormField.vue
@@ -26,7 +26,10 @@ const emit = defineEmits<{
 const { t } = useI18n()
 
 const traceField = form.useField({ name: 'traceAllowedAssociations' })
+const reflectionField = form.useField({ name: 'enableReflection' })
 const isFormDirty = form.useStore(state => state.isDirty)
+
+const isDisabled = computed(() => reflectionField.state.value.value === false)
 
 const debouncedAutosave = debounce((value: number | undefined) => {
   if (isFormDirty.value) {
@@ -49,6 +52,7 @@ const inputEnabled = computed({
     v-model="inputEnabled"
     :title="t('staff.activities.views.EditNationalActivityView.ActivityTraceFormField.title')"
     :icon="MDI_ICONS.ATTACH_FILE"
+    :disabled="isDisabled"
   >
     <span class="b2-regular av-text-text1">{{ t('staff.activities.views.EditNationalActivityView.ActivityTraceFormField.description') }}</span>
   </ToggleParameterCard>

--- a/src/features/staff/activities/locales/en.json
+++ b/src/features/staff/activities/locales/en.json
@@ -71,6 +71,10 @@
           "ActivityPublicationTab": {
             "title": "Prepare publication"
           },
+          "ActivityReflectionFormField": {
+            "description": "When this setting is enabled, learners can write a reflection and associate elements as part of their activity. By keeping the feedback request setting enabled, you will be able to view their reflections when they submit their activities for feedback.",
+            "title": "Reflection"
+          },
           "ActivitySummaryFormField": {
             "placeholder": "Write a short description here that gives a glimpse of the activity and makes people want to sign up."
           },

--- a/src/features/staff/activities/locales/fr.json
+++ b/src/features/staff/activities/locales/fr.json
@@ -71,6 +71,10 @@
           "ActivityPublicationTab": {
             "title": "Préparer la publication"
           },
+          "ActivityReflectionFormField": {
+            "description": "Lorsque le paramètre est activé, les apprenants peuvent rédiger une prise de recul et associer des éléments dans le cadre de leur activité. En conservant le paramètre de demande de feedback, vous pourrez visualiser les prise de recul lorsqu'ils enverront leurs activités pour feedback.",
+            "title": "Prise de recul"
+          },
           "ActivitySummaryFormField": {
             "placeholder": "Rédiger ici un texte court qui permet d'avoir un aperçu de l'activité et donne envie de s'y inscrire."
           },

--- a/src/features/staff/activities/types/forms.types.ts
+++ b/src/features/staff/activities/types/forms.types.ts
@@ -6,6 +6,7 @@ export interface ActivityDraftCreationFormData {
 
 export interface EditActivityFormData extends ActivityDraftCreationFormData {
   description: string
+  enableReflection?: boolean
   executionPeriodInfo: string
   feedbackAllowedIterations?: number
   summary: string

--- a/src/features/staff/activities/views/EditNationalActivityView/EditNationalActivityView.stub.ts
+++ b/src/features/staff/activities/views/EditNationalActivityView/EditNationalActivityView.stub.ts
@@ -20,6 +20,7 @@ export const EditNationalActivityViewFormWrapper = defineComponent({
     const defaultValues: EditActivityFormData = {
       title: 'Test activity',
       description: '',
+      enableReflection: true,
       executionPeriodInfo: '',
       feedbackAllowedIterations: undefined,
       summary: '',
@@ -42,6 +43,7 @@ export const EditNationalActivityViewFormWrapperDirty = defineComponent({
     const defaultValues: EditActivityFormData = {
       title: '',
       description: '',
+      enableReflection: true,
       executionPeriodInfo: '',
       feedbackAllowedIterations: undefined,
       summary: '',

--- a/src/features/staff/activities/views/EditNationalActivityView/EditNationalActivityView.vue
+++ b/src/features/staff/activities/views/EditNationalActivityView/EditNationalActivityView.vue
@@ -55,6 +55,7 @@ const defaultValues: EditActivityFormData = reactive({
   description: computed(() => activity.value?.description ?? ''),
   executionPeriodInfo: computed(() => activity.value?.executionPeriodInfo ?? ''),
   feedbackAllowedIterations: computed(() => activity.value?.feedbackAllowedIterations ?? undefined),
+  traceAllowedAssociations: computed(() => activity.value?.traceAllowedAssociations ?? ACTIVITY_TRACE_SETTING_INFINITY_VALUE),
   summary: computed(() => activity.value?.summary ?? ''),
   title: computed(() => activity.value?.title ?? ''),
   traceAllowedAssociations: computed(() => activity.value?.traceAllowedAssociations ?? ACTIVITY_TRACE_SETTING_INFINITY_VALUE),

--- a/src/features/staff/activities/views/EditNationalActivityView/EditNationalActivityView.vue
+++ b/src/features/staff/activities/views/EditNationalActivityView/EditNationalActivityView.vue
@@ -52,12 +52,12 @@ const breadcrumbLinks = computed(() => [
 const { data: activity, isLoading, error } = useGetActivityContent(EActivityStatus.DRAFT, id)
 
 const defaultValues: EditActivityFormData = reactive({
+  title: computed(() => activity.value?.title ?? ''),
   description: computed(() => activity.value?.description ?? ''),
   executionPeriodInfo: computed(() => activity.value?.executionPeriodInfo ?? ''),
-  feedbackAllowedIterations: computed(() => activity.value?.feedbackAllowedIterations ?? undefined),
-  traceAllowedAssociations: computed(() => activity.value?.traceAllowedAssociations ?? ACTIVITY_TRACE_SETTING_INFINITY_VALUE),
   summary: computed(() => activity.value?.summary ?? ''),
-  title: computed(() => activity.value?.title ?? ''),
+  enableReflection: computed(() => activity.value?.enableReflection ?? true),
+  feedbackAllowedIterations: computed(() => activity.value?.feedbackAllowedIterations ?? undefined),
   traceAllowedAssociations: computed(() => activity.value?.traceAllowedAssociations ?? ACTIVITY_TRACE_SETTING_INFINITY_VALUE),
 })
 
@@ -83,8 +83,9 @@ const form = useForm({
         title: value.title,
         description: value.description,
         executionPeriodInfo: value.executionPeriodInfo,
-        feedbackAllowedIterations: value.feedbackAllowedIterations ?? 0,
         summary: value.summary,
+        enableReflection: value.enableReflection ?? true,
+        feedbackAllowedIterations: value.feedbackAllowedIterations ?? 0,
         traceAllowedAssociations: value.traceAllowedAssociations,
       },
     })

--- a/src/features/staff/activities/views/EditNationalActivityView/components/ActivityContentTab/ActivityContentTab.test.ts
+++ b/src/features/staff/activities/views/EditNationalActivityView/components/ActivityContentTab/ActivityContentTab.test.ts
@@ -1,6 +1,7 @@
 import { mockedActivityContent } from '@/__mocks__/fixtures/staffs/activities.fixtures'
 import { ActivityConsignFormFieldStub } from '@/features/staff/activities/components/interactions/formFields/ActivityConsignFormField/ActivityConsignFormField.stub'
 import { ActivityFeedbackFormFieldStub } from '@/features/staff/activities/components/interactions/formFields/ActivityFeedbackFormField/ActivityFeedbackFormField.stub'
+import { ActivityReflectionFormFieldStub } from '@/features/staff/activities/components/interactions/formFields/ActivityReflectionFormField/ActivityReflectionFormField.stub'
 import { ActivityTitleFormFieldStub } from '@/features/staff/activities/components/interactions/formFields/ActivityTitleFormField/ActivityTitleFormField.stub'
 import { ActivityTraceFormFieldStub } from '@/features/staff/activities/components/interactions/formFields/ActivityTraceFormField/ActivityTraceFormField.stub'
 import { ContentSectionId } from '@/features/staff/activities/editActivity.constants'
@@ -20,6 +21,7 @@ BddTest().given('an ActivityContentTab component', () => {
   const stubs = {
     ActivityConsignFormField: ActivityConsignFormFieldStub,
     ActivityFeedbackFormField: ActivityFeedbackFormFieldStub,
+    ActivityReflectionFormField: ActivityReflectionFormFieldStub,
     ActivityTitleFormField: ActivityTitleFormFieldStub,
     ActivityTraceFormField: ActivityTraceFormFieldStub,
     EditNationalActivityViewTabActions: EditNationalActivityViewTabActionsStub,
@@ -61,6 +63,10 @@ BddTest().given('an ActivityContentTab component', () => {
 
     BddTest().then('it should render ActivityFeedbackFormField', () => {
       expect(tab.findComponent({ name: 'ActivityFeedbackFormField' }).exists()).toBe(true)
+    })
+
+    BddTest().then('it should render ActivityReflectionFormField', () => {
+      expect(tab.findComponent({ name: 'ActivityReflectionFormField' }).exists()).toBe(true)
     })
 
     BddTest().then('it should render ActivityTraceFormField', () => {

--- a/src/features/staff/activities/views/EditNationalActivityView/components/ActivityContentTab/ActivityContentTab.vue
+++ b/src/features/staff/activities/views/EditNationalActivityView/components/ActivityContentTab/ActivityContentTab.vue
@@ -5,6 +5,7 @@ import ActivityConsignFormField from '@/features/staff/activities/components/int
 import ActivityExecutionPeriodFormField
   from '@/features/staff/activities/components/interactions/formFields/ActivityExecutionPeriodFormField/ActivityExecutionPeriodFormField.vue'
 import ActivityFeedbackFormField from '@/features/staff/activities/components/interactions/formFields/ActivityFeedbackFormField/ActivityFeedbackFormField.vue'
+import ActivityReflectionFormField from '@/features/staff/activities/components/interactions/formFields/ActivityReflectionFormField/ActivityReflectionFormField.vue'
 import ActivityTitleFormField from '@/features/staff/activities/components/interactions/formFields/ActivityTitleFormField/ActivityTitleFormField.vue'
 import ActivityTraceFormField from '@/features/staff/activities/components/interactions/formFields/ActivityTraceFormField/ActivityTraceFormField.vue'
 import { ContentSectionId } from '@/features/staff/activities/editActivity.constants'
@@ -66,6 +67,10 @@ const { t } = useI18n()
         :title="t('staff.activities.views.AddNationalActivityView.sideNavigation.content.MODALITIES')"
         :title-icon="MDI_ICONS.SETTINGS"
       >
+        <ActivityReflectionFormField
+          :form="form"
+          @autosave="save"
+        />
         <ActivityTraceFormField
           :form="form"
           @autosave="save"

--- a/src/features/staff/global/components/cards/ToggleParameterCard/ToggleParameterCard.stub.ts
+++ b/src/features/staff/global/components/cards/ToggleParameterCard/ToggleParameterCard.stub.ts
@@ -1,5 +1,5 @@
 export const ToggleParameterCardStub = defineComponent({
   name: 'ToggleParameterCard',
-  props: ['title', 'icon'],
+  props: ['title', 'icon', 'disabled'],
   template: '<div class="toggle-parameter-card" />',
 })

--- a/src/features/staff/global/components/cards/ToggleParameterCard/ToggleParameterCard.vue
+++ b/src/features/staff/global/components/cards/ToggleParameterCard/ToggleParameterCard.vue
@@ -6,9 +6,10 @@ import FormFieldCardContainer from '@/features/staff/global/components/cards/For
 export interface ToggleParameterCardProps {
   title: string
   icon: string
+  disabled?: boolean
 }
 
-defineProps<ToggleParameterCardProps>()
+const { title, icon, disabled = false } = defineProps<ToggleParameterCardProps>()
 defineSlots<{
   default?: Slot
 }>()
@@ -27,6 +28,7 @@ const model = defineModel<boolean>({ default: true })
       <Toggle
         v-model="model"
         description=""
+        :disabled="disabled"
       />
     </template>
 


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
This PR introduces the activity reflection setting feature, adding a new form field component for managing activity reflection parameters. The implementation includes the ActivityReflectionFormField component with full test coverage, TypeScript types, and internationalization support for both English and French locales.

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1525

---

### Documentation
- Added new ActivityReflectionFormField component with test and stub files
- Updated form types to include reflection field support
- Added i18n translations in both en.json and fr.json locales under activities feature
- Updated ActivityTraceFormField with reflection parameter support

---

### Target Branch
`develop`

---

### Additional Notes
- New form field follows project patterns with proper TypeScript typing
- Component includes both unit tests and a stub file for testing parent components
- All i18n keys are properly organized and alphabetically ordered
- Updates to EditNationalActivityView and ActivityContentTab ensure proper integration

---

### Known Limitations or Side Effects
None identified.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [x] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [x] i18n handled (texts are translated)
- [x] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [x] Semantic Versioning respected
- [x] Add to `CHANGELOG.md` file all properties and database change and detaiils for the update process