### PR TITLE
feat(1543): hide my perspective section when reflection is disabled

### DIFF
--- a/src/__mocks__/fixtures/student/activities.fixtures.ts
+++ b/src/__mocks__/fixtures/student/activities.fixtures.ts
@@ -355,6 +355,7 @@ export function createMockedDeclaredActivityDetails (id: string): DeclaredActivi
       id: activity.id ?? mockedDeclaredActivityDetails.activity.id,
       title: activity.title ?? mockedDeclaredActivityDetails.activity.title,
       summary: activity.summary ?? mockedDeclaredActivityDetails.activity.summary,
+      enableReflection: true,
       executionPeriodInfo: activity.executionPeriodInfo ?? mockedDeclaredActivityDetails.activity.executionPeriodInfo,
       createdAt: activity.createdAt ?? mockedDeclaredActivityDetails.activity.createdAt,
       updatedAt: activity.updatedAt ?? mockedDeclaredActivityDetails.activity.updatedAt,

--- a/src/common/components/SectionNavigationLayout/SectionNavigationLayout.stub.ts
+++ b/src/common/components/SectionNavigationLayout/SectionNavigationLayout.stub.ts
@@ -1,14 +1,44 @@
+import type {
+  SectionNavigationItem,
+} from '@/common/components/SectionNavigationLayout/SectionNavigationLayout.types'
+import type { Component, PropType } from 'vue'
+
 export const SectionNavigationLayoutStub = defineComponent({
   name: 'SectionNavigationLayout',
-  props: [
-    'items',
-    'defaultSection',
-    'componentBySection',
-    'propsBySection',
-    'sideNavigationWidth',
-    'selectPlaceholder',
-    'selectLabel',
-  ],
+  props: {
+    items: {
+      type: Array as PropType<SectionNavigationItem[]>,
+      required: true,
+    },
+    defaultSection: {
+      type: String,
+      required: true,
+    },
+    componentBySection: {
+      type: Object as PropType<Record<string, Component>>,
+      required: true,
+    },
+    propsBySection: {
+      type: Object as PropType<Record<string, Record<string, unknown>>>,
+      required: false,
+    },
+    sideNavigationWidth: {
+      type: String,
+      required: false,
+    },
+    selectPlaceholder: {
+      type: String,
+      required: true,
+    },
+    selectLabel: {
+      type: String,
+      required: false,
+    },
+    isLoading: {
+      type: Boolean,
+      required: false,
+    },
+  },
   template: `
     <div data-testid="section-navigation-layout" />
   `,

--- a/src/features/staff/activities/views/EditNationalActivityView/components/ActivityContentTab/ActivityContentTab.vue
+++ b/src/features/staff/activities/views/EditNationalActivityView/components/ActivityContentTab/ActivityContentTab.vue
@@ -66,6 +66,7 @@ const { t } = useI18n()
       <FormFieldCardContainer
         :title="t('staff.activities.views.AddNationalActivityView.sideNavigation.content.MODALITIES')"
         :title-icon="MDI_ICONS.SETTINGS"
+        collapsible
       >
         <ActivityReflectionFormField
           :form="form"

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/ProjectActivityDetailedLayout/ProjectActivityDetailedLayout.test.ts
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/ProjectActivityDetailedLayout/ProjectActivityDetailedLayout.test.ts
@@ -1,4 +1,7 @@
 import type { DeclaredActivityDetailsDTO } from '@/api/avenir-esr'
+import type {
+  SectionNavigationItem,
+} from '@/common/components/SectionNavigationLayout/SectionNavigationLayout.types'
 import {
   EActivityThematic,
   EDeclaredActivityStatus,
@@ -49,6 +52,7 @@ BddTest().given('a project activity detailed layout component', () => {
       executionPeriodInfo: '- Première période\n- Deuxième période',
       createdAt: '2025-01-01T10:00:00Z',
       updatedAt: '2025-01-02T10:00:00Z',
+      enableReflection: true,
     },
   }
 
@@ -123,7 +127,7 @@ BddTest().given('a project activity detailed layout component', () => {
 
     BddTest().then('it should pass the declared activity details in props by section', () => {
       const sectionNavigationLayout = wrapper.findComponent(SectionNavigationLayoutStub)
-      const propsBySection = sectionNavigationLayout.props('propsBySection') as Record<string, Record<string, unknown>>
+      const propsBySection = sectionNavigationLayout.props('propsBySection')
 
       expect(sectionNavigationLayout.exists()).toBe(true)
       expect(propsBySection).toEqual({
@@ -159,7 +163,7 @@ BddTest().given('a project activity detailed layout component', () => {
 
     BddTest().then('it should use the global detail label for the activity detailed item', () => {
       const sectionNavigationLayout = wrapper.findComponent(SectionNavigationLayoutStub)
-      const items = sectionNavigationLayout.props('items') as Array<Record<string, string>>
+      const items = sectionNavigationLayout.props('items') as SectionNavigationItem[]
 
       expect(sectionNavigationLayout.exists()).toBe(true)
       expect(items[0]).toEqual({
@@ -167,6 +171,37 @@ BddTest().given('a project activity detailed layout component', () => {
         label: 'Détail',
         icon: ICONS.ACTIVITY,
       })
+    })
+  })
+
+  BddTest().when('reflection is disabled', () => {
+    beforeEach(async () => {
+      wrapper = mountComponent(ProjectActivityDetailedLayout, {
+        props: {
+          declaredActivityDetails: {
+            ...declaredActivityDetails,
+            activity: {
+              ...declaredActivityDetails.activity,
+              enableReflection: false,
+            },
+          },
+        },
+        global: {
+          stubs,
+        },
+      })
+
+      await flushPromises()
+    })
+
+    BddTest().then('it should not include the my perspective section in navigation items', () => {
+      const sectionNavigationLayout = wrapper.findComponent(SectionNavigationLayoutStub)
+      const items = sectionNavigationLayout.props('items')
+
+      expect(sectionNavigationLayout.exists()).toBe(true)
+      expect(items).toHaveLength(1)
+      expect(items[0].id).toBe(ACTIVITY_DETAILED_SECTIONS.ACTIVITY_DETAILED)
+      expect(items.some(item => item.id === ACTIVITY_DETAILED_SECTIONS.MY_PERSPECTIVE)).toBe(false)
     })
   })
 })

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/ProjectActivityDetailedLayout/ProjectActivityDetailedLayout.vue
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/ProjectActivityDetailedLayout/ProjectActivityDetailedLayout.vue
@@ -21,17 +21,23 @@ const { declaredActivityDetails } = defineProps<ProjectActivityDetailedLayoutPro
 
 const { t } = useI18n()
 
+const reflectionEnabled = computed(() => declaredActivityDetails.activity.enableReflection)
+
 const items = computed(() => [
   {
     id: ACTIVITY_DETAILED_SECTIONS.ACTIVITY_DETAILED,
     label: declaredActivityDetails.activity.title || t('global.detail'),
     icon: ICONS.ACTIVITY,
   },
-  {
-    id: ACTIVITY_DETAILED_SECTIONS.MY_PERSPECTIVE,
-    label: t('student.buildProject.activities.views.ProjectActivityDetailedView.ActivityDetailedSideNavigation.myPerspective'),
-    icon: MS_ICONS.FEATURED_PLAY_LIST_OUTLINE,
-  },
+  ...(reflectionEnabled.value
+    ? [
+        {
+          id: ACTIVITY_DETAILED_SECTIONS.MY_PERSPECTIVE,
+          label: t('student.buildProject.activities.views.ProjectActivityDetailedView.ActivityDetailedSideNavigation.myPerspective'),
+          icon: MS_ICONS.FEATURED_PLAY_LIST_OUTLINE,
+        }
+      ]
+    : [])
 ])
 
 const componentBySection = {


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
This PR implements the conditional hiding of the "My Perspective" (reflection) section in the Activity Detailed view based on the `enableReflection` parameter. When reflection is disabled by the backend, the navigation item and section are completely hidden from the learner's view.

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1543

---

### Documentation
- Updated ProjectActivityDetailedLayout component to conditionally include MY_PERSPECTIVE based on enableReflection flag
- Added proper TypeScript typing to SectionNavigationLayout stub using PropType
- Enhanced test coverage with new test case for disabled reflection scenario

---

### Target Branch
`develop`

---

### Additional Notes
- The implementation checks the `enableReflection` property from `declaredActivityDetails.activity`
- When disabled, the MY_PERSPECTIVE section is completely removed from the navigation items array
- Stub component now properly typed with Vue's PropType for better type safety
- Test fixture updated to include the enableReflection property for accurate testing

---

### Known Limitations or Side Effects
None identified.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [x] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [x] i18n handled (texts are translated)
- [x] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [x] Semantic Versioning respected
- [x] Add to `CHANGELOG.md` file all properties and database change and detaiils for the update process