### PR TITLE
fix(1685): remove status column from staff all activities tab

### DIFF
--- a/src/features/staff/activities/views/ActivitiesView/components/StaffAllActivitiesTab/StaffAllActivitiesTab.test.ts
+++ b/src/features/staff/activities/views/ActivitiesView/components/StaffAllActivitiesTab/StaffAllActivitiesTab.test.ts
@@ -36,7 +36,6 @@ BddTest().given('a StaffAllActivitiesTab component', () => {
       expect(activitiesTab.exists()).toBe(true)
       expect(activitiesTab.props('title')).toBe('Toutes les activités publiées dans mon établissement (0)')
       expect(activitiesTab.props('emptyStateMessage')).toBe('Aucune activité pour le moment.')
-      expect(activitiesTab.props('withStatus')).toBe(true)
 
       expect(params.currentPageRef.value).toBe(0)
       expect(params.pageSizeRef.value).toBe(PageSizes.TWELVE)

--- a/src/features/staff/activities/views/ActivitiesView/components/StaffAllActivitiesTab/StaffAllActivitiesTab.vue
+++ b/src/features/staff/activities/views/ActivitiesView/components/StaffAllActivitiesTab/StaffAllActivitiesTab.vue
@@ -21,7 +21,6 @@ const usePaginatedStaffActivitesParams = {
     :title="t('staff.activities.views.ActivitiesView.StaffAllActivitiesTab.title', { count: totalActivities })"
     :empty-state-message="t('staff.activities.views.ActivitiesView.StaffAllActivitiesTab.emptyState')"
     :use-paginated-staff-activites-params="usePaginatedStaffActivitesParams"
-    with-status
     @update-activities-count="totalActivities = $event"
   />
 </template>


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
- Removed `with-status` from `StaffAllActivitiesTab`

---

### Reference to an Issue, Feature, Task, User Story or another PR
- Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1685

---

**Modified areas:**
- `src/features/staff/activities/views/ActivitiesView/components/StaffAllActivitiesTab/StaffAllActivitiesTab.test.ts`
- `src/features/staff/activities/views/ActivitiesView/components/StaffAllActivitiesTab/StaffAllActivitiesTab.vue`

---

### Target Branch
`develop`

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process