### PR TITLE
fix(1688): collapse instruction section by default on activity creation

### DIFF
--- a/src/features/staff/activities/views/EditNationalActivityView/components/ActivityContentTab/ActivityContentTab.test.ts
+++ b/src/features/staff/activities/views/EditNationalActivityView/components/ActivityContentTab/ActivityContentTab.test.ts
@@ -61,6 +61,13 @@ BddTest().given('an ActivityContentTab component', () => {
       expect(tab.find(`#${ContentSectionId.INSTRUCTIONS}`).exists()).toBe(true)
     })
 
+    BddTest().then('it should render the INSTRUCTIONS FormFieldCardContainer as collapsible and collapsed', () => {
+      const instructionsSection = tab.find(`#${ContentSectionId.INSTRUCTIONS}`)
+      const cardContainer = instructionsSection.findComponent({ name: 'FormFieldCardContainer' })
+      expect(cardContainer.props('collapsible')).toBeDefined()
+      expect(cardContainer.props('collapsed')).toBeDefined()
+    })
+
     BddTest().then('it should render ActivityExecutionPeriodFormField', () => {
       expect(tab.findComponent({ name: 'ActivityExecutionPeriodFormField' }).exists()).toBe(true)
     })

--- a/src/features/staff/activities/views/EditNationalActivityView/components/ActivityContentTab/ActivityContentTab.vue
+++ b/src/features/staff/activities/views/EditNationalActivityView/components/ActivityContentTab/ActivityContentTab.vue
@@ -61,6 +61,8 @@ const isFormDirty = form.useStore(state => state.isDirty)
       <FormFieldCardContainer
         :title="t('staff.activities.views.AddNationalActivityView.sideNavigation.content.INSTRUCTIONS')"
         :title-icon="MDI_ICONS.TEXT_BOX_EDIT_OUTLINE"
+        collapsible
+        collapsed
       >
         <ActivityConsignFormField
           :form="form"


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
Fix the "Consigne" accordion section in the national activity creation form so that it is collapsed by default, as specified in the acceptance criteria.

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1688

### Target Branch
develop

### Additional Notes
- Added `collapsible` and `collapsed` props to the `FormFieldCardContainer` wrapping `ActivityConsignFormField` in `ActivityContentTab`
- Added unit test to verify the INSTRUCTIONS section renders as collapsible and collapsed by default

## ✅ Checklist
- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [ ] No unnecessary code (e.g., debug logs, commented code)
- [ ] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process