### PR TITLE
fix(1569): SF category - update i18n keys

### DIFF
--- a/src/features/student/selfKnowledge/locales/en.json
+++ b/src/features/student/selfKnowledge/locales/en.json
@@ -3,10 +3,10 @@
     "selfKnowledge": {
       "categoryType": {
         "ASPIRATIONS": "aspiration | aspirations",
-        "IMPROVEMENT_AREAS": "area for improvement | areas for improvement",
+        "IMPROVEMENT": "area for improvement | areas for improvement",
         "INSPIRATIONS": "inspiration | inspirations",
         "INTERESTS": "interest | interests",
-        "MOTIVATIONS": "professional motivation | professional motivations",
+        "MOTIVATION": "professional motivation | professional motivations",
         "OBLIGATIONS": "obligation | obligations",
         "STRENGTHS": "strength | strengths",
         "TESTIMONIALS": "testimonial | testimonials",

--- a/src/features/student/selfKnowledge/locales/fr.json
+++ b/src/features/student/selfKnowledge/locales/fr.json
@@ -3,10 +3,10 @@
     "selfKnowledge": {
       "categoryType": {
         "ASPIRATIONS": "envie | envies",
-        "IMPROVEMENT_AREAS": "axe d'amélioration | axes d'amélioration",
+        "IMPROVEMENT": "axe d'amélioration | axes d'amélioration",
         "INSPIRATIONS": "inspiration | inspirations",
         "INTERESTS": "centre d'intérêt | centres d'intérêt",
-        "MOTIVATIONS": "motivation professionnelle | motivations professionnelles",
+        "MOTIVATION": "motivation professionnelle | motivations professionnelles",
         "OBLIGATIONS": "obligation | obligations",
         "STRENGTHS": "point fort | points forts",
         "TESTIMONIALS": "témoignage | témoignages",


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
This PR updates self-knowledge category translation keys in both French and English locale files to align labels with the expected i18n naming.

**Main changes:**
- 🐛 Fixes i18n key mapping for self-knowledge category labels
- 🌐 Updates locale entries in French and English

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1569

---

### Documentation
- Locale resources were updated in self-knowledge translation files.
- No additional configuration or migration is required.

**Modified files:**
- `src/features/student/selfKnowledge/locales/en.json`
- `src/features/student/selfKnowledge/locales/fr.json`

---

### Target Branch
`develop`

---

### Additional Notes
This change is intentionally minimal and limited to translation key corrections to avoid behavioral side effects.

---

### Known Limitations or Side Effects
No known limitations or side effects.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [ ] No unnecessary code (e.g., debug logs, commented code)
- [ ] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process
