### PR TITLE
test(1574): add e2e tests for us 1146 activity thematic

### DIFF
--- a/e2e/framework/staff/activities/StaffEditNationalActivityPage.ts
+++ b/e2e/framework/staff/activities/StaffEditNationalActivityPage.ts
@@ -138,6 +138,11 @@ class StaffEditNationalActivityPage extends BasePage {
     await this.sideNav().verifyHidden()
   }
 
+  @Then('the thematic select field is visible')
+  async verifyThematicSelectVisible () {
+    await this.tabs().verifyThematicSelectVisible()
+  }
+
   @Then('the context of realization section is collapsed by default')
   async verifyContextSectionCollapsedByDefault () {
     await this.tabs().verifyContextSectionCollapsed()

--- a/e2e/framework/staff/activities/componentObjects/EditActivityTabs.ts
+++ b/e2e/framework/staff/activities/componentObjects/EditActivityTabs.ts
@@ -8,6 +8,10 @@ export class EditActivityTabs {
     return this.page.getByTestId('add-national-activity-tabs')
   }
 
+  private getThematicSelect () {
+    return this.page.getByTestId('thematic-select-form-field')
+  }
+
   private getActivityConsignFormField () {
     return this.page.getByTestId('activity-consign-form-field')
   }
@@ -72,6 +76,10 @@ export class EditActivityTabs {
   async verifyPublicationTabActive () {
     await expect(this.getPublicationTab()).toHaveAttribute('aria-selected', 'true')
     await expect(this.getPublicationTabPanel()).toBeVisible()
+  }
+
+  async verifyThematicSelectVisible () {
+    await expect(this.getThematicSelect()).toBeVisible()
   }
 
   async verifyReflectionToggleVisible () {

--- a/e2e/tests/staff/activities/edit-national-activity.feature
+++ b/e2e/tests/staff/activities/edit-national-activity.feature
@@ -102,6 +102,10 @@ Feature: Staff Edit National Activity Page
   Rule: Content tab elements
 
     @high
+    Scenario: The thematic select field is visible in the content tab
+      Then the thematic select field is visible
+
+    @high
     Scenario: The context of realization section is collapsed by default in the content tab
       Then the context of realization section is collapsed by default
   

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "avenirs-cofolio-client",
       "version": "0.0.0",
       "dependencies": {
-        "@avenirs-esr/avenirs-dsav": "^0.1.219",
+        "@avenirs-esr/avenirs-dsav": "^0.1.221",
         "@tanstack/vue-form": "^1.15.0",
         "@tanstack/vue-query": "^5.74.9",
         "@vue-flow/core": "^1.48.0",
@@ -348,9 +348,9 @@
       "license": "ISC"
     },
     "node_modules/@avenirs-esr/avenirs-dsav": {
-      "version": "0.1.219",
-      "resolved": "https://registry.npmjs.org/@avenirs-esr/avenirs-dsav/-/avenirs-dsav-0.1.219.tgz",
-      "integrity": "sha512-A9Cu5kuRIzQp+7unQL+GoIEiowy0K7RwDmztsVKupDEcke/chW20B+w0+1BkL2LVv6H1LuTDfLudlrBrp7d0YA==",
+      "version": "0.1.221",
+      "resolved": "https://registry.npmjs.org/@avenirs-esr/avenirs-dsav/-/avenirs-dsav-0.1.221.tgz",
+      "integrity": "sha512-6MadxNnnXDgwq4N0dpuyTt1sfN5cyH7Y7amSBJJeqieEYFn3VSRSMKeX84KcoCj6WHs/s73Xe6y7ALFLLuZG6A==",
       "dependencies": {
         "@tanstack/vue-table": "^8.21.3",
         "@tiptap/extension-character-count": "^3.20.2",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
-    "@avenirs-esr/avenirs-dsav": "^0.1.219",
+    "@avenirs-esr/avenirs-dsav": "^0.1.221",
     "@tanstack/vue-form": "^1.15.0",
     "@tanstack/vue-query": "^5.74.9",
     "@vue-flow/core": "^1.48.0",

--- a/src/features/staff/activities/locales/fr.json
+++ b/src/features/staff/activities/locales/fr.json
@@ -13,11 +13,11 @@
         "inputs": {
           "ActivityTitleInput": {
             "label": "Titre de l'activité"
-          },
-          "ThematicSelect": {
-            "label": "Thématique",
-            "placeholder": "Choisir une thématique"
           }
+        },
+        "ThematicSelect": {
+          "label": "Thématique",
+          "placeholder": "Choisir une thématique"
         }
       },
       "views": {

--- a/src/features/staff/activities/views/ActivitiesView/components/tabs/NationalActivityContentTab/interactions/formFields/ThematicSelectFormField/ThematicSelectFormField.vue
+++ b/src/features/staff/activities/views/ActivitiesView/components/tabs/NationalActivityContentTab/interactions/formFields/ThematicSelectFormField/ThematicSelectFormField.vue
@@ -48,6 +48,7 @@ function onUpdateThematic (
     <template #default="{ field }">
       <ThematicSelect
         v-bind="$attrs"
+        data-testid="thematic-select-form-field"
         :model-value="{
           itemId: field.state.value as EActivityThematic,
         }"

--- a/src/features/staff/activities/views/ActivitiesView/components/tabs/NationalActivityContentTab/interactions/inputs/ThematicSelect/ThematicSelect.vue
+++ b/src/features/staff/activities/views/ActivitiesView/components/tabs/NationalActivityContentTab/interactions/inputs/ThematicSelect/ThematicSelect.vue
@@ -19,8 +19,8 @@ const avSelectProps = computed<AvSelectProps>(() => ({
   ...restProps,
   label:
     label
-    ?? t('staff.activities.interactions.inputs.ThematicSelect.label',),
-  placeholder: t('staff.activities.interactions.inputs.ThematicSelect.placeholder',),
+    ?? t('staff.activities.interactions.ThematicSelect.label',),
+  placeholder: t('staff.activities.interactions.ThematicSelect.placeholder',),
   prefixIcon: MDI_ICONS.BOOK_OPEN_VARIANT,
   options: options.value,
   required: true,

--- a/src/features/staff/activities/views/EditNationalActivityView/components/ActivityContentTab/ActivityContentTab.vue
+++ b/src/features/staff/activities/views/EditNationalActivityView/components/ActivityContentTab/ActivityContentTab.vue
@@ -51,7 +51,7 @@ const isFormDirty = form.useStore(state => state.isDirty)
 
     <div :id="ContentSectionId.THEMATIC">
       <FormFieldCardContainer
-        :title="`${t('staff.activities.interactions.inputs.ThematicSelect.label')} *`"
+        :title="`${t('staff.activities.interactions.ThematicSelect.label')} *`"
         :title-icon="MDI_ICONS.BOOK_OPEN_VARIANT"
       >
         <ThematicSelectFormField


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
Implement E2E tests for the thematic select field of the national activity creation form, as part of US #1146.

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1574

---

### Target Branch
develop

---

### Known Limitations or Side Effects
<!-- List any limitations, known bugs, or side effects this PR may introduce. -->

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and detaiils for the update process

