### PR TITLE
feat: Edit staff activity - add autosaves

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "avenirs-cofolio-client",
       "version": "0.0.0",
       "dependencies": {
-        "@avenirs-esr/avenirs-dsav": "^0.1.215",
+        "@avenirs-esr/avenirs-dsav": "^0.1.219",
         "@tanstack/vue-form": "^1.15.0",
         "@tanstack/vue-query": "^5.74.9",
         "@vue-flow/core": "^1.48.0",
@@ -348,9 +348,9 @@
       "license": "ISC"
     },
     "node_modules/@avenirs-esr/avenirs-dsav": {
-      "version": "0.1.215",
-      "resolved": "https://registry.npmjs.org/@avenirs-esr/avenirs-dsav/-/avenirs-dsav-0.1.215.tgz",
-      "integrity": "sha512-O4oWN0hsstWyZmuy+iw8Ve+oiXjnvNYvaGJ1n6ljcwdq7t50lQ1/N8IG7d/03Gk2r94OajCosrc7NxWPwzJdzw==",
+      "version": "0.1.219",
+      "resolved": "https://registry.npmjs.org/@avenirs-esr/avenirs-dsav/-/avenirs-dsav-0.1.219.tgz",
+      "integrity": "sha512-A9Cu5kuRIzQp+7unQL+GoIEiowy0K7RwDmztsVKupDEcke/chW20B+w0+1BkL2LVv6H1LuTDfLudlrBrp7d0YA==",
       "dependencies": {
         "@tanstack/vue-table": "^8.21.3",
         "@tiptap/extension-character-count": "^3.20.2",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
-    "@avenirs-esr/avenirs-dsav": "^0.1.215",
+    "@avenirs-esr/avenirs-dsav": "^0.1.219",
     "@tanstack/vue-form": "^1.15.0",
     "@tanstack/vue-query": "^5.74.9",
     "@vue-flow/core": "^1.48.0",

--- a/src/features/staff/activities/components/interactions/inputs/ActivityTitleInput/ActivityTitleInput.test.ts
+++ b/src/features/staff/activities/components/interactions/inputs/ActivityTitleInput/ActivityTitleInput.test.ts
@@ -38,8 +38,8 @@ BddTest().given('ActivityTitleInput component', () => {
       expect(inputStub.props('label')).toBe('Titre de l\'activité')
     })
 
-    BddTest().then('it should set labelVisible to true', () => {
-      expect(inputStub.props('labelVisible')).toBe(true)
+    BddTest().then('it should set labelVisible to false', () => {
+      expect(inputStub.props('labelVisible')).toBe(false)
     })
 
     BddTest().then('it should set required to true', () => {
@@ -121,16 +121,16 @@ BddTest().given('ActivityTitleInput component', () => {
     })
   })
 
-  BddTest().when('mounted with labelVisible set to false', () => {
+  BddTest().when('mounted with labelVisible set to true', () => {
     beforeEach(() => {
       wrapper = mount(ActivityTitleInput, {
-        props: { labelVisible: false },
+        props: { labelVisible: true },
         global: { stubs },
       })
     })
 
-    BddTest().then('it should pass labelVisible false to Input', () => {
-      expect(wrapper.findComponent(InputStub).props('labelVisible')).toBe(false)
+    BddTest().then('it should pass labelVisible true to Input', () => {
+      expect(wrapper.findComponent(InputStub).props('labelVisible')).toBe(true)
     })
   })
 

--- a/src/features/staff/activities/components/interactions/inputs/ActivityTitleInput/ActivityTitleInput.vue
+++ b/src/features/staff/activities/components/interactions/inputs/ActivityTitleInput/ActivityTitleInput.vue
@@ -8,7 +8,7 @@ type ActivityTitleInputProps = Omit<InputProps, 'maxlength'>
 
 const {
   isTextarea = false,
-  labelVisible = true,
+  labelVisible = false,
   required = true,
   id,
   label,
@@ -26,7 +26,7 @@ const inputProps = computed(() => ({
   errorMessage,
   class: isTextarea ? 'n4' : undefined,
   labelClass: isTextarea ? 's1-regular' : 'b2-light',
-  labelVisible: isTextarea ? false : labelVisible,
+  labelVisible,
   maxlength: ACTIVITY_TITLE_MAX_LENGTH,
   id: id ?? `activity-title-input-${crypto.randomUUID()}`,
   label: label ?? t('staff.activities.interactions.inputs.ActivityTitleInput.label'),

--- a/src/features/staff/activities/views/ActivitiesView/components/tabs/NationalActivityContentTab/interactions/formFields/ThematicSelectFormField/ThematicSelectFormField.stub.ts
+++ b/src/features/staff/activities/views/ActivitiesView/components/tabs/NationalActivityContentTab/interactions/formFields/ThematicSelectFormField/ThematicSelectFormField.stub.ts
@@ -1,6 +1,7 @@
 export const ThematicSelectFormFieldStub = defineComponent({
   name: 'ThematicSelectFormField',
   props: ['form'],
+  emits: ['autosave'],
   template:
     '<div data-testid="thematic-select-form-field" />',
 })

--- a/src/features/staff/activities/views/ActivitiesView/components/tabs/NationalActivityContentTab/interactions/formFields/ThematicSelectFormField/ThematicSelectFormField.vue
+++ b/src/features/staff/activities/views/ActivitiesView/components/tabs/NationalActivityContentTab/interactions/formFields/ThematicSelectFormField/ThematicSelectFormField.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
-import type { EActivityThematic } from '@/api/avenir-esr'
+import type { ActivityDraftUpdateRequest, EActivityThematic } from '@/api/avenir-esr'
 import type { EditActivityForm } from '@/features/staff/activities/types/forms.types'
+import { ACTIVITY_AUTO_SAVE_DEBOUNCE } from '@/features/staff/activities/config'
 import ThematicSelect from '@/features/staff/activities/views/ActivitiesView/components/tabs/NationalActivityContentTab/interactions/inputs/ThematicSelect/ThematicSelect.vue'
+import { debounce } from 'lodash-es'
 import { markRaw } from 'vue'
 
 interface ThematicSelectFormFieldProps {
@@ -13,16 +15,30 @@ defineOptions({
 })
 
 const { form } = defineProps<ThematicSelectFormFieldProps>()
+
+const emit = defineEmits<{
+  autosave: [value: ActivityDraftUpdateRequest]
+}>()
+
 const FormField = markRaw(form.Field)
 const thematicField = form.useField({
   name: 'thematic',
 })
+
+const isFormDirty = form.useStore(state => state.isDirty)
+
+const debouncedAutosave = debounce((value: EActivityThematic) => {
+  if (isFormDirty.value) {
+    emit('autosave', { thematic: value })
+  }
+}, ACTIVITY_AUTO_SAVE_DEBOUNCE)
 
 function onUpdateThematic (
   value: { itemId: EActivityThematic } | undefined,
 ) {
   if (value?.itemId) {
     thematicField.api.handleChange(value.itemId)
+    debouncedAutosave(value.itemId)
   }
 }
 </script>

--- a/src/features/staff/activities/views/ActivitiesView/components/tabs/NationalActivityContentTab/interactions/inputs/ThematicSelect/ThematicSelect.vue
+++ b/src/features/staff/activities/views/ActivitiesView/components/tabs/NationalActivityContentTab/interactions/inputs/ThematicSelect/ThematicSelect.vue
@@ -23,6 +23,7 @@ const avSelectProps = computed<AvSelectProps>(() => ({
   placeholder: t('staff.activities.interactions.inputs.ThematicSelect.placeholder',),
   prefixIcon: MDI_ICONS.BOOK_OPEN_VARIANT,
   options: options.value,
+  required: true,
 }))
 </script>
 

--- a/src/features/staff/activities/views/EditNationalActivityView/components/ActivityContentTab/ActivityContentTab.vue
+++ b/src/features/staff/activities/views/EditNationalActivityView/components/ActivityContentTab/ActivityContentTab.vue
@@ -39,20 +39,24 @@ const isFormDirty = form.useStore(state => state.isDirty)
   >
     <div :id="ContentSectionId.TITLE">
       <FormFieldCardContainer
-        :title="t('staff.activities.views.AddNationalActivityView.sideNavigation.content.TITLE')"
+        :title="`${t('staff.activities.interactions.inputs.ActivityTitleInput.label')} *`"
         :title-icon="ICONS.ACTIVITY"
       >
-        <ActivityTitleFormField :form="form" />
+        <ActivityTitleFormField
+          :form="form"
+          @autosave="save"
+        />
       </FormFieldCardContainer>
     </div>
 
     <div :id="ContentSectionId.THEMATIC">
       <FormFieldCardContainer
-        :title="t('staff.activities.interactions.inputs.ThematicSelect.label')"
+        :title="`${t('staff.activities.interactions.inputs.ThematicSelect.label')} *`"
         :title-icon="MDI_ICONS.BOOK_OPEN_VARIANT"
       >
         <ThematicSelectFormField
           :form="form"
+          @autosave="save"
         />
       </FormFieldCardContainer>
     </div>

--- a/src/features/staff/activities/views/EditNationalActivityView/components/ActivityPublicationTab/ActivityPublicationTab.vue
+++ b/src/features/staff/activities/views/EditNationalActivityView/components/ActivityPublicationTab/ActivityPublicationTab.vue
@@ -84,7 +84,7 @@ async function publishActivityDraft () {
   >
     <div :id="PublicationSectionId.ACTIVITY_TITLE">
       <FormFieldCardContainer
-        :title="t('staff.activities.views.AddNationalActivityView.sideNavigation.content.TITLE')"
+        :title="`${t('staff.activities.interactions.inputs.ActivityTitleInput.label')} *`"
         :title-icon="ICONS.ACTIVITY"
       >
         <ActivityTitleFormField


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
This PR adds autosave handling to the staff activity edit flow and marks the thematic field as required in the UI.

**Main changes:**
- ✨ Adds autosave emission from the thematic select form field when the value changes
- 🔧 Wires the edit activity content tab to forward autosave events to the save handler
- 💄 Marks the thematic field as required in the thematic select component

---

### Reference to an Issue, Feature, Task, User Story or another PR
No issue number could be extracted from the branch name `feat/edit-staff-activities-add-autosaves`.

---

### Documentation
- Updated the activity content tab wiring so autosave changes are sent through the existing save flow.
- Updated the thematic select UI to reflect the required field state.

**Modified files:**
- `src/features/staff/activities/views/ActivitiesView/components/tabs/NationalActivityContentTab/interactions/formFields/ThematicSelectFormField/ThematicSelectFormField.vue` - emit autosave on thematic changes
- `src/features/staff/activities/views/ActivitiesView/components/tabs/NationalActivityContentTab/interactions/inputs/ThematicSelect/ThematicSelect.vue` - mark the field as required
- `src/features/staff/activities/views/EditNationalActivityView/components/ActivityContentTab/ActivityContentTab.vue` - forward autosave events to the save handler

---

### Target Branch
`develop`

---

### Additional Notes
The autosave flow is now wired through the staff activity edit tab so thematic updates are persisted through the same save path as the other content fields.

---

### Known Limitations or Side Effects
- No issue could be linked automatically from the branch name.
- No dedicated test updates are included in this branch state.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [ ] No unnecessary code (e.g., debug logs, commented code)
- [ ] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process
