### PR TITLE
fix(1614): Traces - update form validators

### DIFF
--- a/src/features/student/traces/components/interactions/formFields/TraceAiJustificationTextareaFormField/TraceAiJustificationTextareaFormField.test.ts
+++ b/src/features/student/traces/components/interactions/formFields/TraceAiJustificationTextareaFormField/TraceAiJustificationTextareaFormField.test.ts
@@ -1,5 +1,6 @@
 import type { CreateTraceForm } from '@/features/student/traces'
 import TraceAiJustificationTextareaFormField from '@/features/student/traces/components/interactions/formFields/TraceAiJustificationTextareaFormField/TraceAiJustificationTextareaFormField.vue'
+import { TraceAiJustificationTextareaStub } from '@/features/student/traces/components/interactions/inputs/TraceAiJustificationTextarea/TraceAiJustificationTextarea.stub'
 import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { useForm } from '@tanstack/vue-form'
 import { mount, type VueWrapper } from '@vue/test-utils'
@@ -53,13 +54,10 @@ const TestWrapper = {
 BddTest().given('a trace AI justification textarea form field component', () => {
   let wrapper: VueWrapper
 
+  const getTextarea = () => wrapper.findComponent(TraceAiJustificationTextareaStub)
+
   const stubs = {
-    TraceIaJustificationTextarea: {
-      name: 'TraceIaJustificationTextarea',
-      props: ['id', 'modelValue', 'errorMessage', 'required', 'labelVisible'],
-      emits: ['blur', 'update:modelValue'],
-      template: '<div><textarea :id="id" :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" @blur="$emit(\'blur\')"></textarea><span v-if="errorMessage" class="error">{{ errorMessage }}</span></div>'
-    }
+    TraceAiJustificationTextarea: TraceAiJustificationTextareaStub
   }
 
   beforeEach(() => {
@@ -78,27 +76,27 @@ BddTest().given('a trace AI justification textarea form field component', () => 
 
   BddTest().when('the component is mounted', () => {
     BddTest().then('it should render the AI justification textarea', () => {
-      const textarea = wrapper.findComponent({ name: 'TraceIaJustificationTextarea' })
+      const textarea = getTextarea()
       expect(textarea.exists()).toBe(true)
     })
 
     BddTest().then('it should have the correct id', () => {
-      const textarea = wrapper.findComponent({ name: 'TraceIaJustificationTextarea' })
+      const textarea = getTextarea()
       expect(textarea.props('id')).toBe('ia-justification')
     })
 
     BddTest().then('it should have required prop set to true when shown', () => {
-      const textarea = wrapper.findComponent({ name: 'TraceIaJustificationTextarea' })
+      const textarea = getTextarea()
       expect(textarea.props('required')).toBe(true)
     })
 
     BddTest().then('it should have labelVisible prop passed correctly', () => {
-      const textarea = wrapper.findComponent({ name: 'TraceIaJustificationTextarea' })
+      const textarea = getTextarea()
       expect(textarea.props('labelVisible')).toBe(true)
     })
 
     BddTest().then('it should have empty initial value', () => {
-      const textarea = wrapper.findComponent({ name: 'TraceIaJustificationTextarea' })
+      const textarea = getTextarea()
       expect(textarea.props('modelValue')).toBe('')
     })
   })
@@ -117,21 +115,21 @@ BddTest().given('a trace AI justification textarea form field component', () => 
     })
 
     BddTest().then('it should not render the textarea', () => {
-      const textarea = wrapper.findComponent({ name: 'TraceIaJustificationTextarea' })
+      const textarea = getTextarea()
       expect(textarea.exists()).toBe(false)
     })
   })
 
   BddTest().when('the user types in the textarea', () => {
     BddTest().then('it should update the form field value', async () => {
-      const textarea = wrapper.findComponent({ name: 'TraceIaJustificationTextarea' })
+      const textarea = getTextarea()
       const textareaElement = textarea.find('textarea')
 
       await textareaElement.setValue('My AI justification text')
       await wrapper.vm.$nextTick()
 
       await vi.waitFor(() => {
-        const updatedTextarea = wrapper.findComponent({ name: 'TraceIaJustificationTextarea' })
+        const updatedTextarea = getTextarea()
         expect(updatedTextarea.props('modelValue')).toBe('My AI justification text')
       })
     })
@@ -139,7 +137,7 @@ BddTest().given('a trace AI justification textarea form field component', () => 
 
   BddTest().when('the user blurs the textarea', () => {
     BddTest().then('it should trigger blur handler', async () => {
-      const textarea = wrapper.findComponent({ name: 'TraceIaJustificationTextarea' })
+      const textarea = getTextarea()
       const textareaElement = textarea.find('textarea')
 
       await textareaElement.trigger('blur')
@@ -155,7 +153,7 @@ BddTest().given('a trace AI justification textarea form field component', () => 
       await wrapper.vm.$nextTick()
 
       await vi.waitFor(() => {
-        const textarea = wrapper.findComponent({ name: 'TraceIaJustificationTextarea' })
+        const textarea = getTextarea()
         expect(textarea.props('errorMessage')).toBe('Ce champ est requis')
       })
     })
@@ -174,7 +172,7 @@ BddTest().given('a trace AI justification textarea form field component', () => 
 
   BddTest().when('the form is submitted with valid value', () => {
     BddTest().then('it should not show validation error', async () => {
-      const textarea = wrapper.findComponent({ name: 'TraceIaJustificationTextarea' })
+      const textarea = getTextarea()
       const textareaElement = textarea.find('textarea')
 
       await textareaElement.setValue('Valid AI justification')
@@ -184,7 +182,7 @@ BddTest().given('a trace AI justification textarea form field component', () => 
       await wrapper.vm.$nextTick()
 
       await vi.waitFor(() => {
-        const updatedTextarea = wrapper.findComponent({ name: 'TraceIaJustificationTextarea' })
+        const updatedTextarea = getTextarea()
         expect(updatedTextarea.props('errorMessage')).toBeFalsy()
       })
     })
@@ -204,14 +202,14 @@ BddTest().given('a trace AI justification textarea form field component', () => 
     })
 
     BddTest().then('it should pass labelVisible as false to the textarea', () => {
-      const textarea = wrapper.findComponent({ name: 'TraceIaJustificationTextarea' })
+      const textarea = getTextarea()
       expect(textarea.props('labelVisible')).toBe(false)
     })
   })
 
   BddTest().when('the user enters only whitespace', () => {
     BddTest().then('it should show validation error on submit', async () => {
-      const textarea = wrapper.findComponent({ name: 'TraceIaJustificationTextarea' })
+      const textarea = getTextarea()
       const textareaElement = textarea.find('textarea')
 
       await textareaElement.setValue('   ')
@@ -221,7 +219,7 @@ BddTest().given('a trace AI justification textarea form field component', () => 
       await wrapper.vm.$nextTick()
 
       await vi.waitFor(() => {
-        const updatedTextarea = wrapper.findComponent({ name: 'TraceIaJustificationTextarea' })
+        const updatedTextarea = getTextarea()
         expect(updatedTextarea.props('errorMessage')).toBe('Ce champ est requis')
       })
     })

--- a/src/features/student/traces/components/interactions/formFields/TraceAiJustificationTextareaFormField/TraceAiJustificationTextareaFormField.vue
+++ b/src/features/student/traces/components/interactions/formFields/TraceAiJustificationTextareaFormField/TraceAiJustificationTextareaFormField.vue
@@ -1,15 +1,15 @@
 <script setup lang="ts">
 import type { CreateTraceForm, UpdateTraceForm } from '@/features/student/traces/types/forms.types'
-import TraceIaJustificationTextarea from '@/features/student/traces/components/interactions/inputs/TraceIaJustificationTextarea/TraceIaJustificationTextarea.vue'
+import TraceAiJustificationTextarea from '@/features/student/traces/components/interactions/inputs/TraceAiJustificationTextarea/TraceAiJustificationTextarea.vue'
 import { markRaw } from 'vue'
 
-interface TraceIaJustificationTextareaFormFieldProps {
+interface TraceAiJustificationTextareaFormFieldProps {
   form: CreateTraceForm | UpdateTraceForm
   showAiJustification: boolean
   labelVisible?: boolean
 }
 
-const { form } = defineProps<TraceIaJustificationTextareaFormFieldProps>()
+const { form } = defineProps<TraceAiJustificationTextareaFormFieldProps>()
 const FormField = markRaw(form.Field)
 </script>
 
@@ -19,7 +19,7 @@ const FormField = markRaw(form.Field)
     name="iaJustification"
   >
     <template #default="{ field }">
-      <TraceIaJustificationTextarea
+      <TraceAiJustificationTextarea
         id="ia-justification"
         v-model="field.state.value"
         :error-message="field.state.meta.errors.join(', ')"

--- a/src/features/student/traces/components/interactions/inputs/TraceAiJustificationTextarea/TraceAiJustificationTextarea.stub.ts
+++ b/src/features/student/traces/components/interactions/inputs/TraceAiJustificationTextarea/TraceAiJustificationTextarea.stub.ts
@@ -1,0 +1,6 @@
+export const TraceAiJustificationTextareaStub = defineComponent({
+  name: 'TraceAiJustificationTextarea',
+  props: ['id', 'modelValue', 'errorMessage', 'required', 'labelVisible', 'disabled'],
+  emits: ['blur', 'update:modelValue'],
+  template: '<div><textarea :id="id" :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" @blur="$emit(\'blur\')"></textarea><span v-if="errorMessage" class="error">{{ errorMessage }}</span></div>'
+})

--- a/src/features/student/traces/components/interactions/inputs/TraceAiJustificationTextarea/TraceAiJustificationTextarea.test.ts
+++ b/src/features/student/traces/components/interactions/inputs/TraceAiJustificationTextarea/TraceAiJustificationTextarea.test.ts
@@ -1,4 +1,4 @@
-import TraceIaJustificationTextarea from '@/features/student/traces/components/interactions/inputs/TraceIaJustificationTextarea/TraceIaJustificationTextarea.vue'
+import TraceAiJustificationTextarea from '@/features/student/traces/components/interactions/inputs/TraceAiJustificationTextarea/TraceAiJustificationTextarea.vue'
 import { TRACE_IA_JUSTIFICATION_MAX_LENGTH } from '@/features/student/traces/config'
 import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { mount, type VueWrapper } from '@vue/test-utils'
@@ -39,10 +39,10 @@ const stubs = {
 }
 
 BddTest().given('a trace ia justification textarea component', () => {
-  let wrapper: VueWrapper<InstanceType<typeof TraceIaJustificationTextarea>>
+  let wrapper: VueWrapper<InstanceType<typeof TraceAiJustificationTextarea>>
 
   beforeEach(() => {
-    wrapper = mount(TraceIaJustificationTextarea, {
+    wrapper = mount(TraceAiJustificationTextarea, {
       global: {
         stubs
       }
@@ -73,7 +73,7 @@ BddTest().given('a trace ia justification textarea component', () => {
 
   BddTest().when('custom label is provided', () => {
     BddTest().then('it should use the custom label', () => {
-      wrapper = mount(TraceIaJustificationTextarea, {
+      wrapper = mount(TraceAiJustificationTextarea, {
         props: {
           label: 'Custom Label'
         },
@@ -90,7 +90,7 @@ BddTest().given('a trace ia justification textarea component', () => {
 
   BddTest().when('custom placeholder is provided', () => {
     BddTest().then('it should use the custom placeholder', () => {
-      wrapper = mount(TraceIaJustificationTextarea, {
+      wrapper = mount(TraceAiJustificationTextarea, {
         props: {
           placeholder: 'Custom placeholder text'
         },
@@ -107,7 +107,7 @@ BddTest().given('a trace ia justification textarea component', () => {
 
   BddTest().when('custom maxlength is provided', () => {
     BddTest().then('it should use the custom maxlength', () => {
-      wrapper = mount(TraceIaJustificationTextarea, {
+      wrapper = mount(TraceAiJustificationTextarea, {
         props: {
           maxlength: 500
         },
@@ -124,7 +124,7 @@ BddTest().given('a trace ia justification textarea component', () => {
 
   BddTest().when('the component is disabled', () => {
     BddTest().then('it should pass disabled state to AvInput', () => {
-      wrapper = mount(TraceIaJustificationTextarea, {
+      wrapper = mount(TraceAiJustificationTextarea, {
         props: {
           disabled: true
         },
@@ -141,7 +141,7 @@ BddTest().given('a trace ia justification textarea component', () => {
 
   BddTest().when('the component is required', () => {
     BddTest().then('it should pass required state to AvInput', () => {
-      wrapper = mount(TraceIaJustificationTextarea, {
+      wrapper = mount(TraceAiJustificationTextarea, {
         props: {
           required: true
         },
@@ -158,7 +158,7 @@ BddTest().given('a trace ia justification textarea component', () => {
 
   BddTest().when('labelVisible is false', () => {
     BddTest().then('it should hide the label', () => {
-      wrapper = mount(TraceIaJustificationTextarea, {
+      wrapper = mount(TraceAiJustificationTextarea, {
         props: {
           labelVisible: false
         },
@@ -175,7 +175,7 @@ BddTest().given('a trace ia justification textarea component', () => {
 
   BddTest().when('isValid is true', () => {
     BddTest().then('it should pass valid state to AvInput', () => {
-      wrapper = mount(TraceIaJustificationTextarea, {
+      wrapper = mount(TraceAiJustificationTextarea, {
         props: {
           isValid: true
         },
@@ -200,7 +200,7 @@ BddTest().given('a trace ia justification textarea component', () => {
     })
 
     BddTest().then('it should update the character count hint', async () => {
-      wrapper = mount(TraceIaJustificationTextarea, {
+      wrapper = mount(TraceAiJustificationTextarea, {
         props: {
           modelValue: 'Some text here'
         },
@@ -219,7 +219,7 @@ BddTest().given('a trace ia justification textarea component', () => {
     BddTest().then('it should pass the value to AvInput', () => {
       const testValue = 'This is a test justification for AI usage'
 
-      wrapper = mount(TraceIaJustificationTextarea, {
+      wrapper = mount(TraceAiJustificationTextarea, {
         props: {
           modelValue: testValue
         },
@@ -236,7 +236,7 @@ BddTest().given('a trace ia justification textarea component', () => {
 
   BddTest().when('errorMessage is provided', () => {
     BddTest().then('it should pass the error message to AvInput', () => {
-      wrapper = mount(TraceIaJustificationTextarea, {
+      wrapper = mount(TraceAiJustificationTextarea, {
         props: {
           errorMessage: 'Ce champ est requis'
         },
@@ -255,7 +255,7 @@ BddTest().given('a trace ia justification textarea component', () => {
     BddTest().then('it should display the correct count in hint', () => {
       const maxText = 'a'.repeat(TRACE_IA_JUSTIFICATION_MAX_LENGTH)
 
-      wrapper = mount(TraceIaJustificationTextarea, {
+      wrapper = mount(TraceAiJustificationTextarea, {
         props: {
           modelValue: maxText
         },

--- a/src/features/student/traces/components/interactions/inputs/TraceAiJustificationTextarea/TraceAiJustificationTextarea.vue
+++ b/src/features/student/traces/components/interactions/inputs/TraceAiJustificationTextarea/TraceAiJustificationTextarea.vue
@@ -4,7 +4,7 @@ import { AvInput, type AvInputProps } from '@avenirs-esr/avenirs-dsav'
 import { useAttrs } from 'vue'
 import { useI18n } from 'vue-i18n'
 
-interface TraceIaJustificationTextareaProps extends Omit<AvInputProps, 'label' | 'placeholder' | 'modelValue' | 'maxlength' | 'isTextarea'> {
+interface TraceAiJustificationTextareaProps extends Omit<AvInputProps, 'label' | 'placeholder' | 'modelValue' | 'maxlength' | 'isTextarea'> {
   label?: string
   placeholder?: string
   maxlength?: number
@@ -21,7 +21,7 @@ const {
   label,
   placeholder,
   errorMessage,
-} = defineProps<TraceIaJustificationTextareaProps>()
+} = defineProps<TraceAiJustificationTextareaProps>()
 
 const modelValue = defineModel<string>()
 const { t } = useI18n()
@@ -36,13 +36,13 @@ const avInputProps = computed(() => ({
   required,
   maxlength,
   errorMessage,
-  label: label ?? t('student.traces.interactions.inputs.TraceIaJustificationTextarea.label'),
-  placeholder: placeholder ?? t('student.traces.interactions.inputs.TraceIaJustificationTextarea.placeholder')
+  label: label ?? t('student.traces.interactions.inputs.TraceAiJustificationTextarea.label'),
+  placeholder: placeholder ?? t('student.traces.interactions.inputs.TraceAiJustificationTextarea.placeholder')
 }))
 </script>
 
 <template>
-  <div class="trace-ia-justification-textarea">
+  <div class="trace-ai-justification-textarea">
     <AvInput
       v-bind="avInputProps"
       v-model="modelValue"

--- a/src/features/student/traces/composables/use-trace-form-validators/use-trace-form-validators.test.ts
+++ b/src/features/student/traces/composables/use-trace-form-validators/use-trace-form-validators.test.ts
@@ -1,0 +1,144 @@
+import type { TraceFormData } from '@/features/student/traces/types/traces.types'
+import { useTraceFormValidators } from '@/features/student/traces/composables/use-trace-form-validators/use-trace-form-validators'
+import { TRACE_IA_JUSTIFICATION_MAX_LENGTH, TRACE_LINK_MAX_LENGTH, TRACE_NAME_MAX_LENGTH, TRACE_PERSONAL_NOTE_MAX_LENGTH } from '@/features/student/traces/config'
+import { TraceType } from '@/features/student/traces/types/traces.types'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { mountComposable } from 'tests/utils'
+import { beforeEach, expect } from 'vitest'
+
+function buildLinkTraceFormData (overrides: Partial<TraceFormData> = {}): TraceFormData {
+  return {
+    traceType: TraceType.LINK,
+    link: 'https://example.com',
+    traceName: 'Trace title',
+    personalNote: 'Personal note',
+    isAuthentic: true,
+    isGroup: false,
+    useIA: false,
+    iaJustification: '',
+    ...overrides,
+  } as TraceFormData
+}
+
+function buildFileTraceFormData (overrides: Partial<TraceFormData> = {}): TraceFormData {
+  return {
+    traceType: TraceType.FILE,
+    file: new File(['content'], 'trace.txt', { type: 'text/plain' }),
+    traceName: 'Trace title',
+    personalNote: 'Personal note',
+    isAuthentic: true,
+    isGroup: false,
+    useIA: false,
+    iaJustification: '',
+    ...overrides,
+  } as TraceFormData
+}
+
+BddTest().given('a trace form validators composable', () => {
+  let composableResult: ReturnType<typeof useTraceFormValidators>
+
+  beforeEach(() => {
+    const result = mountComposable(() => useTraceFormValidators(), {
+      useI18n: true
+    })
+    composableResult = result.result
+  })
+
+  BddTest().when('the composable is initialized', () => {
+    BddTest().then('it should expose the validators builder', () => {
+      expect(composableResult.buildValidators).toBeDefined()
+    })
+  })
+
+  BddTest().when('validating a file trace', () => {
+    BddTest().and('file is missing', () => {
+      BddTest().then('it should return required error for file', () => {
+        const result = composableResult.buildValidators(buildFileTraceFormData({ file: null }))
+        expect(result.fields.file).toBe('Ce champ est requis.')
+      })
+    })
+
+    BddTest().and('all values are valid', () => {
+      BddTest().then('it should not return file or link errors', () => {
+        const result = composableResult.buildValidators(buildFileTraceFormData())
+        expect(result.fields.file).toBeUndefined()
+        expect(result.fields.link).toBeUndefined()
+      })
+    })
+  })
+
+  BddTest().when('validating a link trace', () => {
+    BddTest().and('link is empty', () => {
+      BddTest().then('it should return required error for link', () => {
+        const result = composableResult.buildValidators(buildLinkTraceFormData({ link: '' }))
+        expect(result.fields.link).toBe('Ce champ est requis.')
+      })
+    })
+
+    BddTest().and('link format is invalid', () => {
+      BddTest().then('it should return invalid URL error', () => {
+        const result = composableResult.buildValidators(buildLinkTraceFormData({ link: 'invalid-link' }))
+        expect(result.fields.link).toBe('Veuillez renseigner une URL valide (ex. : http://www.exemple.com)')
+      })
+    })
+
+    BddTest().and('link exceeds max length', () => {
+      BddTest().then('it should return max length error for link', () => {
+        const tooLongValidLink = `https://example.com/${'a'.repeat(TRACE_LINK_MAX_LENGTH)}`
+        const result = composableResult.buildValidators(buildLinkTraceFormData({ link: tooLongValidLink }))
+        expect(result.fields.link).toBe(`Veuillez limiter votre saisie à ${TRACE_LINK_MAX_LENGTH} caractères`)
+      })
+    })
+  })
+
+  BddTest().when('validating common fields', () => {
+    BddTest().and('traceName is empty', () => {
+      BddTest().then('it should return required error for traceName', () => {
+        const result = composableResult.buildValidators(buildLinkTraceFormData({ traceName: '' }))
+        expect(result.fields.traceName).toBe('Ce champ est requis.')
+      })
+    })
+
+    BddTest().and('traceName exceeds max length', () => {
+      BddTest().then('it should return max length error for traceName', () => {
+        const result = composableResult.buildValidators(buildLinkTraceFormData({ traceName: 'a'.repeat(TRACE_NAME_MAX_LENGTH + 1) }))
+        expect(result.fields.traceName).toBe(`Veuillez limiter votre saisie à ${TRACE_NAME_MAX_LENGTH} caractères`)
+      })
+    })
+
+    BddTest().and('isAuthentic is false', () => {
+      BddTest().then('it should return an authenticity error', () => {
+        const result = composableResult.buildValidators(buildLinkTraceFormData({ isAuthentic: false }))
+        expect(result.fields.isAuthentic).toBeDefined()
+      })
+    })
+
+    BddTest().and('useIA is true and iaJustification is empty', () => {
+      BddTest().then('it should return required error for IA justification', () => {
+        const result = composableResult.buildValidators(buildLinkTraceFormData({ useIA: true, iaJustification: '' }))
+        expect(result.fields.iaJustification).toBe('Ce champ est requis.')
+      })
+    })
+
+    BddTest().and('useIA is true and iaJustification exceeds max length', () => {
+      BddTest().then('it should return max length error for IA justification', () => {
+        const result = composableResult.buildValidators(
+          buildLinkTraceFormData({
+            useIA: true,
+            iaJustification: 'a'.repeat(TRACE_IA_JUSTIFICATION_MAX_LENGTH + 1)
+          })
+        )
+        expect(result.fields.iaJustification).toBe(`Veuillez limiter votre saisie à ${TRACE_IA_JUSTIFICATION_MAX_LENGTH} caractères`)
+      })
+    })
+
+    BddTest().and('personalNote exceeds max length', () => {
+      BddTest().then('it should return max length error for personalNote', () => {
+        const result = composableResult.buildValidators(
+          buildLinkTraceFormData({ personalNote: 'a'.repeat(TRACE_PERSONAL_NOTE_MAX_LENGTH + 1) })
+        )
+        expect(result.fields.personalNote).toBe(`Veuillez limiter votre saisie à ${TRACE_PERSONAL_NOTE_MAX_LENGTH} caractères`)
+      })
+    })
+  })
+})

--- a/src/features/student/traces/composables/use-trace-form-validators/use-trace-form-validators.ts
+++ b/src/features/student/traces/composables/use-trace-form-validators/use-trace-form-validators.ts
@@ -1,0 +1,34 @@
+import type { TraceFormData } from '@/features/student/traces/types/traces.types'
+import { useFormValidators } from '@/common/composables/use-form-validators/use-form-validators'
+import { useTraceFileValidation } from '@/features/student/traces/composables/use-trace-file/use-trace-file'
+import { TRACE_IA_JUSTIFICATION_MAX_LENGTH, TRACE_LINK_MAX_LENGTH, TRACE_NAME_MAX_LENGTH, TRACE_PERSONAL_NOTE_MAX_LENGTH } from '@/features/student/traces/config'
+import { isTraceFileType, isTraceLinkType } from '@/features/student/traces/utils/trace.types-guard'
+import { useI18n } from 'vue-i18n'
+
+/**
+ * Composable providing validation logic for student trace forms, including both creation and update forms.
+ * It centralizes the validation rules for trace form fields, ensuring consistency across different trace-related components.
+ * @returns An object containing the `buildValidators` function, which generates validation results based on the current form values.
+ */
+export function useTraceFormValidators () {
+  const { t } = useI18n()
+  const { validateLink, validateRequired, validateMaxLength } = useFormValidators()
+  const { validateFile } = useTraceFileValidation(true)
+
+  function buildValidators (value: TraceFormData) {
+    return {
+      fields: {
+        file: isTraceFileType(value) ? validateFile(value.file) : undefined,
+        link: isTraceLinkType(value) ? validateLink(value.link, true) ?? validateMaxLength(value.link, TRACE_LINK_MAX_LENGTH) : undefined,
+        traceName: validateRequired(value.traceName) ?? validateMaxLength(value.traceName, TRACE_NAME_MAX_LENGTH),
+        isAuthentic: !value.isAuthentic ? t('student.traces.interactions.toggles.TraceAuthenticDeclarationToggle.requiredMessage') : undefined,
+        iaJustification: value.useIA && (validateRequired(value.iaJustification) ?? validateMaxLength(value.iaJustification, TRACE_IA_JUSTIFICATION_MAX_LENGTH)),
+        personalNote: validateMaxLength(value.personalNote, TRACE_PERSONAL_NOTE_MAX_LENGTH)
+      }
+    }
+  }
+
+  return {
+    buildValidators
+  }
+}

--- a/src/features/student/traces/locales/en.json
+++ b/src/features/student/traces/locales/en.json
@@ -32,7 +32,7 @@
             "addedOn": "Added on {date}",
             "documentLabel": "My uploaded document"
           },
-          "TraceIaJustificationTextarea": {
+          "TraceAiJustificationTextarea": {
             "label": "AI usage justification",
             "placeholder": "Describe how and why you used AI..."
           },

--- a/src/features/student/traces/locales/fr.json
+++ b/src/features/student/traces/locales/fr.json
@@ -32,7 +32,7 @@
             "addedOn": "Ajouté le {date}",
             "documentLabel": "Mon document chargé"
           },
-          "TraceIaJustificationTextarea": {
+          "TraceAiJustificationTextarea": {
             "label": "Justification de l'usage de l'IA",
             "placeholder": "Décrivez comment et pourquoi vous avez utilisé l'IA..."
           },

--- a/src/features/student/traces/views/StudentToolsTracesView/components/StudentToolsTracesAddTraceDrawer/components/CreateTraceFormDeclarationItems/CreateTraceFormDeclarationItems.test.ts
+++ b/src/features/student/traces/views/StudentToolsTracesView/components/StudentToolsTracesAddTraceDrawer/components/CreateTraceFormDeclarationItems/CreateTraceFormDeclarationItems.test.ts
@@ -1,5 +1,6 @@
 import type { TraceFormData } from '@/features/student/traces'
 import { ToggleStub } from '@/common/components/Toggle/Toggle.stub'
+import { TraceAiJustificationTextareaStub } from '@/features/student/traces/components/interactions/inputs/TraceAiJustificationTextarea/TraceAiJustificationTextarea.stub'
 import { isTraceFileType } from '@/features/student/traces/utils/trace.types-guard'
 import CreateTraceFormDeclarationItems from '@/features/student/traces/views/StudentToolsTracesView/components/StudentToolsTracesAddTraceDrawer/components/CreateTraceFormDeclarationItems/CreateTraceFormDeclarationItems.vue'
 import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
@@ -47,14 +48,11 @@ const TestWrapper = {
 BddTest().given('a create trace form declaration items component', () => {
   let wrapper: VueWrapper
 
+  const getIaJustificationInput = () => wrapper.findComponent(TraceAiJustificationTextareaStub)
+
   const stubs = {
     Toggle: ToggleStub,
-    TraceIaJustificationTextarea: {
-      name: 'TraceIaJustificationTextarea',
-      props: ['id', 'modelValue', 'errorMessage', 'required'],
-      emits: ['blur', 'update:modelValue'],
-      template: '<div><textarea :id="id" :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" @blur="$emit(\'blur\')"></textarea></div>'
-    }
+    TraceAiJustificationTextarea: TraceAiJustificationTextareaStub
   }
 
   beforeEach(() => {
@@ -120,7 +118,7 @@ BddTest().given('a create trace form declaration items component', () => {
     })
 
     BddTest().then('it should not render IA justification textarea initially', () => {
-      const iaJustificationInput = wrapper.findComponent({ name: 'TraceIaJustificationTextarea' })
+      const iaJustificationInput = getIaJustificationInput()
       expect(iaJustificationInput.exists()).toBe(false)
     })
   })
@@ -163,7 +161,7 @@ BddTest().given('a create trace form declaration items component', () => {
       await iaToggle?.vm.$emit('update:modelValue', true)
       await wrapper.vm.$nextTick()
 
-      const iaJustificationInput = wrapper.findComponent({ name: 'TraceIaJustificationTextarea' })
+      const iaJustificationInput = getIaJustificationInput()
       expect(iaJustificationInput.exists()).toBe(true)
       expect(iaJustificationInput.props('id')).toBe('ia-justification')
       expect(iaJustificationInput.props('required')).toBe(true)
@@ -192,7 +190,7 @@ BddTest().given('a create trace form declaration items component', () => {
       await iaToggle?.vm.$emit('update:modelValue', true)
       await wrapper.vm.$nextTick()
 
-      const iaJustificationInput = wrapper.findComponent({ name: 'TraceIaJustificationTextarea' })
+      const iaJustificationInput = getIaJustificationInput()
       await iaJustificationInput.vm.$emit('update:modelValue', 'Some justification')
       await wrapper.vm.$nextTick()
 
@@ -213,7 +211,7 @@ BddTest().given('a create trace form declaration items component', () => {
       await iaToggle?.vm.$emit('update:modelValue', true)
       await wrapper.vm.$nextTick()
 
-      const iaJustificationInput = wrapper.findComponent({ name: 'TraceIaJustificationTextarea' })
+      const iaJustificationInput = getIaJustificationInput()
       const textarea = iaJustificationInput.find('textarea')
 
       textarea.element.value = 'My IA justification'
@@ -221,7 +219,7 @@ BddTest().given('a create trace form declaration items component', () => {
       await wrapper.vm.$nextTick()
 
       await vi.waitFor(() => {
-        const updatedInput = wrapper.findComponent({ name: 'TraceIaJustificationTextarea' })
+        const updatedInput = getIaJustificationInput()
         expect(updatedInput.props('modelValue')).toBe('My IA justification')
       })
     })
@@ -252,7 +250,7 @@ BddTest().given('a create trace form declaration items component', () => {
       await wrapper.find('form').trigger('submit')
       await wrapper.vm.$nextTick()
 
-      const iaJustificationInput = wrapper.findComponent({ name: 'TraceIaJustificationTextarea' })
+      const iaJustificationInput = getIaJustificationInput()
       await vi.waitFor(() => {
         expect(iaJustificationInput.props('errorMessage')).toBe('Required field')
       })

--- a/src/features/student/traces/views/StudentToolsTracesView/components/StudentToolsTracesAddTraceDrawer/use-create-tarce-form/use-create-trace-form.ts
+++ b/src/features/student/traces/views/StudentToolsTracesView/components/StudentToolsTracesAddTraceDrawer/use-create-tarce-form/use-create-trace-form.ts
@@ -4,8 +4,7 @@ import type { ComputedRef } from 'vue'
 import { ELanguage, type TraceAssociationsDTO } from '@/api/avenir-esr'
 import { useApiErrors } from '@/common/composables/use-api-errors/use-api-errors'
 import { useFormValidators } from '@/common/composables/use-form-validators/use-form-validators'
-import { useTraceFileValidation } from '@/features/student/traces/composables/use-trace-file/use-trace-file'
-import { TRACE_LINK_MAX_LENGTH, TRACE_NAME_MAX_LENGTH, TRACE_PERSONAL_NOTE_MAX_LENGTH } from '@/features/student/traces/config'
+import { useTraceFormValidators } from '@/features/student/traces/composables/use-trace-form-validators/use-trace-form-validators'
 import {
   useAssociateTraceWithActivitiesMutation,
   useAssociateTraceWithDeclaredSkillsMutation,
@@ -26,7 +25,8 @@ export function useCreateTraceForm (onTraceCreated?: () => void) {
 
   const { getErrorMessage } = useApiErrors()
   const { addErrorMessage } = useToasterStore()
-  const { validateLink, validateMaxLength, hasFieldErrors } = useFormValidators()
+  const { buildValidators } = useTraceFormValidators()
+  const { hasFieldErrors } = useFormValidators()
 
   function onCreateTraceError (error: BaseApiException) {
     addErrorMessage({
@@ -57,8 +57,6 @@ export function useCreateTraceForm (onTraceCreated?: () => void) {
   const { mutateAsync: associateWithDeclaredSkills, isPending: isPendingAssociateWithDeclaredSkills } = useAssociateTraceWithDeclaredSkillsMutation()
 
   const isFileUploading = ref(false)
-
-  const { validateFile } = useTraceFileValidation(true)
 
   function associateElements (traceId: string, associationSelections: Record<string, Association[]>) {
     const pendingAssociations = []
@@ -133,25 +131,10 @@ export function useCreateTraceForm (onTraceCreated?: () => void) {
     } as TraceFormData,
     validators: {
       onSubmit ({ value }: { value: TraceFormData }) {
-        return {
-          fields: {
-            file: isTraceFileType(value) ? validateFile(value.file) : undefined,
-            link: isTraceLinkType(value) ? validateLink(value.link, true) : undefined,
-            traceName: !value.traceName.trim() ? t('global.error.form.requiredField') : undefined,
-            isAuthentic: !value.isAuthentic ? t('student.traces.interactions.toggles.TraceAuthenticDeclarationToggle.requiredMessage') : undefined,
-            iaJustification: value.useIA && (!value.iaJustification || !value.iaJustification.trim()) ? t('global.error.form.requiredField') : undefined,
-          }
-        }
+        return buildValidators(value)
       },
       onChange ({ value }: { value: TraceFormData }) {
-        return {
-          fields: {
-            link: isTraceLinkType(value) ? validateMaxLength(value.link, TRACE_LINK_MAX_LENGTH) : undefined,
-            traceName: validateMaxLength(value.traceName, TRACE_NAME_MAX_LENGTH),
-            personalNote: validateMaxLength(value.personalNote, TRACE_PERSONAL_NOTE_MAX_LENGTH),
-            file: isTraceFileType(value) ? validateFile(value.file) : undefined,
-          }
-        }
+        return buildValidators(value)
       }
     },
     onSubmit: ({ value }: { value: TraceFormData }) => {

--- a/src/features/student/traces/views/StudentToolsTracesView/components/StudentTraceDetails/StudentTraceDetails.test.ts
+++ b/src/features/student/traces/views/StudentToolsTracesView/components/StudentTraceDetails/StudentTraceDetails.test.ts
@@ -1,5 +1,6 @@
 import { EFileType, type TraceDetailDTO } from '@/api/avenir-esr'
 import { CreationUpdateDateDetailsStub } from '@/common/components/CreationUpdateDateDetails/CreationUpdateDateDetails.stub'
+import { TraceAiJustificationTextareaStub } from '@/features/student/traces/components/interactions/inputs/TraceAiJustificationTextarea/TraceAiJustificationTextarea.stub'
 import { TraceAiUsageToggleStub } from '@/features/student/traces/components/interactions/toggles/TraceAiUsageToggle/TraceAiUsageToggle.stub'
 import StudentTraceDetails
   from '@/features/student/traces/views/StudentToolsTracesView/components/StudentTraceDetails/StudentTraceDetails.vue'
@@ -25,12 +26,6 @@ const TracePersonalNoteTextareaStub = {
   template: '<div class="trace-personal-note-textarea-stub"></div>'
 }
 
-const TraceIaJustificationTextareaStub = {
-  name: 'TraceIaJustificationTextarea',
-  props: ['modelValue', 'labelVisible', 'disabled'],
-  template: '<div class="trace-ia-justification-textarea-stub"></div>'
-}
-
 const AvIconTextStub = {
   name: 'AvIconText',
   props: ['typographyClass', 'iconColor', 'icon', 'text'],
@@ -41,7 +36,7 @@ const stubs = {
   TraceNameInput: TraceNameInputStub,
   TraceFileUpload: TraceFileUploadStub,
   TracePersonalNoteTextarea: TracePersonalNoteTextareaStub,
-  TraceIaJustificationTextarea: TraceIaJustificationTextareaStub,
+  TraceAiJustificationTextarea: TraceAiJustificationTextareaStub,
   AvIconText: AvIconTextStub,
   TraceAiUsageToggle: TraceAiUsageToggleStub,
   CreationUpdateDateDetails: CreationUpdateDateDetailsStub
@@ -152,7 +147,7 @@ BddTest().given('a student detailed trace information component', () => {
     })
 
     BddTest().then('it should not render the IA justification textarea when aiUseJustification is empty', () => {
-      const iaJustificationTextarea = wrapper.findComponent({ name: 'TraceIaJustificationTextarea' })
+      const iaJustificationTextarea = wrapper.findComponent({ name: 'TraceAiJustificationTextarea' })
 
       expect(iaJustificationTextarea.exists()).toBe(false)
     })
@@ -200,7 +195,7 @@ BddTest().given('a student detailed trace information component', () => {
     })
 
     BddTest().then('it should render the IA justification textarea', () => {
-      const iaJustificationTextarea = wrapper.findComponent({ name: 'TraceIaJustificationTextarea' })
+      const iaJustificationTextarea = wrapper.findComponent({ name: 'TraceAiJustificationTextarea' })
 
       expect(iaJustificationTextarea.exists()).toBe(true)
       expect(iaJustificationTextarea.props('modelValue')).toBe('Test AI justification text')

--- a/src/features/student/traces/views/StudentToolsTracesView/components/StudentTraceDetails/StudentTraceDetails.vue
+++ b/src/features/student/traces/views/StudentToolsTracesView/components/StudentTraceDetails/StudentTraceDetails.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import type { TraceDetailDTO } from '@/api/avenir-esr'
 import { CreationUpdateDateDetails } from '@/common/components'
+import TraceAiJustificationTextarea from '@/features/student/traces/components/interactions/inputs/TraceAiJustificationTextarea/TraceAiJustificationTextarea.vue'
 import TraceFileUpload from '@/features/student/traces/components/interactions/inputs/TraceFileUpload/TraceFileUpload.vue'
-import TraceIaJustificationTextarea from '@/features/student/traces/components/interactions/inputs/TraceIaJustificationTextarea/TraceIaJustificationTextarea.vue'
 import TraceNameInput from '@/features/student/traces/components/interactions/inputs/TraceNameInput/TraceNameInput.vue'
 import TracePersonalNoteTextarea from '@/features/student/traces/components/interactions/inputs/TracePersonalNoteTextarea/TracePersonalNoteTextarea.vue'
 import TraceAiUsageToggle from '@/features/student/traces/components/interactions/toggles/TraceAiUsageToggle/TraceAiUsageToggle.vue'
@@ -101,7 +101,7 @@ const traceFileUploadLabel = computed(() => {
           :description="t('student.traces.views.StudentToolsTracesView.studentTraceDetails.iaToggleLabel')"
           disabled
         />
-        <TraceIaJustificationTextarea
+        <TraceAiJustificationTextarea
           v-if="trace.aiUseJustification"
           :model-value="trace.aiUseJustification"
           :label-visible="false"

--- a/src/features/student/traces/views/StudentTraceView/components/UpdateTraceForm/UpdateTraceForm.vue
+++ b/src/features/student/traces/views/StudentTraceView/components/UpdateTraceForm/UpdateTraceForm.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { TraceDetailDTO } from '@/api/avenir-esr'
+import type { UpdateTraceForm as UpdateTraceFormType } from '@/features/student/traces/types/forms.types'
 import { useDateUtils } from '@/common/composables'
 import TraceAiJustificationTextareaFormField from '@/features/student/traces/components/interactions/formFields/TraceAiJustificationTextareaFormField/TraceAiJustificationTextareaFormField.vue'
 import TraceAiUsageToggleFormField from '@/features/student/traces/components/interactions/formFields/TraceAiUsageToggleFormField/TraceAiUsageToggleFormField.vue'
@@ -15,10 +16,12 @@ import { useUpdateTraceForm } from '@/features/student/traces/views/StudentTrace
 import { useToasterStore } from '@/store'
 import { useI18n } from 'vue-i18n'
 
-const { trace } = defineProps<UpdateTraceFormProps>()
 interface UpdateTraceFormProps {
   trace: TraceDetailDTO
+  form?: UpdateTraceFormType
 }
+
+const { trace, form: injectedForm } = defineProps<UpdateTraceFormProps>()
 
 const { addSuccessMessage } = useToasterStore()
 const { hideUpdateTraceModal } = useTracesStore()
@@ -33,7 +36,7 @@ function onTraceUpdated () {
   hideUpdateTraceModal()
 }
 
-const { form } = useUpdateTraceForm(trace, onTraceUpdated)
+const form = injectedForm ?? useUpdateTraceForm(trace, onTraceUpdated).form
 const { formatTranslatedDateTime } = useDateUtils()
 
 const useIAField = form.useField({ name: 'useIA' })

--- a/src/features/student/traces/views/StudentTraceView/components/UpdateTraceForm/use-update-trace-form/use-update-trace-form.ts
+++ b/src/features/student/traces/views/StudentTraceView/components/UpdateTraceForm/use-update-trace-form/use-update-trace-form.ts
@@ -3,8 +3,8 @@ import type { TraceFormData } from '@/features/student/traces/types/traces.types
 import { ELanguage, type TraceDetailDTO } from '@/api/avenir-esr'
 import { useApiErrors } from '@/common/composables/use-api-errors/use-api-errors'
 import { useFormValidators } from '@/common/composables/use-form-validators/use-form-validators'
-import { useTraceAttachmentFile, useTraceFileValidation } from '@/features/student/traces/composables/use-trace-file/use-trace-file'
-import { TRACE_LINK_MAX_LENGTH, TRACE_NAME_MAX_LENGTH, TRACE_PERSONAL_NOTE_MAX_LENGTH } from '@/features/student/traces/config'
+import { useTraceAttachmentFile } from '@/features/student/traces/composables/use-trace-file/use-trace-file'
+import { useTraceFormValidators } from '@/features/student/traces/composables/use-trace-form-validators/use-trace-form-validators'
 import { useUpdateTraceMutation, useUploadAttachmentMutation } from '@/features/student/traces/queries/use-traces.query/use-traces.query'
 import { useTracesStore } from '@/features/student/traces/stores/traces.store'
 import { TraceType } from '@/features/student/traces/types/traces.types'
@@ -19,8 +19,8 @@ export function useUpdateTraceForm (trace: TraceDetailDTO, onTraceUpdated?: () =
   const { getErrorMessage } = useApiErrors()
   const { addErrorMessage } = useToasterStore()
   const { setUpdateTraceForm, setUpdateTraceFormModified } = useTracesStore()
-  const { validateMaxLength } = useFormValidators()
-  const { validateFile } = useTraceFileValidation()
+  const { buildValidators } = useTraceFormValidators()
+  const { hasFieldErrors } = useFormValidators()
   const { attachmentFile } = useTraceAttachmentFile(trace.attachment)
 
   const onUpdateTraceError = (error: BaseApiException) => {
@@ -59,25 +59,10 @@ export function useUpdateTraceForm (trace: TraceDetailDTO, onTraceUpdated?: () =
     } as TraceFormData,
     validators: {
       onSubmit ({ value }: { value: TraceFormData }) {
-        return {
-          fields: {
-            file: isTraceFileType(value) ? validateFile(value.file) : undefined,
-            link: isTraceLinkType(value) ? validateMaxLength(value.link, TRACE_LINK_MAX_LENGTH) : undefined,
-            isAuthentic: !value.isAuthentic ? t('student.traces.interactions.toggles.TraceAuthenticDeclarationToggle.requiredMessage') : undefined,
-            traceName: !value.traceName.trim() ? t('global.error.form.requiredField') : undefined,
-            iaJustification: value.useIA && (!value.iaJustification || !value.iaJustification.trim()) ? t('global.error.form.requiredField') : undefined,
-          }
-        }
+        return buildValidators(value)
       },
       onChange ({ value }: { value: TraceFormData }) {
-        return {
-          fields: {
-            traceName: validateMaxLength(value.traceName, TRACE_NAME_MAX_LENGTH),
-            personalNote: validateMaxLength(value.personalNote, TRACE_PERSONAL_NOTE_MAX_LENGTH),
-            link: isTraceLinkType(value) ? validateMaxLength(value.link, TRACE_LINK_MAX_LENGTH) : undefined,
-            file: isTraceFileType(value) ? validateFile(value.file) : undefined,
-          }
-        }
+        return buildValidators(value)
       }
     },
     onSubmit: async ({ value }: { value: TraceFormData }) => {
@@ -133,6 +118,8 @@ export function useUpdateTraceForm (trace: TraceDetailDTO, onTraceUpdated?: () =
     return state.value.isDirty && state.value.isValid && !state.value.isValidating
   })
 
+  const hasErrors = hasFieldErrors(form, ['file', 'link', 'traceName', 'personalNote', 'iaJustification', 'isAuthentic'])
+
   watch(() => form, () => {
     setUpdateTraceForm(form)
   }, { immediate: true })
@@ -143,6 +130,7 @@ export function useUpdateTraceForm (trace: TraceDetailDTO, onTraceUpdated?: () =
 
   return {
     form,
-    isFormValid
+    isFormValid,
+    hasErrors
   }
 }

--- a/src/features/student/traces/views/StudentTraceView/components/UpdateTraceModal/UpdateStep.test.ts
+++ b/src/features/student/traces/views/StudentTraceView/components/UpdateTraceModal/UpdateStep.test.ts
@@ -1,3 +1,4 @@
+import type { UpdateTraceForm as UpdateTraceFormApi } from '@/features/student/traces/types/forms.types'
 import { mockedTraceAssociations } from '@/__mocks__/fixtures/student'
 import { EFileType, type TraceDetailDTO } from '@/api/avenir-esr'
 import UpdateStep from '@/features/student/traces/views/StudentTraceView/components/UpdateTraceModal/UpdateStep.vue'
@@ -19,6 +20,7 @@ vi.mock('@/store', async () => {
 
 BddTest().given('an update step', () => {
   let wrapper: VueWrapper<InstanceType<typeof UpdateStep>>
+  const mockForm = {} as UpdateTraceFormApi
 
   const mockedTrace: TraceDetailDTO = {
     id: 'mock-trace',
@@ -55,7 +57,7 @@ BddTest().given('an update step', () => {
     },
     UpdateTraceForm: {
       name: 'UpdateTraceForm',
-      props: ['trace'],
+      props: ['trace', 'form'],
       template: '<div class="update-trace-form">Update Trace Form</div>'
     },
     TraceAssociations: {
@@ -67,7 +69,7 @@ BddTest().given('an update step', () => {
 
   beforeEach(async () => {
     vi.clearAllMocks()
-    wrapper = mount(UpdateStep, { props: { trace: mockedTrace, associations: mockedTraceAssociations }, global: { stubs } })
+    wrapper = mount(UpdateStep, { props: { trace: mockedTrace, associations: mockedTraceAssociations, form: mockForm }, global: { stubs } })
   })
 
   BddTest().when('the component is mounted', () => {
@@ -87,6 +89,11 @@ BddTest().given('an update step', () => {
     BddTest().then('it should pass trace prop to UpdateTraceForm', () => {
       const updateTraceForm = wrapper.findComponent({ name: 'UpdateTraceForm' })
       expect(updateTraceForm.props('trace')).toEqual(mockedTrace)
+    })
+
+    BddTest().then('it should pass form prop to UpdateTraceForm', () => {
+      const updateTraceForm = wrapper.findComponent({ name: 'UpdateTraceForm' })
+      expect(updateTraceForm.props('form')).toEqual(mockForm)
     })
 
     BddTest().then('it should initialize activeTab to 0', () => {

--- a/src/features/student/traces/views/StudentTraceView/components/UpdateTraceModal/UpdateStep.vue
+++ b/src/features/student/traces/views/StudentTraceView/components/UpdateTraceModal/UpdateStep.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { TraceAssociationsDTO, TraceDetailDTO } from '@/api/avenir-esr'
+import type { UpdateTraceForm as UpdateTraceFormApi } from '@/features/student/traces/types/forms.types'
 import TraceAssociations from '@/features/student/traces/components/composites/TraceAssociations/TraceAssociations.vue'
 import UpdateTraceForm from '@/features/student/traces/views/StudentTraceView/components/UpdateTraceForm/UpdateTraceForm.vue'
 import { AvTab, AvTabs, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
@@ -8,6 +9,7 @@ import { useI18n } from 'vue-i18n'
 interface UpdateStepProps {
   trace: TraceDetailDTO
   associations: TraceAssociationsDTO
+  form: UpdateTraceFormApi
 }
 
 defineProps<UpdateStepProps>()
@@ -29,6 +31,7 @@ const activeTab = ref(0)
       >
         <UpdateTraceForm
           :trace="trace"
+          :form="form"
         />
       </AvTab>
       <AvTab

--- a/src/features/student/traces/views/StudentTraceView/components/UpdateTraceModal/UpdateTraceModal.test.ts
+++ b/src/features/student/traces/views/StudentTraceView/components/UpdateTraceModal/UpdateTraceModal.test.ts
@@ -55,7 +55,7 @@ BddTest().given('an update trace modal', () => {
     },
     UpdateStep: {
       name: 'UpdateStep',
-      props: ['trace', 'associations'],
+      props: ['trace', 'associations', 'form'],
       template: '<div class="update-step" />'
     },
     ConfirmationModal: ConfirmationModalStub

--- a/src/features/student/traces/views/StudentTraceView/components/UpdateTraceModal/UpdateTraceModal.vue
+++ b/src/features/student/traces/views/StudentTraceView/components/UpdateTraceModal/UpdateTraceModal.vue
@@ -3,8 +3,10 @@ import type { TraceAssociationsDTO, TraceDetailDTO } from '@/api/avenir-esr'
 import { ConfirmationModal } from '@/common/components'
 import { useModal } from '@/common/composables'
 import { useTracesStore } from '@/features/student/traces/stores/traces.store'
+import { useUpdateTraceForm } from '@/features/student/traces/views/StudentTraceView/components/UpdateTraceForm/use-update-trace-form/use-update-trace-form'
 import TermsStep from '@/features/student/traces/views/StudentTraceView/components/UpdateTraceModal/TermsStep.vue'
 import UpdateStep from '@/features/student/traces/views/StudentTraceView/components/UpdateTraceModal/UpdateStep.vue'
+import { useToasterStore } from '@/store'
 import { AvModal, AvStepper, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
 import { useI18n } from 'vue-i18n'
 
@@ -23,6 +25,17 @@ enum UpdateTraceModalSteps {
 const { t } = useI18n()
 const tracesStore = useTracesStore()
 const { showUpdateTraceModal, updateTraceFormModified } = toRefs(tracesStore)
+const { addSuccessMessage } = useToasterStore()
+
+function onTraceUpdated () {
+  addSuccessMessage({
+    timeout: 2000,
+    description: t('student.traces.views.StudentTraceView.updateTraceModal.success')
+  })
+  closeModal()
+}
+
+const { form, hasErrors } = useUpdateTraceForm(trace, onTraceUpdated)
 
 const {
   showModal: showConfirmationModal,
@@ -36,6 +49,8 @@ const steps = computed(() => [
   t('student.traces.views.StudentTraceView.updateTraceModal.steps.terms.title'),
   t('student.traces.views.StudentTraceView.updateTraceModal.steps.update.title')
 ])
+
+const confirmDisabled = computed(() => currentStep.value === UpdateTraceModalSteps.Update && hasErrors.value)
 
 function goToNextStep () {
   currentStep.value++
@@ -84,6 +99,7 @@ const confirmIcon = computed(() => currentStep.value === UpdateTraceModalSteps.T
     :close-button-label="t('student.traces.views.StudentTraceView.updateTraceModal.buttons.close')"
     :confirm-button-label="confirmLabel"
     :confirm-button-icon="confirmIcon"
+    :confirm-button-disabled="confirmDisabled"
     @close="handleClose"
     @confirm="handleConfirm"
   >
@@ -106,6 +122,7 @@ const confirmIcon = computed(() => currentStep.value === UpdateTraceModalSteps.T
         :is="displayedStep"
         :trace="trace"
         :associations="associations"
+        :form="form"
       />
     </div>
   </AvModal>


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
This PR strengthens trace form validation logic by introducing dedicated validators and applying a maximum length constraint on AI justification fields across create and update flows.

Main changes:
- 🐛 Fixes form validation behavior for trace forms
- ✨ Introduces a reusable trace form validators composable and its tests
- ✅ Updates unit tests for create/update modal and trace details flows
- 💬 Aligns trace-related i18n messages in English and French locales

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1614

---

### Documentation
- Validation logic refactored into a dedicated composable for better maintainability
- Test suite expanded to cover validators and impacted UI flows
- No additional runtime configuration required

Modified areas include:
- Trace AI justification form field components and stubs/tests
- Trace form create/update composables
- Student trace details and update modal components/tests
- Trace locales (en.json, fr.json)

---

### Target Branch
develop

---

### Additional Notes
The comparison against origin/develop...HEAD shows 17 files changed with 264 insertions and 85 deletions, centered on validation hardening and test updates.

---

### Known Limitations or Side Effects
No known limitations or side effects at this stage.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [ ] No unnecessary code (e.g., debug logs, commented code)
- [ ] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to CHANGELOG.md file all properties and database change and details for the update process
