### PR TITLE
test(1578): add e2e tests for us 1512 publish activity

### DIFF
--- a/e2e/framework/staff/activities/StaffEditNationalActivityPage.ts
+++ b/e2e/framework/staff/activities/StaffEditNationalActivityPage.ts
@@ -207,4 +207,36 @@ class StaffEditNationalActivityPage extends BasePage {
   async verifyConsignFormFieldCollapsed () {
     await this.tabs().verifyActivityConsignFormFieldCollapsed()
   }
+
+  @Then('the publish button is visible and enabled')
+  async verifyPublishButtonVisibleAndEnabled () {
+    await this.tabs().verifyPublishButtonVisible()
+    await this.tabs().verifyPublishButtonEnabled()
+  }
+
+  @When('the staff clicks on the publish button')
+  async clickPublishButton () {
+    await this.tabs().clickPublishButton()
+  }
+
+  @Then('the publish confirmation modal is visible')
+  async verifyPublishConfirmationModalVisible () {
+    await this.tabs().verifyPublishConfirmationModalVisible()
+  }
+
+  @Then('the confirm and cancel buttons are visible')
+  async verifyConfirmAndCancelButtonsVisible () {
+    await this.tabs().verifyPublishConfirmButtonVisible()
+    await this.tabs().verifyPublishCancelButtonVisible()
+  }
+
+  @When('the staff clicks on the cancel button in the confirmation modal')
+  async clickPublishCancelButton () {
+    await this.tabs().clickPublishCancelButton()
+  }
+
+  @Then('the confirmation modal is closed')
+  async verifyPublishConfirmationModalClosed () {
+    await this.tabs().verifyPublishConfirmationModalNotVisible()
+  }
 }

--- a/e2e/framework/staff/activities/componentObjects/EditActivityTabs.ts
+++ b/e2e/framework/staff/activities/componentObjects/EditActivityTabs.ts
@@ -28,6 +28,22 @@ export class EditActivityTabs {
     return this.page.getByTestId('activity-summary-input')
   }
 
+  private getPublishButton () {
+    return this.page.getByTestId('publish-button')
+  }
+
+  private getPublishConfirmationModal () {
+    return this.page.getByTestId('publish-confirmation-modal')
+  }
+
+  private getPublishCancelButton () {
+    return this.page.getByTestId('publish-confirmation-modal').getByTestId('cancel-button')
+  }
+
+  private getPublishConfirmButton () {
+    return this.page.getByTestId('publish-confirmation-modal').getByTestId('confirm-button')
+  }
+
   private getContentTab () {
     return this.getTabs().getByTestId('activity-content-tab-item')
   }
@@ -152,5 +168,37 @@ export class EditActivityTabs {
 
   async verifyFeedbackMaxInputHidden () {
     await expect(this.getFeedbackMaxInputContainer()).toBeHidden()
+  }
+
+  async verifyPublishButtonVisible () {
+    await expect(this.getPublishButton()).toBeVisible()
+  }
+
+  async verifyPublishButtonEnabled () {
+    await expect(this.getPublishButton()).toBeEnabled()
+  }
+
+  async clickPublishButton () {
+    await clickOnElement(this.getPublishButton())
+  }
+
+  async verifyPublishConfirmationModalVisible () {
+    await expect(this.getPublishConfirmationModal()).toBeVisible()
+  }
+
+  async verifyPublishConfirmationModalNotVisible () {
+    await expect(this.getPublishConfirmationModal()).not.toBeVisible()
+  }
+
+  async verifyPublishConfirmButtonVisible () {
+    await expect(this.getPublishConfirmButton()).toBeVisible()
+  }
+
+  async verifyPublishCancelButtonVisible () {
+    await expect(this.getPublishCancelButton()).toBeVisible()
+  }
+
+  async clickPublishCancelButton () {
+    await clickOnElement(this.getPublishCancelButton())
   }
 }

--- a/e2e/tests/staff/activities/edit-national-activity.feature
+++ b/e2e/tests/staff/activities/edit-national-activity.feature
@@ -155,3 +155,19 @@ Feature: Staff Edit National Activity Page
     @high
     Scenario: The summary section is visible in the publication tab
       Then the summary section is visible
+
+    @high
+    Scenario: The publish button is visible and enabled by default
+      Then the publish button is visible and enabled
+
+    @high
+    Scenario: The staff can see the confirmation modal when clicking publish
+      When the staff clicks on the publish button
+      Then the publish confirmation modal is visible
+      And the confirm and cancel buttons are visible
+
+    @high
+    Scenario: The staff can cancel the publication
+      When the staff clicks on the publish button
+      And the staff clicks on the cancel button in the confirmation modal
+      Then the confirmation modal is closed

--- a/src/features/staff/activities/views/EditNationalActivityView/components/ActivityPublicationTab/ActivityPublicationTab.test.ts
+++ b/src/features/staff/activities/views/EditNationalActivityView/components/ActivityPublicationTab/ActivityPublicationTab.test.ts
@@ -54,7 +54,7 @@ const ConfirmationModalStub = defineComponent({
   },
   emits: ['confirm', 'close'],
   template: `
-    <div data-testid="confirmation-modal" :data-show="show ? 'true' : 'false'">
+    <div data-testid="publish-confirmation-modal" :data-show="show ? 'true' : 'false'">
       <button data-testid="confirm-publication" @click="$emit('confirm')">confirm</button>
       <button data-testid="close-publication" @click="$emit('close')">close</button>
     </div>
@@ -231,7 +231,7 @@ BddTest().given('an ActivityPublicationTab component', () => {
     })
 
     BddTest().then('it should keep confirmation modal closed', async () => {
-      await vi.waitFor(() => expect(tab.find('[data-testid="confirmation-modal"]').attributes('data-show')).toBe('false'))
+      await vi.waitFor(() => expect(tab.find('[data-testid="publish-confirmation-modal"]').attributes('data-show')).toBe('false'))
     })
   })
 
@@ -247,7 +247,7 @@ BddTest().given('an ActivityPublicationTab component', () => {
     })
 
     BddTest().then('it should open confirmation modal', async () => {
-      await vi.waitFor(() => expect(tab.find('[data-testid="confirmation-modal"]').attributes('data-show')).toBe('true'))
+      await vi.waitFor(() => expect(tab.find('[data-testid="publish-confirmation-modal"]').attributes('data-show')).toBe('true'))
     })
   })
 
@@ -261,7 +261,7 @@ BddTest().given('an ActivityPublicationTab component', () => {
       tab = wrapper.findComponent(ActivityPublicationTab)
 
       await tab.find('[data-testid="publish-button"]').trigger('click')
-      await vi.waitFor(() => expect(tab.find('[data-testid="confirmation-modal"]').attributes('data-show')).toBe('true'))
+      await vi.waitFor(() => expect(tab.find('[data-testid="publish-confirmation-modal"]').attributes('data-show')).toBe('true'))
       await tab.find('[data-testid="confirm-publication"]').trigger('click')
     })
 
@@ -290,7 +290,7 @@ BddTest().given('an ActivityPublicationTab component', () => {
       tab = wrapper.findComponent(ActivityPublicationTab)
 
       await tab.find('[data-testid="publish-button"]').trigger('click')
-      await vi.waitFor(() => expect(tab.find('[data-testid="confirmation-modal"]').attributes('data-show')).toBe('true'))
+      await vi.waitFor(() => expect(tab.find('[data-testid="publish-confirmation-modal"]').attributes('data-show')).toBe('true'))
       await tab.find('[data-testid="confirm-publication"]').trigger('click')
     })
 

--- a/src/features/staff/activities/views/EditNationalActivityView/components/ActivityPublicationTab/ActivityPublicationTab.vue
+++ b/src/features/staff/activities/views/EditNationalActivityView/components/ActivityPublicationTab/ActivityPublicationTab.vue
@@ -134,6 +134,7 @@ async function publishActivityDraft () {
     </div>
   </div>
   <ConfirmationModal
+    data-testid="publish-confirmation-modal"
     :show="showModal"
     :title="t('staff.activities.views.EditNationalActivityView.ActivityPublicationTab.confirmTitle')"
     :description="t('staff.activities.views.EditNationalActivityView.ActivityPublicationTab.confirmDescription')"


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
Implement E2E tests for the publish button and confirmation modal of the national activity publication tab, as part of US #1512

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1578

---

### Target Branch
develop

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process

