### PR TITLE
fix: UpdateProfile - make form dirty when picture updated

### DIFF
--- a/src/common/components/overlay/drawers/UpdateProfileDrawer/use-update-profile-form.test.ts
+++ b/src/common/components/overlay/drawers/UpdateProfileDrawer/use-update-profile-form.test.ts
@@ -114,7 +114,10 @@ BddTest().given('a useUpdateProfileForm composable', () => {
 
   BddTest().when('the composable is mounted', () => {
     BddTest().then('it should expose initial form values', () => {
-      expect(result.form.state.values).toEqual(initialData)
+      expect(result.form.state.values).toEqual({
+        ...initialData,
+        hasPicturesChanged: false,
+      })
     })
 
     BddTest().then('isModified should be false', () => {
@@ -127,6 +130,7 @@ BddTest().given('a useUpdateProfileForm composable', () => {
       const file = new File(['cover'], 'cover.jpg', { type: 'image/jpeg' })
       result.onCoverPictureUpdate(file)
       expect(result.isModified.value).toBe(true)
+      expect(result.form.state.values.hasPicturesChanged).toBe(true)
 
       const newCoverUrl = 'https://example.com/new-cover.jpg'
       result.onUpdateProfileCoverSuccess(newCoverUrl)
@@ -139,6 +143,7 @@ BddTest().given('a useUpdateProfileForm composable', () => {
       const file = new File(['profile'], 'profile.jpg', { type: 'image/jpeg' })
       result.onProfilePictureUpdate(file)
       expect(result.isModified.value).toBe(true)
+      expect(result.form.state.values.hasPicturesChanged).toBe(true)
 
       const newPhotoUrl = 'https://example.com/new-photo.jpg'
       result.onUpdateProfilePhotoSuccess(newPhotoUrl)
@@ -160,7 +165,10 @@ BddTest().given('a useUpdateProfileForm composable', () => {
       result.onCoverPictureUpdate(new File(['a'], 'a.jpg'))
       result.onProfilePictureUpdate(new File(['b'], 'b.jpg'))
       result.resetForm()
-      expect(result.form.state.values).toEqual(initialData)
+      expect(result.form.state.values).toEqual({
+        ...initialData,
+        hasPicturesChanged: false,
+      })
       expect(result.isModified.value).toBe(false)
     })
   })

--- a/src/common/components/overlay/drawers/UpdateProfileDrawer/use-update-profile-form.ts
+++ b/src/common/components/overlay/drawers/UpdateProfileDrawer/use-update-profile-form.ts
@@ -15,6 +15,7 @@ import { useI18n } from 'vue-i18n'
 
 interface UseUpdateProfileFormData extends Omit<ProfileOverviewDTO, 'bio'> {
   bio?: string
+  hasPicturesChanged?: boolean
 }
 
 export function useUpdateProfileForm (initialData: UseUpdateProfileFormData, profile: EUserCategory, onSuccess: () => void) {
@@ -28,6 +29,10 @@ export function useUpdateProfileForm (initialData: UseUpdateProfileFormData, pro
 
   const coverPictureFile = ref<File | null>(null)
   const profilePictureFile = ref<File | null>(null)
+  const defaultValues: UseUpdateProfileFormData = {
+    ...initialData,
+    hasPicturesChanged: false
+  }
 
   const validateBiography = (value?: string) => {
     if (!value) {
@@ -36,7 +41,7 @@ export function useUpdateProfileForm (initialData: UseUpdateProfileFormData, pro
     return value.trim().length > BIOGRAPHY_MAX_LENGTH ? t('global.overlay.drawers.UpdateProfileDrawer.identity.biography.errors.tooLong', { maxLength: BIOGRAPHY_MAX_LENGTH }) : undefined
   }
   const form = useForm({
-    defaultValues: { ...initialData },
+    defaultValues,
     validators: {
       onChange ({ value }: { value: UseUpdateProfileFormData }) {
         return {
@@ -97,10 +102,12 @@ export function useUpdateProfileForm (initialData: UseUpdateProfileFormData, pro
 
   function onCoverPictureUpdate (file: File | null) {
     coverPictureFile.value = file
+    form.setFieldValue('hasPicturesChanged', !!coverPictureFile.value || !!profilePictureFile.value)
   }
 
   function onProfilePictureUpdate (file: File | null) {
     profilePictureFile.value = file
+    form.setFieldValue('hasPicturesChanged', !!coverPictureFile.value || !!profilePictureFile.value)
   }
 
   const isPending = computed(() =>
@@ -129,7 +136,7 @@ export function useUpdateProfileForm (initialData: UseUpdateProfileFormData, pro
   })
 
   function resetForm () {
-    form.reset(initialData)
+    form.reset(defaultValues)
     coverPictureFile.value = null
     profilePictureFile.value = null
   }


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
This PR fixes the profile update drawer behavior so the form is marked as modified when a picture file is selected or removed from the upload component.

Main changes:
- 🐛 Ensure form dirty state reflects picture updates from file uploads
- 🏷️ Add an internal form field to track picture-change state
- ♻️ Align form reset with full default values including picture-change tracking

---

### Reference to an Issue, Feature, Task, User Story or another PR
No issue number detected in branch name (fix/update-profile-add-image-modified).

---

### Documentation
- Updated profile drawer form state management in the update profile form composable
- No API contract change
- No configuration change

---

### Target Branch
develop

---

### Additional Notes
The root cause was that uploaded files were stored in local refs outside TanStack form values, so state.isDirty could remain false. The fix synchronizes a dedicated internal form field whenever picture refs change.

---

### Known Limitations or Side Effects
No known limitations or side effects.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [ ] No unnecessary code (e.g., debug logs, commented code)
- [ ] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to CHANGELOG.md file all properties and database change and details for the update process
