### PR TITLE
refactor(1746): PageTitle - remove back prop

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -321,7 +321,7 @@ There is no `ProfileCardSteps` fixture because: it appears in one place, has no 
 
 **`PageTitle` — ComponentObject + Steps fixture (`PageTitleSteps`)**
 
-`PageTitle` is interactive (back button, expandable breadcrumb) and appears on every content page with page-specific title and breadcrumb items. These rules need to be verified in Gherkin, and they are the same steps regardless of which page they run on.
+`PageTitle` is interactive (expandable breadcrumb) and appears on every content page with page-specific title and breadcrumb items. These rules need to be verified in Gherkin, and they are the same steps regardless of which page they run on.
 
 ```typescript
 // PageTitleSteps.ts — wraps PageTitle, resolves page-specific data at runtime
@@ -337,9 +337,6 @@ async verifyPageTitleCorrect () {
 async verifyBreadcrumbCorrect () {
   await this.getPageTitle().verifyBreadcrumbItems(this.getCurrentPageConfig().breadcrumbItems)
 }
-
-@When('the user clicks the back button')
-async clickBackButton () { await this.getPageTitle().clickBackButton() }
 ```
 
 A Steps fixture is needed when: the component appears on multiple pages, has user interactions (`click*`), or carries functional rules (correct title, correct breadcrumb structure) that belong in Gherkin scenarios.

--- a/e2e/framework/shared/componentObjects/PageTitle.ts
+++ b/e2e/framework/shared/componentObjects/PageTitle.ts
@@ -27,10 +27,6 @@ export class PageTitle extends BaseObject {
     return this.getBreadcrumb().getByRole('link', { name: text })
   }
 
-  getBackButton () {
-    return this.root.getByRole('button', { name: t('global.buttons.goBack') })
-  }
-
   getShowBreadcrumbButton () {
     return this.getBreadcrumb().getByRole('button', { name: t('global.breadcrumb.expandButtonLabel') })
   }
@@ -70,10 +66,6 @@ export class PageTitle extends BaseObject {
     await this.getBreadcrumbLinkByIndex(index).click()
   }
 
-  async verifyBackButtonVisible () {
-    await expect(this.getBackButton()).toBeVisible()
-  }
-
   async verifyTitleVisible () {
     await expect(this.getTitle()).toBeVisible()
   }
@@ -81,21 +73,11 @@ export class PageTitle extends BaseObject {
   async verifyVisible () {
     await this.isVisible()
     await this.verifyBreadcrumbVisible()
-    await this.verifyBackButtonVisible()
     await this.verifyTitleVisible()
   }
 
   async verifyTitle (expectedTitle: string) {
     await expect(this.getTitle()).toHaveText(expectedTitle)
-  }
-
-  async verifyBackButton () {
-    await expect(this.getBackButton()).toBeVisible()
-    await expect(this.getBackButton()).toHaveAttribute('title', t('global.buttons.goBack'))
-  }
-
-  async clickBackButton () {
-    await this.getBackButton().click()
   }
 
   async verifyBreadcrumbItemsHidden () {

--- a/e2e/framework/shared/steps/PageTitleSteps.ts
+++ b/e2e/framework/shared/steps/PageTitleSteps.ts
@@ -64,17 +64,6 @@ class PageTitleSteps {
     await this.getPageTitle().verifyBreadcrumbItems(config.breadcrumbItems)
   }
 
-  @Then('the back button is correct')
-  async verifyBackButtonCorrect () {
-    await this.getPageTitle().verifyBackButton()
-  }
-
-  @When('the user clicks the back button')
-  async clickBackButton () {
-    await this.getPageTitle().clickBackButton()
-    await waitForPageLoad(this.page)
-  }
-
   @When('the user clicks the first breadcrumb link')
   async clickFirstBreadcrumbLink () {
     await this.getPageTitle().clickBreadcrumbLink(0)

--- a/e2e/tests/student/lifeProject/activities/activities.feature
+++ b/e2e/tests/student/lifeProject/activities/activities.feature
@@ -22,14 +22,8 @@ Feature: Student Project Activities Page
       And the show breadcrumb button is hidden
       And the breadcrumb items are visible
       And the breadcrumb is correct
-      And the back button is correct
       And the all activities tab new activities paginator card is correct
       And the all activities tab all activities section is correct
-
-    @high @page-title
-    Scenario: Student can interact with the page title back button
-      When the user clicks the back button
-      Then the page navigates to home page
 
     @high @page-title
     Scenario: Student can interact with the page title first breadcrumb link

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "avenirs-cofolio-client",
       "version": "0.0.0",
       "dependencies": {
-        "@avenirs-esr/avenirs-dsav": "^0.1.221",
+        "@avenirs-esr/avenirs-dsav": "^0.1.224",
         "@tanstack/vue-form": "^1.15.0",
         "@tanstack/vue-query": "^5.74.9",
         "@vue-flow/core": "^1.48.0",
@@ -348,9 +348,9 @@
       "license": "ISC"
     },
     "node_modules/@avenirs-esr/avenirs-dsav": {
-      "version": "0.1.221",
-      "resolved": "https://registry.npmjs.org/@avenirs-esr/avenirs-dsav/-/avenirs-dsav-0.1.221.tgz",
-      "integrity": "sha512-6MadxNnnXDgwq4N0dpuyTt1sfN5cyH7Y7amSBJJeqieEYFn3VSRSMKeX84KcoCj6WHs/s73Xe6y7ALFLLuZG6A==",
+      "version": "0.1.224",
+      "resolved": "https://registry.npmjs.org/@avenirs-esr/avenirs-dsav/-/avenirs-dsav-0.1.224.tgz",
+      "integrity": "sha512-pbvfRTZkMUSWcnDvSCmwuNnxf6UNALFZXOx34snxIp3oF/V6q9R1MAQ2KZDgIhZO0qSTwlhnVyt02mU+c2Lnmg==",
       "dependencies": {
         "@tanstack/vue-table": "^8.21.3",
         "@tiptap/extension-character-count": "^3.20.2",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
-    "@avenirs-esr/avenirs-dsav": "^0.1.221",
+    "@avenirs-esr/avenirs-dsav": "^0.1.224",
     "@tanstack/vue-form": "^1.15.0",
     "@tanstack/vue-query": "^5.74.9",
     "@vue-flow/core": "^1.48.0",

--- a/src/common/components/PageTitle/PageTitle.stub.ts
+++ b/src/common/components/PageTitle/PageTitle.stub.ts
@@ -1,19 +1,16 @@
 import type { AvBreadcrumbProps } from '@avenirs-esr/avenirs-dsav'
 import type { PropType } from 'vue'
-import type { RouteLocationRaw } from 'vue-router'
 
 export const PageTitleStub = defineComponent({
   name: 'PageTitle',
-  template: '<div><slot name="title" /></div>',
+  template: '<div data-testid="page-title"><slot name="title" /></div>',
   props: {
     title: {
       type: String,
     },
     breadcrumbLinks: {
       type: Array as PropType<AvBreadcrumbProps['links']>,
-    },
-    back: {
-      type: [String, Object] as PropType<RouteLocationRaw>,
+      required: true,
     },
   },
 })

--- a/src/common/components/PageTitle/PageTitle.test.ts
+++ b/src/common/components/PageTitle/PageTitle.test.ts
@@ -1,16 +1,8 @@
 import type { VueWrapper } from '@vue/test-utils'
 import PageTitle from '@/common/components/PageTitle/PageTitle.vue'
-import { ROUTES } from '@/common/constants'
 import { AvBreadcrumbStub, AvButtonStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { mountWithRouter } from 'tests/utils'
-import { beforeEach, expect, type MockedFunction, vi } from 'vitest'
-import { type Router, useRouter } from 'vue-router'
-
-vi.mock('vue-router', () => ({
-  useRouter: vi.fn(),
-}))
-
-const mockedUseRouter: MockedFunction<typeof useRouter> = vi.mocked(useRouter)
+import { beforeEach, expect, vi } from 'vitest'
 
 BddTest().given('a page title', () => {
   let wrapper: VueWrapper
@@ -20,7 +12,6 @@ BddTest().given('a page title', () => {
     { text: 'Page name' }
   ]
   const title = 'Page title'
-  const back = ROUTES.STUDENT.PROJECT_SKILLS
   const props = {
     breadcrumbLinks,
     title
@@ -67,46 +58,6 @@ BddTest().given('a page title', () => {
       const pageTitle = wrapper.find('.page-title')
       const slotTitleElement = pageTitle.find('.slot-title')
       expect(slotTitleElement.text()).toBe(slotTitle)
-    })
-  })
-
-  BddTest().when('clicking on the back button without back provided', () => {
-    let mockRouter: Partial<Router>
-
-    beforeEach(async () => {
-      mockRouter = { push: vi.fn() }
-      mockedUseRouter.mockReturnValue(mockRouter as Router)
-
-      wrapper = await mountWithRouter(PageTitle, {
-        props,
-        global: { stubs }
-      })
-    })
-
-    BddTest().then('it should call router.push with default "back" path', async () => {
-      const button = wrapper.findComponent(AvButtonStub)
-      await button.trigger('click')
-      expect(mockRouter.push).toHaveBeenCalledWith(ROUTES.STUDENT.HOME)
-    })
-  })
-
-  BddTest().when('clicking on the back button with back provided', () => {
-    let mockRouter: Partial<Router>
-
-    beforeEach(async () => {
-      mockRouter = { push: vi.fn() }
-      mockedUseRouter.mockReturnValue(mockRouter as Router)
-
-      wrapper = await mountWithRouter(PageTitle, {
-        props: { ...props, back },
-        global: { stubs }
-      })
-    })
-
-    BddTest().then('it should call router.push with provided "back" path', async () => {
-      const button = wrapper.findComponent(AvButtonStub)
-      await button.trigger('click')
-      expect(mockRouter.push).toHaveBeenCalledWith(back)
     })
   })
 })

--- a/src/common/components/PageTitle/PageTitle.vue
+++ b/src/common/components/PageTitle/PageTitle.vue
@@ -1,37 +1,23 @@
 <script setup lang="ts">
 import type { Slot } from 'vue'
-import type { RouteLocationRaw } from 'vue-router'
-import { ROUTES } from '@/common/constants'
-import { AvBreadcrumb, type AvBreadcrumbProps, AvButton, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
+import { AvBreadcrumb, type AvBreadcrumbProps } from '@avenirs-esr/avenirs-dsav'
 import { useI18n } from 'vue-i18n'
 
 export interface PageTitleProps {
   breadcrumbLinks: AvBreadcrumbProps['links']
   title: string
-  back?: RouteLocationRaw
 }
 
 const {
   breadcrumbLinks,
   title,
-  back = ROUTES.STUDENT.HOME
 } = defineProps<PageTitleProps>()
 
 defineSlots<{
   title: Slot
 }>()
 
-const router = useRouter()
 const { t } = useI18n()
-
-function goBack () {
-  if (window.history.state?.back) {
-    router.back()
-  }
-  else {
-    router.push(back)
-  }
-}
 </script>
 
 <template>
@@ -45,18 +31,9 @@ function goBack () {
         :show-breadcrumb-label="t('global.breadcrumb.expandButtonLabel')"
         :links="breadcrumbLinks"
       />
-      <div class="av-row av-gap-sm av-align-center">
-        <AvButton
-          :label="t('global.buttons.goBack')"
-          :icon-only="true"
-          variant="OUTLINED"
-          :icon="MDI_ICONS.ARROW_LEFT_THIN"
-          @click="goBack"
-        />
-        <slot name="title">
-          <h1>{{ title }}</h1>
-        </slot>
-      </div>
+      <slot name="title">
+        <h1>{{ title }}</h1>
+      </slot>
     </div>
   </div>
 </template>

--- a/src/common/components/UpdatePageTitle/UpdatePageTitle.stub.ts
+++ b/src/common/components/UpdatePageTitle/UpdatePageTitle.stub.ts
@@ -1,8 +1,8 @@
 import type { AvBreadcrumbProps } from 'node_modules/@avenirs-esr/avenirs-dsav/dist/components/navigation/AvBreadcrumb/AvBreadcrumb.vue'
 import type { PropType } from 'vue'
 
-export const DetailedPageTitleStub = defineComponent({
-  name: 'DetailedPageTitle',
+export const UpdatePageTitleStub = defineComponent({
+  name: 'UpdatePageTitle',
   props: {
     title: {
       type: String,
@@ -13,7 +13,7 @@ export const DetailedPageTitleStub = defineComponent({
     },
   },
   template: `
-    <div data-testid="detailed-page-title">
+    <div data-testid="update-page-title">
       <slot name="title" />
     </div>
   `

--- a/src/common/components/UpdatePageTitle/UpdatePageTitle.test.ts
+++ b/src/common/components/UpdatePageTitle/UpdatePageTitle.test.ts
@@ -1,0 +1,57 @@
+import type { VueWrapper } from '@vue/test-utils'
+import { PageTitleStub } from '@/common/components/PageTitle/PageTitle.stub'
+import UpdatePageTitle from '@/common/components/UpdatePageTitle/UpdatePageTitle.vue'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { mountWithRouter } from 'tests/utils'
+import { beforeEach, expect, vi } from 'vitest'
+
+BddTest().given('an update page title', () => {
+  let wrapper: VueWrapper<InstanceType<typeof UpdatePageTitle>>
+
+  const breadcrumbLinks = [
+    { text: 'Home', to: '/' },
+    { text: 'Update' }
+  ]
+  const title = 'My page title'
+  const props = {
+    title,
+    breadcrumbLinks
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  BddTest().when('the component is mounted', () => {
+    beforeEach(async () => {
+      wrapper = await mountWithRouter<typeof UpdatePageTitle>(UpdatePageTitle, {
+        props,
+        global: {
+          stubs: {
+            PageTitle: PageTitleStub
+          }
+        }
+      })
+    })
+
+    BddTest().then('it should render PageTitle with correct props', () => {
+      const pageTitle = wrapper.getComponent(PageTitleStub)
+
+      expect(pageTitle.props('title')).toBe(title)
+      expect(pageTitle.props('breadcrumbLinks')).toStrictEqual(breadcrumbLinks)
+    })
+
+    BddTest().then('it should render the detailed title slot', () => {
+      const titleContainer = wrapper.find('h1')
+      expect(titleContainer.exists()).toBe(true)
+      expect(titleContainer.text()).toContain('Modifier')
+      expect(titleContainer.text()).toContain(title)
+    })
+
+    BddTest().then('the page title should be highlighted', () => {
+      const highlightedTitle = wrapper.find('.n4')
+      expect(highlightedTitle.exists()).toBe(true)
+      expect(highlightedTitle.text()).toBe(title)
+    })
+  })
+})

--- a/src/common/components/UpdatePageTitle/UpdatePageTitle.vue
+++ b/src/common/components/UpdatePageTitle/UpdatePageTitle.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+import PageTitle, { type PageTitleProps } from '@/common/components/PageTitle/PageTitle.vue'
+import { useI18n } from 'vue-i18n'
+
+defineProps<PageTitleProps>()
+
+const { t } = useI18n()
+</script>
+
+<template>
+  <PageTitle v-bind="$props">
+    <template #title>
+      <h1 class="av-text-title">
+        {{ t('global.buttons.update') }}
+        <span class="n4">{{ title }}</span>
+      </h1>
+    </template>
+  </PageTitle>
+</template>
+
+<style lang="scss" scoped>
+.n4 {
+  color: var(--dark-background-neutral)
+}
+</style>

--- a/src/common/types/router.types.ts
+++ b/src/common/types/router.types.ts
@@ -18,6 +18,5 @@ export interface BreadcrumbLinkRaw {
 }
 
 export interface RoutePageProps {
-  backRoute?: RouteLocationRaw
   breadcrumbLinksRaw?: BreadcrumbLinkRaw[]
 }

--- a/src/common/views/AccessibilityView/AccessibilityView.test.ts
+++ b/src/common/views/AccessibilityView/AccessibilityView.test.ts
@@ -20,25 +20,10 @@ BddTest().given('a accessibility view', () => {
     beforeEach(() => mountDefault())
 
     BddTest().then('it should render PageTitle with correct props', () => {
-      const pageTitle = wrapper.findComponent({ name: 'PageTitle' })
+      const pageTitle = wrapper.findComponent(PageTitleStub)
 
       expect(pageTitle.props('title')).toBe(title)
       expect(pageTitle.props('breadcrumbLinks')).toEqual(defaultBreadcrumbLinks)
-      expect(pageTitle.props('back')).toBe(undefined)
-    })
-  })
-
-  BddTest().when('the view is mounted with back route', () => {
-    const backRoute = '/back-route'
-
-    beforeEach(() => mountDefault({ backRoute }))
-
-    BddTest().then('it should render PageTitle with correct props', () => {
-      const pageTitle = wrapper.findComponent({ name: 'PageTitle' })
-
-      expect(pageTitle.props('title')).toBe(title)
-      expect(pageTitle.props('breadcrumbLinks')).toEqual(defaultBreadcrumbLinks)
-      expect(pageTitle.props('back')).toBe('/back-route')
     })
   })
 
@@ -48,11 +33,10 @@ BddTest().given('a accessibility view', () => {
     beforeEach(() => mountDefault({ breadcrumbLinksRaw }))
 
     BddTest().then('it should render PageTitle with correct props', () => {
-      const pageTitle = wrapper.findComponent({ name: 'PageTitle' })
+      const pageTitle = wrapper.findComponent(PageTitleStub)
 
       expect(pageTitle.props('title')).toBe(title)
       expect(pageTitle.props('breadcrumbLinks')).toEqual([{ text: title }, ...defaultBreadcrumbLinks])
-      expect(pageTitle.props('back')).toBe(undefined)
     })
   })
 })

--- a/src/common/views/AccessibilityView/AccessibilityView.vue
+++ b/src/common/views/AccessibilityView/AccessibilityView.vue
@@ -3,10 +3,7 @@ import type { RoutePageProps } from '@/common/types'
 import PageTitle from '@/common/components/PageTitle/PageTitle.vue'
 import { useI18n } from 'vue-i18n'
 
-const {
-  backRoute,
-  breadcrumbLinksRaw = []
-} = defineProps<RoutePageProps>()
+const { breadcrumbLinksRaw = [] } = defineProps<RoutePageProps>()
 
 const { t, locale } = useI18n()
 
@@ -35,7 +32,6 @@ watchEffect(() => {
   <PageTitle
     :title="title"
     :breadcrumb-links="allBreadcrumbLinks"
-    :back="backRoute"
   />
 
   <div

--- a/src/common/views/CookiesView/CookiesView.test.ts
+++ b/src/common/views/CookiesView/CookiesView.test.ts
@@ -20,25 +20,10 @@ BddTest().given('a cookies view', () => {
     beforeEach(() => mountDefault())
 
     BddTest().then('it should render PageTitle with correct props', () => {
-      const pageTitle = wrapper.findComponent({ name: 'PageTitle' })
+      const pageTitle = wrapper.findComponent(PageTitleStub)
 
       expect(pageTitle.props('title')).toBe(title)
       expect(pageTitle.props('breadcrumbLinks')).toEqual(defaultBreadcrumbLinks)
-      expect(pageTitle.props('back')).toBe(undefined)
-    })
-  })
-
-  BddTest().when('the view is mounted with back route', () => {
-    const backRoute = '/back-route'
-
-    beforeEach(() => mountDefault({ backRoute }))
-
-    BddTest().then('it should render PageTitle with correct props', () => {
-      const pageTitle = wrapper.findComponent({ name: 'PageTitle' })
-
-      expect(pageTitle.props('title')).toBe(title)
-      expect(pageTitle.props('breadcrumbLinks')).toEqual(defaultBreadcrumbLinks)
-      expect(pageTitle.props('back')).toBe('/back-route')
     })
   })
 
@@ -48,11 +33,10 @@ BddTest().given('a cookies view', () => {
     beforeEach(() => mountDefault({ breadcrumbLinksRaw }))
 
     BddTest().then('it should render PageTitle with correct props', () => {
-      const pageTitle = wrapper.findComponent({ name: 'PageTitle' })
+      const pageTitle = wrapper.findComponent(PageTitleStub)
 
       expect(pageTitle.props('title')).toBe(title)
       expect(pageTitle.props('breadcrumbLinks')).toEqual([{ text: title }, ...defaultBreadcrumbLinks])
-      expect(pageTitle.props('back')).toBe(undefined)
     })
   })
 })

--- a/src/common/views/CookiesView/CookiesView.vue
+++ b/src/common/views/CookiesView/CookiesView.vue
@@ -3,10 +3,7 @@ import type { RoutePageProps } from '@/common/types'
 import PageTitle from '@/common/components/PageTitle/PageTitle.vue'
 import { useI18n } from 'vue-i18n'
 
-const {
-  backRoute,
-  breadcrumbLinksRaw = []
-} = defineProps<RoutePageProps>()
+const { breadcrumbLinksRaw = [] } = defineProps<RoutePageProps>()
 
 const { t } = useI18n()
 
@@ -22,6 +19,5 @@ const allBreadcrumbLinks = computed(() => [
   <PageTitle
     :title="title"
     :breadcrumb-links="allBreadcrumbLinks"
-    :back="backRoute"
   />
 </template>

--- a/src/common/views/LegalView/LegalView.test.ts
+++ b/src/common/views/LegalView/LegalView.test.ts
@@ -20,25 +20,10 @@ BddTest().given('a legal view', () => {
     beforeEach(() => mountDefault())
 
     BddTest().then('it should render PageTitle with correct props', () => {
-      const pageTitle = wrapper.findComponent({ name: 'PageTitle' })
+      const pageTitle = wrapper.findComponent(PageTitleStub)
 
       expect(pageTitle.props('title')).toBe(title)
       expect(pageTitle.props('breadcrumbLinks')).toEqual(defaultBreadcrumbLinks)
-      expect(pageTitle.props('back')).toBe(undefined)
-    })
-  })
-
-  BddTest().when('the view is mounted with back route', () => {
-    const backRoute = '/back-route'
-
-    beforeEach(() => mountDefault({ backRoute }))
-
-    BddTest().then('it should render PageTitle with correct props', () => {
-      const pageTitle = wrapper.findComponent({ name: 'PageTitle' })
-
-      expect(pageTitle.props('title')).toBe(title)
-      expect(pageTitle.props('breadcrumbLinks')).toEqual(defaultBreadcrumbLinks)
-      expect(pageTitle.props('back')).toBe('/back-route')
     })
   })
 
@@ -48,11 +33,10 @@ BddTest().given('a legal view', () => {
     beforeEach(() => mountDefault({ breadcrumbLinksRaw }))
 
     BddTest().then('it should render PageTitle with correct props', () => {
-      const pageTitle = wrapper.findComponent({ name: 'PageTitle' })
+      const pageTitle = wrapper.findComponent(PageTitleStub)
 
       expect(pageTitle.props('title')).toBe(title)
       expect(pageTitle.props('breadcrumbLinks')).toEqual([{ text: title }, ...defaultBreadcrumbLinks])
-      expect(pageTitle.props('back')).toBe(undefined)
     })
   })
 })

--- a/src/common/views/LegalView/LegalView.vue
+++ b/src/common/views/LegalView/LegalView.vue
@@ -3,10 +3,7 @@ import type { RoutePageProps } from '@/common/types'
 import PageTitle from '@/common/components/PageTitle/PageTitle.vue'
 import { useI18n } from 'vue-i18n'
 
-const {
-  backRoute,
-  breadcrumbLinksRaw = []
-} = defineProps<RoutePageProps>()
+const { breadcrumbLinksRaw = [] } = defineProps<RoutePageProps>()
 
 const { t } = useI18n()
 
@@ -22,6 +19,5 @@ const allBreadcrumbLinks = computed(() => [
   <PageTitle
     :title="title"
     :breadcrumb-links="allBreadcrumbLinks"
-    :back="backRoute"
   />
 </template>

--- a/src/common/views/PersonalDataView/PersonalDataView.test.ts
+++ b/src/common/views/PersonalDataView/PersonalDataView.test.ts
@@ -20,25 +20,10 @@ BddTest().given('a personal data view', () => {
     beforeEach(() => mountDefault())
 
     BddTest().then('it should render PageTitle with correct props', () => {
-      const pageTitle = wrapper.findComponent({ name: 'PageTitle' })
+      const pageTitle = wrapper.findComponent(PageTitleStub)
 
       expect(pageTitle.props('title')).toBe(title)
       expect(pageTitle.props('breadcrumbLinks')).toEqual(defaultBreadcrumbLinks)
-      expect(pageTitle.props('back')).toBe(undefined)
-    })
-  })
-
-  BddTest().when('the view is mounted with back route', () => {
-    const backRoute = '/back-route'
-
-    beforeEach(() => mountDefault({ backRoute }))
-
-    BddTest().then('it should render PageTitle with correct props', () => {
-      const pageTitle = wrapper.findComponent({ name: 'PageTitle' })
-
-      expect(pageTitle.props('title')).toBe(title)
-      expect(pageTitle.props('breadcrumbLinks')).toEqual(defaultBreadcrumbLinks)
-      expect(pageTitle.props('back')).toBe('/back-route')
     })
   })
 
@@ -48,11 +33,10 @@ BddTest().given('a personal data view', () => {
     beforeEach(() => mountDefault({ breadcrumbLinksRaw }))
 
     BddTest().then('it should render PageTitle with correct props', () => {
-      const pageTitle = wrapper.findComponent({ name: 'PageTitle' })
+      const pageTitle = wrapper.findComponent(PageTitleStub)
 
       expect(pageTitle.props('title')).toBe(title)
       expect(pageTitle.props('breadcrumbLinks')).toEqual([{ text: title }, ...defaultBreadcrumbLinks])
-      expect(pageTitle.props('back')).toBe(undefined)
     })
   })
 })

--- a/src/common/views/PersonalDataView/PersonalDataView.vue
+++ b/src/common/views/PersonalDataView/PersonalDataView.vue
@@ -3,10 +3,7 @@ import type { RoutePageProps } from '@/common/types'
 import PageTitle from '@/common/components/PageTitle/PageTitle.vue'
 import { useI18n } from 'vue-i18n'
 
-const {
-  backRoute,
-  breadcrumbLinksRaw = []
-} = defineProps<RoutePageProps>()
+const { breadcrumbLinksRaw = [] } = defineProps<RoutePageProps>()
 
 const { t } = useI18n()
 
@@ -22,6 +19,5 @@ const allBreadcrumbLinks = computed(() => [
   <PageTitle
     :title="title"
     :breadcrumb-links="allBreadcrumbLinks"
-    :back="backRoute"
   />
 </template>

--- a/src/features/staff/activities/views/ActivitiesView/ActivitiesView.test.ts
+++ b/src/features/staff/activities/views/ActivitiesView/ActivitiesView.test.ts
@@ -46,7 +46,6 @@ BddTest().given('a staff activities view', () => {
         { text: 'Accueil', to: ROUTES.STAFF.HOME },
         { text: 'Bibliothèque des activités' },
       ])
-      expect(pageTitle.props('back')).toBe(ROUTES.STAFF.HOME)
     })
 
     BddTest().then('it should render AvTabs component', () => {

--- a/src/features/staff/activities/views/ActivitiesView/ActivitiesView.vue
+++ b/src/features/staff/activities/views/ActivitiesView/ActivitiesView.vue
@@ -26,7 +26,6 @@ const activeTab = useEnumRouteQuery('tab', ActivitiesViewTab, ActivitiesViewTab.
   <PageTitle
     :title="t('staff.global.views.ActivitiesView.title')"
     :breadcrumb-links="breadcrumbLinks"
-    :back="ROUTES.STAFF.HOME"
   />
   <AvTabs v-model="activeTab">
     <AvTab

--- a/src/features/staff/activities/views/EditNationalActivityView/EditNationalActivityView.test.ts
+++ b/src/features/staff/activities/views/EditNationalActivityView/EditNationalActivityView.test.ts
@@ -97,7 +97,7 @@ BddTest().given('a national activity view', () => {
     })
 
     BddTest().then('it should render PageTitle with add props', () => {
-      const pageTitle = wrapper.findComponent({ name: 'PageTitle' })
+      const pageTitle = wrapper.findComponent(PageTitleStub)
 
       expect(pageTitle.props('title')).toBe('Créer mon activité')
       expect(pageTitle.props('breadcrumbLinks')).toEqual([
@@ -105,7 +105,6 @@ BddTest().given('a national activity view', () => {
         { text: 'Bibliothèque des activités', to: ROUTES.STAFF.ACTIVITIES },
         { text: 'Créer mon activité' }
       ])
-      expect(pageTitle.props('back')).toBe(ROUTES.STAFF.ACTIVITIES)
     })
   })
 
@@ -116,7 +115,7 @@ BddTest().given('a national activity view', () => {
     })
 
     BddTest().then('it should render PageTitle with edit props', () => {
-      const pageTitle = wrapper.findComponent({ name: 'PageTitle' })
+      const pageTitle = wrapper.findComponent(PageTitleStub)
 
       expect(pageTitle.props('title')).toBe('Modifier l\'activité')
       expect(pageTitle.props('breadcrumbLinks')).toEqual([
@@ -124,7 +123,6 @@ BddTest().given('a national activity view', () => {
         { text: 'Bibliothèque des activités', to: ROUTES.STAFF.ACTIVITIES },
         { text: 'Modifier l\'activité' }
       ])
-      expect(pageTitle.props('back')).toBe(ROUTES.STAFF.ACTIVITIES)
     })
   })
 
@@ -181,7 +179,7 @@ BddTest().given('a national activity view', () => {
       mockMode.value = 'edit'
       wrapper = mountView()
       await vi.waitFor(() => {
-        expect(wrapper.findComponent({ name: 'QuerySuspense' }).props('isLoading')).toBe(false)
+        expect(wrapper.findComponent(QuerySuspenseStub).props('isLoading')).toBe(false)
       })
     })
 
@@ -210,7 +208,7 @@ BddTest().given('a national activity view', () => {
       mockMode.value = 'edit'
       wrapper = mountView()
       await vi.waitFor(() => {
-        expect(wrapper.findComponent({ name: 'QuerySuspense' }).props('isLoading')).toBe(false)
+        expect(wrapper.findComponent(QuerySuspenseStub).props('isLoading')).toBe(false)
       })
       wrapper.findComponent({ name: 'AvTabs' }).vm.$emit('update:modelValue', EditActivityTabIndex.PUBLICATION)
       await wrapper.vm.$nextTick()
@@ -226,7 +224,7 @@ BddTest().given('a national activity view', () => {
       mockMode.value = 'edit'
       wrapper = mountView()
       await vi.waitFor(() => {
-        expect(wrapper.findComponent({ name: 'QuerySuspense' }).props('isLoading')).toBe(false)
+        expect(wrapper.findComponent(QuerySuspenseStub).props('isLoading')).toBe(false)
       })
       wrapper.findComponent(ActivityContentTabStub).vm.$emit('nextStep')
       await wrapper.vm.$nextTick()
@@ -242,10 +240,10 @@ BddTest().given('a national activity view', () => {
       mockMode.value = 'edit'
       wrapper = mountView()
       await vi.waitFor(() => {
-        expect(wrapper.findComponent({ name: 'QuerySuspense' }).props('isLoading')).toBe(false)
+        expect(wrapper.findComponent(QuerySuspenseStub).props('isLoading')).toBe(false)
       })
 
-      wrapper.findComponent({ name: 'AvTabs' }).vm.$emit('update:modelValue', EditActivityTabIndex.PUBLICATION)
+      wrapper.findComponent(AvTabsStub).vm.$emit('update:modelValue', EditActivityTabIndex.PUBLICATION)
       await wrapper.vm.$nextTick()
 
       wrapper.findComponent(ActivityPublicationTabStub).vm.$emit('published')

--- a/src/features/staff/activities/views/EditNationalActivityView/EditNationalActivityView.vue
+++ b/src/features/staff/activities/views/EditNationalActivityView/EditNationalActivityView.vue
@@ -155,7 +155,6 @@ provideEditNationalActivityViewContext({ form, isUpdating: isPending, save, canc
   <PageTitle
     :title="title"
     :breadcrumb-links="breadcrumbLinks"
-    :back="ROUTES.STAFF.ACTIVITIES"
   />
   <QuerySuspense
     :is-loading="isLoading"

--- a/src/features/staff/activities/views/NationalActivityCatalogView/NationalActivityCatalogView.test.ts
+++ b/src/features/staff/activities/views/NationalActivityCatalogView/NationalActivityCatalogView.test.ts
@@ -53,24 +53,20 @@ BddTest().given('a national activity catalog view', () => {
       ])
     })
 
-    BddTest().then('it should render PageTitle with the correct back route', () => {
-      expect(pageTitle.props('back')).toBe(ROUTES.STAFF.ACTIVITIES)
-    })
-
     BddTest().then('it should render QuerySuspense with the correct error title', () => {
-      expect(wrapper.findComponent({ name: 'QuerySuspense' }).props('errorTitle')).toBe('Impossible de charger l\'activité')
+      expect(wrapper.findComponent(QuerySuspenseStub).props('errorTitle')).toBe('Impossible de charger l\'activité')
     })
   })
 
   BddTest().when('the activity is loaded', () => {
     beforeEach(async () => {
       await vi.waitFor(() => {
-        expect(wrapper.findComponent({ name: 'QuerySuspense' }).props('isLoading')).toBe(false)
+        expect(wrapper.findComponent(QuerySuspenseStub).props('isLoading')).toBe(false)
       })
     })
 
     BddTest().then('it should render NationalActivityContentTab with the correct activity', () => {
-      expect(wrapper.findComponent({ name: 'NationalActivityContentTab' }).props('activity')).toEqual(mockedActivityContent)
+      expect(wrapper.findComponent(NationalActivityContentTabStub).props('activity')).toEqual(mockedActivityContent)
     })
   })
 
@@ -82,7 +78,7 @@ BddTest().given('a national activity catalog view', () => {
 
     BddTest().then('it should render QuerySuspense with an error', async () => {
       await vi.waitFor(() => {
-        expect(wrapper.findComponent({ name: 'QuerySuspense' }).props('error')).toBeTruthy()
+        expect(wrapper.findComponent(QuerySuspenseStub).props('error')).toBeTruthy()
       })
     })
   })

--- a/src/features/staff/activities/views/NationalActivityCatalogView/NationalActivityCatalogView.vue
+++ b/src/features/staff/activities/views/NationalActivityCatalogView/NationalActivityCatalogView.vue
@@ -29,7 +29,6 @@ const breadcrumbLinks = computed(() => [
   <PageTitle
     :title="t('staff.activities.views.NationalActivityCatalogView.title')"
     :breadcrumb-links="breadcrumbLinks"
-    :back="ROUTES.STAFF.ACTIVITIES"
   />
   <QuerySuspense
     :is-loading="isLoading"

--- a/src/features/staff/global/routes/index.ts
+++ b/src/features/staff/global/routes/index.ts
@@ -3,7 +3,6 @@ import { ROUTES } from '@/common/constants'
 import { staffActivitiesEditNationalActivityRoute, staffActivitiesRoute, staffActivityCatalogRoute } from '@/features/staff/activities/routes'
 
 const footerLegalProps: RoutePageProps = {
-  backRoute: ROUTES.STAFF.HOME,
   breadcrumbLinksRaw: [
     { textKey: 'staff.global.navigation.tabs.home', to: ROUTES.STAFF.HOME },
   ]

--- a/src/features/student/buildProject/views/ProjectActivitiesCatalogView/ProjectActivitiesCatalogView.test.ts
+++ b/src/features/student/buildProject/views/ProjectActivitiesCatalogView/ProjectActivitiesCatalogView.test.ts
@@ -78,24 +78,19 @@ BddTest().given('a project activities catalog view', () => {
       expect(pageTitle.props('title')).toBe('Toutes les activités disponibles')
     })
 
-    BddTest().then('it should pass the correct back route', () => {
-      const pageTitle = wrapper.findComponent(PageTitleStub)
-      expect(pageTitle.props('back')).toBe(ROUTES.STUDENT.HOME)
-    })
-
     BddTest().then('it should pass the correct breadcrumb links', () => {
       const pageTitle = wrapper.findComponent(PageTitleStub)
       const breadcrumbLinks = pageTitle.props('breadcrumbLinks')
 
       expect(breadcrumbLinks).toHaveLength(3)
-      expect(breadcrumbLinks?.[0]).toEqual({
+      expect(breadcrumbLinks[0]).toEqual({
         text: 'Accueil',
         to: ROUTES.STUDENT.HOME
       })
-      expect(breadcrumbLinks?.[1]).toEqual({
+      expect(breadcrumbLinks[1]).toEqual({
         text: 'Construire mon projet de vie'
       })
-      expect(breadcrumbLinks?.[2]).toEqual({
+      expect(breadcrumbLinks[2]).toEqual({
         text: 'Mes activités',
         to: ROUTES.STUDENT.PROJECT_ACTIVITIES,
       })

--- a/src/features/student/buildProject/views/ProjectActivitiesCatalogView/ProjectActivitiesCatalogView.vue
+++ b/src/features/student/buildProject/views/ProjectActivitiesCatalogView/ProjectActivitiesCatalogView.vue
@@ -76,7 +76,6 @@ const breadcrumbLinks = computed(() => [
   <PageTitle
     :title="t('student.buildProject.activities.views.ProjectActivitiesCatalogView.title')"
     :breadcrumb-links="breadcrumbLinks"
-    :back="ROUTES.STUDENT.HOME"
   />
   <div
     class="av-py-md av-gap-sm"

--- a/src/features/student/buildProject/views/ProjectActivitiesView/ProjectActivitiesView.test.ts
+++ b/src/features/student/buildProject/views/ProjectActivitiesView/ProjectActivitiesView.test.ts
@@ -40,22 +40,17 @@ BddTest().given('a project activities view', () => {
 
   BddTest().when('the view is mounted', () => {
     BddTest().then('it should render the page title component', () => {
-      const pageTitle = wrapper.findComponent({ name: 'PageTitle' })
+      const pageTitle = wrapper.findComponent(PageTitleStub)
       expect(pageTitle.exists()).toBe(true)
     })
 
     BddTest().then('it should pass the correct title', () => {
-      const pageTitle = wrapper.findComponent({ name: 'PageTitle' })
+      const pageTitle = wrapper.findComponent(PageTitleStub)
       expect(pageTitle.props('title')).toBe('Mes activités')
     })
 
-    BddTest().then('it should pass the correct back route', () => {
-      const pageTitle = wrapper.findComponent({ name: 'PageTitle' })
-      expect(pageTitle.props('back')).toBe(ROUTES.STUDENT.HOME)
-    })
-
     BddTest().then('it should pass the correct breadcrumb links', () => {
-      const pageTitle = wrapper.findComponent({ name: 'PageTitle' })
+      const pageTitle = wrapper.findComponent(PageTitleStub)
       const breadcrumbLinks = pageTitle.props('breadcrumbLinks')
 
       expect(breadcrumbLinks).toHaveLength(3)
@@ -78,7 +73,7 @@ BddTest().given('a project activities view', () => {
 
   BddTest().when('the library tab is selected', () => {
     beforeEach(async () => {
-      wrapper.findComponent({ name: 'AvTabs' }).vm.$emit('update:modelValue', 1)
+      wrapper.findComponent(AvTabsStub).vm.$emit('update:modelValue', 1)
       await wrapper.vm.$nextTick()
     })
 

--- a/src/features/student/buildProject/views/ProjectActivitiesView/ProjectActivitiesView.vue
+++ b/src/features/student/buildProject/views/ProjectActivitiesView/ProjectActivitiesView.vue
@@ -46,7 +46,6 @@ const breadcrumbLinks = computed(() => [
   <PageTitle
     :title="t('student.buildProject.views.projectActivitiesView.title')"
     :breadcrumb-links="breadcrumbLinks"
-    :back="ROUTES.STUDENT.HOME"
   />
   <AvTabs
     v-model="activeTab"

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/ProjectActivityDetailedView.test.ts
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/ProjectActivityDetailedView.test.ts
@@ -72,24 +72,19 @@ BddTest().given('a project activity detailed view', () => {
       expect(title.text()).toContain('Détail Activité "Connaissance de soi" : Définir ses valeurs')
     })
 
-    BddTest().then('it should pass the correct back route', () => {
-      const pageTitle = wrapper.findComponent(PageTitleStub)
-      expect(pageTitle.props('back')).toBe(ROUTES.STUDENT.HOME)
-    })
-
     BddTest().then('it should pass the correct breadcrumb links', () => {
       const pageTitle = wrapper.findComponent(PageTitleStub)
       const breadcrumbLinks = pageTitle.props('breadcrumbLinks')
 
       expect(breadcrumbLinks).toHaveLength(3)
-      expect(breadcrumbLinks?.[0]).toEqual({
+      expect(breadcrumbLinks[0]).toEqual({
         text: 'Accueil',
         to: ROUTES.STUDENT.HOME
       })
-      expect(breadcrumbLinks?.[1]).toEqual({
+      expect(breadcrumbLinks[1]).toEqual({
         text: 'Construire mon projet de vie'
       })
-      expect(breadcrumbLinks?.[2]).toEqual({
+      expect(breadcrumbLinks[2]).toEqual({
         text: 'Mes activités'
       })
     })

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/ProjectActivityDetailedView.vue
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/ProjectActivityDetailedView.vue
@@ -55,7 +55,6 @@ function onUnsubscribed () {
       <PageTitle
         :title="t('global.detail')"
         :breadcrumb-links="breadcrumbLinks"
-        :back="ROUTES.STUDENT.HOME"
       >
         <template #title>
           <h1

--- a/src/features/student/declaredSkills/locales/en.json
+++ b/src/features/student/declaredSkills/locales/en.json
@@ -109,8 +109,7 @@
             "details": {
               "title": "My declared skill"
             }
-          },
-          "title": "Declared skill details"
+          }
         },
         "StudentUpdateDeclaredSkillView": {
           "tabs": {
@@ -118,7 +117,6 @@
               "title": "My declared skill"
             }
           },
-          "title": "Update my declared skill",
           "updateAssociations": {
             "addTraceButton": "Add a trace",
             "errors": {

--- a/src/features/student/declaredSkills/locales/fr.json
+++ b/src/features/student/declaredSkills/locales/fr.json
@@ -109,8 +109,7 @@
             "details": {
               "title": "Ma compétence déclarée"
             }
-          },
-          "title": "Détail de ma compétence déclarée"
+          }
         },
         "StudentUpdateDeclaredSkillView": {
           "tabs": {
@@ -118,7 +117,6 @@
               "title": "Ma compétence déclarée"
             }
           },
-          "title": "Modifier ma compétence déclarée",
           "updateAssociations": {
             "addTraceButton": "Ajouter une trace",
             "errors": {

--- a/src/features/student/declaredSkills/views/StudentDeclaredSkillView/StudentDeclaredSkillView.test.ts
+++ b/src/features/student/declaredSkills/views/StudentDeclaredSkillView/StudentDeclaredSkillView.test.ts
@@ -3,9 +3,11 @@ import {
   detailedSkillProgressNotFoundErrorHandler
 } from '@/__mocks__/msw/handlers/student/skills.handlers'
 import { server } from '@/__mocks__/msw/server'
+import { DetailedPageTitleStub } from '@/common/components/DetailedPageTitle/DetailedPageTitle.stub'
 import { ErrorMessageStub } from '@/common/components/feedback/ErrorMessage/ErrorMessage.stub'
-import { PageTitleStub } from '@/common/components/PageTitle/PageTitle.stub'
 import { ROUTES } from '@/common/constants'
+import { DeclaredSkillDetailsStub } from '@/features/student/declaredSkills/views/StudentDeclaredSkillView/components/DeclaredSkillDetails/DeclaredSkillDetails.stub'
+import { DeclaredSkillSettingDropdownStub } from '@/features/student/declaredSkills/views/StudentDeclaredSkillView/components/DeclaredSkillSettingDropdown/DeclaredSkillSettingDropdown.stub'
 import { DeleteDeclaredSkillConfirmModalStub } from '@/features/student/declaredSkills/views/StudentDeclaredSkillView/components/DeleteDeclaredSkillConfirmModal/DeleteDeclaredSkillConfirmModal.stub'
 import { StudentDeclaredSkillAssociationsStub } from '@/features/student/declaredSkills/views/StudentDeclaredSkillView/components/StudentDeclaredSkillAssociations/StudentDeclaredSkillAssociations.stub'
 import StudentDeclaredSkillView from '@/features/student/declaredSkills/views/StudentDeclaredSkillView/StudentDeclaredSkillView.vue'
@@ -28,21 +30,14 @@ vi.mock('@/common/composables', async () => {
 })
 
 const stubs = {
-  PageTitle: PageTitleStub,
+  DetailedPageTitle: DetailedPageTitleStub,
   ErrorMessage: ErrorMessageStub,
   DeleteDeclaredSkillConfirmModal: DeleteDeclaredSkillConfirmModalStub,
   StudentDeclaredSkillAssociations: StudentDeclaredSkillAssociationsStub,
   AvTabs: AvTabsStub,
   AvTab: AvTabStub,
-  DeclaredSkillDetails: {
-    name: 'DeclaredSkillDetails',
-    props: ['declaredSkillProgressDetails'],
-    template: '<div class="declared-skill-details-stub" />'
-  },
-  DeclaredSkillSettingDropdown: {
-    name: 'DeclaredSkillSettingDropdown',
-    template: '<div class="declared-skill-setting-dropdown-stub" />'
-  }
+  DeclaredSkillDetails: DeclaredSkillDetailsStub,
+  DeclaredSkillSettingDropdown: DeclaredSkillSettingDropdownStub
 }
 
 BddTest().given('a student declared skill view', () => {
@@ -59,12 +54,14 @@ BddTest().given('a student declared skill view', () => {
   })
 
   BddTest().when('the component is mounted', () => {
-    BddTest().then('it should render PageTitle with correct props', () => {
-      const pageTitle = wrapper.findComponent({ name: 'PageTitle' })
+    BddTest().then('it should render DetailedPageTitle with correct props', async () => {
+      const pageTitle = wrapper.findComponent(DetailedPageTitleStub)
 
       expect(pageTitle.exists()).toBe(true)
-      expect(pageTitle.props('title')).toBe('Détail de ma compétence déclarée')
-      expect(pageTitle.props('back')).toBe(ROUTES.STUDENT.PROJECT_SKILLS)
+
+      await vi.waitFor(() => {
+        expect(pageTitle.props('title')).toBe('Conduire un projet de bout en bout')
+      })
 
       const breadcrumbLinks = pageTitle.props('breadcrumbLinks')
       expect(breadcrumbLinks).toHaveLength(4)
@@ -84,21 +81,13 @@ BddTest().given('a student declared skill view', () => {
       })
     })
 
-    BddTest().then('it should render the skill title from query data', async () => {
-      await vi.waitFor(() => {
-        const title = wrapper.find('[data-testid="student-declared-skill-view__title"] .n4')
-        expect(title.exists()).toBe(true)
-        expect(title.text()).toBe('Conduire un projet de bout en bout')
-      })
-    })
-
     BddTest().then('it should render DeclaredSkillSettingDropdown', () => {
-      const settingDropdown = wrapper.findComponent({ name: 'DeclaredSkillSettingDropdown' })
+      const settingDropdown = wrapper.findComponent(DeclaredSkillSettingDropdownStub)
       expect(settingDropdown.exists()).toBe(true)
     })
 
     BddTest().then('it should render AvTabs', () => {
-      const tabs = wrapper.findComponent({ name: 'AvTabs' })
+      const tabs = wrapper.findComponent(AvTabsStub)
       expect(tabs.exists()).toBe(true)
     })
 
@@ -112,7 +101,7 @@ BddTest().given('a student declared skill view', () => {
 
     BddTest().then('it should render DeclaredSkillDetails component with correct props', async () => {
       await vi.waitFor(() => {
-        const detailsComponent = wrapper.findComponent({ name: 'DeclaredSkillDetails' })
+        const detailsComponent = wrapper.findComponent(DeclaredSkillDetailsStub)
         expect(detailsComponent.exists()).toBe(true)
         expect(detailsComponent.props('declaredSkillProgressDetails')).toBeDefined()
         expect(detailsComponent.props('declaredSkillProgressDetails').title).toBe('Conduire un projet de bout en bout')
@@ -120,7 +109,7 @@ BddTest().given('a student declared skill view', () => {
     })
 
     BddTest().then('it should render StudentDeclaredSkillAssociations component with correct props when associations tab is active', async () => {
-      const tabs = wrapper.findComponent({ name: 'AvTabs' })
+      const tabs = wrapper.findComponent(AvTabsStub)
       await tabs.vm.$emit('update:modelValue', 1)
 
       await vi.waitFor(() => {
@@ -139,7 +128,7 @@ BddTest().given('a student declared skill view', () => {
     })
 
     BddTest().then('it should display the correct count of associations in associations tab title when associations tab is active', async () => {
-      const tabs = wrapper.findComponent({ name: 'AvTabs' })
+      const tabs = wrapper.findComponent(AvTabsStub)
       await tabs.vm.$emit('update:modelValue', 1)
 
       await vi.waitFor(() => {
@@ -151,7 +140,7 @@ BddTest().given('a student declared skill view', () => {
 
     BddTest().then('it should not render ErrorMessage', async () => {
       await vi.waitFor(() => {
-        const errorMessage = wrapper.findComponent({ name: 'ErrorMessage' })
+        const errorMessage = wrapper.findComponent(ErrorMessageStub)
         expect(errorMessage.exists()).toBe(false)
       })
     })
@@ -159,7 +148,7 @@ BddTest().given('a student declared skill view', () => {
 
   BddTest().when('the update selected event is emitted', () => {
     BddTest().then('it should handle the event', async () => {
-      const settingDropdown = wrapper.findComponent({ name: 'DeclaredSkillSettingDropdown' })
+      const settingDropdown = wrapper.findComponent(DeclaredSkillSettingDropdownStub)
       await settingDropdown.vm.$emit('updateSelected')
       expect(navigateToStudentUpdateDeclaredSkill).toHaveBeenCalled()
     })
@@ -167,13 +156,13 @@ BddTest().given('a student declared skill view', () => {
 
   BddTest().when('the delete selected event is emitted', () => {
     beforeEach(async () => {
-      const settingDropdown = wrapper.findComponent({ name: 'DeclaredSkillSettingDropdown' })
+      const settingDropdown = wrapper.findComponent(DeclaredSkillSettingDropdownStub)
       await settingDropdown.vm.$emit('deleteSelected')
     })
 
     BddTest().then('it should show the delete confirmation modal', async () => {
       await vi.waitFor(() => {
-        const deleteModal = wrapper.findComponent({ name: 'DeleteDeclaredSkillConfirmModal' })
+        const deleteModal = wrapper.findComponent(DeleteDeclaredSkillConfirmModalStub)
         expect(deleteModal.exists()).toBe(true)
         expect(deleteModal.props('show')).toBe(true)
       })
@@ -181,13 +170,13 @@ BddTest().given('a student declared skill view', () => {
 
     BddTest().and('the modal emits the close event', () => {
       beforeEach(async () => {
-        const deleteModal = wrapper.findComponent({ name: 'DeleteDeclaredSkillConfirmModal' })
+        const deleteModal = wrapper.findComponent(DeleteDeclaredSkillConfirmModalStub)
         await deleteModal.vm.$emit('close')
       })
 
       BddTest().then('it should hide the delete confirmation modal', async () => {
         await vi.waitFor(() => {
-          const deleteModal = wrapper.findComponent({ name: 'DeleteDeclaredSkillConfirmModal' })
+          const deleteModal = wrapper.findComponent(DeleteDeclaredSkillConfirmModalStub)
           expect(deleteModal.exists()).toBe(true)
           expect(deleteModal.props('show')).toBe(false)
         })
@@ -196,13 +185,13 @@ BddTest().given('a student declared skill view', () => {
 
     BddTest().and('the modal emits the skill deleted event', () => {
       beforeEach(async () => {
-        const deleteModal = wrapper.findComponent({ name: 'DeleteDeclaredSkillConfirmModal' })
+        const deleteModal = wrapper.findComponent(DeleteDeclaredSkillConfirmModalStub)
         await deleteModal.vm.$emit('skillDeleted')
       })
 
       BddTest().then('it should hide the delete confirmation modal', async () => {
         await vi.waitFor(() => {
-          const deleteModal = wrapper.findComponent({ name: 'DeleteDeclaredSkillConfirmModal' })
+          const deleteModal = wrapper.findComponent(DeleteDeclaredSkillConfirmModalStub)
           expect(deleteModal.exists()).toBe(true)
           expect(deleteModal.props('show')).toBe(false)
         })
@@ -228,7 +217,7 @@ BddTest().given('a student declared skill view', () => {
 
     BddTest().then('it should render ErrorMessage with not found title and description', async () => {
       await vi.waitFor(() => {
-        const errorMessage = wrapper.findComponent({ name: 'ErrorMessage' })
+        const errorMessage = wrapper.findComponent(ErrorMessageStub)
         expect(errorMessage.exists()).toBe(true)
         expect(errorMessage.props('title')).toBe('Compétence déclarée introuvable')
         expect(errorMessage.props('description')).toBe('La compétence que vous recherchez n\'existe pas ou n\'est pas accessible.')
@@ -245,7 +234,7 @@ BddTest().given('a student declared skill view', () => {
     })
 
     BddTest().then('it should render StudentDeclaredSkillAssociations with empty associations', async () => {
-      const tabs = wrapper.findComponent({ name: 'AvTabs' })
+      const tabs = wrapper.findComponent(AvTabsStub)
       await tabs.vm.$emit('update:modelValue', 1)
 
       await vi.waitFor(() => {
@@ -268,7 +257,7 @@ BddTest().given('a student declared skill view', () => {
     })
 
     BddTest().then('it should pass the associations error to StudentDeclaredSkillAssociations', async () => {
-      const tabs = wrapper.findComponent({ name: 'AvTabs' })
+      const tabs = wrapper.findComponent(AvTabsStub)
       await tabs.vm.$emit('update:modelValue', 1)
 
       await vi.waitFor(() => {

--- a/src/features/student/declaredSkills/views/StudentDeclaredSkillView/StudentDeclaredSkillView.vue
+++ b/src/features/student/declaredSkills/views/StudentDeclaredSkillView/StudentDeclaredSkillView.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useGetDeclaredSkillProgressDetails, useGetDeclaredSkillWithDeclaredActivities } from '@/api/avenir-esr'
+import DetailedPageTitle from '@/common/components/DetailedPageTitle/DetailedPageTitle.vue'
 import ErrorMessage from '@/common/components/feedback/ErrorMessage/ErrorMessage.vue'
-import PageTitle from '@/common/components/PageTitle/PageTitle.vue'
 import { useModal, useNavigation } from '@/common/composables'
 import { useApiErrors } from '@/common/composables/use-api-errors/use-api-errors'
 import { ErrorCodes, ICONS, ROUTES } from '@/common/constants'
@@ -60,17 +60,15 @@ function handleSkillDeleted () {
 </script>
 
 <template>
-  <PageTitle
-    :title="t('student.declaredSkills.views.StudentDeclaredSkillView.title')"
+  <DetailedPageTitle
+    :title="skillTitle"
     :breadcrumb-links="breadcrumbLinks"
-    :back="ROUTES.STUDENT.PROJECT_SKILLS"
   />
 
   <div
-    class="av-gap-sm av-pb-md av-row--lg av-align-baseline--lg av-justify-between--lg"
+    class="av-pb-md av-row av-justify-end"
     data-testid="student-declared-skill-view__title"
   >
-    <span class="n4 av-text-text2">{{ skillTitle }}</span>
     <DeclaredSkillSettingDropdown
       @delete-selected="displayModal"
       @update-selected="handleUpdateSelected"

--- a/src/features/student/declaredSkills/views/StudentDeclaredSkillView/components/DeclaredSkillDetails/DeclaredSkillDetails.stub.ts
+++ b/src/features/student/declaredSkills/views/StudentDeclaredSkillView/components/DeclaredSkillDetails/DeclaredSkillDetails.stub.ts
@@ -1,0 +1,5 @@
+export const DeclaredSkillDetailsStub = defineComponent({
+  name: 'DeclaredSkillDetails',
+  props: ['declaredSkillProgressDetails'],
+  template: '<div data-testid="declared-skill-details" />'
+})

--- a/src/features/student/declaredSkills/views/StudentDeclaredSkillView/components/DeclaredSkillSettingDropdown/DeclaredSkillSettingDropdown.stub.ts
+++ b/src/features/student/declaredSkills/views/StudentDeclaredSkillView/components/DeclaredSkillSettingDropdown/DeclaredSkillSettingDropdown.stub.ts
@@ -1,0 +1,4 @@
+export const DeclaredSkillSettingDropdownStub = defineComponent({
+  name: 'DeclaredSkillSettingDropdown',
+  template: '<div data-testid="declared-skill-setting-dropdown" />'
+})

--- a/src/features/student/declaredSkills/views/StudentUpdateDeclaredSkillView/StudentUpdateDeclaredSkillView.test.ts
+++ b/src/features/student/declaredSkills/views/StudentUpdateDeclaredSkillView/StudentUpdateDeclaredSkillView.test.ts
@@ -1,6 +1,9 @@
 import type { VueWrapper } from '@vue/test-utils'
 import { ConfirmationModalStub } from '@/common/components/ConfirmationModal/ConfirmationModal.stub'
+import { UpdatePageTitleStub } from '@/common/components/UpdatePageTitle/UpdatePageTitle.stub'
 import { ROUTES } from '@/common/constants'
+import { UpdateDeclaredSkillAssociationsStub } from '@/features/student/declaredSkills/views/StudentUpdateDeclaredSkillView/components/UpdateDeclaredSkillAssociations/UpdateDeclaredSkillAssociations.stub'
+import { UpdateDeclaredSkillFormStub } from '@/features/student/declaredSkills/views/StudentUpdateDeclaredSkillView/components/UpdateDeclaredSkillForm/UpdateDeclaredSkillForm.stub'
 import StudentUpdateDeclaredSkillView from '@/features/student/declaredSkills/views/StudentUpdateDeclaredSkillView/StudentUpdateDeclaredSkillView.vue'
 import { UpdateInProgressBadgeStub } from '@/features/student/global/components/badges/UpdateInProgressBadge/UpdateInProgressBadge.stub'
 import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
@@ -50,27 +53,8 @@ const AvTabStub = {
   template: '<div class="av-tab-stub"><slot /></div>'
 }
 
-const PageTitleStubWithBack = {
-  name: 'PageTitle',
-  template: '<div />',
-  props: ['title', 'breadcrumbLinks', 'back']
-}
-
-const UpdateDeclaredSkillFormStub = {
-  name: 'UpdateDeclaredSkillForm',
-  props: ['declaredSkillProgressDetails', 'onSkillUpdated', 'onCancel'],
-  emits: ['dirty-change'],
-  template: '<div class="update-form-stub" />',
-}
-
-const UpdateDeclaredSkillAssociationsStub = {
-  name: 'UpdateDeclaredSkillAssociations',
-  props: ['traceAssociations', 'declaredSkillId'],
-  template: '<div class="update-associations-stub" />'
-}
-
 const stubs = {
-  PageTitle: PageTitleStubWithBack,
+  UpdatePageTitle: UpdatePageTitleStub,
   AvTabs: AvTabsStub,
   AvTab: AvTabStub,
   UpdateDeclaredSkillForm: UpdateDeclaredSkillFormStub,
@@ -97,12 +81,14 @@ BddTest().given('a student update declared skill view component', () => {
   })
 
   BddTest().when('the component is mounted', () => {
-    BddTest().then('it should render PageTitle with correct props', () => {
-      const pageTitle = wrapper.findComponent({ name: 'PageTitle' })
+    BddTest().then('it should render UpdatePageTitle with correct props', async () => {
+      const pageTitle = wrapper.findComponent(UpdatePageTitleStub)
 
       expect(pageTitle.exists()).toBe(true)
-      expect(pageTitle.props('title')).toBe('Modifier ma compétence déclarée')
-      expect(pageTitle.props('back')).toBe(ROUTES.STUDENT.PROJECT_SKILLS)
+
+      await vi.waitFor(() => {
+        expect(pageTitle.props('title')).toBe('Conduire un projet de bout en bout')
+      })
 
       const breadcrumbLinks = pageTitle.props('breadcrumbLinks')
       expect(breadcrumbLinks).toHaveLength(4)
@@ -122,16 +108,8 @@ BddTest().given('a student update declared skill view component', () => {
       })
     })
 
-    BddTest().then('it should render the skill title', async () => {
-      await vi.waitFor(() => {
-        const title = wrapper.find('[data-testid="update-declared-skill-view__title"] .n4')
-        expect(title.exists()).toBe(true)
-        expect(title.text()).toBe('Conduire un projet de bout en bout')
-      })
-    })
-
     BddTest().then('it should render AvTabs', () => {
-      const tabs = wrapper.findComponent({ name: 'AvTabs' })
+      const tabs = wrapper.findComponent(AvTabsStub)
       expect(tabs.exists()).toBe(true)
     })
 
@@ -171,10 +149,10 @@ BddTest().given('a student update declared skill view component', () => {
   BddTest().when('the form triggers onSkillUpdated', () => {
     BddTest().then('it should navigate using useNavigation.navigateToStudentDeclaredSkill', async () => {
       await vi.waitFor(() => {
-        const form = wrapper.findComponent({ name: 'UpdateDeclaredSkillForm' })
+        const form = wrapper.findComponent(UpdateDeclaredSkillFormStub)
         expect(form.exists()).toBe(true)
       })
-      const form = wrapper.findComponent({ name: 'UpdateDeclaredSkillForm' })
+      const form = wrapper.findComponent(UpdateDeclaredSkillFormStub)
       await form.vm.$props.onSkillUpdated()
       expect(navigateToStudentDeclaredSkill).toHaveBeenCalledTimes(1)
     })
@@ -183,10 +161,10 @@ BddTest().given('a student update declared skill view component', () => {
   BddTest().when('the form emits dirty-change event', () => {
     BddTest().then('it should show the update in progress badge when dirty is true', async () => {
       await vi.waitFor(() => {
-        const form = wrapper.findComponent({ name: 'UpdateDeclaredSkillForm' })
+        const form = wrapper.findComponent(UpdateDeclaredSkillFormStub)
         expect(form.exists()).toBe(true)
       })
-      const form = wrapper.findComponent({ name: 'UpdateDeclaredSkillForm' })
+      const form = wrapper.findComponent(UpdateDeclaredSkillFormStub)
       await form.vm.$emit('dirty-change', true)
       await wrapper.vm.$nextTick()
 
@@ -196,10 +174,10 @@ BddTest().given('a student update declared skill view component', () => {
 
     BddTest().then('it should hide the update in progress badge when dirty is false', async () => {
       await vi.waitFor(() => {
-        const form = wrapper.findComponent({ name: 'UpdateDeclaredSkillForm' })
+        const form = wrapper.findComponent(UpdateDeclaredSkillFormStub)
         expect(form.exists()).toBe(true)
       })
-      const form = wrapper.findComponent({ name: 'UpdateDeclaredSkillForm' })
+      const form = wrapper.findComponent(UpdateDeclaredSkillFormStub)
       await form.vm.$emit('dirty-change', true)
       await wrapper.vm.$nextTick()
 
@@ -218,10 +196,10 @@ BddTest().given('a student update declared skill view component', () => {
     BddTest().and('canLeave is true', () => {
       beforeEach(async () => {
         await vi.waitFor(() => {
-          const form = wrapper.findComponent({ name: 'UpdateDeclaredSkillForm' })
+          const form = wrapper.findComponent(UpdateDeclaredSkillFormStub)
           expect(form.exists()).toBe(true)
         })
-        const form = wrapper.findComponent({ name: 'UpdateDeclaredSkillForm' })
+        const form = wrapper.findComponent(UpdateDeclaredSkillFormStub)
         await form.vm.$props.onCancel()
         await wrapper.vm.$nextTick()
       })
@@ -235,10 +213,10 @@ BddTest().given('a student update declared skill view component', () => {
       beforeEach(async () => {
         mockCanLeave.mockResolvedValue(false)
         await vi.waitFor(() => {
-          const form = wrapper.findComponent({ name: 'UpdateDeclaredSkillForm' })
+          const form = wrapper.findComponent(UpdateDeclaredSkillFormStub)
           expect(form.exists()).toBe(true)
         })
-        const form = wrapper.findComponent({ name: 'UpdateDeclaredSkillForm' })
+        const form = wrapper.findComponent(UpdateDeclaredSkillFormStub)
         await form.vm.$props.onCancel()
         await wrapper.vm.$nextTick()
       })
@@ -249,7 +227,7 @@ BddTest().given('a student update declared skill view component', () => {
 
       BddTest().and('confirming the modal', () => {
         beforeEach(async () => {
-          const confirmationModal = wrapper.findComponent({ name: 'ConfirmationModal' })
+          const confirmationModal = wrapper.findComponent(ConfirmationModalStub)
           await confirmationModal.vm.$emit('confirm')
           await wrapper.vm.$nextTick()
         })
@@ -261,7 +239,7 @@ BddTest().given('a student update declared skill view component', () => {
 
       BddTest().and('closing the modal', () => {
         beforeEach(async () => {
-          const confirmationModal = wrapper.findComponent({ name: 'ConfirmationModal' })
+          const confirmationModal = wrapper.findComponent(ConfirmationModalStub)
           await confirmationModal.vm.$emit('close')
           await wrapper.vm.$nextTick()
         })

--- a/src/features/student/declaredSkills/views/StudentUpdateDeclaredSkillView/StudentUpdateDeclaredSkillView.vue
+++ b/src/features/student/declaredSkills/views/StudentUpdateDeclaredSkillView/StudentUpdateDeclaredSkillView.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { useGetDeclaredSkillProgressDetails } from '@/api/avenir-esr'
-import { ConfirmationModal, PageTitle } from '@/common/components'
+import { ConfirmationModal } from '@/common/components'
+import UpdatePageTitle from '@/common/components/UpdatePageTitle/UpdatePageTitle.vue'
 import { useModal, useNavigation } from '@/common/composables'
 import { useUnsavedChangesGuard } from '@/common/composables/use-unsaved-changes-guard/use-unsaved-changes-guard'
 import { ICONS, ROUTES } from '@/common/constants'
@@ -57,24 +58,10 @@ async function handleCancel () {
 </script>
 
 <template>
-  <ConfirmationModal
-    :show="showModal"
-    @confirm="confirm"
-    @close="cancel"
-  />
-
-  <PageTitle
-    :title="t('student.declaredSkills.views.StudentUpdateDeclaredSkillView.title')"
+  <UpdatePageTitle
+    :title="declaredSkillDetailed?.title ?? ''"
     :breadcrumb-links="breadcrumbLinks"
-    :back="ROUTES.STUDENT.PROJECT_SKILLS"
   />
-
-  <div
-    class="av-row av-py-md"
-    data-testid="update-declared-skill-view__title"
-  >
-    <span class="n4 av-text-text2">{{ declaredSkillDetailed?.title ?? '' }}</span>
-  </div>
 
   <UpdateInProgressBadge :show="updateInProgress" />
 
@@ -102,4 +89,10 @@ async function handleCancel () {
       />
     </AvTab>
   </AvTabs>
+
+  <ConfirmationModal
+    :show="showModal"
+    @confirm="confirm"
+    @close="cancel"
+  />
 </template>

--- a/src/features/student/declaredSkills/views/StudentUpdateDeclaredSkillView/components/UpdateDeclaredSkillAssociations/UpdateDeclaredSkillAssociations.stub.ts
+++ b/src/features/student/declaredSkills/views/StudentUpdateDeclaredSkillView/components/UpdateDeclaredSkillAssociations/UpdateDeclaredSkillAssociations.stub.ts
@@ -1,0 +1,5 @@
+export const UpdateDeclaredSkillAssociationsStub = defineComponent({
+  name: 'UpdateDeclaredSkillAssociations',
+  props: ['traceAssociations', 'declaredSkillId'],
+  template: '<div class="update-associations-stub" />'
+})

--- a/src/features/student/declaredSkills/views/StudentUpdateDeclaredSkillView/components/UpdateDeclaredSkillForm/UpdateDeclaredSkillForm.stub.ts
+++ b/src/features/student/declaredSkills/views/StudentUpdateDeclaredSkillView/components/UpdateDeclaredSkillForm/UpdateDeclaredSkillForm.stub.ts
@@ -1,0 +1,6 @@
+export const UpdateDeclaredSkillFormStub = defineComponent({
+  name: 'UpdateDeclaredSkillForm',
+  props: ['declaredSkillProgressDetails', 'onSkillUpdated', 'onCancel'],
+  emits: ['dirty-change'],
+  template: '<div class="update-form-stub" />',
+})

--- a/src/features/student/global/routes/index.ts
+++ b/src/features/student/global/routes/index.ts
@@ -9,7 +9,6 @@ import { studentEducationSkillsRoute, studentProjectSkillsRoute, studentSkillRou
 import { studentToolsTracesRoute, studentTraceRoute } from '@/features/student/traces/routes'
 
 const footerLegalProps: RoutePageProps = {
-  backRoute: ROUTES.STUDENT.HOME,
   breadcrumbLinksRaw: [
     { textKey: 'student.global.navigation.tabs.home', to: ROUTES.STUDENT.HOME },
   ]

--- a/src/features/student/global/views/StudentApcUnavailableView/StudentApcUnavailableView.vue
+++ b/src/features/student/global/views/StudentApcUnavailableView/StudentApcUnavailableView.vue
@@ -25,7 +25,6 @@ watch(showApcGenericInfoPage, (value) => {
   <PageTitle
     :title="t('student.global.navigation.tabs.apcUnavailable.title')"
     :breadcrumb-links="breadcrumbLinks"
-    :back="ROUTES.STUDENT.HOME"
   />
 </template>
 

--- a/src/features/student/global/views/StudentDeliverablesView/StudentDeliverablesView.vue
+++ b/src/features/student/global/views/StudentDeliverablesView/StudentDeliverablesView.vue
@@ -15,6 +15,5 @@ const breadcrumbLinks = computed(() => [
   <PageTitle
     :title="t('student.global.views.studentDeliverablesView.title')"
     :breadcrumb-links="breadcrumbLinks"
-    :back="ROUTES.STUDENT.HOME"
   />
 </template>

--- a/src/features/student/global/views/StudentEventsView/StudentEventsView.vue
+++ b/src/features/student/global/views/StudentEventsView/StudentEventsView.vue
@@ -15,6 +15,5 @@ const breadcrumbLinks = computed(() => [
   <PageTitle
     :title="t('student.global.views.studentEventsView.title')"
     :breadcrumb-links="breadcrumbLinks"
-    :back="{ name: ROUTES.STUDENT.HOME.name }"
   />
 </template>

--- a/src/features/student/global/views/StudentProjectTrajectoriesView/StudentProjectTrajectoriesView.vue
+++ b/src/features/student/global/views/StudentProjectTrajectoriesView/StudentProjectTrajectoriesView.vue
@@ -18,7 +18,6 @@ const breadcrumbLinks = computed(() => [
   <PageTitle
     :title="t('student.global.views.studentProjectTrajectoriesView.title')"
     :breadcrumb-links="breadcrumbLinks"
-    :back="ROUTES.STUDENT.HOME"
   />
   <StudentProjectTrajectoriesContainer />
 </template>

--- a/src/features/student/global/views/StudentToolsPagesView/StudentToolsPagesView.vue
+++ b/src/features/student/global/views/StudentToolsPagesView/StudentToolsPagesView.vue
@@ -15,6 +15,5 @@ const breadcrumbLinks = computed(() => [
   <PageTitle
     :title="t('student.global.views.studentToolsPagesView.title')"
     :breadcrumb-links="breadcrumbLinks"
-    :back="ROUTES.STUDENT.HOME"
   />
 </template>

--- a/src/features/student/global/views/StudentToolsResumesView/StudentToolsResumesView.vue
+++ b/src/features/student/global/views/StudentToolsResumesView/StudentToolsResumesView.vue
@@ -15,6 +15,5 @@ const breadcrumbLinks = computed(() => [
   <PageTitle
     :title="t('student.global.views.studentToolsResumesView.title')"
     :breadcrumb-links="breadcrumbLinks"
-    :back="ROUTES.STUDENT.HOME"
   />
 </template>

--- a/src/features/student/personalCareer/locales/en.json
+++ b/src/features/student/personalCareer/locales/en.json
@@ -211,8 +211,7 @@
             "details": {
               "title": "My declared program"
             }
-          },
-          "title": "Detail {programTitle}"
+          }
         },
         "DeclaredProgramUpdateView": {
           "confirmationModal": {
@@ -223,8 +222,7 @@
               "updateDeclaredProgram": "An error occurred while updating the declared program"
             },
             "success": "Declared program updated successfully"
-          },
-          "title": "Update {programTitle}"
+          }
         },
         "PersonalCareerView": {
           "ExperiencesSection": {

--- a/src/features/student/personalCareer/locales/fr.json
+++ b/src/features/student/personalCareer/locales/fr.json
@@ -211,8 +211,7 @@
             "details": {
               "title": "Ma formation déclarée"
             }
-          },
-          "title": "Détail {programTitle}"
+          }
         },
         "DeclaredProgramUpdateView": {
           "confirmationModal": {
@@ -223,8 +222,7 @@
               "updateDeclaredProgram": "Une erreur est survenue lors de la mise à jour de la formation déclarée"
             },
             "success": "Formation déclarée mise à jour avec succès"
-          },
-          "title": "Modifier {programTitle}"
+          }
         },
         "PersonalCareerView": {
           "ExperiencesSection": {

--- a/src/features/student/personalCareer/views/DeclaredExperienceUpdateView/DeclaredExperienceUpdateView.test.ts
+++ b/src/features/student/personalCareer/views/DeclaredExperienceUpdateView/DeclaredExperienceUpdateView.test.ts
@@ -1,5 +1,5 @@
 import type { VueWrapper } from '@vue/test-utils'
-import { PageTitleStub } from '@/common/components/PageTitle/PageTitle.stub'
+import { UpdatePageTitleStub } from '@/common/components/UpdatePageTitle/UpdatePageTitle.stub'
 import { ROUTES } from '@/common/constants/route-names'
 import { UpdateInProgressBadgeStub } from '@/features/student/global/components/badges/UpdateInProgressBadge/UpdateInProgressBadge.stub'
 import DeclaredExperienceUpdateView, { type DeclaredExperienceUpdateViewProps } from '@/features/student/personalCareer/views/DeclaredExperienceUpdateView/DeclaredExperienceUpdateView.vue'
@@ -38,7 +38,7 @@ const UpdateDeclaredExperienceFormStub = {
 }
 const stubs = {
   AvIconText: AvIconTextStub,
-  PageTitle: PageTitleStub,
+  UpdatePageTitle: UpdatePageTitleStub,
   UpdateInProgressBadge: UpdateInProgressBadgeStub,
   UpdateDeclaredExperienceForm: UpdateDeclaredExperienceFormStub,
   AvTabs: { template: '<div><slot /></div>' },
@@ -64,8 +64,8 @@ BddTest().given('a declared experience update view', () => {
       await mountComponentWithDefaults()
     })
 
-    BddTest().then('it should render PageTitle', () => {
-      const pageTitle = wrapper.findComponent({ name: 'PageTitle' })
+    BddTest().then('it should render UpdatePageTitle', () => {
+      const pageTitle = wrapper.findComponent(UpdatePageTitleStub)
       expect(pageTitle.exists()).toBe(true)
     })
 

--- a/src/features/student/personalCareer/views/DeclaredExperienceUpdateView/DeclaredExperienceUpdateView.vue
+++ b/src/features/student/personalCareer/views/DeclaredExperienceUpdateView/DeclaredExperienceUpdateView.vue
@@ -2,7 +2,7 @@
 import { useGetDeclaredExperience } from '@/api/avenir-esr'
 import { ConfirmationModal } from '@/common/components'
 import Loader from '@/common/components/Loader/Loader.vue'
-import PageTitle from '@/common/components/PageTitle/PageTitle.vue'
+import UpdatePageTitle from '@/common/components/UpdatePageTitle/UpdatePageTitle.vue'
 import { useModal } from '@/common/composables'
 import { useUnsavedChangesGuard } from '@/common/composables/use-unsaved-changes-guard/use-unsaved-changes-guard'
 import { ROUTES } from '@/common/constants/route-names'
@@ -78,18 +78,10 @@ function onExperienceUpdated () {
 </script>
 
 <template>
-  <PageTitle
-    title=""
+  <UpdatePageTitle
+    :title="declaredExperienceTitle"
     :breadcrumb-links="breadcrumbLinks"
-    :back="{ name: ROUTES.STUDENT.DECLARED_EXPERIENCE.name, params: { id: selectedExperienceId } }"
-  >
-    <template #title>
-      <h1 class="av-text-title">
-        {{ t('global.buttons.update') }}
-        <span class="n4">{{ declaredExperienceTitle }}</span>
-      </h1>
-    </template>
-  </PageTitle>
+  />
 
   <div class="av-row av-gap-sm">
     <DeclaredExperienceSideMenu

--- a/src/features/student/personalCareer/views/DeclaredExperienceView/DeclaredExperienceView.test.ts
+++ b/src/features/student/personalCareer/views/DeclaredExperienceView/DeclaredExperienceView.test.ts
@@ -105,10 +105,10 @@ BddTest().given('a declared experience view component', () => {
 
     BddTest().then('it should render DetailedPageTitle with correct breadcrumb links', async () => {
       await vi.waitFor(() => {
-        const pageTitle = wrapper.findComponent({ name: 'DetailedPageTitle' })
+        const pageTitle = wrapper.findComponent(DetailedPageTitleStub)
         expect(pageTitle.exists()).toBe(true)
 
-        const breadcrumbLinks = pageTitle.props('breadcrumbLinks') as Array<{ text: string, to?: string }>
+        const breadcrumbLinks = pageTitle.props('breadcrumbLinks')
         expect(breadcrumbLinks).toHaveLength(5)
         expect(breadcrumbLinks[0]).toEqual({ text: 'Accueil', to: ROUTES.STUDENT.HOME })
         expect(breadcrumbLinks[1]).toEqual({ text: 'Construire mon projet de vie' })

--- a/src/features/student/personalCareer/views/DeclaredProgramDetailedView/DeclaredProgramDetailedView.test.ts
+++ b/src/features/student/personalCareer/views/DeclaredProgramDetailedView/DeclaredProgramDetailedView.test.ts
@@ -120,11 +120,10 @@ BddTest().given('a declared program detailed view component', () => {
     })
 
     BddTest().then('it should render DetailedPageTitle with correct props', () => {
-      const pageTitle = wrapper.findComponent({ name: 'DetailedPageTitle' })
+      const pageTitle = wrapper.findComponent(DetailedPageTitleStub)
       expect(pageTitle.exists()).toBe(true)
-      expect(pageTitle.props('back')).toBe(ROUTES.STUDENT.PROJECT_SKILLS)
 
-      const breadcrumbLinks = pageTitle.props('breadcrumbLinks') as Array<{ text: string, to?: string }>
+      const breadcrumbLinks = pageTitle.props('breadcrumbLinks')
       expect(breadcrumbLinks).toHaveLength(5)
       expect(breadcrumbLinks[0]).toEqual({ text: 'Accueil', to: ROUTES.STUDENT.HOME })
       expect(breadcrumbLinks[1]).toEqual({ text: 'Construire mon projet de vie' })
@@ -135,7 +134,7 @@ BddTest().given('a declared program detailed view component', () => {
 
     BddTest().then('it should build the title using the selected program title', async () => {
       await vi.waitFor(() => {
-        const pageTitle = wrapper.findComponent({ name: 'DetailedPageTitle' })
+        const pageTitle = wrapper.findComponent(DetailedPageTitleStub)
         expect(String(pageTitle.props('title'))).toContain('Formation déclarée 1')
       })
     })

--- a/src/features/student/personalCareer/views/DeclaredProgramDetailedView/DeclaredProgramDetailedView.vue
+++ b/src/features/student/personalCareer/views/DeclaredProgramDetailedView/DeclaredProgramDetailedView.vue
@@ -52,7 +52,6 @@ function handleConfirmDelete () {
   <DetailedPageTitle
     :title="programTitle"
     :breadcrumb-links="breadcrumbLinks"
-    :back="ROUTES.STUDENT.PROJECT_SKILLS"
   />
   <div class="av-row av-gap-2xl">
     <div class="av-col">

--- a/src/features/student/personalCareer/views/DeclaredProgramUpdateView/DeclaredProgramUpdateView.test.ts
+++ b/src/features/student/personalCareer/views/DeclaredProgramUpdateView/DeclaredProgramUpdateView.test.ts
@@ -2,7 +2,7 @@ import type { DeclaredProgramViewDTO } from '@/api/avenir-esr'
 import { declaredProgramDetailedHandler } from '@/__mocks__/msw/handlers/student/declaredPrograms.handlers'
 import { server } from '@/__mocks__/msw/server'
 import { ConfirmationModalStub } from '@/common/components/ConfirmationModal/ConfirmationModal.stub'
-import { PageTitleStub } from '@/common/components/PageTitle/PageTitle.stub'
+import { UpdatePageTitleStub } from '@/common/components/UpdatePageTitle/UpdatePageTitle.stub'
 import { ROUTES } from '@/common/constants'
 import { UpdateInProgressBadgeStub } from '@/features/student/global/components/badges/UpdateInProgressBadge/UpdateInProgressBadge.stub'
 import { DeclaredProgramSideMenuStub } from '@/features/student/personalCareer/components/navigation/DeclaredProgramSideMenu/DeclaredProgramSideMenu.stub'
@@ -81,7 +81,7 @@ const DeclaredProgramUpdateFormStub = {
 }
 
 const stubs = {
-  PageTitle: PageTitleStub,
+  UpdatePageTitle: UpdatePageTitleStub,
   DeclaredProgramSideMenu: DeclaredProgramSideMenuStub,
   DeclaredProgramUpdateForm: DeclaredProgramUpdateFormStub,
   ConfirmationModal: ConfirmationModalStub,
@@ -133,16 +133,12 @@ BddTest().given('a declared program update view component', () => {
       await mountComponentWithDefaults()
     })
 
-    BddTest().then('it should render PageTitle with correct props', () => {
-      const pageTitle = wrapper.findComponent({ name: 'PageTitle' })
+    BddTest().then('it should render UpdatePageTitle with correct props', () => {
+      const pageTitle = wrapper.findComponent(UpdatePageTitleStub)
 
       expect(pageTitle.exists()).toBe(true)
-      expect(pageTitle.props('back')).toStrictEqual({
-        name: ROUTES.STUDENT.PERSONAL_CAREER_DECLARED_PROGRAM_DETAILED.name,
-        params: { id: 'declared-program-1' }
-      })
 
-      const breadcrumbLinks = pageTitle.props('breadcrumbLinks') as Array<{ text: string, to?: string }>
+      const breadcrumbLinks = pageTitle.props('breadcrumbLinks')
       expect(breadcrumbLinks).toHaveLength(5)
       expect(breadcrumbLinks[0]).toEqual({ text: 'Accueil', to: ROUTES.STUDENT.HOME })
       expect(breadcrumbLinks[1]).toEqual({ text: 'Construire mon projet de vie' })
@@ -153,8 +149,8 @@ BddTest().given('a declared program update view component', () => {
 
     BddTest().then('it should build the title using the selected program title', async () => {
       await vi.waitFor(() => {
-        const pageTitle = wrapper.findComponent({ name: 'PageTitle' })
-        expect(String(pageTitle.props('title'))).toContain('Modifier Formation déclarée 1')
+        const pageTitle = wrapper.findComponent(UpdatePageTitleStub)
+        expect(String(pageTitle.props('title'))).toContain('Formation déclarée 1')
       })
     })
 
@@ -331,17 +327,8 @@ BddTest().given('a declared program update view component', () => {
 
     BddTest().then('it should render title for that program', async () => {
       await vi.waitFor(() => {
-        const pageTitle = wrapper.findComponent({ name: 'PageTitle' })
-        expect(String(pageTitle.props('title'))).toContain('Modifier Formation déclarée 2')
-      })
-    })
-
-    BddTest().then('it should render PageTitle back props with the route param id', () => {
-      const pageTitle = wrapper.findComponent({ name: 'PageTitle' })
-
-      expect(pageTitle.props('back')).toStrictEqual({
-        name: ROUTES.STUDENT.PERSONAL_CAREER_DECLARED_PROGRAM_DETAILED.name,
-        params: { id: 'declared-program-2' }
+        const pageTitle = wrapper.findComponent(UpdatePageTitleStub)
+        expect(String(pageTitle.props('title'))).toContain('Formation déclarée 2')
       })
     })
   })

--- a/src/features/student/personalCareer/views/DeclaredProgramUpdateView/DeclaredProgramUpdateView.vue
+++ b/src/features/student/personalCareer/views/DeclaredProgramUpdateView/DeclaredProgramUpdateView.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useGetDeclaredProgram } from '@/api/avenir-esr'
 import { ConfirmationModal } from '@/common/components'
-import PageTitle from '@/common/components/PageTitle/PageTitle.vue'
+import UpdatePageTitle from '@/common/components/UpdatePageTitle/UpdatePageTitle.vue'
 import { useModal } from '@/common/composables'
 import { useUnsavedChangesGuard } from '@/common/composables/use-unsaved-changes-guard/use-unsaved-changes-guard'
 import { ROUTES } from '@/common/constants'
@@ -66,10 +66,9 @@ function onProgramUpdated () {
 </script>
 
 <template>
-  <PageTitle
-    :title="t('student.personalCareer.views.DeclaredProgramUpdateView.title', { programTitle })"
+  <UpdatePageTitle
+    :title="programTitle"
     :breadcrumb-links="breadcrumbLinks"
-    :back="{ name: ROUTES.STUDENT.PERSONAL_CAREER_DECLARED_PROGRAM_DETAILED.name, params: { id: selectedProgramId } }"
   />
   <div class="av-row av-gap-sm">
     <DeclaredProgramSideMenu

--- a/src/features/student/personalCareer/views/PersonalCareerView/PersonalCareerView.test.ts
+++ b/src/features/student/personalCareer/views/PersonalCareerView/PersonalCareerView.test.ts
@@ -26,7 +26,7 @@ BddTest().given('a student project experiences view component', () => {
 
   BddTest().when('the component is mounted', () => {
     BddTest().then('it should render PageTitle with correct props', () => {
-      const pageTitle = wrapper.findComponent({ name: 'PageTitle' })
+      const pageTitle = wrapper.findComponent(PageTitleStub)
 
       expect(pageTitle.exists()).toBe(true)
       expect(pageTitle.props('title')).toBe('Mon parcours')

--- a/src/features/student/personalCareer/views/PersonalCareerView/PersonalCareerView.vue
+++ b/src/features/student/personalCareer/views/PersonalCareerView/PersonalCareerView.vue
@@ -18,7 +18,6 @@ const breadcrumbLinks = computed(() => [
   <PageTitle
     :title="t('student.global.navigation.tabs.project.items.experiences')"
     :breadcrumb-links="breadcrumbLinks"
-    :back="ROUTES.STUDENT.HOME"
   />
 
   <PersonalCareerLayout />

--- a/src/features/student/selfKnowledge/locales/en.json
+++ b/src/features/student/selfKnowledge/locales/en.json
@@ -150,7 +150,6 @@
               "title": "Update my {categoryType}"
             }
           },
-          "title": "Update my {categoryType}",
           "updateForm": {
             "errors": {
               "updateElement": "Error updating item"

--- a/src/features/student/selfKnowledge/locales/fr.json
+++ b/src/features/student/selfKnowledge/locales/fr.json
@@ -149,7 +149,6 @@
               "title": "Modifier mes {categoryType}"
             }
           },
-          "title": "Modifier mes {categoryType}",
           "updateForm": {
             "errors": {
               "updateElement": "Erreur lors de la mise à jour de l'élément"

--- a/src/features/student/selfKnowledge/views/SelfKnowledgeCategoryView/SelfKnowledgeCategoryView.test.ts
+++ b/src/features/student/selfKnowledge/views/SelfKnowledgeCategoryView/SelfKnowledgeCategoryView.test.ts
@@ -123,11 +123,11 @@ BddTest().given('a self knowledge category view component', () => {
     })
 
     BddTest().then('it should render DetailedPageTitle with correct props', () => {
-      const pageTitle = wrapper.findComponent({ name: 'DetailedPageTitle' })
+      const pageTitle = wrapper.findComponent(DetailedPageTitleStub)
 
       expect(pageTitle.exists()).toBe(true)
 
-      const breadcrumbLinks = pageTitle.props('breadcrumbLinks') as Array<{ text: string, to?: string }>
+      const breadcrumbLinks = pageTitle.props('breadcrumbLinks')
 
       expect(breadcrumbLinks).toHaveLength(4)
       expect(breadcrumbLinks[0]).toEqual({

--- a/src/features/student/selfKnowledge/views/SelfKnowledgeElementUpdateView/SelfKnowledgeElementUpdateView.vue
+++ b/src/features/student/selfKnowledge/views/SelfKnowledgeElementUpdateView/SelfKnowledgeElementUpdateView.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import { useGetSelfKnowledgeElementDetails } from '@/api/avenir-esr'
-import PageTitle from '@/common/components/PageTitle/PageTitle.vue'
+import UpdatePageTitle from '@/common/components/UpdatePageTitle/UpdatePageTitle.vue'
 import { useNavigation } from '@/common/composables'
 import { ROUTES } from '@/common/constants/route-names'
 import UpdateInProgressBadge from '@/features/student/global/components/badges/UpdateInProgressBadge/UpdateInProgressBadge.vue'
@@ -10,6 +10,7 @@ import SelfKnowledgeElementTabs from '@/features/student/selfKnowledge/component
 import { useSelfKnowledgeCategory } from '@/features/student/selfKnowledge/composables/use-self-knowledge-category/use-self-knowledge-category'
 import { useSelfKnowledgePaginatedElements } from '@/features/student/selfKnowledge/composables/use-self-knowledge-paginated-elements/use-self-knowledge-paginated-elements'
 import SelfKnowledgeElementUpdateForm from '@/features/student/selfKnowledge/views/SelfKnowledgeElementUpdateView/components/SelfKnowledgeElementUpdateForm/SelfKnowledgeElementUpdateForm.vue'
+import { toSentenceCase } from '@avenirs-esr/avenirs-dsav'
 import { useI18n } from 'vue-i18n'
 
 export interface SelfKnowledgeElementUpdateViewProps {
@@ -44,7 +45,8 @@ const breadcrumbLinks = computed(() => [
   { text: t('student.global.navigation.tabs.home'), to: ROUTES.STUDENT.HOME },
   { text: t('student.global.navigation.tabs.project.header') },
   { text: t('student.global.navigation.tabs.project.items.trajectories'), to: ROUTES.STUDENT.PROJECT_TRAJECTORIES },
-  { text: t('student.global.navigation.tabs.project.items.selfKnowledge') }
+  { text: t('student.global.navigation.tabs.project.items.selfKnowledge') },
+  { text: t('student.selfKnowledge.views.SelfKnowledgeElementUpdateView.breadcrumb.current.title', { categoryType: categoryTypeLabel.value }) }
 ])
 
 function onSelectElement (selectedElementId: string) {
@@ -64,8 +66,8 @@ function backToElementDetails () {
 </script>
 
 <template>
-  <PageTitle
-    :title="t('student.selfKnowledge.views.SelfKnowledgeElementUpdateView.title', { categoryType: categoryTypeLabel })"
+  <UpdatePageTitle
+    :title="`${toSentenceCase(categoryTypeLabel)} - ${element?.title}`"
     :breadcrumb-links="breadcrumbLinks"
   />
   <div class="self-knowledge-element-update-view av-row av-gap-sm">

--- a/src/features/student/skills/views/StudentEducationSkillsView/StudentEducationSkillsView.test.ts
+++ b/src/features/student/skills/views/StudentEducationSkillsView/StudentEducationSkillsView.test.ts
@@ -69,7 +69,7 @@ BddTest().given('a student education skills view', () => {
 
       BddTest().then('it should render PageTitle with singular title', () => {
         wrapper = createWrapper()
-        const pageTitle = wrapper.findComponent({ name: 'PageTitle' })
+        const pageTitle = wrapper.findComponent(PageTitleStub)
 
         expect(pageTitle.props('title')).toBe(title)
         expect(pageTitle.props('breadcrumbLinks')).toEqual([
@@ -80,14 +80,14 @@ BddTest().given('a student education skills view', () => {
 
       BddTest().then('it should not render any StudentEducationSkillsViewContainer', () => {
         wrapper = createWrapper()
-        const containers = wrapper.findAllComponents({ name: 'StudentEducationSkillsViewContainer' })
+        const containers = wrapper.findAllComponents(StudentEducationSkillsViewContainerStub)
 
         expect(containers).toHaveLength(0)
       })
 
       BddTest().then('it should render SkillsSortContainer', () => {
         wrapper = createWrapper()
-        const filtersContainer = wrapper.findComponent({ name: 'SkillsSortContainer' })
+        const filtersContainer = wrapper.findComponent(SkillsSortContainerStub)
 
         expect(filtersContainer.exists()).toBe(true)
       })
@@ -103,7 +103,7 @@ BddTest().given('a student education skills view', () => {
         wrapper = createWrapper()
 
         await vi.waitFor(() => {
-          const containers = wrapper.findAllComponents({ name: 'StudentEducationSkillsViewContainer' })
+          const containers = wrapper.findAllComponents(StudentEducationSkillsViewContainerStub)
           expect(containers).toHaveLength(1)
         })
       })
@@ -119,7 +119,7 @@ BddTest().given('a student education skills view', () => {
         wrapper = createWrapper()
 
         await vi.waitFor(() => {
-          const pageTitle = wrapper.findComponent({ name: 'PageTitle' })
+          const pageTitle = wrapper.findComponent(PageTitleStub)
           expect(pageTitle.props('title')).toBe(title_plural)
         })
       })
@@ -128,7 +128,7 @@ BddTest().given('a student education skills view', () => {
         wrapper = createWrapper()
 
         await vi.waitFor(() => {
-          const containers = wrapper.findAllComponents({ name: 'StudentEducationSkillsViewContainer' })
+          const containers = wrapper.findAllComponents(StudentEducationSkillsViewContainerStub)
           expect(containers).toHaveLength(mockedProgramsProgressView.length)
         })
       })
@@ -142,7 +142,7 @@ BddTest().given('a student education skills view', () => {
 
       wrapper = createWrapper()
 
-      const filtersContainer = wrapper.findComponent({ name: 'SkillsSortContainer' })
+      const filtersContainer = wrapper.findComponent(SkillsSortContainerStub)
 
       const defaultSort = formatSortParam(StudentProgressViewSortableFields.NAME, SortDirection.ASC)
       expect(filtersContainer.props('sort')).toEqual({ itemId: defaultSort })
@@ -167,10 +167,10 @@ BddTest().given('a student education skills view', () => {
         expect(mockAddErrorMessage).toHaveBeenCalled()
       })
 
-      const containers = wrapper.findAllComponents({ name: 'StudentEducationSkillsViewContainer' })
+      const containers = wrapper.findAllComponents(StudentEducationSkillsViewContainerStub)
       expect(containers).toHaveLength(0)
 
-      const filtersContainer = wrapper.findComponent({ name: 'SkillsSortContainer' })
+      const filtersContainer = wrapper.findComponent(SkillsSortContainerStub)
       expect(filtersContainer.exists()).toBe(true)
     })
   })

--- a/src/features/student/skills/views/StudentEducationSkillsView/StudentEducationSkillsView.vue
+++ b/src/features/student/skills/views/StudentEducationSkillsView/StudentEducationSkillsView.vue
@@ -36,7 +36,6 @@ const breadcrumbLinks = computed(() => [
   <PageTitle
     :title="t('student.skills.views.StudentEducationSkillsView.title', { count: courses?.length ?? 1 })"
     :breadcrumb-links="breadcrumbLinks"
-    :back="ROUTES.STUDENT.HOME"
   />
   <SkillsSortContainer v-model:sort="selectedSortOption" />
   <div class="av-col av-gap-4xl">

--- a/src/features/student/skills/views/StudentProjectSkillsView/StudentProjectSkillsView.vue
+++ b/src/features/student/skills/views/StudentProjectSkillsView/StudentProjectSkillsView.vue
@@ -17,7 +17,6 @@ const breadcrumbLinks = computed(() => [
   <PageTitle
     :title="t('student.skills.views.StudentProjectSkillsView.title')"
     :breadcrumb-links="breadcrumbLinks"
-    :back="{ name: ROUTES.STUDENT.HOME.name }"
   />
   <SkillsViewTabs />
 </template>

--- a/src/features/student/skills/views/StudentSkillView/StudentSkillView.test.ts
+++ b/src/features/student/skills/views/StudentSkillView/StudentSkillView.test.ts
@@ -1,8 +1,8 @@
 import { mockedSkillDetailed } from '@/__mocks__/fixtures/student/skills.fixtures'
 import { createDetailedSkillHandler, detailedSkillNotFoundErrorHandler } from '@/__mocks__/msw/handlers/student/skills.handlers'
 import { server } from '@/__mocks__/msw/server'
+import { DetailedPageTitleStub } from '@/common/components/DetailedPageTitle/DetailedPageTitle.stub'
 import { ErrorMessageStub } from '@/common/components/feedback/ErrorMessage/ErrorMessage.stub'
-import { PageTitleStub } from '@/common/components/PageTitle/PageTitle.stub'
 import { ROUTES } from '@/common/constants'
 import StudentSkillView from '@/features/student/skills/views/StudentSkillView/StudentSkillView.vue'
 import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
@@ -14,7 +14,7 @@ BddTest().given('a student skill view', () => {
   let wrapper: VueWrapper<InstanceType<typeof StudentSkillView>>
 
   const stubs = {
-    PageTitle: PageTitleStub,
+    DetailedPageTitle: DetailedPageTitleStub,
     ErrorMessage: ErrorMessageStub,
     StudentSkillViewContainer: {
       name: 'StudentSkillViewContainer',
@@ -38,12 +38,12 @@ BddTest().given('a student skill view', () => {
       })
     })
 
-    BddTest().then('it should render PageTitle with correct props', async () => {
+    BddTest().then('it should render DetailedPageTitle with correct props', async () => {
       await flushPromises()
 
-      const pageTitle = wrapper.findComponent({ name: 'PageTitle' })
+      const pageTitle = wrapper.findComponent(DetailedPageTitleStub)
 
-      expect(pageTitle.props('title')).toBe('Compétence Réaliser un cahier des charges fonctionnels')
+      expect(pageTitle.props('title')).toBe('Réaliser un cahier des charges fonctionnels')
       expect(pageTitle.props('breadcrumbLinks')).toEqual([
         { text: 'Accueil', to: ROUTES.STUDENT.HOME },
         { text: 'Mes compétences', to: ROUTES.STUDENT.EDUCATION_SKILLS },
@@ -84,10 +84,10 @@ BddTest().given('a student skill view', () => {
       expect(notFound.props('description')).toBe('La compétence que vous recherchez n\'existe pas ou n\'est pas accessible.')
     })
 
-    BddTest().then('it should render PageTitle with empty title', async () => {
+    BddTest().then('it should render DetailedPageTitle with empty title', async () => {
       await flushPromises()
 
-      const pageTitle = wrapper.findComponent({ name: 'PageTitle' })
+      const pageTitle = wrapper.findComponent(DetailedPageTitleStub)
       expect(pageTitle.props('title')).toBe('')
     })
   })

--- a/src/features/student/skills/views/StudentSkillView/StudentSkillView.vue
+++ b/src/features/student/skills/views/StudentSkillView/StudentSkillView.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useGetDetailedSkill } from '@/api/avenir-esr'
+import DetailedPageTitle from '@/common/components/DetailedPageTitle/DetailedPageTitle.vue'
 import ErrorMessage from '@/common/components/feedback/ErrorMessage/ErrorMessage.vue'
-import PageTitle from '@/common/components/PageTitle/PageTitle.vue'
 import { useApiErrors } from '@/common/composables/use-api-errors/use-api-errors'
 import { ErrorCodes, ROUTES } from '@/common/constants'
 import StudentSkillViewContainer
@@ -29,10 +29,9 @@ const breadcrumbLinks = computed(() => [
 </script>
 
 <template>
-  <PageTitle
-    :title="skillDetailed ? t('student.skills.views.StudentSkillView.title', { skill: skillDetailed?.name ?? '' }) : ''"
+  <DetailedPageTitle
+    :title="skillDetailed?.name ?? ''"
     :breadcrumb-links="breadcrumbLinks"
-    :back="ROUTES.STUDENT.HOME"
   />
   <ErrorMessage
     v-if="error"

--- a/src/features/student/traces/views/StudentToolsTracesView/StudentToolsTracesView.vue
+++ b/src/features/student/traces/views/StudentToolsTracesView/StudentToolsTracesView.vue
@@ -17,7 +17,6 @@ const breadcrumbLinks = computed(() => [
   <PageTitle
     :title="t('student.traces.views.StudentToolsTracesView.title')"
     :breadcrumb-links="breadcrumbLinks"
-    :back="ROUTES.STUDENT.HOME"
   />
 
   <StudentToolsTracesViewContainer />

--- a/src/features/student/traces/views/StudentTraceView/StudentTraceView.vue
+++ b/src/features/student/traces/views/StudentTraceView/StudentTraceView.vue
@@ -82,7 +82,6 @@ const breadcrumbLinks = computed(() => [
   <PageTitle
     :title="t('student.traces.views.StudentTraceView.title', { trace: traceDetailed?.title ?? '' })"
     :breadcrumb-links="breadcrumbLinks"
-    :back="ROUTES.STUDENT.HOME"
   />
 
   <Loader :is-loading>

--- a/src/features/student/user/views/StudentMailboxView/StudentMailboxView.vue
+++ b/src/features/student/user/views/StudentMailboxView/StudentMailboxView.vue
@@ -15,6 +15,5 @@ const breadcrumbLinks = computed(() => [
   <PageTitle
     :title="t('student.user.views.StudentMailboxView.title')"
     :breadcrumb-links="breadcrumbLinks"
-    :back="ROUTES.STUDENT.HOME"
   />
 </template>

--- a/src/features/student/user/views/StudentNotificationsView/StudentNotificationsView.vue
+++ b/src/features/student/user/views/StudentNotificationsView/StudentNotificationsView.vue
@@ -15,6 +15,5 @@ const breadcrumbLinks = computed(() => [
   <PageTitle
     :title="t('student.user.views.StudentNotificationsView.title')"
     :breadcrumb-links="breadcrumbLinks"
-    :back="ROUTES.STUDENT.HOME"
   />
 </template>


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
This PR refactors the page title system by removing legacy `back` prop usage and introducing a dedicated update variant component used across views and tests.

**Main changes:**
- ♻️ Removes `back` handling from `PageTitle` and updates call sites
- ✨ Adds `UpdatePageTitle` component with dedicated stub and tests
- ✅ Updates multiple view/component tests to align with the new title API
- 🏷️ Simplifies related route typing by removing obsolete `showBack` metadata
- ⬆️ Updates frontend dependencies in `package.json`/`package-lock.json`

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1746
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1692

---

### Documentation
- Test files were updated to reflect the new title component behavior and stubs.
- Locales and affected views were adjusted where title/back-label behavior changed.
- No dedicated functional documentation page update in this PR.

**Notable modified areas:**
- `src/common/components/PageTitle/*`
- `src/common/components/UpdatePageTitle/*`
- `src/common/types/router.types.ts`
- multiple views/tests under `src/common/views/` and `src/features/**/views/`

---

### Target Branch
`develop`

---

### Additional Notes
This change separates standard title rendering from update/edit flows to reduce implicit behavior in a single component and make tests/stubs clearer and more maintainable.

---

### Known Limitations or Side Effects
- This is a broad refactor touching many tests and views; regression checks should focus on title rendering and navigation affordances in update/edit pages.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [ ] No unnecessary code (e.g., debug logs, commented code)
- [ ] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process
