### PR TITLE
fix(1811): FormFieldCardContainer - add inline prop to AvIconText

### DIFF
--- a/src/features/staff/activities/views/EditNationalActivityView/components/ActivityContentTab/ActivityContentTab.vue
+++ b/src/features/staff/activities/views/EditNationalActivityView/components/ActivityContentTab/ActivityContentTab.vue
@@ -108,7 +108,7 @@ const isFormDirty = form.useStore(state => state.isDirty)
         />
       </FormFieldCardContainer>
     </div>
-    <div class="av-row av-gap-sm av-justify-end">
+    <div class="av-row av-wrap av-gap-sm av-justify-end">
       <EditNationalActivityViewTabActions />
       <AvButton
         data-testid="activity-content-tab-next-step-button"

--- a/src/features/staff/activities/views/EditNationalActivityView/components/ActivityPublicationTab/ActivityPublicationTab.vue
+++ b/src/features/staff/activities/views/EditNationalActivityView/components/ActivityPublicationTab/ActivityPublicationTab.vue
@@ -95,9 +95,9 @@ async function publishActivityDraft () {
     </div>
     <div
       :id="PublicationSectionId.SUMMARY_CONTEXT"
-      class="av-row av-w-full av-gap-sm"
+      class="av-col av-row--md av-w-full--md av-gap-sm"
     >
-      <div class="av-flex-fill">
+      <div class="av-flex-fill--md">
         <FormFieldCardContainer
           :title="`${t('staff.activities.views.EditNationalActivityView.ActivitySummaryFormField.label')} *`"
           :title-icon="MDI_ICONS.FILE_DOCUMENT_EDIT_OUTLINE"
@@ -108,7 +108,7 @@ async function publishActivityDraft () {
           />
         </FormFieldCardContainer>
       </div>
-      <div class="av-flex-fill">
+      <div class="av-flex-fill--md">
         <FormFieldCardContainer
           :title="t('staff.activities.interactions.formFields.ActivityExecutionPeriodFormField.label')"
           :title-icon="MDI_ICONS.TEXT_BOX_EDIT_OUTLINE"
@@ -120,7 +120,7 @@ async function publishActivityDraft () {
         </FormFieldCardContainer>
       </div>
     </div>
-    <div class="av-row av-gap-sm av-justify-end">
+    <div class="av-row av-wrap av-gap-sm av-justify-end">
       <EditNationalActivityViewTabActions />
       <AvButton
         data-testid="publish-button"

--- a/src/features/staff/global/components/cards/FormFieldCardContainer/FormFieldCardContainer.vue
+++ b/src/features/staff/global/components/cards/FormFieldCardContainer/FormFieldCardContainer.vue
@@ -39,6 +39,7 @@ defineSlots<{
           text-color="var(--text1)"
           typography-class="s1-regular"
           gap="var(--spacing-xs)"
+          inline
         />
         <slot name="title" />
       </div>


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
<!-- Describe the changes introduced by this pull request. -->

:lipstick: FormFieldCardContainer - add inline prop to AvIconText
:lipstick: ActivityContentTab - add av-wrap to buttons layout
:lipstick: ActivityPublicationTab - add av-wrap to buttons layout
:lipstick: ActivityPublicationTab - update layout to full col on mobile

---

### Reference to an Issue, Feature, Task, User Story or another PR
<!-- Mention related issue numbers or links (e.g. Closes #123, Implements #456). -->
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1811

---

### Documentation
<!-- Detail any updates made to documentation, configuration steps, or technical specs. -->

---

### Target Branch
<!-- Which branch is this PR targeting (e.g. `main`, `develop`)? -->

develop

---

### Additional Notes
<!-- Include any relevant context, technical details, or reasons behind certain decisions. -->

---

### Known Limitations or Side Effects
<!-- List any limitations, known bugs, or side effects this PR may introduce. -->

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [ ] No unnecessary code (e.g., debug logs, commented code)
- [ ] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and detaiils for the update process

---

# Remember

**DO NOT** keep this template as is when you submit. Please remove or adjust the description when you submit your pull request.

Please do not submit a pull request to ask questions.

Do not submit pull requests without tests that verify or reproduce your intended use case. The pull request will
most likely be automatically closed immediately, unless the change is extremely trivial. 

