### PR TITLE
fix(1662): TraceFileUpload - update trace name handling

### DIFF
--- a/src/features/student/traces/components/interactions/formFields/TraceFileUploadFormField/TraceFileUploadFormField.test.ts
+++ b/src/features/student/traces/components/interactions/formFields/TraceFileUploadFormField/TraceFileUploadFormField.test.ts
@@ -182,6 +182,20 @@ BddTest().given('a trace file upload form field component', () => {
       })
     })
 
+    BddTest().then('it should emit the deleted file name', async () => {
+      const formField = wrapper.findComponent(TraceFileUploadFormField)
+      const fileUpload = wrapper.findComponent({ name: 'TraceFileUpload' })
+      const file = new File(['content'], 'test.pdf', { type: 'application/pdf' })
+
+      await fileUpload.vm.$emit('update:modelValue', file)
+      await wrapper.vm.$nextTick()
+
+      await fileUpload.vm.$emit('update:modelValue', null)
+      await wrapper.vm.$nextTick()
+
+      expect(formField.emitted('fileDeleted')?.[0]).toEqual(['test.pdf'])
+    })
+
     BddTest().then('it should not show valid message', async () => {
       const fileUpload = wrapper.findComponent({ name: 'TraceFileUpload' })
       const file = new File(['content'], 'test.pdf', { type: 'application/pdf' })

--- a/src/features/student/traces/components/interactions/formFields/TraceFileUploadFormField/TraceFileUploadFormField.vue
+++ b/src/features/student/traces/components/interactions/formFields/TraceFileUploadFormField/TraceFileUploadFormField.vue
@@ -11,6 +11,7 @@ interface TraceFileUploadFormFieldProps {
 const { form } = defineProps<TraceFileUploadFormFieldProps>()
 const emit = defineEmits<{
   fileSelected: [file: File]
+  fileDeleted: [fileName: string]
 }>()
 
 const FormField = markRaw(form.Field)
@@ -29,6 +30,16 @@ function handleFilesChange (files: FileList) {
     emit('fileSelected', files[0])
   }
 }
+
+function handleFileValueChange (file: File | null) {
+  const previousFile = fileField.state.value.value
+
+  fileField.api.handleChange(file)
+
+  if (!file && previousFile) {
+    emit('fileDeleted', previousFile.name)
+  }
+}
 </script>
 
 <template>
@@ -42,7 +53,7 @@ function handleFilesChange (files: FileList) {
         :valid-message="getFileInputSuccessMessage(field.state.value)"
         @blur="field.handleBlur"
         @change="handleFilesChange"
-        @update:model-value="(value: File | null) => field.handleChange(value)"
+        @update:model-value="handleFileValueChange"
       />
     </template>
   </FormField>

--- a/src/features/student/traces/views/StudentToolsTracesView/components/StudentToolsTracesAddTraceDrawer/components/CreateTraceFormTraceDefinitionItems/CreateTraceFormTraceDefinitionItems.test.ts
+++ b/src/features/student/traces/views/StudentToolsTracesView/components/StudentToolsTracesAddTraceDrawer/components/CreateTraceFormTraceDefinitionItems/CreateTraceFormTraceDefinitionItems.test.ts
@@ -150,6 +150,30 @@ BddTest().given('a create trace form trace definition items component', () => {
       const TraceFileUploadComponent = wrapper.findComponent({ name: 'TraceFileUpload' })
       expect(TraceFileUploadComponent.props('validMessage')).toBe(`Document chargé.`)
     })
+
+    BddTest().then('it should clear trace name when the file is deleted', async () => {
+      const mockFile = new File(['test'], 'test.pdf', { type: 'application/pdf' })
+      const fileInput = wrapper.find('#trace-file-upload')
+
+      Object.defineProperty(fileInput.element, 'files', {
+        value: [mockFile],
+        writable: false,
+      })
+
+      await fileInput.trigger('change')
+      await wrapper.vm.$nextTick()
+
+      const fileUpload = wrapper.findComponent({ name: 'TraceFileUpload' })
+
+      const traceNameInputBeforeDelete = wrapper.findComponent({ name: 'TraceNameInput' })
+      expect(traceNameInputBeforeDelete.props('modelValue')).toBe('test.pdf')
+
+      await fileUpload.vm.$emit('update:modelValue', null)
+      await wrapper.vm.$nextTick()
+
+      const traceNameInputAfterDelete = wrapper.findComponent({ name: 'TraceNameInput' })
+      expect(traceNameInputAfterDelete.props('modelValue')).toBe('')
+    })
   })
 
   BddTest().when('trace name is changed', () => {

--- a/src/features/student/traces/views/StudentToolsTracesView/components/StudentToolsTracesAddTraceDrawer/components/CreateTraceFormTraceDefinitionItems/CreateTraceFormTraceDefinitionItems.vue
+++ b/src/features/student/traces/views/StudentToolsTracesView/components/StudentToolsTracesAddTraceDrawer/components/CreateTraceFormTraceDefinitionItems/CreateTraceFormTraceDefinitionItems.vue
@@ -24,6 +24,12 @@ function handleFileSelected (file: File) {
     form.setFieldValue('traceName', file.name)
   }
 }
+
+function handleFileDeleted (fileName: string) {
+  if (form.getFieldValue('traceName') === fileName) {
+    form.setFieldValue('traceName', '')
+  }
+}
 </script>
 
 <template>
@@ -41,6 +47,7 @@ function handleFileSelected (file: File) {
         <TraceFileUploadFormField
           :form="form"
           @file-selected="handleFileSelected"
+          @file-deleted="handleFileDeleted"
         />
       </div>
 

--- a/src/features/student/traces/views/StudentTraceView/components/UpdateTraceForm/UpdateTraceForm.test.ts
+++ b/src/features/student/traces/views/StudentTraceView/components/UpdateTraceForm/UpdateTraceForm.test.ts
@@ -1,5 +1,7 @@
+import type { UpdateTraceForm as UpdateTraceFormType } from '@/features/student/traces/types/forms.types'
 import type { VueWrapper } from '@vue/test-utils'
 import { EFileType, type TraceDetailDTO } from '@/api/avenir-esr'
+import { TraceType } from '@/features/student/traces/types/traces.types'
 import UpdateTraceForm from '@/features/student/traces/views/StudentTraceView/components/UpdateTraceForm/UpdateTraceForm.vue'
 import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { mountComponent } from 'tests/utils'
@@ -223,6 +225,125 @@ BddTest().given('an update trace form component', () => {
     BddTest().then('it should render link field', () => {
       const linkField = wrapper.findComponent({ name: 'TraceLinkInputFormField' })
       expect(linkField.exists()).toBe(true)
+    })
+  })
+
+  BddTest().when('file events are emitted from file upload field', () => {
+    function createMockForm (traceName: string) {
+      const values = {
+        traceType: TraceType.FILE,
+        traceName
+      }
+
+      return {
+        handleSubmit: vi.fn(),
+        getFieldValue: vi.fn((name: keyof typeof values) => values[name]),
+        setFieldValue: vi.fn((name: keyof typeof values, value: string | TraceType) => {
+          values[name] = value as never
+        }),
+        useField: vi.fn(({ name }: { name: string }) => {
+          if (name === 'useIA') {
+            return {
+              state: { value: { value: false } },
+              api: { handleChange: vi.fn() }
+            }
+          }
+
+          if (name === 'iaJustification') {
+            return {
+              state: { value: { value: '' } },
+              api: { handleChange: vi.fn() }
+            }
+          }
+
+          return {
+            state: { value: { value: undefined } },
+            api: { handleChange: vi.fn() }
+          }
+        })
+      } as unknown as UpdateTraceFormType
+    }
+
+    BddTest().then('it should set trace name when a file is selected and trace name is empty', async () => {
+      const form = createMockForm('')
+
+      wrapper = mountComponent<typeof UpdateTraceForm>(UpdateTraceForm, {
+        props: {
+          trace: mockTraceWithFile,
+          form
+        },
+        global: {
+          stubs
+        }
+      })
+
+      const fileUploadField = wrapper.findComponent({ name: 'TraceFileUploadFormField' })
+      const selectedFile = new File(['content'], 'selected-file.pdf', { type: 'application/pdf' })
+
+      await fileUploadField.vm.$emit('file-selected', selectedFile)
+
+      expect(form.setFieldValue).toHaveBeenCalledWith('traceName', 'selected-file.pdf')
+    })
+
+    BddTest().then('it should not overwrite trace name when a file is selected and trace name is already filled', async () => {
+      const form = createMockForm('already-filled-name')
+
+      wrapper = mountComponent<typeof UpdateTraceForm>(UpdateTraceForm, {
+        props: {
+          trace: mockTraceWithFile,
+          form
+        },
+        global: {
+          stubs
+        }
+      })
+
+      const fileUploadField = wrapper.findComponent({ name: 'TraceFileUploadFormField' })
+      const selectedFile = new File(['content'], 'selected-file.pdf', { type: 'application/pdf' })
+
+      await fileUploadField.vm.$emit('file-selected', selectedFile)
+
+      expect(form.setFieldValue).not.toHaveBeenCalledWith('traceName', 'selected-file.pdf')
+    })
+
+    BddTest().then('it should clear trace name when a deleted file name matches trace name', async () => {
+      const form = createMockForm('selected-file.pdf')
+
+      wrapper = mountComponent<typeof UpdateTraceForm>(UpdateTraceForm, {
+        props: {
+          trace: mockTraceWithFile,
+          form
+        },
+        global: {
+          stubs
+        }
+      })
+
+      const fileUploadField = wrapper.findComponent({ name: 'TraceFileUploadFormField' })
+
+      await fileUploadField.vm.$emit('file-deleted', 'selected-file.pdf')
+
+      expect(form.setFieldValue).toHaveBeenCalledWith('traceName', '')
+    })
+
+    BddTest().then('it should not clear trace name when a deleted file name does not match trace name', async () => {
+      const form = createMockForm('another-name.pdf')
+
+      wrapper = mountComponent<typeof UpdateTraceForm>(UpdateTraceForm, {
+        props: {
+          trace: mockTraceWithFile,
+          form
+        },
+        global: {
+          stubs
+        }
+      })
+
+      const fileUploadField = wrapper.findComponent({ name: 'TraceFileUploadFormField' })
+
+      await fileUploadField.vm.$emit('file-deleted', 'selected-file.pdf')
+
+      expect(form.setFieldValue).not.toHaveBeenCalledWith('traceName', '')
     })
   })
 })

--- a/src/features/student/traces/views/StudentTraceView/components/UpdateTraceForm/UpdateTraceForm.vue
+++ b/src/features/student/traces/views/StudentTraceView/components/UpdateTraceForm/UpdateTraceForm.vue
@@ -57,6 +57,18 @@ const traceFileUploadLabel = computed(() => {
   const uploadDate = formatTranslatedDateTime(trace.attachment?.uploadedAt ?? '')
   return `${t('student.traces.interactions.inputs.TraceFileUpload.documentLabel')} - ${t('student.traces.interactions.inputs.TraceFileUpload.addedOn', { date: uploadDate })}`
 })
+
+function handleFileSelected (file: File) {
+  if (file && form.getFieldValue('traceName') === '') {
+    form.setFieldValue('traceName', file.name)
+  }
+}
+
+function handleFileDeleted (fileName: string) {
+  if (form.getFieldValue('traceName') === fileName) {
+    form.setFieldValue('traceName', '')
+  }
+}
 </script>
 
 <template>
@@ -73,6 +85,8 @@ const traceFileUploadLabel = computed(() => {
           v-if="form.getFieldValue('traceType') === TraceType.FILE"
           :form="form"
           :label="traceFileUploadLabel"
+          @file-selected="handleFileSelected"
+          @file-deleted="handleFileDeleted"
         />
         <TraceLinkInputFormField
           v-else


### PR DESCRIPTION
## 📝 Pull Request Description

:sparkles: TraceFileUpload - update trace name handling

```
on file upload:
if traceName exists -> keep existing traceName
if traceName doesn't exist -> use fileName as traceName

On file delete:
if traceName equals fileName -> delete traceName
if traceName doesn't equal fileName -> keep traceName
```

---

### Reference to an Issue, Feature, Task, User Story or another PR
<!-- Mention related issue numbers or links (e.g. Closes #123, Implements #456). -->
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1662

---

### Documentation
<!-- Detail any updates made to documentation, configuration steps, or technical specs. -->

---

### Target Branch
<!-- Which branch is this PR targeting (e.g. `main`, `develop`)? -->

develop

---

### Additional Notes
<!-- Include any relevant context, technical details, or reasons behind certain decisions. -->

https://github.com/user-attachments/assets/840a1696-bc5d-4f8b-a35e-3fd35fb8ba5e

---

### Known Limitations or Side Effects
<!-- List any limitations, known bugs, or side effects this PR may introduce. -->

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [ ] No unnecessary code (e.g., debug logs, commented code)
- [ ] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and detaiils for the update process

---

# Remember

**DO NOT** keep this template as is when you submit. Please remove or adjust the description when you submit your pull request.

Please do not submit a pull request to ask questions.

Do not submit pull requests without tests that verify or reproduce your intended use case. The pull request will
most likely be automatically closed immediately, unless the change is extremely trivial. 

