### PR TITLE
fix(1693): SelfKnowledge - update mobile rendering

### DIFF
--- a/src/features/student/selfKnowledge/components/SelfKnowledgeMainSection/SelfKnowledgeMainSection.vue
+++ b/src/features/student/selfKnowledge/components/SelfKnowledgeMainSection/SelfKnowledgeMainSection.vue
@@ -44,7 +44,7 @@ const categories = computed(() => fetchedCategories.value ?? [])
     >
       <AvButton
         :icon="MDI_ICONS.PENCIL_OUTLINE"
-        :label="t('global.buttons.update')"
+        :label="t('student.selfKnowledge.SelfKnowledgeMainSection.buttons.updateBio')"
         variant="OUTLINED"
         small
         data-testid="display-update-profile-drawer-button"

--- a/src/features/student/selfKnowledge/components/cards/SelfKnowledgeCategoryElementsPaginatorCard/SelfKnowledgeCategoryElementsPaginatorCard.vue
+++ b/src/features/student/selfKnowledge/components/cards/SelfKnowledgeCategoryElementsPaginatorCard/SelfKnowledgeCategoryElementsPaginatorCard.vue
@@ -74,7 +74,7 @@ function onElementDeleted () {
     collapsible
   >
     <template #title>
-      <div class="av-row av-align-center av-justify-between av-w-full av-gap-md av-px-md">
+      <div class="av-col av-row--md av-align-center--md av-justify-between av-w-full av-gap-md av-px-md">
         <AvIconText
           typography-class="n5"
           :icon="categoryIcon"
@@ -82,6 +82,7 @@ function onElementDeleted () {
           :text="categoryTitle"
           text-color="var(--title)"
           gap="var(--spacing-sm)"
+          inline
         />
         <div class="av-row av-align-center av-gap-sm">
           <SelfKnowledgeElementsDropdown

--- a/src/features/student/selfKnowledge/components/dropdowns/SelfKnowledgeElementsDropdown/SelfKnowledgeElementsDropdown.vue
+++ b/src/features/student/selfKnowledge/components/dropdowns/SelfKnowledgeElementsDropdown/SelfKnowledgeElementsDropdown.vue
@@ -93,6 +93,3 @@ function handleItemSelected (itemName: string) {
     @item-selected="handleItemSelected"
   />
 </template>
-
-<style lang="scss" scoped>
-</style>

--- a/src/features/student/selfKnowledge/locales/en.json
+++ b/src/features/student/selfKnowledge/locales/en.json
@@ -55,7 +55,8 @@
       },
       "SelfKnowledgeMainSection": {
         "buttons": {
-          "addCategory": "Add category"
+          "addCategory": "Add category",
+          "updateBio": "Update my bio"
         },
         "categoryElementsPaginator": {
           "buttons": {

--- a/src/features/student/selfKnowledge/locales/fr.json
+++ b/src/features/student/selfKnowledge/locales/fr.json
@@ -54,7 +54,8 @@
       },
       "SelfKnowledgeMainSection": {
         "buttons": {
-          "addCategory": "Ajouter une catégorie"
+          "addCategory": "Ajouter une catégorie",
+          "updateBio": "Modifier ma bio"
         },
         "categoryElementsPaginator": {
           "buttons": {


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
<!-- Describe the changes introduced by this pull request. -->

:iphone: SelfKnowledge - update mobile rendering

---

### Reference to an Issue, Feature, Task, User Story or another PR
<!-- Mention related issue numbers or links (e.g. Closes #123, Implements #456). -->
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1693

---

### Documentation
<!-- Detail any updates made to documentation, configuration steps, or technical specs. -->

---

### Target Branch
<!-- Which branch is this PR targeting (e.g. `main`, `develop`)? -->

develop

---

### Additional Notes
<!-- Include any relevant context, technical details, or reasons behind certain decisions. -->

<img width="391" height="637" alt="image" src="https://github.com/user-attachments/assets/c29e3f9e-7d5f-4716-871c-1aecc970dcd7" />

---

### Known Limitations or Side Effects
<!-- List any limitations, known bugs, or side effects this PR may introduce. -->

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [ ] No unnecessary code (e.g., debug logs, commented code)
- [ ] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and detaiils for the update process

---

# Remember

**DO NOT** keep this template as is when you submit. Please remove or adjust the description when you submit your pull request.

Please do not submit a pull request to ask questions.

Do not submit pull requests without tests that verify or reproduce your intended use case. The pull request will
most likely be automatically closed immediately, unless the change is extremely trivial. 

