### PR TITLE
feat(1738): create AssociatedElementTypeBadge component

### DIFF
--- a/src/features/staff/activities/components/badges/AssociatedElementTypeBadge/AssociatedElementTypeBadge.stub.ts
+++ b/src/features/staff/activities/components/badges/AssociatedElementTypeBadge/AssociatedElementTypeBadge.stub.ts
@@ -1,0 +1,5 @@
+export const AssociatedElementTypeBadgeStub = defineComponent({
+  name: 'AssociatedElementTypeBadge',
+  props: { associatedElementType: { type: String, required: true } },
+  template: '<div data-testid="associated-element-type-badge">{{ associatedElementType }}</div>'
+})

--- a/src/features/staff/activities/components/badges/AssociatedElementTypeBadge/AssociatedElementTypeBadge.test.ts
+++ b/src/features/staff/activities/components/badges/AssociatedElementTypeBadge/AssociatedElementTypeBadge.test.ts
@@ -1,0 +1,63 @@
+import { EAssociationContextType } from '@/api/avenir-esr'
+import { ICONS } from '@/common/constants/icons'
+import AssociatedElementTypeBadge from '@/features/staff/activities/components/badges/AssociatedElementTypeBadge/AssociatedElementTypeBadge.vue'
+import { AvBadgeStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { mount, type VueWrapper } from '@vue/test-utils'
+
+const stubs = {
+  AvBadge: AvBadgeStub
+}
+
+BddTest().given('an AssociatedElementTypeBadge component', () => {
+  let wrapper: VueWrapper<InstanceType<typeof AssociatedElementTypeBadge>>
+
+  const scenario: Array<{
+    type: EAssociationContextType
+    label: string
+    icon: string
+  }> = [
+    {
+      type: EAssociationContextType.TRACE,
+      label: 'Trace',
+      icon: ICONS.TRACES
+    },
+    {
+      type: EAssociationContextType.DECLARED_SKILL,
+      label: 'Compétence',
+      icon: ICONS.SKILLS
+    },
+    {
+      type: EAssociationContextType.DECLARED_EXPERIENCE,
+      label: 'Expérience',
+      icon: ICONS.EXPERIENCES
+    },
+    {
+      type: EAssociationContextType.DECLARED_ACTIVITY,
+      label: 'Activité',
+      icon: ICONS.ACTIVITY
+    },
+  ]
+
+  scenario.forEach(({ type, label, icon }) => {
+    BddTest().when(`the badge is rendered with type ${type}`, () => {
+      beforeEach(() => {
+        wrapper = mount(AssociatedElementTypeBadge, {
+          props: { associatedElementType: type },
+          global: { stubs }
+        })
+      })
+
+      BddTest().then('it should render AvBadge', () => {
+        expect(wrapper.findComponent(AvBadgeStub).exists()).toBe(true)
+      })
+
+      BddTest().then('it should render the correct label', () => {
+        expect(wrapper.findComponent(AvBadgeStub).props('label')).toBe(label)
+      })
+
+      BddTest().then('it should render the correct icon', () => {
+        expect(wrapper.findComponent(AvBadgeStub).props('icon')).toBe(icon)
+      })
+    })
+  })
+})

--- a/src/features/staff/activities/components/badges/AssociatedElementTypeBadge/AssociatedElementTypeBadge.vue
+++ b/src/features/staff/activities/components/badges/AssociatedElementTypeBadge/AssociatedElementTypeBadge.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import { EAssociationContextType } from '@/api/avenir-esr'
+import { ICONS } from '@/common/constants/icons'
+import { AvBadge } from '@avenirs-esr/avenirs-dsav'
+import { useI18n } from 'vue-i18n'
+
+export interface AssociatedElementTypeBadgeProps {
+  associatedElementType: EAssociationContextType
+}
+
+const { associatedElementType } = defineProps<AssociatedElementTypeBadgeProps>()
+
+const { t } = useI18n()
+
+const ICON_MAP: Record<EAssociationContextType, string> = {
+  [EAssociationContextType.TRACE]: ICONS.TRACES,
+  [EAssociationContextType.DECLARED_SKILL]: ICONS.SKILLS,
+  [EAssociationContextType.DECLARED_EXPERIENCE]: ICONS.EXPERIENCES,
+  [EAssociationContextType.DECLARED_ACTIVITY]: ICONS.ACTIVITY,
+}
+
+const icon = computed(() => ICON_MAP[associatedElementType])
+const label = computed(() => t(`global.activities.badges.associatedElementType.${associatedElementType}`))
+</script>
+
+<template>
+  <AvBadge
+    data-testid="associated-element-type-badge"
+    :data-type="associatedElementType"
+    :label="label"
+    :icon="icon"
+    background-color="var(--light-background-neutral)"
+    color="var(--text1)"
+    border-color="var(--stroke)"
+  />
+</template>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -2,6 +2,12 @@
   "global": {
     "activities": {
       "badges": {
+        "associatedElementType": {
+          "DECLARED_ACTIVITY": "Activity",
+          "DECLARED_EXPERIENCE": "Experience",
+          "DECLARED_SKILL": "Skill",
+          "TRACE": "Trace"
+        },
         "thematics": {
           "EXPERIENCES": "My experiences",
           "FUTURE_PLANS": "Explore my futures",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -2,6 +2,12 @@
   "global": {
     "activities": {
       "badges": {
+        "associatedElementType": {
+          "DECLARED_ACTIVITY": "Activité",
+          "DECLARED_EXPERIENCE": "Expérience",
+          "DECLARED_SKILL": "Compétence",
+          "TRACE": "Trace"
+        },
         "thematics": {
           "EXPERIENCES": "Mes expériences",
           "FUTURE_PLANS": "Explorer mes futures",


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
Add an `AssociatedElementTypeBadge` component that displays a badge based on the `associatedElementType` prop (enum provided by the backend). Each type is associated with a specific icon (from `src/common/constants/icons.ts`) and a label.

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1738

---

### Target Branch
develop

---

### Additional Notes

<img width="924" height="218" alt="Capture d’écran du 2026-06-12 15-40-27" src="https://github.com/user-attachments/assets/3891bf07-e363-4a33-b4b0-9b893501dd67" />


---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [x] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process