### PR TITLE
feat(1740): create AssociatedElementCard component

### DIFF
--- a/api-specs/avenir-esr.swagger.json
+++ b/api-specs/avenir-esr.swagger.json
@@ -507,6 +507,69 @@
         }
       }
     },
+    "/me/activity-progress/feedbacks/{feedbackId}": {
+      "get": {
+        "tags": [
+          "feedback-controller"
+        ],
+        "operationId": "getFeedbackDetails",
+        "parameters": [
+          {
+            "name": "feedbackId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/FeedbackDetailsDTO"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "feedback-controller"
+        ],
+        "operationId": "updateFeedback",
+        "parameters": [
+          {
+            "name": "feedbackId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateFeedbackRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
     "/me/traces": {
       "post": {
         "tags": [
@@ -1397,37 +1460,6 @@
         }
       }
     },
-    "/me/activity-progress/{declaredActivityId}/ask-for-feedback": {
-      "post": {
-        "tags": [
-          "declared-activity-controller"
-        ],
-        "operationId": "askForFeedback",
-        "parameters": [
-          {
-            "name": "declaredActivityId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/FeedbackDetailsDTO"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/me/activity-progress/subscribe/{activityId}": {
       "post": {
         "tags": [
@@ -1462,6 +1494,37 @@
               "*/*": {
                 "schema": {
                   "$ref": "#/components/schemas/CreationResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/me/activity-progress/feedbacks/{declaredActivityId}/ask-for-feedback": {
+      "post": {
+        "tags": [
+          "feedback-controller"
+        ],
+        "operationId": "askForFeedback",
+        "parameters": [
+          {
+            "name": "declaredActivityId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/FeedbackDetailsDTO"
                 }
               }
             }
@@ -1593,6 +1656,36 @@
             }
           }
         ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/me/users/preferences/notification": {
+      "patch": {
+        "tags": [
+          "user-controller"
+        ],
+        "operationId": "updateNotificationPreferences",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NotificationPreferencesRequest"
+              }
+            }
+          },
+          "required": true
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -2922,7 +3015,7 @@
     "/me/activity-progress/feedbacks": {
       "get": {
         "tags": [
-          "declared-activity-controller"
+          "feedback-controller"
         ],
         "operationId": "getStaffFeedbacks",
         "parameters": [
@@ -2969,37 +3062,6 @@
               "*/*": {
                 "schema": {
                   "$ref": "#/components/schemas/PagedResponseFeedbackStaffListItemDTO"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/me/activity-progress/feedback/{feedbackId}": {
-      "get": {
-        "tags": [
-          "declared-activity-controller"
-        ],
-        "operationId": "getFeedbackDetails",
-        "parameters": [
-          {
-            "name": "feedbackId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/FeedbackDetailsDTO"
                 }
               }
             }
@@ -4479,6 +4541,19 @@
           "id"
         ]
       },
+      "UpdateFeedbackRequest": {
+        "type": "object",
+        "properties": {
+          "feedback": {
+            "type": "string",
+            "maxLength": 4000,
+            "minLength": 0
+          }
+        },
+        "required": [
+          "feedback"
+        ]
+      },
       "CreateTraceDTO": {
         "type": "object",
         "properties": {
@@ -5022,6 +5097,26 @@
           "traceAssociations"
         ]
       },
+      "SubscribeDeclaredActivityRequest": {
+        "type": "object",
+        "properties": {
+          "period": {
+            "$ref": "#/components/schemas/DeclaredActivityPeriodDTO"
+          }
+        }
+      },
+      "CreationResponse": {
+        "type": "object",
+        "properties": {
+          "createdItemId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "createdItemId"
+        ]
+      },
       "FeedbackDetailsDTO": {
         "type": "object",
         "properties": {
@@ -5105,26 +5200,6 @@
           "lastName"
         ]
       },
-      "SubscribeDeclaredActivityRequest": {
-        "type": "object",
-        "properties": {
-          "period": {
-            "$ref": "#/components/schemas/DeclaredActivityPeriodDTO"
-          }
-        }
-      },
-      "CreationResponse": {
-        "type": "object",
-        "properties": {
-          "createdItemId": {
-            "type": "string",
-            "format": "uuid"
-          }
-        },
-        "required": [
-          "createdItemId"
-        ]
-      },
       "ActivityDraftCreationRequest": {
         "type": "object",
         "properties": {
@@ -5147,6 +5222,14 @@
         "required": [
           "draftId"
         ]
+      },
+      "NotificationPreferencesRequest": {
+        "type": "object",
+        "properties": {
+          "notificationEnabled": {
+            "type": "boolean"
+          }
+        }
       },
       "ActivityDraftUpdateRequest": {
         "type": "object",

--- a/src/__mocks__/fixtures/student/traces.fixtures.ts
+++ b/src/__mocks__/fixtures/student/traces.fixtures.ts
@@ -249,6 +249,16 @@ export const mockedTraceDetailed = {
   traceAssociations: mockedTraceAssociations
 }
 
+export const mockedTraceDetailedWithFile = {
+  ...mockedTraceDetailed,
+  link: undefined,
+}
+
+export const mockedTraceDetailedWithLink = {
+  ...mockedTraceDetailed,
+  attachment: undefined,
+}
+
 export function createMockedSearchTracesForAssociationResponse (
   params?: SearchTracesForAssociationParams
 ): PagedResponseAssociationSearchResultTraceDTO {

--- a/src/common/composables/use-navigation/use-navigation.test.ts
+++ b/src/common/composables/use-navigation/use-navigation.test.ts
@@ -427,4 +427,28 @@ BddTest().given('a useNavigation composable', () => {
       })
     })
   })
+
+  BddTest().when('trying to navigate to student tools trace', () => {
+    BddTest().then('it should navigate to student tools trace with id', () => {
+      const { navigateToStudentToolsTrace } = navigation
+      navigateToStudentToolsTrace({ id: 'trace-123' })
+
+      expect(pushMock).toHaveBeenCalledWith({
+        name: ROUTES.STUDENT.TOOLS_TRACE.name,
+        params: { id: 'trace-123' }
+      })
+    })
+  })
+
+  BddTest().when('trying to navigate to student project skill', () => {
+    BddTest().then('it should navigate to student project skill with id', () => {
+      const { navigateToStudentProjectSkill } = navigation
+      navigateToStudentProjectSkill({ id: 'skill-123' })
+
+      expect(pushMock).toHaveBeenCalledWith({
+        name: ROUTES.STUDENT.PROJECT_SKILL.name,
+        params: { id: 'skill-123' }
+      })
+    })
+  })
 })

--- a/src/common/composables/use-navigation/use-navigation.ts
+++ b/src/common/composables/use-navigation/use-navigation.ts
@@ -196,6 +196,20 @@ export function useNavigation () {
     })
   }
 
+  const navigateToStudentToolsTrace = ({ id }: { id: string }) => {
+    return router.push({
+      name: ROUTES.STUDENT.TOOLS_TRACE.name,
+      params: { id },
+    })
+  }
+
+  const navigateToStudentProjectSkill = ({ id }: { id: string }) => {
+    return router.push({
+      name: ROUTES.STUDENT.PROJECT_SKILL.name,
+      params: { id },
+    })
+  }
+
   const navigateToStudentToolsUpdateTrace = ({ id }: { id: string }) => {
     return router.push({
       name: ROUTES.STUDENT.TOOLS_UPDATE_TRACE.name,
@@ -234,5 +248,7 @@ export function useNavigation () {
     navigateToStaffActivityCatalog,
     navigateToStudentUpdateTrace,
     navigateToStudentToolsUpdateTrace,
+    navigateToStudentToolsTrace,
+    navigateToStudentProjectSkill,
   }
 }

--- a/src/features/staff/activities/types/feedback.types.ts
+++ b/src/features/staff/activities/types/feedback.types.ts
@@ -1,0 +1,5 @@
+import type { DeclaredSkillProgressDTO, EAssociationContextType, TraceDetailDTO } from '@/api/avenir-esr'
+
+export type FeedbackAssociatedElement =
+  | { type: EAssociationContextType.TRACE, data: TraceDetailDTO }
+  | { type: EAssociationContextType.DECLARED_SKILL, data: DeclaredSkillProgressDTO }

--- a/src/features/staff/activities/utils/feedback.types-guard.test.ts
+++ b/src/features/staff/activities/utils/feedback.types-guard.test.ts
@@ -1,0 +1,48 @@
+import type { FeedbackAssociatedElement } from '@/features/staff/activities/types/feedback.types'
+import { createMockedDeclaredActivityAssociations } from '@/__mocks__/fixtures/student/declaredSkills.fixtures'
+import { mockedTraceDetailedWithFile, mockedTraceDetailedWithLink } from '@/__mocks__/fixtures/student/traces.fixtures'
+import { EAssociationContextType } from '@/api/avenir-esr'
+import { isFeedbackTraceWithFile, isFeedbackTraceWithLink } from '@/features/staff/activities/utils/feedback.types-guard'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+
+const mockedFeedbackTraceWithFile: FeedbackAssociatedElement = {
+  type: EAssociationContextType.TRACE,
+  data: mockedTraceDetailedWithFile,
+}
+
+const mockedFeedbackTraceWithLink: FeedbackAssociatedElement = {
+  type: EAssociationContextType.TRACE,
+  data: mockedTraceDetailedWithLink,
+}
+
+const mockedFeedbackDeclaredSkill: FeedbackAssociatedElement = {
+  type: EAssociationContextType.DECLARED_SKILL,
+  data: createMockedDeclaredActivityAssociations(1)[0].declaredSkill,
+}
+
+BddTest().given('feedback associated element type guards', () => {
+  BddTest().when('the element is a TRACE with a file attachment', () => {
+    BddTest().then('isFeedbackTraceWithFile should return true', () => {
+      expect(isFeedbackTraceWithFile(mockedFeedbackTraceWithFile)).toBe(true)
+    })
+    BddTest().then('isFeedbackTraceWithLink should return false', () => {
+      expect(isFeedbackTraceWithLink(mockedFeedbackTraceWithFile)).toBe(false)
+    })
+  })
+  BddTest().when('the element is a TRACE with a link', () => {
+    BddTest().then('isFeedbackTraceWithFile should return false', () => {
+      expect(isFeedbackTraceWithFile(mockedFeedbackTraceWithLink)).toBe(false)
+    })
+    BddTest().then('isFeedbackTraceWithLink should return true', () => {
+      expect(isFeedbackTraceWithLink(mockedFeedbackTraceWithLink)).toBe(true)
+    })
+  })
+  BddTest().when('the element is a DECLARED_SKILL', () => {
+    BddTest().then('isFeedbackTraceWithFile should return false', () => {
+      expect(isFeedbackTraceWithFile(mockedFeedbackDeclaredSkill)).toBe(false)
+    })
+    BddTest().then('isFeedbackTraceWithLink should return false', () => {
+      expect(isFeedbackTraceWithLink(mockedFeedbackDeclaredSkill)).toBe(false)
+    })
+  })
+})

--- a/src/features/staff/activities/utils/feedback.types-guard.ts
+++ b/src/features/staff/activities/utils/feedback.types-guard.ts
@@ -1,0 +1,10 @@
+import type { FeedbackAssociatedElement } from '@/features/staff/activities/types/feedback.types'
+import { EAssociationContextType, type TraceDetailDTO } from '@/api/avenir-esr'
+
+export function isFeedbackTraceWithFile (element: FeedbackAssociatedElement): element is { type: EAssociationContextType.TRACE, data: TraceDetailDTO } {
+  return element.type === EAssociationContextType.TRACE && !!(element.data as TraceDetailDTO).attachment
+}
+
+export function isFeedbackTraceWithLink (element: FeedbackAssociatedElement): element is { type: EAssociationContextType.TRACE, data: TraceDetailDTO } {
+  return element.type === EAssociationContextType.TRACE && !!(element.data as TraceDetailDTO).link
+}

--- a/src/features/staff/activities/views/FeedbackView/components/AssociatedElementCard/AssociatedElementCard.stub.ts
+++ b/src/features/staff/activities/views/FeedbackView/components/AssociatedElementCard/AssociatedElementCard.stub.ts
@@ -1,0 +1,13 @@
+import type { FeedbackAssociatedElement } from '@/features/staff/activities/types/feedback.types'
+import type { PropType } from 'vue'
+
+export const AssociatedElementCardStub = defineComponent({
+  name: 'AssociatedElementCard',
+  template: '<div data-testid="associated-element-card-stub"></div>',
+  props: {
+    feedbackAssociatedElement: {
+      type: Object as PropType<FeedbackAssociatedElement>,
+      required: true,
+    },
+  },
+})

--- a/src/features/staff/activities/views/FeedbackView/components/AssociatedElementCard/AssociatedElementCard.test.ts
+++ b/src/features/staff/activities/views/FeedbackView/components/AssociatedElementCard/AssociatedElementCard.test.ts
@@ -1,0 +1,132 @@
+import type { FeedbackAssociatedElement } from '@/features/staff/activities/types/feedback.types'
+import type { VueWrapper } from '@vue/test-utils'
+import { createMockedDeclaredActivityAssociations } from '@/__mocks__/fixtures/student/declaredSkills.fixtures'
+import { mockedTraceDetailedWithFile, mockedTraceDetailedWithLink } from '@/__mocks__/fixtures/student/traces.fixtures'
+import { EAssociationContextType } from '@/api/avenir-esr'
+import { AssociatedElementTypeBadgeStub } from '@/features/staff/activities/components/badges/AssociatedElementTypeBadge/AssociatedElementTypeBadge.stub'
+import AssociatedElementCard from '@/features/staff/activities/views/FeedbackView/components/AssociatedElementCard/AssociatedElementCard.vue'
+import { FeedbackTraceActionsStub } from '@/features/staff/activities/views/FeedbackView/components/FeedbackTraceActions/FeedbackTraceActions.stub'
+import { AvButtonStub, AvCardStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { mountComponent } from 'tests/utils'
+import { beforeEach, expect, vi } from 'vitest'
+
+const mockNavigateToStudentToolsTrace = vi.fn()
+const mockNavigateToStudentProjectSkill = vi.fn()
+
+vi.mock('@/common/composables', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/common/composables')>()
+  return {
+    ...actual,
+    useNavigation: () => ({
+      navigateToStudentToolsTrace: mockNavigateToStudentToolsTrace,
+      navigateToStudentProjectSkill: mockNavigateToStudentProjectSkill,
+    }),
+  }
+})
+
+const mockedFeedbackTraceWithFile: FeedbackAssociatedElement = {
+  type: EAssociationContextType.TRACE,
+  data: mockedTraceDetailedWithFile,
+}
+const mockedFeedbackTraceWithLink: FeedbackAssociatedElement = {
+  type: EAssociationContextType.TRACE,
+  data: mockedTraceDetailedWithLink,
+}
+
+const mockedFeedbackDeclaredSkill: FeedbackAssociatedElement = {
+  type: EAssociationContextType.DECLARED_SKILL,
+  data: createMockedDeclaredActivityAssociations(1)[0].declaredSkill,
+}
+
+const stubs = {
+  AvCard: AvCardStub,
+  AvButton: AvButtonStub,
+  AssociatedElementTypeBadge: AssociatedElementTypeBadgeStub,
+  FeedbackTraceActions: FeedbackTraceActionsStub,
+}
+
+BddTest().given('an AssociatedElementCard component', () => {
+  let wrapper: VueWrapper<InstanceType<typeof AssociatedElementCard>>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  BddTest().when('the element is a TRACE with a file attachment', () => {
+    beforeEach(() => {
+      wrapper = mountComponent(AssociatedElementCard, {
+        props: { feedbackAssociatedElement: mockedFeedbackTraceWithFile },
+        global: { stubs },
+      })
+    })
+
+    BddTest().then('it should render the card', () => {
+      expect(wrapper.findComponent(AvCardStub).exists()).toBe(true)
+    })
+
+    BddTest().then('it should render the badge with correct type', () => {
+      const badge = wrapper.findComponent(AssociatedElementTypeBadgeStub)
+      expect(badge.exists()).toBe(true)
+      expect(badge.props('associatedElementType')).toBe(EAssociationContextType.TRACE)
+    })
+
+    BddTest().then('it should render the title', () => {
+      expect(wrapper.text()).toContain(mockedFeedbackTraceWithFile.data.title)
+    })
+
+    BddTest().then('it should render FeedbackTraceActions', () => {
+      expect(wrapper.findComponent(FeedbackTraceActionsStub).exists()).toBe(true)
+    })
+
+    BddTest().then('it should render the detail button', () => {
+      expect(wrapper.find('[data-testid="associated-element-card-detail-button"]').exists()).toBe(true)
+    })
+
+    BddTest().then('it should navigate to trace detail when detail button is clicked', async () => {
+      await wrapper.find('[data-testid="associated-element-card-detail-button"]').trigger('click')
+      expect(mockNavigateToStudentToolsTrace).toHaveBeenCalledWith({ id: mockedFeedbackTraceWithFile.data.id })
+    })
+  })
+
+  BddTest().when('the element is a TRACE with a link', () => {
+    beforeEach(() => {
+      wrapper = mountComponent(AssociatedElementCard, {
+        props: { feedbackAssociatedElement: mockedFeedbackTraceWithLink },
+        global: { stubs },
+      })
+    })
+
+    BddTest().then('it should render FeedbackTraceActions', () => {
+      expect(wrapper.findComponent(FeedbackTraceActionsStub).exists()).toBe(true)
+    })
+
+    BddTest().then('it should navigate to trace detail when detail button is clicked', async () => {
+      await wrapper.find('[data-testid="associated-element-card-detail-button"]').trigger('click')
+      expect(mockNavigateToStudentToolsTrace).toHaveBeenCalledWith({ id: mockedFeedbackTraceWithLink.data.id })
+    })
+  })
+
+  BddTest().when('the element is a DECLARED_SKILL', () => {
+    beforeEach(() => {
+      wrapper = mountComponent(AssociatedElementCard, {
+        props: { feedbackAssociatedElement: mockedFeedbackDeclaredSkill },
+        global: { stubs },
+      })
+    })
+
+    BddTest().then('it should render the badge with correct type', () => {
+      const badge = wrapper.findComponent(AssociatedElementTypeBadgeStub)
+      expect(badge.exists()).toBe(true)
+      expect(badge.props('associatedElementType')).toBe(EAssociationContextType.DECLARED_SKILL)
+    })
+
+    BddTest().then('it should not render FeedbackTraceActions', () => {
+      expect(wrapper.findComponent(FeedbackTraceActionsStub).exists()).toBe(false)
+    })
+
+    BddTest().then('it should navigate to skill detail when detail button is clicked', async () => {
+      await wrapper.find('[data-testid="associated-element-card-detail-button"]').trigger('click')
+      expect(mockNavigateToStudentProjectSkill).toHaveBeenCalledWith({ id: mockedFeedbackDeclaredSkill.data.id })
+    })
+  })
+})

--- a/src/features/staff/activities/views/FeedbackView/components/AssociatedElementCard/AssociatedElementCard.vue
+++ b/src/features/staff/activities/views/FeedbackView/components/AssociatedElementCard/AssociatedElementCard.vue
@@ -1,0 +1,83 @@
+<script setup lang="ts">
+import type { TraceDetailDTO } from '@/api/avenir-esr'
+import type { FeedbackAssociatedElement } from '@/features/staff/activities/types/feedback.types'
+import { EAssociationContextType } from '@/api/avenir-esr'
+import { useNavigation } from '@/common/composables'
+import AssociatedElementTypeBadge from '@/features/staff/activities/components/badges/AssociatedElementTypeBadge/AssociatedElementTypeBadge.vue'
+import FeedbackTraceActions from '@/features/staff/activities/views/FeedbackView/components/FeedbackTraceActions/FeedbackTraceActions.vue'
+import { AvButton, AvCard, CUIDA_ICONS } from '@avenirs-esr/avenirs-dsav'
+import { useI18n } from 'vue-i18n'
+
+export interface AssociatedElementCardProps {
+  feedbackAssociatedElement: FeedbackAssociatedElement
+}
+
+const { feedbackAssociatedElement } = defineProps<AssociatedElementCardProps>()
+
+const { t } = useI18n()
+const { navigateToStudentToolsTrace, navigateToStudentProjectSkill } = useNavigation()
+
+const traceData = computed(() =>
+  feedbackAssociatedElement.type === EAssociationContextType.TRACE
+    ? (feedbackAssociatedElement.data as TraceDetailDTO)
+    : null
+)
+const title = computed(() => feedbackAssociatedElement.data.title)
+
+function openDetail () {
+  switch (feedbackAssociatedElement.type) {
+    case EAssociationContextType.TRACE:
+      navigateToStudentToolsTrace({ id: feedbackAssociatedElement.data.id })
+      break
+    case EAssociationContextType.DECLARED_SKILL:
+      navigateToStudentProjectSkill({ id: feedbackAssociatedElement.data.id })
+      break
+  }
+}
+</script>
+
+<template>
+  <AvCard
+    collapsible
+    :collapsed="true"
+    data-testid="associated-element-card"
+    :data-element-id="feedbackAssociatedElement.data.id"
+  >
+    <template #title="{ collapsed }">
+      <div class="av-row av-align-center av-gap-sm av-flex-fill ellipsis-container">
+        <div class="badge-container">
+          <AssociatedElementTypeBadge
+            :associated-element-type="feedbackAssociatedElement.type"
+          />
+        </div>
+        <span
+          class="av-text-text1"
+          :class="collapsed ? 'ellipsis' : ''"
+        >
+          {{ title }}
+        </span>
+      </div>
+      <div class="av-row av-align-center av-gap-sm">
+        <FeedbackTraceActions
+          v-if="traceData"
+          :trace="traceData"
+        />
+        <AvButton
+          :icon="CUIDA_ICONS.VISIBILITY_ON_OUTLINE"
+          :label="t('global.detail')"
+          data-testid="associated-element-card-detail-button"
+          @click.stop="openDetail"
+        />
+      </div>
+    </template>
+
+    <slot />
+  </AvCard>
+</template>
+
+<style scoped lang="scss">
+  .badge-container {
+    width: var(--dimension-6xl);
+    flex-shrink: 0;
+  }
+</style>

--- a/src/features/staff/activities/views/FeedbackView/components/FeedbackTraceActions/FeedbackTraceActions.stub.ts
+++ b/src/features/staff/activities/views/FeedbackView/components/FeedbackTraceActions/FeedbackTraceActions.stub.ts
@@ -1,0 +1,13 @@
+import type { TraceDetailDTO } from '@/api/avenir-esr'
+import type { PropType } from 'vue'
+
+export const FeedbackTraceActionsStub = defineComponent({
+  name: 'FeedbackTraceActions',
+  template: '<div data-testid="feedback-trace-actions-stub"></div>',
+  props: {
+    trace: {
+      type: Object as PropType<TraceDetailDTO>,
+      required: true,
+    },
+  },
+})

--- a/src/features/staff/activities/views/FeedbackView/components/FeedbackTraceActions/FeedbackTraceActions.test.ts
+++ b/src/features/staff/activities/views/FeedbackView/components/FeedbackTraceActions/FeedbackTraceActions.test.ts
@@ -1,0 +1,78 @@
+import { mockedTraceDetailedWithFile, mockedTraceDetailedWithLink } from '@/__mocks__/fixtures/student/traces.fixtures'
+import FeedbackTraceActions from '@/features/staff/activities/views/FeedbackView/components/FeedbackTraceActions/FeedbackTraceActions.vue'
+import { AvButtonStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { flushPromises } from '@vue/test-utils'
+import { mockAddErrorMessage } from 'tests/mocks'
+import { mountComponent } from 'tests/utils'
+import { beforeEach, expect, vi } from 'vitest'
+
+vi.mock('@/store', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/store')>()
+  return {
+    ...actual,
+    useToasterStore: () => ({
+      addErrorMessage: mockAddErrorMessage,
+    }),
+  }
+})
+
+const mockOpenLink = vi.fn()
+vi.stubGlobal('open', mockOpenLink)
+
+const traceWithFile = mockedTraceDetailedWithFile
+const traceWithLink = mockedTraceDetailedWithLink
+
+const stubs = { AvButton: AvButtonStub }
+
+BddTest().given('a FeedbackTraceActions component', () => {
+  let wrapper: ReturnType<typeof mountComponent<typeof FeedbackTraceActions>>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  BddTest().when('the trace has a file attachment', () => {
+    beforeEach(() => {
+      wrapper = mountComponent(FeedbackTraceActions, {
+        props: { trace: traceWithFile },
+        global: { stubs },
+      })
+    })
+
+    BddTest().then('it should render the download button', () => {
+      expect(wrapper.find('[data-testid="feedback-trace-actions-download-button"]').exists()).toBe(true)
+    })
+
+    BddTest().then('it should not render the link button', () => {
+      expect(wrapper.find('[data-testid="feedback-trace-actions-link-button"]').exists()).toBe(false)
+    })
+
+    BddTest().then('it should trigger the download when download button is clicked', async () => {
+      await wrapper.find('[data-testid="feedback-trace-actions-download-button"]').trigger('click')
+      await flushPromises()
+      expect(mockAddErrorMessage).not.toHaveBeenCalled()
+    })
+  })
+
+  BddTest().when('the trace has a link', () => {
+    beforeEach(() => {
+      wrapper = mountComponent(FeedbackTraceActions, {
+        props: { trace: traceWithLink },
+        global: { stubs },
+      })
+    })
+
+    BddTest().then('it should render the link button', () => {
+      expect(wrapper.find('[data-testid="feedback-trace-actions-link-button"]').exists()).toBe(true)
+    })
+
+    BddTest().then('it should not render the download button', () => {
+      expect(wrapper.find('[data-testid="feedback-trace-actions-download-button"]').exists()).toBe(false)
+    })
+
+    BddTest().then('it should open the link in a new tab when link button is clicked', async () => {
+      await wrapper.find('[data-testid="feedback-trace-actions-link-button"]').trigger('click')
+      expect(mockOpenLink).toHaveBeenCalledWith(traceWithLink.link, '_blank', 'noopener,noreferrer')
+    })
+  })
+})

--- a/src/features/staff/activities/views/FeedbackView/components/FeedbackTraceActions/FeedbackTraceActions.vue
+++ b/src/features/staff/activities/views/FeedbackView/components/FeedbackTraceActions/FeedbackTraceActions.vue
@@ -1,0 +1,63 @@
+<script setup lang="ts">
+import type { TraceDetailDTO } from '@/api/avenir-esr'
+import type { BaseApiException } from '@/common/exceptions'
+import { useDownloadFile } from '@/api/avenir-esr'
+import { useApiErrors } from '@/common/composables/use-api-errors/use-api-errors'
+import { downloadBlob } from '@/common/utils/download/download'
+import { useToasterStore } from '@/store'
+import { AvButton, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
+import { useI18n } from 'vue-i18n'
+
+export interface FeedbackTraceActionsProps {
+  trace: TraceDetailDTO
+}
+
+const { trace } = defineProps<FeedbackTraceActionsProps>()
+
+const { t } = useI18n()
+const { getErrorMessage } = useApiErrors()
+const { addErrorMessage } = useToasterStore()
+
+const { mutate: mutateDownloadAttachment } = useDownloadFile()
+
+function downloadAttachment () {
+  if (!trace.attachment) {
+    return
+  }
+  mutateDownloadAttachment(
+    { fileId: trace.attachment.id },
+    {
+      onError: (error: BaseApiException) => {
+        addErrorMessage({
+          title: t('global.errors.download'),
+          description: getErrorMessage(error)
+        })
+      },
+      onSuccess: data => downloadBlob(data, trace.attachment?.fileName)
+    }
+  )
+}
+
+function openLink () {
+  if (trace.link) {
+    window.open(trace.link, '_blank', 'noopener,noreferrer')
+  }
+}
+</script>
+
+<template>
+  <AvButton
+    v-if="trace.attachment"
+    :icon="MDI_ICONS.DOWNLOAD_OUTLINE"
+    :label="t('global.buttons.download')"
+    data-testid="feedback-trace-actions-download-button"
+    @click.stop="downloadAttachment"
+  />
+  <AvButton
+    v-else-if="trace.link"
+    :icon="MDI_ICONS.LINK"
+    :label="t('global.buttons.access')"
+    data-testid="feedback-trace-actions-link-button"
+    @click.stop="openLink"
+  />
+</template>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -96,6 +96,7 @@
       "expandButtonLabel": "View breadcrumb"
     },
     "buttons": {
+      "access": "Access",
       "add": "Add",
       "associate": "Associate",
       "cancel": "Cancel",
@@ -103,6 +104,7 @@
       "collapse": "Collapse",
       "confirm": "Confirm",
       "delete": "Delete",
+      "download": "Download",
       "exit": "Exit",
       "expand": "Expand",
       "goBack": "Go back",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -94,6 +94,7 @@
       "expandButtonLabel": "Voir le fil d'Ariane"
     },
     "buttons": {
+      "access": "Accéder",
       "add": "Ajouter",
       "associate": "Associer",
       "cancel": "Annuler",
@@ -101,6 +102,7 @@
       "collapse": "Réduire",
       "confirm": "Confirmer",
       "delete": "Supprimer",
+      "download": "Télécharger",
       "exit": "Quitter",
       "expand": "Développer",
       "goBack": "Retour",


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
Add the AssociatedElementCard component displaying an associated element (trace or declared skill) in a collapsible AvCard. The title is truncated when collapsed and fully displayed when expanded. Action buttons allow downloading (file trace), accessing (link trace), or navigating to the element detail.

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1740

---

### Target Branch
develop

---

### Additional Notes

<img width="1038" height="110" alt="Capture d’écran du 2026-06-15 17-07-15" src="https://github.com/user-attachments/assets/97606219-ae44-41f6-b74b-062c4b3e20ae" />
<img width="1038" height="110" alt="Capture d’écran du 2026-06-15 17-07-02" src="https://github.com/user-attachments/assets/17b55be3-353c-49aa-8450-7f7017fdfeaf" />
<img width="1038" height="110" alt="Capture d’écran du 2026-06-15 17-06-37" src="https://github.com/user-attachments/assets/e9b4cd28-6d32-46eb-ab71-b7a738b6881e" />
<img width="1038" height="169" alt="Capture d’écran du 2026-06-15 17-07-25" src="https://github.com/user-attachments/assets/a0d0290d-68f9-4825-a659-d10b26100430" />



---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [x] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process

