### PR TITLE
test(1776): add e2e tests for FeedbackInfoCard in MyPerspectiveTab

### DIFF
--- a/e2e/framework/student/lifeProject/activityDetails/StudentProjectActivityDetails.ts
+++ b/e2e/framework/student/lifeProject/activityDetails/StudentProjectActivityDetails.ts
@@ -203,4 +203,19 @@ export class StudentProjectActivityDetails extends BasePage {
   async verifyAssociateTracesConfirmationModalHidden () {
     await this.getMyPerspectiveSection().verifyAssociateTracesConfirmationModalHidden()
   }
+
+  @Then('the feedback info card is visible')
+  async verifyFeedbackInfoCardVisible () {
+    await this.getMyPerspectiveSection().verifyFeedbackInfoCardVisible()
+  }
+
+  @Then('the feedback info card title is visible')
+  async verifyFeedbackInfoCardTitleVisible () {
+    await this.getMyPerspectiveSection().verifyFeedbackInfoCardTitleVisible()
+  }
+
+  @Then('the feedback info card iterations badge is visible')
+  async verifyFeedbackInfoCardBadgeVisible () {
+    await this.getMyPerspectiveSection().verifyFeedbackInfoCardBadgeVisible()
+  }
 }

--- a/e2e/framework/student/lifeProject/activityDetails/componentObjects/MyPerspectiveSectionObject.ts
+++ b/e2e/framework/student/lifeProject/activityDetails/componentObjects/MyPerspectiveSectionObject.ts
@@ -210,4 +210,28 @@ export class MyPerspectiveSectionObject extends BaseObject {
     await expect(this.getEditPerspectiveButton()).toBeHidden({ timeout: 10000 })
     await expect(this.getRichTextEditor()).toBeVisible({ timeout: 10000 })
   }
+
+  getFeedbackInfoCard () {
+    return this.root.getByTestId('feedback-info-card')
+  }
+
+  getFeedbackInfoCardTitle () {
+    return this.root.getByTestId('feedback-info-card-title')
+  }
+
+  getFeedbackInfoCardBadge () {
+    return this.root.getByTestId('feedback-info-card-iterations-badge')
+  }
+
+  async verifyFeedbackInfoCardVisible () {
+    await expect(this.getFeedbackInfoCard()).toBeVisible()
+  }
+
+  async verifyFeedbackInfoCardTitleVisible () {
+    await expect(this.getFeedbackInfoCardTitle()).toBeVisible()
+  }
+
+  async verifyFeedbackInfoCardBadgeVisible () {
+    await expect(this.getFeedbackInfoCardBadge()).toBeVisible()
+  }
 }

--- a/e2e/tests/student/lifeProject/activityDetails/activityDetails.feature
+++ b/e2e/tests/student/lifeProject/activityDetails/activityDetails.feature
@@ -76,6 +76,18 @@ Feature: Student Project Activity Detail Page
       When the student cancels the perspective edition
       Then the my perspective card is in readonly mode
 
+    @high @activity-details @feedback-info-card
+    Scenario: Student can see the feedback info card in the my perspective tab
+      When the student opens the project activities page
+      And the student open activity library tab
+      And the student clicks a library activity card with in progress status
+      And the project activity details are loaded
+      And the student clicks the my perspective item in the activity side menu
+      And the my perspective section is visible
+      Then the feedback info card is visible
+      And the feedback info card title is visible
+      And the feedback info card iterations badge is visible
+
   Rule: Finish declared activity
 
     Background:


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> Ajout des tests e2e pour le composant `FeedbackInfoCard` introduit dans la US #1774. Les tests vérifient la visibilité de la carte, de son titre et du badge d'itérations dans l'onglet « Ma prise de recul » de la page de détail d'une activité déclarée (activité en cours).
>
> Fichiers modifiés :
> - `e2e/tests/student/lifeProject/activityDetails/activityDetails.feature` — nouveau scénario `@feedback-info-card` dans la Rule « My perspective »
> - `e2e/framework/student/lifeProject/activityDetails/componentObjects/MyPerspectiveSectionObject.ts` — 3 getters + 3 méthodes `verify*` pour les éléments de `FeedbackInfoCard`
> - `e2e/framework/student/lifeProject/activityDetails/StudentProjectActivityDetails.ts` — 3 steps `@Then`

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1776

---

### Documentation
> Aucune mise à jour de documentation requise. Les conventions de tests e2e existantes sont respectées (pattern BDD Playwright-BDD, ComponentObject, PageObject).

---

### Target Branch
> `develop`

---

### Additional Notes
> Les tests suivent le même pattern de navigation que les scénarios `@perspective` existants : navigation vers une activité « in progress » via `@dataset-full`, ouverture du side menu « Ma prise de recul », puis assertions sur les éléments de la `FeedbackInfoCard`.
>
> Le composant n'est rendu que si `feedbackAllowedIterations !== 0`, ce qui est le cas pour les activités du dataset full (valeur par défaut = 10).

---

### Known Limitations or Side Effects
> Le scénario ne couvre pas le cas `feedbackAllowedIterations === 0` (carte cachée) car le dataset full ne contient pas d'activité avec cette valeur. Ce cas est couvert par les tests unitaires.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process