### PR TITLE
feat(1796): add FeedbackCard component

### DIFF
--- a/api-specs/avenir-esr.swagger.json
+++ b/api-specs/avenir-esr.swagger.json
@@ -6471,7 +6471,15 @@
             "type": "string",
             "format": "date-time"
           }
-        }
+        },
+        "required": [
+          "createdAt",
+          "id",
+          "staff",
+          "status",
+          "student",
+          "updatedAt"
+        ]
       },
       "AssociationSearchResultTraceDTO": {
         "type": "object",

--- a/src/features/student/buildProject/locales/en.json
+++ b/src/features/student/buildProject/locales/en.json
@@ -118,6 +118,10 @@
               "success": "The selected associations have been successfully deleted.",
               "title": "Which association(s) do you want to delete?"
             },
+            "FeedbackCard": {
+              "receivedAt": "Feedback received on",
+              "staffRole": "Teacher"
+            },
             "FeedbackInfoCard": {
               "description": "Requesting feedback will allow you to receive a response from a referring advisor. This request will allow them to access your activity while writing their comment.",
               "iterations": "{count} iteration maximum | {count} iterations maximum",

--- a/src/features/student/buildProject/locales/fr.json
+++ b/src/features/student/buildProject/locales/fr.json
@@ -117,6 +117,10 @@
               "success": "Les associations sélectionnées ont été supprimées avec succès.",
               "title": "Quelle(s) association(s) souhaitez-vous supprimer ?"
             },
+            "FeedbackCard": {
+              "receivedAt": "Feedback reçu le",
+              "staffRole": "Enseignant"
+            },
             "FeedbackInfoCard": {
               "description": "Demander un feedback vous permettra de recevoir un retour de la part d'un conseiller référent. Cette demande lui permettra d'accéder à votre activité le temps de rédiger son commentaire.",
               "iterations": "{count} itération maximum | {count} itérations maximum",

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/cards/FeedbackCard/FeedbackCard.stub.ts
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/cards/FeedbackCard/FeedbackCard.stub.ts
@@ -1,0 +1,13 @@
+import type { FeedbackOverviewDTO } from '@/api/avenir-esr'
+import type { PropType } from 'vue'
+
+export const FeedbackCardStub = defineComponent({
+  name: 'FeedbackCard',
+  template: '<div data-testid="feedback-card-stub"></div>',
+  props: {
+    feedback: {
+      type: Object as PropType<FeedbackOverviewDTO>,
+      required: true,
+    },
+  },
+})

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/cards/FeedbackCard/FeedbackCard.test.ts
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/cards/FeedbackCard/FeedbackCard.test.ts
@@ -1,0 +1,85 @@
+import type { FeedbackOverviewDTO } from '@/api/avenir-esr'
+import type { VueWrapper } from '@vue/test-utils'
+import { EFeedbackStatus } from '@/api/avenir-esr'
+import { CardStub } from '@/common/components/cards/Card/Card.stub'
+import { ICONS } from '@/common/constants'
+import FeedbackCard from '@/features/student/buildProject/views/ProjectActivityDetailedView/components/cards/FeedbackCard/FeedbackCard.vue'
+import { AvIconTextStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { mountComponent } from 'tests/utils'
+import { beforeEach, expect } from 'vitest'
+
+const feedback: FeedbackOverviewDTO = {
+  id: 'feedback-1',
+  staff: {
+    id: 'staff-1',
+    email: 'perceval@test.fr',
+    firstName: 'Marc',
+    lastName: 'Perceval',
+  },
+  student: {
+    id: 'student-1',
+    email: 'student@test.fr',
+    firstName: 'Alice',
+    lastName: 'Martin',
+  },
+  feedback: 'Il faudrait que vous puissiez citer vos références méthodologiques.',
+  status: EFeedbackStatus.NEW,
+  createdAt: '2025-05-05T10:00:00.000Z',
+  updatedAt: '2025-05-05T10:00:00.000Z',
+}
+
+const stubs = {
+  Card: CardStub,
+  AvIconText: AvIconTextStub,
+}
+
+BddTest().given('a FeedbackCard component', () => {
+  let wrapper: VueWrapper<InstanceType<typeof FeedbackCard>>
+
+  BddTest().when('the component is mounted with a full feedback', () => {
+    beforeEach(() => {
+      wrapper = mountComponent(FeedbackCard, {
+        props: { feedback },
+        global: { stubs },
+      })
+    })
+
+    BddTest().then('it should render the card with gray background and no border', () => {
+      const card = wrapper.findComponent(CardStub)
+
+      expect(card.exists()).toBe(true)
+      expect(card.props('backgroundColor')).toBe('var(--surface-background)')
+      expect(card.props('titleBackground')).toBe('var(--surface-background)')
+      expect(card.props('borderColor')).toBe('transparent')
+    })
+
+    BddTest().then('it should render the title with the feedback icon and date in dd/MM/yyyy format', () => {
+      const title = wrapper.findComponent(AvIconTextStub)
+
+      expect(title.exists()).toBe(true)
+      expect(title.props('icon')).toBe(ICONS.FEEDBACK)
+      expect(title.props('text')).toContain('05/05/2025')
+    })
+
+    BddTest().then('it should render the staff name with role in the body', () => {
+      expect(wrapper.find('[data-testid="feedback-card-staff"]').text()).toBe('M. Perceval (Enseignant)')
+    })
+
+    BddTest().then('it should render the feedback content in the body', () => {
+      expect(wrapper.find('[data-testid="feedback-card-content"]').text()).toBe(feedback.feedback)
+    })
+  })
+
+  BddTest().when('the component is mounted without feedback content', () => {
+    beforeEach(() => {
+      wrapper = mountComponent(FeedbackCard, {
+        props: { feedback: { ...feedback, feedback: undefined } },
+        global: { stubs },
+      })
+    })
+
+    BddTest().then('it should not render the feedback content element', () => {
+      expect(wrapper.find('[data-testid="feedback-card-content"]').exists()).toBe(false)
+    })
+  })
+})

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/cards/FeedbackCard/FeedbackCard.vue
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/cards/FeedbackCard/FeedbackCard.vue
@@ -1,0 +1,64 @@
+<script lang="ts" setup>
+import type { FeedbackOverviewDTO } from '@/api/avenir-esr'
+import Card from '@/common/components/cards/Card/Card.vue'
+import { ICONS } from '@/common/constants'
+import { AvIconText } from '@avenirs-esr/avenirs-dsav'
+import { format } from 'date-fns'
+import { useI18n } from 'vue-i18n'
+
+export interface FeedbackCardProps {
+  feedback: FeedbackOverviewDTO
+}
+
+const { feedback } = defineProps<FeedbackCardProps>()
+const { t } = useI18n()
+
+const i18nKey = 'student.buildProject.activities.views.ProjectActivityDetailedView.FeedbackCard'
+
+const titleLabel = computed(() => `${t(`${i18nKey}.receivedAt`)} ${format(new Date(feedback.createdAt), 'dd/MM/yyyy')}`)
+
+const staffLabel = computed(() =>
+  `${feedback.staff?.firstName?.[0]}. ${feedback.staff?.lastName} (${t(`${i18nKey}.staffRole`)})`
+)
+</script>
+
+<template>
+  <Card
+    background-color="var(--surface-background)"
+    title-background="var(--surface-background)"
+    border-color="transparent"
+    data-testid="feedback-card"
+    :data-feedback-id="feedback.id"
+  >
+    <template #title>
+      <AvIconText
+        typography-class="n6"
+        :icon="ICONS.FEEDBACK"
+        icon-color="var(--text1)"
+        :text="titleLabel"
+        text-color="var(--text1)"
+        gap="var(--spacing-sm)"
+        data-testid="feedback-card-title"
+      />
+    </template>
+
+    <template #body>
+      <div class="av-col av-gap-xs">
+        <span
+          class="b2-regular av-text-text2"
+          data-testid="feedback-card-staff"
+        >
+          {{ staffLabel }}
+        </span>
+
+        <span
+          v-if="feedback.feedback"
+          class="b2-light av-text-text1"
+          data-testid="feedback-card-content"
+        >
+          {{ feedback.feedback }}
+        </span>
+      </div>
+    </template>
+  </Card>
+</template>


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> Ajout du composant `FeedbackCard` dans la vue `ProjectActivityDetailedView` côté étudiant. Ce composant affiche un feedback reçu à partir d'un `FeedbackOverviewDTO` : titre avec icône et date au format `JJ/MM/AAAA`, nom de l'enseignant avec son rôle traduit, et contenu du feedback. La card utilise un fond gris (`var(--surface-background)`) sans bordure, conformément au visuel cible.

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1796

---

### Documentation
> Aucune mise à jour de documentation requise. Les clés i18n ont été ajoutées dans `fr.json` et `en.json`.

---

### Target Branch
> `develop`

---

### Additional Notes
> - La date est formatée en `dd/MM/yyyy` via `date-fns/format` (sans passer par `useDateUtils` car les fonctions existantes ne garantissent pas ce format strict).
> - Le rôle "Enseignant" / "Teacher" est traduit via i18n (`FeedbackCard.staffRole`).
> - Les fichiers suivants ont été créés : `FeedbackCard.vue`, `FeedbackCard.stub.ts`, `FeedbackCard.test.ts`.

---

### Known Limitations or Side Effects
> Aucune.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [x] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process