### PR TITLE
feat(1775): display received feedbacks section in MyPerspectiveTab

### DIFF
--- a/src/features/student/buildProject/locales/en.json
+++ b/src/features/student/buildProject/locales/en.json
@@ -160,6 +160,11 @@
             "ProjectActivityDetails": {
               "executionPeriodTitle": "Implementation period"
             },
+            "ReceivedFeedbacksSection": {
+              "empty": "You have not received any feedback yet",
+              "titleLimited": "Feedback received ({count}/{max}) | Feedbacks received ({count}/{max})",
+              "titleUnlimited": "Feedback received ({count}) | Feedbacks received ({count})"
+            },
             "requestFeedbackActivity": {
               "error": "An error occurred while requesting feedback. Please try again later.",
               "feedbackPending": "Your request is being processed",

--- a/src/features/student/buildProject/locales/fr.json
+++ b/src/features/student/buildProject/locales/fr.json
@@ -159,6 +159,12 @@
             "ProjectActivityDetails": {
               "executionPeriodTitle": "Période de réalisation"
             },
+            "ReceivedFeedbacksSection": {
+              "empty": "Vous n'avez reçu aucun feedback pour le moment",
+              "titleLimited": "Feedback reçu ({count}/{max}) | Feedbacks reçus ({count}/{max})",
+              "titleUnlimited": "Feedback reçu ({count}) | Feedbacks reçus ({count})"
+
+            },
             "requestFeedbackActivity": {
               "error": "Une erreur est survenue lors de la demande de feedback. Veuillez réessayer plus tard.",
               "feedbackPending": "Votre demande est en cours de traitement",

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/sections/ReceivedFeedbacksSection/ReceivedFeedbacksSection.stub.ts
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/sections/ReceivedFeedbacksSection/ReceivedFeedbacksSection.stub.ts
@@ -1,0 +1,13 @@
+import type { DeclaredActivityDetailsDTO } from '@/api/avenir-esr'
+import type { PropType } from 'vue'
+
+export const ReceivedFeedbacksSectionStub = defineComponent({
+  name: 'ReceivedFeedbacksSection',
+  template: '<div data-testid="received-feedbacks-section-stub"></div>',
+  props: {
+    declaredActivityDetails: {
+      type: Object as PropType<DeclaredActivityDetailsDTO>,
+      required: true,
+    },
+  },
+})

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/sections/ReceivedFeedbacksSection/ReceivedFeedbacksSection.test.ts
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/sections/ReceivedFeedbacksSection/ReceivedFeedbacksSection.test.ts
@@ -1,0 +1,174 @@
+import type { DeclaredActivityDetailsDTO } from '@/api/avenir-esr'
+import type { VueWrapper } from '@vue/test-utils'
+import { mockedDeclaredActivityDetails } from '@/__mocks__/fixtures/student/activities.fixtures'
+import { EFeedbackStatus } from '@/api/avenir-esr'
+import { FeedbackCardStub } from '@/features/student/buildProject/views/ProjectActivityDetailedView/components/cards/FeedbackCard/FeedbackCard.stub'
+import ReceivedFeedbacksSection from '@/features/student/buildProject/views/ProjectActivityDetailedView/components/sections/ReceivedFeedbacksSection/ReceivedFeedbacksSection.vue'
+import { AvCardStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { mountComponent } from 'tests/utils'
+import { beforeEach, expect } from 'vitest'
+
+const submittedFeedback1 = {
+  id: 'feedback-1',
+  staff: { id: 'staff-1', email: 'staff@test.fr', firstName: 'Marc', lastName: 'Perceval' },
+  student: { id: 'student-1', email: 'student@test.fr', firstName: 'Alice', lastName: 'Martin' },
+  feedback: 'Premier feedback soumis',
+  status: EFeedbackStatus.SUBMITTED,
+  createdAt: '2025-05-05T10:00:00.000Z',
+  updatedAt: '2025-05-05T10:00:00.000Z',
+}
+
+const submittedFeedback2 = {
+  id: 'feedback-2',
+  staff: { id: 'staff-1', email: 'staff@test.fr', firstName: 'Marc', lastName: 'Perceval' },
+  student: { id: 'student-1', email: 'student@test.fr', firstName: 'Alice', lastName: 'Martin' },
+  feedback: 'Deuxième feedback soumis',
+  status: EFeedbackStatus.SUBMITTED,
+  createdAt: '2025-06-01T10:00:00.000Z',
+  updatedAt: '2025-06-01T10:00:00.000Z',
+}
+
+const nonSubmittedFeedback = {
+  id: 'feedback-3',
+  staff: { id: 'staff-1', email: 'staff@test.fr', firstName: 'Marc', lastName: 'Perceval' },
+  student: { id: 'student-1', email: 'student@test.fr', firstName: 'Alice', lastName: 'Martin' },
+  feedback: 'Feedback non soumis',
+  status: EFeedbackStatus.NEW,
+  createdAt: '2025-06-10T10:00:00.000Z',
+  updatedAt: '2025-06-10T10:00:00.000Z',
+}
+
+const stubs = {
+  FeedbackCard: FeedbackCardStub,
+  AvCard: AvCardStub,
+}
+
+BddTest().given('a ReceivedFeedbacksSection component', () => {
+  let wrapper: VueWrapper<InstanceType<typeof ReceivedFeedbacksSection>>
+
+  BddTest().when('feedbackAllowedIterations is limited and no submitted feedbacks', () => {
+    beforeEach(() => {
+      wrapper = mountComponent(ReceivedFeedbacksSection, {
+        props: { declaredActivityDetails: mockedDeclaredActivityDetails },
+        global: { stubs },
+      })
+    })
+
+    BddTest().then('it should render the section', () => {
+      expect(wrapper.find('[data-testid="received-feedbacks-section"]').exists()).toBe(true)
+    })
+
+    BddTest().then('it should render the title in plural with count 0 out of max', () => {
+      expect(wrapper.find('[data-testid="received-feedbacks-section-title"]').text()).toBe('Feedbacks reçus (0/10)')
+    })
+
+    BddTest().then('it should not render any FeedbackCard', () => {
+      expect(wrapper.findAllComponents(FeedbackCardStub)).toHaveLength(0)
+    })
+
+    BddTest().then('it should render the empty state', () => {
+      expect(wrapper.find('[data-testid="received-feedbacks-section-empty"]').exists()).toBe(true)
+    })
+
+    BddTest().then('it should display the empty state message', () => {
+      expect(wrapper.find('[data-testid="received-feedbacks-section-empty"]').text()).toContain('Vous n\'avez reçu aucun feedback pour le moment')
+    })
+  })
+
+  BddTest().when('feedbackAllowedIterations is limited and only non-submitted feedbacks', () => {
+    beforeEach(() => {
+      wrapper = mountComponent(ReceivedFeedbacksSection, {
+        props: {
+          declaredActivityDetails: {
+            ...mockedDeclaredActivityDetails,
+            feedbacks: [nonSubmittedFeedback],
+          },
+        },
+        global: { stubs },
+      })
+    })
+
+    BddTest().then('it should not render any FeedbackCard', () => {
+      expect(wrapper.findAllComponents(FeedbackCardStub)).toHaveLength(0)
+    })
+
+    BddTest().then('it should render the empty state', () => {
+      expect(wrapper.find('[data-testid="received-feedbacks-section-empty"]').exists()).toBe(true)
+    })
+  })
+
+  BddTest().when('feedbackAllowedIterations is limited and has submitted feedbacks', () => {
+    const declaredActivityDetails: DeclaredActivityDetailsDTO = {
+      ...mockedDeclaredActivityDetails,
+      feedbacks: [submittedFeedback1, submittedFeedback2],
+    }
+
+    beforeEach(() => {
+      wrapper = mountComponent(ReceivedFeedbacksSection, {
+        props: { declaredActivityDetails },
+        global: { stubs },
+      })
+    })
+
+    BddTest().then('it should render the title in plural with submitted count and max', () => {
+      expect(wrapper.find('[data-testid="received-feedbacks-section-title"]').text()).toBe('Feedbacks reçus (2/10)')
+    })
+
+    BddTest().then('it should render one FeedbackCard per submitted feedback', () => {
+      expect(wrapper.findAllComponents(FeedbackCardStub)).toHaveLength(2)
+    })
+
+    BddTest().then('it should pass correct props to each FeedbackCard', () => {
+      const cards = wrapper.findAllComponents(FeedbackCardStub)
+      expect(cards[0].props('feedback')).toEqual(submittedFeedback1)
+      expect(cards[1].props('feedback')).toEqual(submittedFeedback2)
+    })
+
+    BddTest().then('it should not render the empty state', () => {
+      expect(wrapper.find('[data-testid="received-feedbacks-section-empty"]').exists()).toBe(false)
+    })
+  })
+
+  BddTest().when('feedbackAllowedIterations is limited and has mixed feedback statuses', () => {
+    beforeEach(() => {
+      wrapper = mountComponent(ReceivedFeedbacksSection, {
+        props: {
+          declaredActivityDetails: {
+            ...mockedDeclaredActivityDetails,
+            feedbacks: [submittedFeedback1, nonSubmittedFeedback],
+          },
+        },
+        global: { stubs },
+      })
+    })
+
+    BddTest().then('it should count only submitted feedbacks in the title', () => {
+      expect(wrapper.find('[data-testid="received-feedbacks-section-title"]').text()).toBe('Feedback reçu (1/10)')
+    })
+
+    BddTest().then('it should render only submitted FeedbackCards', () => {
+      const cards = wrapper.findAllComponents(FeedbackCardStub)
+      expect(cards).toHaveLength(1)
+      expect(cards[0].props('feedback')).toEqual(submittedFeedback1)
+    })
+  })
+
+  BddTest().when('feedbackAllowedIterations is unlimited (-1) and has submitted feedbacks', () => {
+    beforeEach(() => {
+      wrapper = mountComponent(ReceivedFeedbacksSection, {
+        props: {
+          declaredActivityDetails: {
+            ...mockedDeclaredActivityDetails,
+            activity: { ...mockedDeclaredActivityDetails.activity, feedbackAllowedIterations: -1 },
+            feedbacks: [submittedFeedback1, submittedFeedback2],
+          },
+        },
+        global: { stubs },
+      })
+    })
+
+    BddTest().then('it should render the title in plural with count only', () => {
+      expect(wrapper.find('[data-testid="received-feedbacks-section-title"]').text()).toBe('Feedbacks reçus (2)')
+    })
+  })
+})

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/sections/ReceivedFeedbacksSection/ReceivedFeedbacksSection.vue
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/sections/ReceivedFeedbacksSection/ReceivedFeedbacksSection.vue
@@ -1,0 +1,66 @@
+<script lang="ts" setup>
+import { type DeclaredActivityDetailsDTO, EFeedbackStatus } from '@/api/avenir-esr'
+import FeedbackCard from '@/features/student/buildProject/views/ProjectActivityDetailedView/components/cards/FeedbackCard/FeedbackCard.vue'
+import { AvCard } from '@avenirs-esr/avenirs-dsav'
+import { useI18n } from 'vue-i18n'
+
+export interface ReceivedFeedbacksSectionProps {
+  declaredActivityDetails: DeclaredActivityDetailsDTO
+}
+
+const { declaredActivityDetails } = defineProps<ReceivedFeedbacksSectionProps>()
+const { t } = useI18n()
+
+const submittedFeedbacks = computed(() =>
+  declaredActivityDetails.feedbacks?.filter(f => f.status === EFeedbackStatus.SUBMITTED) ?? []
+)
+
+const title = computed(() => {
+  const count = submittedFeedbacks.value.length
+  const max = declaredActivityDetails.activity.feedbackAllowedIterations
+
+  return max === -1
+    ? t('student.buildProject.activities.views.ProjectActivityDetailedView.ReceivedFeedbacksSection.titleUnlimited', { count })
+    : t('student.buildProject.activities.views.ProjectActivityDetailedView.ReceivedFeedbacksSection.titleLimited', { count, max })
+})
+</script>
+
+<template>
+  <div
+    class="av-col av-gap-md"
+    data-testid="received-feedbacks-section"
+  >
+    <span
+      class="n4 av-text-text1"
+      data-testid="received-feedbacks-section-title"
+    >
+      {{ title }}
+    </span>
+
+    <template v-if="submittedFeedbacks.length">
+      <FeedbackCard
+        v-for="feedback in submittedFeedbacks"
+        :key="feedback.id"
+        :feedback="feedback"
+      />
+    </template>
+
+    <AvCard
+      v-else
+      background-color="var(--surface-background)"
+      border-color="transparent"
+      data-testid="received-feedbacks-section-empty"
+      class="empty-message-card"
+    >
+      <span class="b2-light av-text-text2">
+        {{ t('student.buildProject.activities.views.ProjectActivityDetailedView.ReceivedFeedbacksSection.empty') }}
+      </span>
+    </AvCard>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.empty-message-card {
+  border-radius: var(--radius-lg) !important;
+}
+</style>

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/tabs/MyPerspectiveTab/MyPerspectiveTab.test.ts
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/tabs/MyPerspectiveTab/MyPerspectiveTab.test.ts
@@ -3,6 +3,7 @@ import { mockedDeclaredActivityDetails } from '@/__mocks__/fixtures/student/acti
 import { FeedbackInfoCardStub } from '@/features/student/buildProject/views/ProjectActivityDetailedView/components/cards/FeedbackInfoCard/FeedbackInfoCard.stub'
 import { MyPerspectiveCardStub } from '@/features/student/buildProject/views/ProjectActivityDetailedView/components/cards/MyPerspectiveCard/MyPerspectiveCard.stub'
 import { PerspectiveTabActionsStub } from '@/features/student/buildProject/views/ProjectActivityDetailedView/components/interactions/PerspectiveTabActions/PerspectiveTabActions.stub'
+import { ReceivedFeedbacksSectionStub } from '@/features/student/buildProject/views/ProjectActivityDetailedView/components/sections/ReceivedFeedbacksSection/ReceivedFeedbacksSection.stub'
 import MyPerspectiveTab, {
   type MyPerspectiveTabProps,
 } from '@/features/student/buildProject/views/ProjectActivityDetailedView/components/tabs/MyPerspectiveTab/MyPerspectiveTab.vue'
@@ -17,6 +18,7 @@ BddTest().given('a my perspective tab', () => {
     MyPerspectiveCard: MyPerspectiveCardStub,
     FeedbackInfoCard: FeedbackInfoCardStub,
     PerspectiveTabActions: PerspectiveTabActionsStub,
+    ReceivedFeedbacksSection: ReceivedFeedbacksSectionStub,
   }
 
   BddTest().when('the component is mounted', () => {
@@ -39,13 +41,19 @@ BddTest().given('a my perspective tab', () => {
       expect(wrapper.findComponent(MyPerspectiveCardStub).exists()).toBe(true)
     })
 
+    BddTest().then('it should pass the correct props to MyPerspectiveCard', () => {
+      const card = wrapper.findComponent(MyPerspectiveCardStub)
+      expect(card.props('activityId')).toBe(mockedDeclaredActivityDetails.id)
+      expect(card.props('perspective')).toBe(mockedDeclaredActivityDetails.reflection)
+      expect(card.props('activityStatus')).toBe(mockedDeclaredActivityDetails.status)
+    })
+
     BddTest().then('it should render the feedback info card', () => {
       expect(wrapper.findComponent(FeedbackInfoCardStub).exists()).toBe(true)
     })
 
     BddTest().then('it should pass the correct props to FeedbackInfoCard', () => {
-      const feedbackInfoCard = wrapper.findComponent(FeedbackInfoCardStub)
-      expect(feedbackInfoCard.props('activity')).toEqual(mockedDeclaredActivityDetails)
+      expect(wrapper.findComponent(FeedbackInfoCardStub).props('activity')).toEqual(mockedDeclaredActivityDetails)
     })
 
     BddTest().then('it should render PerspectiveTabActions', () => {
@@ -53,8 +61,15 @@ BddTest().given('a my perspective tab', () => {
     })
 
     BddTest().then('it should pass the correct props to PerspectiveTabActions', () => {
-      const perspectiveTabActions = wrapper.findComponent(PerspectiveTabActionsStub)
-      expect(perspectiveTabActions.props('declaredActivityDetails')).toEqual(mockedDeclaredActivityDetails)
+      expect(wrapper.findComponent(PerspectiveTabActionsStub).props('declaredActivityDetails')).toEqual(mockedDeclaredActivityDetails)
+    })
+
+    BddTest().then('it should render ReceivedFeedbacksSection', () => {
+      expect(wrapper.findComponent(ReceivedFeedbacksSectionStub).exists()).toBe(true)
+    })
+
+    BddTest().then('it should pass the correct props to ReceivedFeedbacksSection', () => {
+      expect(wrapper.findComponent(ReceivedFeedbacksSectionStub).props('declaredActivityDetails')).toEqual(mockedDeclaredActivityDetails)
     })
   })
 
@@ -75,6 +90,10 @@ BddTest().given('a my perspective tab', () => {
 
     BddTest().then('it should not render the feedback info card', () => {
       expect(wrapper.findComponent(FeedbackInfoCardStub).exists()).toBe(false)
+    })
+
+    BddTest().then('it should not render ReceivedFeedbacksSection', () => {
+      expect(wrapper.findComponent(ReceivedFeedbacksSectionStub).exists()).toBe(false)
     })
   })
 })

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/tabs/MyPerspectiveTab/MyPerspectiveTab.vue
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/tabs/MyPerspectiveTab/MyPerspectiveTab.vue
@@ -4,6 +4,7 @@ import FeedbackInfoCard from '@/features/student/buildProject/views/ProjectActiv
 import MyPerspectiveCard from '@/features/student/buildProject/views/ProjectActivityDetailedView/components/cards/MyPerspectiveCard/MyPerspectiveCard.vue'
 import PerspectiveTabActions
   from '@/features/student/buildProject/views/ProjectActivityDetailedView/components/interactions/PerspectiveTabActions/PerspectiveTabActions.vue'
+import ReceivedFeedbacksSection from '@/features/student/buildProject/views/ProjectActivityDetailedView/components/sections/ReceivedFeedbacksSection/ReceivedFeedbacksSection.vue'
 
 export interface MyPerspectiveTabProps {
   declaredActivityDetails: DeclaredActivityDetailsDTO
@@ -31,6 +32,11 @@ const { declaredActivityDetails } = defineProps<MyPerspectiveTabProps>()
     />
 
     <PerspectiveTabActions
+      :declared-activity-details="declaredActivityDetails"
+    />
+
+    <ReceivedFeedbacksSection
+      v-if="declaredActivityDetails.activity.feedbackAllowedIterations !== 0"
       :declared-activity-details="declaredActivityDetails"
     />
   </div>


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> Ajout de la section "Feedbacks reçus" dans le composant `MyPerspectiveTab` côté étudiant. Cette section s'affiche uniquement quand `feedbackAllowedIterations !== 0` et liste les feedbacks filtrés par statut `SUBMITTED`. Le titre affiche le décompte des feedbacks soumis (avec ou sans maximum selon la configuration). En l'absence de feedbacks soumis, une carte vide avec un message informatif est affichée à la place. Le composant `FeedbackCard` a également été créé pour afficher chaque feedback individuel.

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1775

---

### Documentation
> Aucune mise à jour de documentation requise. Les clés i18n ont été ajoutées dans `fr.json` et `en.json` (titre avec pluralisation, message d'état vide).

---

### Target Branch
> `develop`

---

### Additional Notes
> - Seuls les feedbacks avec `status === SUBMITTED` sont affichés et comptabilisés dans le titre.
> - Le titre utilise la pluralisation vue-i18n (`count | counts`) avec le 3ème argument de `t()`.
> - L'état vide utilise une `AvCard` sans titre avec fond gris et sans bordure (`var(--surface-background)` / `border-color: transparent`).
> - Le composant `FeedbackCard` (nouveau) prend un `FeedbackOverviewDTO` et affiche : icône + date `dd/MM/yyyy`, nom de l'enseignant abrégé (`P. Nom`), et le contenu du feedback.

---

### Known Limitations or Side Effects
> Aucune.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [x] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process