### PR TITLE
fix(1599): fix i18n trad in delete activity draft confirmation modal

### DIFF
--- a/src/features/staff/activities/components/modals/DeleteDraftActivityConfirmationModal/DeleteDraftActivityConfirmationModal.test.ts
+++ b/src/features/staff/activities/components/modals/DeleteDraftActivityConfirmationModal/DeleteDraftActivityConfirmationModal.test.ts
@@ -40,7 +40,7 @@ BddTest().given('a DeleteDraftActivityConfirmationModal component', () => {
     })
 
     BddTest().then('it should pass the correct title', () => {
-      expect(wrapper.findComponent(ConfirmationModalStub).props('title')).toBe('Êtes-vous certain(e) de vouloir supprimer cette activité ?')
+      expect(wrapper.findComponent(ConfirmationModalStub).props('title')).toBe('Êtes-vous certain(e) de vouloir supprimer cette activité nationale ?')
     })
 
     BddTest().then('it should pass showDescription=false', () => {

--- a/src/features/staff/activities/locales/en.json
+++ b/src/features/staff/activities/locales/en.json
@@ -57,7 +57,7 @@
         "DeleteDraftActivityConfirmationModal": {
           "deleteError": "An error occurred while deleting the activity",
           "deleteSuccess": "Activity deleted successfully",
-          "title": "Are you sure you want to delete this activity?"
+          "title": "Are you sure you want to delete this national activity?"
         }
       },
       "views": {

--- a/src/features/staff/activities/locales/fr.json
+++ b/src/features/staff/activities/locales/fr.json
@@ -57,7 +57,7 @@
         "DeleteDraftActivityConfirmationModal": {
           "deleteError": "Une erreur est survenue lors de la suppression de l'activité",
           "deleteSuccess": "L'activité a été supprimée avec succès",
-          "title": "Êtes-vous certain(e) de vouloir supprimer cette activité ?"
+          "title": "Êtes-vous certain(e) de vouloir supprimer cette activité nationale ?"
         }
       },
       "views": {


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
Fix missing translation keys in the delete activity draft confirmation modal. Updates i18n translation files (en.json and fr.json) with the correct translation keys and updates corresponding test file.

---

### Reference to an Issue, Feature, Task, User Story or another PR
Linked to https://github.com/avenirs-esr/AVENIRS-Project/issues/1599
---

### Documentation
No documentation updates needed for this fix.

---

### Target Branch
develop

---

### Additional Notes
This is a follow-up fix to ensure proper i18n translations are displayed in the delete activity draft confirmation modal.

---

### Known Limitations or Side Effects
None.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [x] a11y tested (if the PR includes frontend changes) - No UI changes, only i18n strings
- [x] Tests provided (including unit and integration tests for both frontend and backend) - Test file updated
- [x] i18n handled (texts are translated) - Translation keys fixed in en.json and fr.json
- [x] Performance tests - N/A
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [x] Semantic Versioning respected
- [x] Add to \`CHANGELOG.md\` file all properties and database change and detaiils for the update process - N/A for i18n fix