### PR TITLE
feat(feedback):  FeedbackAssociatedElementsCard component

### DIFF
--- a/src/__mocks__/fixtures/staffs/feedbacks.fixtures.ts
+++ b/src/__mocks__/fixtures/staffs/feedbacks.fixtures.ts
@@ -1,5 +1,6 @@
-import type { FeedbackStaffListItemDTO, PagedResponseFeedbackStaffListItemDTO } from '@/api/avenir-esr'
-import { EFeedbackStatus } from '@/api/avenir-esr'
+import { createMockedDeclaredSkillProgressDTO } from '@/__mocks__/fixtures/student/skills.fixtures'
+import { mockedTraceDetailedWithFile } from '@/__mocks__/fixtures/student/traces.fixtures'
+import { EFeedbackStatus, type FeedbackDetailsDTO, type FeedbackStaffListItemDTO, type PagedResponseFeedbackStaffListItemDTO } from '@/api/avenir-esr'
 
 const allFeedbacks: FeedbackStaffListItemDTO[] = [
   {
@@ -24,6 +25,31 @@ const allFeedbacks: FeedbackStaffListItemDTO[] = [
     updatedAt: '2024-03-06T14:00:00Z',
   },
 ]
+
+const mockedStudent = {
+  id: 'student-1',
+  firstName: 'Lucas',
+  lastName: 'Tessier',
+  email: 'lucas.tessier@university.com',
+}
+
+export const mockedFeedbackDetailsWithAssociations: FeedbackDetailsDTO = {
+  id: 'feedback-with-associations',
+  declaredActivityId: 'declared-activity-1',
+  status: EFeedbackStatus.NEW,
+  student: mockedStudent,
+  associatedTraces: [mockedTraceDetailedWithFile],
+  associatedDeclaredSkills: [createMockedDeclaredSkillProgressDTO()],
+  createdAt: '2024-01-15T10:00:00Z',
+  updatedAt: '2024-01-16T10:00:00Z',
+}
+
+export const mockedFeedbackDetailsWithoutAssociations: FeedbackDetailsDTO = {
+  ...mockedFeedbackDetailsWithAssociations,
+  id: 'feedback-without-associations',
+  associatedTraces: [],
+  associatedDeclaredSkills: [],
+}
 
 export function createMockedPagedResponseFeedbackStaffListItemDTO (
   pageSize: number,

--- a/src/__mocks__/msw/handlers/staffs/feedbacks.handlers.ts
+++ b/src/__mocks__/msw/handlers/staffs/feedbacks.handlers.ts
@@ -1,0 +1,25 @@
+import { mockedFeedbackDetailsWithAssociations, mockedFeedbackDetailsWithoutAssociations } from '@/__mocks__/fixtures/staffs/feedbacks.fixtures'
+import { type FeedbackDetailsDTO, getGetFeedbackDetailsUrl } from '@/api/avenir-esr'
+import { HttpStatusCode } from '@/common/utils/http/http-status'
+import { http, HttpResponse } from 'msw'
+
+export const getFeedbackDetailsWithAssociationsHandler = http.get(
+  `*${getGetFeedbackDetailsUrl(':userCategory' as 'STAFF', ':feedbackId')}`,
+  ({ params }) => {
+    if (params.feedbackId === mockedFeedbackDetailsWithoutAssociations.id) {
+      return HttpResponse.json<FeedbackDetailsDTO>(mockedFeedbackDetailsWithoutAssociations, {
+        status: HttpStatusCode.OK,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+
+    return HttpResponse.json<FeedbackDetailsDTO>(mockedFeedbackDetailsWithAssociations, {
+      status: HttpStatusCode.OK,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+)
+
+export const feedbacksHandlers = [
+  getFeedbackDetailsWithAssociationsHandler,
+]

--- a/src/features/staff/activities/locales/en.json
+++ b/src/features/staff/activities/locales/en.json
@@ -13,6 +13,10 @@
       },
       "feedbacks": {
         "cards": {
+          "FeedbackAssociatedElementsCard": {
+            "emptyState": "No elements associated with this feedback found",
+            "title": "Summary of associated elements ({count})"
+          },
           "lastSaved": "Last saved on",
           "receivedAt": "Received on",
           "StudentPerspectiveCard": {

--- a/src/features/staff/activities/locales/fr.json
+++ b/src/features/staff/activities/locales/fr.json
@@ -13,6 +13,10 @@
       },
       "feedbacks": {
         "cards": {
+          "FeedbackAssociatedElementsCard": {
+            "emptyState": "Aucun élément associé à ce feedback trouvé",
+            "title": "Récapitulatif des éléments associés ({count})"
+          },
           "lastSaved": "Dernier enregistrement le",
           "receivedAt": "Reçu le",
           "StudentPerspectiveCard": {

--- a/src/features/staff/activities/views/FeedbacksView/components/FeedbackAssociatedElementsCard/FeedbackAssociatedElementsCard.stub.ts
+++ b/src/features/staff/activities/views/FeedbacksView/components/FeedbackAssociatedElementsCard/FeedbackAssociatedElementsCard.stub.ts
@@ -1,0 +1,10 @@
+export const FeedbackAssociatedElementsCardStub = defineComponent({
+  name: 'FeedbackAssociatedElementsCard',
+  template: '<div data-testid="feedback-associated-elements-card-stub"><slot /></div>',
+  props: {
+    feedbackId: {
+      type: String,
+      required: true,
+    },
+  },
+})

--- a/src/features/staff/activities/views/FeedbacksView/components/FeedbackAssociatedElementsCard/FeedbackAssociatedElementsCard.test.ts
+++ b/src/features/staff/activities/views/FeedbacksView/components/FeedbackAssociatedElementsCard/FeedbackAssociatedElementsCard.test.ts
@@ -1,0 +1,69 @@
+import { mockedFeedbackDetailsWithAssociations, mockedFeedbackDetailsWithoutAssociations } from '@/__mocks__/fixtures/staffs/feedbacks.fixtures'
+import { getFeedbackDetailsWithAssociationsHandler } from '@/__mocks__/msw/handlers/staffs/feedbacks.handlers'
+import { server } from '@/__mocks__/msw/server'
+import { EAssociationContextType } from '@/api/avenir-esr'
+import { QuerySuspenseStub } from '@/common/components/QuerySuspense/QuerySuspense.stub'
+import { AssociatedElementCardStub } from '@/features/staff/activities/views/FeedbacksView/components/AssociatedElementCard/AssociatedElementCard.stub'
+import FeedbackAssociatedElementsCard from '@/features/staff/activities/views/FeedbacksView/components/FeedbackAssociatedElementsCard/FeedbackAssociatedElementsCard.vue'
+import { AvCardStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { flushPromises, type VueWrapper } from '@vue/test-utils'
+import { mountComponent } from 'tests/utils'
+import { beforeEach, expect, vi } from 'vitest'
+
+const stubs = {
+  AvCard: AvCardStub,
+  AssociatedElementCard: AssociatedElementCardStub,
+  QuerySuspense: QuerySuspenseStub,
+}
+
+BddTest().given('a FeedbackAssociatedElementsCard component', () => {
+  let wrapper: VueWrapper<InstanceType<typeof FeedbackAssociatedElementsCard>>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    server.use(getFeedbackDetailsWithAssociationsHandler)
+  })
+
+  BddTest().when('feedback has associated traces and skills', () => {
+    beforeEach(async () => {
+      wrapper = mountComponent(FeedbackAssociatedElementsCard, {
+        props: { feedbackId: mockedFeedbackDetailsWithAssociations.id },
+        global: { stubs },
+      })
+      await flushPromises()
+    })
+
+    BddTest().then('it should render the card', () => {
+      expect(wrapper.find('[data-testid="feedback-associated-elements-card"]').exists()).toBe(true)
+    })
+
+    BddTest().then('it should render the correct number of AssociatedElementCard', () => {
+      const cards = wrapper.findAllComponents(AssociatedElementCardStub)
+      expect(cards).toHaveLength(2)
+    })
+
+    BddTest().then('it should render a TRACE element first', () => {
+      const cards = wrapper.findAllComponents(AssociatedElementCardStub)
+      expect(cards[0].props('feedbackAssociatedElement').type).toBe(EAssociationContextType.TRACE)
+    })
+
+    BddTest().then('it should render a DECLARED_SKILL element second', () => {
+      const cards = wrapper.findAllComponents(AssociatedElementCardStub)
+      expect(cards[1].props('feedbackAssociatedElement').type).toBe(EAssociationContextType.DECLARED_SKILL)
+    })
+  })
+
+  BddTest().when('feedback has no associations', () => {
+    beforeEach(async () => {
+      wrapper = mountComponent(FeedbackAssociatedElementsCard, {
+        props: { feedbackId: mockedFeedbackDetailsWithoutAssociations.id },
+        global: { stubs },
+      })
+      await flushPromises()
+    })
+
+    BddTest().then('it should render no AssociatedElementCard', () => {
+      expect(wrapper.findAllComponents(AssociatedElementCardStub)).toHaveLength(0)
+    })
+  })
+})

--- a/src/features/staff/activities/views/FeedbacksView/components/FeedbackAssociatedElementsCard/FeedbackAssociatedElementsCard.vue
+++ b/src/features/staff/activities/views/FeedbacksView/components/FeedbackAssociatedElementsCard/FeedbackAssociatedElementsCard.vue
@@ -1,0 +1,60 @@
+<script setup lang="ts">
+import type { FeedbackAssociatedElement } from '@/features/staff/activities/types/feedback.types'
+import { EAssociationContextType, EUserCategory, useGetFeedbackDetails } from '@/api/avenir-esr'
+import { QuerySuspense } from '@/common/components'
+import AssociatedElementCard from '@/features/staff/activities/views/FeedbacksView/components/AssociatedElementCard/AssociatedElementCard.vue'
+import { AvCard } from '@avenirs-esr/avenirs-dsav'
+import { useI18n } from 'vue-i18n'
+
+interface FeedbackAssociatedElementsCardProps {
+  feedbackId: string
+}
+
+const { feedbackId } = defineProps<FeedbackAssociatedElementsCardProps>()
+const { t } = useI18n()
+
+const { data: feedbackDetails, isLoading, error } = useGetFeedbackDetails(EUserCategory.STAFF, feedbackId)
+
+const associatedElements = computed<FeedbackAssociatedElement[]>(() => {
+  if (!feedbackDetails.value) {
+    return []
+  }
+
+  const traces = (feedbackDetails.value.associatedTraces ?? []).map(trace => ({
+    type: EAssociationContextType.TRACE as const,
+    data: trace,
+  }))
+
+  const skills = (feedbackDetails.value.associatedDeclaredSkills ?? []).map(skill => ({
+    type: EAssociationContextType.DECLARED_SKILL as const,
+    data: skill,
+  }))
+
+  return [...traces, ...skills]
+})
+</script>
+
+<template>
+  <AvCard
+    collapsible
+    :collapsed="false"
+    data-testid="feedback-associated-elements-card"
+  >
+    <template #title>
+      {{ t('staff.activities.feedbacks.cards.FeedbackAssociatedElementsCard.title', { count: associatedElements.length }) }}
+    </template>
+
+    <QuerySuspense
+      :is-loading="isLoading"
+      :is-empty="associatedElements.length === 0"
+      :empty-state-message="t('staff.activities.feedbacks.cards.FeedbackAssociatedElementsCard.emptyState')"
+      :error="error"
+    >
+      <AssociatedElementCard
+        v-for="element in associatedElements"
+        :key="element.data.id"
+        :feedback-associated-element="element"
+      />
+    </QuerySuspense>
+  </AvCard>
+</template>


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
Add a FeedbackAssociatedElementsCard component displaying a collapsible summary of elements (traces and declared skills) associated to a feedback request.

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1741

---

### Target Branch
develop

---

### Additional Notes

<img width="1100" height="709" alt="Capture d’écran du 2026-06-19 15-32-01" src="https://github.com/user-attachments/assets/74975314-2923-497f-a6c2-8948b68a8092" />
<img width="777" height="679" alt="Capture d’écran du 2026-06-19 15-30-20" src="https://github.com/user-attachments/assets/3b73689d-19c5-4069-9500-07d48981fa96" />
<img width="777" height="759" alt="Capture d’écran du 2026-06-19 15-30-45" src="https://github.com/user-attachments/assets/f8f0f080-8698-42fb-9d2d-bcb0be421e5e" />


---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [x] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and detaiils for the update process
