### PR TITLE
refactor(1947): StudentNavigation - hide education menu in demo mode

### DIFF
--- a/src/features/student/global/components/navigation/StudentNavigation/StudentNavigation.vue
+++ b/src/features/student/global/components/navigation/StudentNavigation/StudentNavigation.vue
@@ -174,7 +174,7 @@ const navItems = computed(() => [
     icon: MDI_ICONS.HOME_VARIANT_OUTLINE,
   },
   ...(
-    isApcVisible.value
+    !__DEMO_MODE__ && isApcVisible.value
       ? [educationMenu.value]
       : []
   ),


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
<!-- Describe the changes introduced by this pull request. -->

:recycle: StudentNavigation - hide education menu in demo mode

---

### Reference to an Issue, Feature, Task, User Story or another PR
<!-- Mention related issue numbers or links (e.g. Closes #123, Implements #456). -->
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1947

---

### Documentation
<!-- Detail any updates made to documentation, configuration steps, or technical specs. -->

---

### Target Branch
<!-- Which branch is this PR targeting (e.g. `main`, `develop`)? -->

develop

---

### Additional Notes
<!-- Include any relevant context, technical details, or reasons behind certain decisions. -->

<img width="1906" height="927" alt="image" src="https://github.com/user-attachments/assets/bf1705d3-1403-4d35-a3a9-82a42cef4203" />

---

### Known Limitations or Side Effects
<!-- List any limitations, known bugs, or side effects this PR may introduce. -->

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [ ] No unnecessary code (e.g., debug logs, commented code)
- [ ] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and detaiils for the update process

---

# Remember

**DO NOT** keep this template as is when you submit. Please remove or adjust the description when you submit your pull request.

Please do not submit a pull request to ask questions.

Do not submit pull requests without tests that verify or reproduce your intended use case. The pull request will
most likely be automatically closed immediately, unless the change is extremely trivial. 

