### PR TITLE
fix(1954): fix unlimited feedback iterations display

### DIFF
--- a/src/features/staff/feedbacks/components/badges/FeedbackIterationBadge/FeedbackIterationBadge.test.ts
+++ b/src/features/staff/feedbacks/components/badges/FeedbackIterationBadge/FeedbackIterationBadge.test.ts
@@ -6,14 +6,25 @@ BddTest().given('a FeedbackIterationBadge component', () => {
   let wrapper: VueWrapper<InstanceType<typeof FeedbackIterationBadge>>
   const stubs = { AvBadge: AvBadgeStub }
 
-  BddTest().when('the component is mounted', () => {
+  BddTest().when('the component is mounted without maxIterations', () => {
     beforeEach(() => {
       wrapper = mount(FeedbackIterationBadge, { props: { iteration: 1 }, global: { stubs } })
     })
-
-    BddTest().then('it should render the badge', () => {
+    BddTest().then('it should render only the iteration without max', () => {
       expect(wrapper.findComponent(AvBadgeStub).exists()).toBe(true)
       expect(wrapper.text()).toContain('Demande 1')
+      expect(wrapper.text()).not.toContain('Demande 1/')
+    })
+  })
+
+  BddTest().when('the component is mounted with unlimited iterations', () => {
+    beforeEach(() => {
+      wrapper = mount(FeedbackIterationBadge, { props: { iteration: 1, maxIterations: -1 }, global: { stubs } })
+    })
+    BddTest().then('it should render only the iteration without max', () => {
+      expect(wrapper.findComponent(AvBadgeStub).exists()).toBe(true)
+      expect(wrapper.text()).toContain('Demande 1')
+      expect(wrapper.text()).not.toContain('/-1')
     })
   })
 

--- a/src/features/staff/feedbacks/components/badges/FeedbackIterationBadge/FeedbackIterationBadge.vue
+++ b/src/features/staff/feedbacks/components/badges/FeedbackIterationBadge/FeedbackIterationBadge.vue
@@ -17,7 +17,7 @@ const label = computed(() =>
 )
 
 const resolvedLabel = computed(() =>
-  maxIterations
+  maxIterations && maxIterations > 0
     ? `${label.value}/${maxIterations}`
     : label.value
 )


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
Fix the FeedbackIterationBadge component to correctly handle unlimited iterations. When maxIterations is -1 (unlimited), only the iteration number is displayed without the denominator. maxIterations is now required since the backend always sends it.

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1954

---

### Target Branch
develop

---

### Additional Notes
The backend always sends feedbackAllowedIterations as an int with -1 meaning unlimited. maxIterations prop is now required (removed ?) to reflect this contract.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [x] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and detaiils for the update process