### PR TITLE
refactor(1960): move countAssociations computation into TraceAssociations

### DIFF
--- a/src/features/student/traces/components/composites/TraceAssociations/TraceAssociations.stub.ts
+++ b/src/features/student/traces/components/composites/TraceAssociations/TraceAssociations.stub.ts
@@ -7,7 +7,6 @@ export const TraceAssociationsStub = defineComponent({
   props: {
     associations: { type: Object as PropType<TraceAssociationsDTO>, required: true },
     traceId: { type: String, required: true },
-    countAssociations: { type: Number, required: false },
     associationsError: { type: Object as PropType<BaseApiException | null>, required: false }
   },
   template: `<div data-testid="trace-associations-stub"></div>`

--- a/src/features/student/traces/components/composites/TraceAssociations/TraceAssociations.test.ts
+++ b/src/features/student/traces/components/composites/TraceAssociations/TraceAssociations.test.ts
@@ -47,7 +47,6 @@ BddTest().given('a student trace associations component', () => {
         props: {
           associations: mockedEmptyTraceAssociations,
           traceId,
-          countAssociations: 0,
         },
         global: {
           stubs
@@ -255,7 +254,6 @@ BddTest().given('a student trace associations component', () => {
         props: {
           associations: associationsProps,
           traceId,
-          countAssociations: declaredSkillAssociations.length
         },
         global: {
           stubs
@@ -324,7 +322,6 @@ BddTest().given('a student trace associations component', () => {
         props: {
           associations: associationsProps,
           traceId,
-          countAssociations: declaredActivityAssociations.length
         },
         global: {
           stubs

--- a/src/features/student/traces/components/composites/TraceAssociations/TraceAssociations.vue
+++ b/src/features/student/traces/components/composites/TraceAssociations/TraceAssociations.vue
@@ -22,7 +22,7 @@ import DeleteTraceAssociatedSkillsModal
   from '@/features/student/traces/views/StudentTraceView/components/overlays/modals/DeleteTraceAssociatedSkillsModal/DeleteTraceAssociatedSkillsModal.vue'
 import { useI18n } from 'vue-i18n'
 
-const { associations, traceId, associationsError, countAssociations = 0 } = defineProps<TraceAssociationsProps>()
+const { associations, traceId, associationsError } = defineProps<TraceAssociationsProps>()
 
 const { t } = useI18n()
 
@@ -30,7 +30,6 @@ export interface TraceAssociationsProps {
   associations: TraceAssociationsDTO | undefined
   traceId: string
   associationsError?: BaseApiException | null
-  countAssociations?: number
 }
 
 const { showModal: showSkillsModal, displayModal: displaySkillsModal, hideModal: hideSkillsModal } = useModal()
@@ -42,6 +41,9 @@ const { showModal: showAssociateExperiencesModal, displayModal: displayAssociate
 
 const declaredSkillAssociations = computed(() => associations?.declaredSkillAssociations ?? [])
 const declaredActivityAssociations = computed(() => associations?.declaredActivityAssociations ?? [])
+const declaredExperienceAssociations = computed(() => associations?.declaredExperienceAssociations ?? [])
+
+const countAssociations = computed(() => declaredSkillAssociations.value.length + declaredActivityAssociations.value.length + declaredExperienceAssociations.value.length)
 
 const deletableDeclaredActivityAssociations = computed(() =>
   declaredActivityAssociations.value.filter(({ declaredActivity }) => declaredActivity.status !== EDeclaredActivityStatus.COMPLETED)

--- a/src/features/student/traces/views/StudentTraceView/StudentTraceView.test.ts
+++ b/src/features/student/traces/views/StudentTraceView/StudentTraceView.test.ts
@@ -294,7 +294,6 @@ BddTest().given('a student trace view', () => {
       const traceAssociations = wrapper.findComponent(TraceAssociationsStub)
 
       expect(traceAssociations.exists()).toBe(true)
-      expect(traceAssociations.props('countAssociations')).toBe(5)
       expect(traceAssociations.props('associationsError')).toBeNull()
     })
   })

--- a/src/features/student/traces/views/StudentTraceView/StudentTraceView.vue
+++ b/src/features/student/traces/views/StudentTraceView/StudentTraceView.vue
@@ -167,7 +167,6 @@ const breadcrumbLinks = computed(() =>
               :associations="traceAssociations"
               :trace-id="traceDetailed.id"
               :associations-error="associationsError"
-              :count-associations="countAssociations"
             />
           </Loader>
         </AvTab>


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> Le composant `TraceAssociations` recevait `countAssociations` en prop alors que cette valeur peut être calculée directement depuis la prop `associations` déjà disponible. Le calcul a été déplacé dans le composant sous forme de computed, incluant désormais les `declaredExperienceAssociations` en plus des skills et activités.

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1960

---

### Documentation
> Aucune mise à jour de documentation nécessaire.

---

### Target Branch
> `develop`

---

### Additional Notes
> Le computed `countAssociations` dans `StudentTraceView` est conservé car il est utilisé pour afficher le compteur dans le titre de l'onglet.

---

### Known Limitations or Side Effects
> Aucune.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process