### PR TITLE
fix(1956): add disabled prop to trace association dropdowns

### DIFF
--- a/src/features/student/buildProject/components/cards/AssociatedDeclaredActivitiesCard/AssociatedDeclaredActivitiesCard.stub.ts
+++ b/src/features/student/buildProject/components/cards/AssociatedDeclaredActivitiesCard/AssociatedDeclaredActivitiesCard.stub.ts
@@ -6,6 +6,10 @@ export const AssociatedDeclaredActivitiesCardStub = defineComponent({
     associatedActivities: {
       type: Array as () => DeclaredActivityAssociationDTO[],
       required: true
+    },
+    disabled: {
+      type: Boolean,
+      required: false
     }
   },
   template: `

--- a/src/features/student/buildProject/components/cards/AssociatedDeclaredActivitiesCard/AssociatedDeclaredActivitiesCard.test.ts
+++ b/src/features/student/buildProject/components/cards/AssociatedDeclaredActivitiesCard/AssociatedDeclaredActivitiesCard.test.ts
@@ -63,4 +63,22 @@ BddTest().given('an associated declared activities card', () => {
       expect(wrapper.findComponent(AssociationsCardStub).exists()).toBe(false)
     })
   })
+
+  BddTest().when('the component is mounted with disabled=true', () => {
+    const props: AssociatedDeclaredActivitiesCardProps = {
+      associatedActivities: mockedTraceDeclaredActivityAssociations,
+      disabled: true
+    }
+
+    beforeEach(() => {
+      vi.clearAllMocks()
+      wrapper = mount(AssociatedDeclaredActivitiesCard, { props, global: { stubs } })
+    })
+
+    BddTest().then('it should pass disabled=true to each AssociatedActivityCard', () => {
+      const activityCards = wrapper.findAllComponents(AssociatedActivityCardStub)
+      expect(activityCards.length).toBeGreaterThan(0)
+      activityCards.forEach(card => expect(card.props('disabled')).toBe(true))
+    })
+  })
 })

--- a/src/features/student/buildProject/components/cards/AssociatedDeclaredActivitiesCard/AssociatedDeclaredActivitiesCard.vue
+++ b/src/features/student/buildProject/components/cards/AssociatedDeclaredActivitiesCard/AssociatedDeclaredActivitiesCard.vue
@@ -7,9 +7,10 @@ import { useI18n } from 'vue-i18n'
 
 export interface AssociatedDeclaredActivitiesCardProps {
   associatedActivities: DeclaredActivityAssociationDTO[]
+  disabled?: boolean
 }
 
-const { associatedActivities } = defineProps<AssociatedDeclaredActivitiesCardProps>()
+const { associatedActivities, disabled } = defineProps<AssociatedDeclaredActivitiesCardProps>()
 
 const { t } = useI18n()
 
@@ -27,6 +28,7 @@ const title = computed(() => t('student.buildProject.activities.cards.Associated
       v-for="associatedActivity in associatedActivities"
       :key="associatedActivity.associationId"
       :declared-activity="associatedActivity.declaredActivity"
+      :disabled="disabled"
     />
   </AssociationsCard>
 </template>

--- a/src/features/student/declaredSkills/components/cards/AssociatedDeclaredSkillsCard/AssociatedDeclaredSkillsCard.stub.ts
+++ b/src/features/student/declaredSkills/components/cards/AssociatedDeclaredSkillsCard/AssociatedDeclaredSkillsCard.stub.ts
@@ -6,6 +6,10 @@ export const AssociatedDeclaredSkillsCardStub = defineComponent({
     associatedDeclaredSkills: {
       type: Object as () => DeclaredSkillAssociationDTO[],
       required: true
+    },
+    disabled: {
+      type: Boolean,
+      required: false
     }
   },
   template: `

--- a/src/features/student/declaredSkills/components/cards/AssociatedDeclaredSkillsCard/AssociatedDeclaredSkillsCard.test.ts
+++ b/src/features/student/declaredSkills/components/cards/AssociatedDeclaredSkillsCard/AssociatedDeclaredSkillsCard.test.ts
@@ -51,4 +51,22 @@ BddTest().given('an associated declared skills card', () => {
       expect(wrapper.findComponent(AssociationsCardStub).exists()).toBe(false)
     })
   })
+
+  BddTest().when('the component is mounted with disabled=true', () => {
+    const props: AssociatedDeclaredSkillsCardProps = {
+      associatedDeclaredSkills: createMockedDeclaredActivityAssociations(3),
+      disabled: true
+    }
+
+    beforeEach(() => {
+      vi.clearAllMocks()
+      wrapper = mount(AssociatedDeclaredSkillsCard, { props, global: { stubs } })
+    })
+
+    BddTest().then('it should pass disabled=true to each AssociatedSkillCard', () => {
+      const skillCards = wrapper.findAllComponents(AssociatedSkillCardStub)
+      expect(skillCards.length).toBeGreaterThan(0)
+      skillCards.forEach(card => expect(card.props('disabled')).toBe(true))
+    })
+  })
 })

--- a/src/features/student/declaredSkills/components/cards/AssociatedDeclaredSkillsCard/AssociatedDeclaredSkillsCard.vue
+++ b/src/features/student/declaredSkills/components/cards/AssociatedDeclaredSkillsCard/AssociatedDeclaredSkillsCard.vue
@@ -7,9 +7,10 @@ import { useI18n } from 'vue-i18n'
 
 export interface AssociatedDeclaredSkillsCardProps {
   associatedDeclaredSkills: DeclaredSkillAssociationDTO[]
+  disabled?: boolean
 }
 
-const { associatedDeclaredSkills } = defineProps<AssociatedDeclaredSkillsCardProps>()
+const { associatedDeclaredSkills, disabled } = defineProps<AssociatedDeclaredSkillsCardProps>()
 
 const { t } = useI18n()
 
@@ -27,6 +28,7 @@ const title = computed(() => t('student.declaredSkills.cards.AssociatedDeclaredS
       v-for="associatedDeclaredSkill in associatedDeclaredSkills"
       :key="associatedDeclaredSkill.associationId"
       :declared-skill="associatedDeclaredSkill.declaredSkill"
+      :disabled="disabled"
     />
   </AssociationsCard>
 </template>

--- a/src/features/student/global/components/cards/AssociatedActivityCard/AssociatedActivityCard.stub.ts
+++ b/src/features/student/global/components/cards/AssociatedActivityCard/AssociatedActivityCard.stub.ts
@@ -7,6 +7,10 @@ export const AssociatedActivityCardStub = defineComponent({
     declaredActivity: {
       type: Object as PropType<DeclaredActivityViewDTO>,
       required: true
+    },
+    disabled: {
+      type: Boolean,
+      required: false
     }
   },
   template: '<div data-testid="associated-declared-activity-card"></div>'

--- a/src/features/student/global/components/cards/AssociatedActivityCard/AssociatedActivityCard.test.ts
+++ b/src/features/student/global/components/cards/AssociatedActivityCard/AssociatedActivityCard.test.ts
@@ -60,5 +60,26 @@ BddTest().given('an associated activity card', () => {
         }
       })
     })
+
+    BddTest().then('it should pass disabled as false to the AssociationCard by default', () => {
+      const associationCard = wrapper.findComponent(AssociationCardStub)
+      expect(associationCard.props('disabled')).toBe(false)
+    })
+  })
+
+  BddTest().when('the component is mounted with disabled=true', () => {
+    const props: AssociatedActivityCardProps = {
+      declaredActivity: mockedDeclaredActivity,
+      disabled: true
+    }
+
+    beforeEach(() => {
+      wrapper = mount(AssociatedActivityCard, { props, global: { stubs } })
+    })
+
+    BddTest().then('it should pass disabled=true to the AssociationCard', () => {
+      const associationCard = wrapper.findComponent(AssociationCardStub)
+      expect(associationCard.props('disabled')).toBe(true)
+    })
   })
 })

--- a/src/features/student/global/components/cards/AssociatedActivityCard/AssociatedActivityCard.vue
+++ b/src/features/student/global/components/cards/AssociatedActivityCard/AssociatedActivityCard.vue
@@ -6,9 +6,10 @@ import AssociationCard from '@/features/student/global/components/cards/Associat
 
 export interface AssociatedActivityCardProps {
   declaredActivity: DeclaredActivityViewDTO
+  disabled?: boolean
 }
 
-const { declaredActivity } = defineProps<AssociatedActivityCardProps>()
+const { declaredActivity, disabled } = defineProps<AssociatedActivityCardProps>()
 </script>
 
 <template>
@@ -20,6 +21,7 @@ const { declaredActivity } = defineProps<AssociatedActivityCardProps>()
     icon-border-color="var(--other-border-skill-card)"
     background-color="var(--surface-background)"
     :to="{ name: ROUTES.STUDENT.PROJECT_ACTIVITIES_DETAILED.name, params: { id: declaredActivity.id, thematic: declaredActivity.thematic } }"
+    :disabled="disabled"
     data-testid="associated-declared-activity-card"
   >
     <template #body>

--- a/src/features/student/global/components/cards/AssociatedSkillCard/AssociatedSkillCard.stub.ts
+++ b/src/features/student/global/components/cards/AssociatedSkillCard/AssociatedSkillCard.stub.ts
@@ -7,6 +7,10 @@ export const AssociatedSkillCardStub = defineComponent({
     declaredSkill: {
       type: Object as PropType<DeclaredSkillProgressDTO>,
       required: true
+    },
+    disabled: {
+      type: Boolean,
+      required: false
     }
   },
   template: '<div data-testid="associated-skill-card"></div>'

--- a/src/features/student/global/components/cards/AssociatedSkillCard/AssociatedSkillCard.test.ts
+++ b/src/features/student/global/components/cards/AssociatedSkillCard/AssociatedSkillCard.test.ts
@@ -36,5 +36,26 @@ BddTest().given('an associatied skill card', () => {
         backgroundColor: 'var(--dark-background-primary1)',
       })
     })
+
+    BddTest().then('it should pass disabled as false to the AssociationCard by default', () => {
+      const associationCard = wrapper.findComponent(AssociationCardStub)
+      expect(associationCard.props('disabled')).toBe(false)
+    })
+  })
+
+  BddTest().when('the component is mounted with disabled=true', () => {
+    const props: AssociatedSkillCardProps = {
+      declaredSkill: createMockedDeclaredSkillProgressDTO(),
+      disabled: true
+    }
+
+    beforeEach(() => {
+      wrapper = mount(AssociatedSkillCard, { props, global: { stubs } })
+    })
+
+    BddTest().then('it should pass disabled=true to the AssociationCard', () => {
+      const associationCard = wrapper.findComponent(AssociationCardStub)
+      expect(associationCard.props('disabled')).toBe(true)
+    })
   })
 })

--- a/src/features/student/global/components/cards/AssociatedSkillCard/AssociatedSkillCard.vue
+++ b/src/features/student/global/components/cards/AssociatedSkillCard/AssociatedSkillCard.vue
@@ -7,9 +7,10 @@ import { useI18n } from 'vue-i18n'
 
 export interface AssociatedSkillCardProps {
   declaredSkill: DeclaredSkillProgressDTO
+  disabled?: boolean
 }
 
-const { declaredSkill } = defineProps<AssociatedSkillCardProps>()
+const { declaredSkill, disabled } = defineProps<AssociatedSkillCardProps>()
 
 const { t } = useI18n()
 
@@ -36,6 +37,7 @@ const pathBadge = computed<AvBadgeProps>(() => ({
     color="var(--card)"
     background-color="var(--dark-background-primary1)"
     :to="{ name: ROUTES.STUDENT.PROJECT_DECLARED_SKILL.name, params: { id: declaredSkill.id } }"
+    :disabled="disabled"
     data-testid="associated-declared-skill-card"
   >
     <template #body>

--- a/src/features/student/global/components/cards/AssociationCard/AssociationCard.stub.ts
+++ b/src/features/student/global/components/cards/AssociationCard/AssociationCard.stub.ts
@@ -28,6 +28,10 @@ export const AssociationCardStub = defineComponent({
     to: {
       type: [String, Object],
       required: true
+    },
+    disabled: {
+      type: Boolean,
+      required: false
     }
   },
   template: '<div data-testid="association-card"></div>'

--- a/src/features/student/global/components/cards/AssociationCard/AssociationCard.vue
+++ b/src/features/student/global/components/cards/AssociationCard/AssociationCard.vue
@@ -1,8 +1,8 @@
 <script lang="ts" setup>
 import type { IconOptions } from '@/features/student/global/components/cards/FloatingIconCard/FloatingIconCard.vue'
 import type { Slot } from 'vue'
-import type { RouteLocationRaw } from 'vue-router'
 import { FloatingIconCard } from '@/features/student/global'
+import { type RouteLocationRaw, RouterLink } from 'vue-router'
 
 export interface AssociationCardProps {
   title: string
@@ -12,13 +12,14 @@ export interface AssociationCardProps {
   hoverBorderColor?: string
   iconBorderColor?: string
   to: RouteLocationRaw
+  disabled?: boolean
 }
 
 defineOptions({
   inheritAttrs: false
 })
 
-const { title, icon, color, backgroundColor, hoverBorderColor, iconBorderColor, to } = defineProps<AssociationCardProps>()
+const { title, icon, color, backgroundColor, hoverBorderColor, iconBorderColor, to, disabled } = defineProps<AssociationCardProps>()
 
 defineSlots<{
   body?: Slot
@@ -34,9 +35,11 @@ const iconOptions: IconOptions = {
 </script>
 
 <template>
-  <RouterLink
+  <component
+    :is="disabled ? 'div' : RouterLink"
     class="association-card av-w-full"
-    :to="to"
+    :class="{ 'association-card--disabled': disabled }"
+    v-bind="disabled ? {} : { to }"
     data-testid="association-card"
   >
     <FloatingIconCard
@@ -46,7 +49,7 @@ const iconOptions: IconOptions = {
       :color="backgroundColor"
       :title-color="color"
       border-color="var(--other-border-skill-card)"
-      :border-color-on-hover="hoverBorderColor ?? backgroundColor"
+      :border-color-on-hover="disabled ? 'transparent' : (hoverBorderColor ?? backgroundColor)"
       title-typography-classes="s2-regular"
       :header-rows="3"
       height="21.625rem"
@@ -58,7 +61,7 @@ const iconOptions: IconOptions = {
         <slot name="footer" />
       </template>
     </FloatingIconCard>
-  </RouterLink>
+  </component>
 </template>
 
 <style lang="scss" scoped>
@@ -67,6 +70,14 @@ const iconOptions: IconOptions = {
 .association-card {
   @include dsav.min-width(md) {
     width: 21.625rem;
+  }
+
+  &--disabled {
+    cursor: not-allowed;
+
+    :deep(.av-card__title:hover) {
+      cursor: not-allowed !important;
+    }
   }
 }
 </style>

--- a/src/features/student/traces/components/composites/TraceAssociations/TraceAssociations.test.ts
+++ b/src/features/student/traces/components/composites/TraceAssociations/TraceAssociations.test.ts
@@ -295,6 +295,29 @@ BddTest().given('a student trace associations component', () => {
     })
   })
 
+  BddTest().when('the component is mounted with disabled=true', () => {
+    beforeEach(() => {
+      wrapper = mountComponent(TraceAssociations, {
+        props: {
+          associations: { declaredSkillAssociations: mockedTraceDeclaredSkillAssociations, declaredActivityAssociations: mockedTraceDeclaredActivityAssociations },
+          traceId,
+          disabled: true,
+        },
+        global: { stubs }
+      })
+    })
+
+    BddTest().then('it should pass disabled=true to AssociatedDeclaredSkillsCard', () => {
+      const skillsCard = wrapper.findComponent(AssociatedDeclaredSkillsCardStub)
+      expect(skillsCard.props('disabled')).toBe(true)
+    })
+
+    BddTest().then('it should pass disabled=true to AssociatedDeclaredActivitiesCard', () => {
+      const activitiesCard = wrapper.findComponent(AssociatedDeclaredActivitiesCardStub)
+      expect(activitiesCard.props('disabled')).toBe(true)
+    })
+  })
+
   BddTest().when('the component is mounted with only declared activity associations', () => {
     const declaredActivityAssociations: DeclaredActivityAssociationDTO[] = [
       ...mockedTraceDeclaredActivityAssociations,

--- a/src/features/student/traces/components/composites/TraceAssociations/TraceAssociations.vue
+++ b/src/features/student/traces/components/composites/TraceAssociations/TraceAssociations.vue
@@ -22,7 +22,7 @@ import DeleteTraceAssociatedSkillsModal
   from '@/features/student/traces/views/StudentTraceView/components/overlays/modals/DeleteTraceAssociatedSkillsModal/DeleteTraceAssociatedSkillsModal.vue'
 import { useI18n } from 'vue-i18n'
 
-const { associations, traceId, associationsError } = defineProps<TraceAssociationsProps>()
+const { associations, traceId, associationsError, disabled } = defineProps<TraceAssociationsProps>()
 
 const { t } = useI18n()
 
@@ -30,6 +30,7 @@ export interface TraceAssociationsProps {
   associations: TraceAssociationsDTO | undefined
   traceId: string
   associationsError?: BaseApiException | null
+  disabled?: boolean
 }
 
 const { showModal: showSkillsModal, displayModal: displaySkillsModal, hideModal: hideSkillsModal } = useModal()
@@ -77,8 +78,14 @@ const deletableDeclaredActivityAssociations = computed(() =>
       :empty-state-message="t('student.traces.views.StudentTraceView.empty.associations')"
       :is-empty="countAssociations === 0"
     >
-      <AssociatedDeclaredSkillsCard :associated-declared-skills="declaredSkillAssociations" />
-      <AssociatedDeclaredActivitiesCard :associated-activities="declaredActivityAssociations" />
+      <AssociatedDeclaredSkillsCard
+        :associated-declared-skills="declaredSkillAssociations"
+        :disabled="disabled"
+      />
+      <AssociatedDeclaredActivitiesCard
+        :associated-activities="declaredActivityAssociations"
+        :disabled="disabled"
+      />
     </QuerySuspense>
   </div>
 

--- a/src/features/student/traces/components/composites/TraceAssociations/TraceAssociations.vue
+++ b/src/features/student/traces/components/composites/TraceAssociations/TraceAssociations.vue
@@ -58,12 +58,14 @@ const deletableDeclaredActivityAssociations = computed(() =>
   >
     <div class="av-row av-flex-fill av-justify-end av-gap-md">
       <DeleteTraceAssociatedElementsDropdown
+        :disabled="disabled"
         :activities-disabled="deletableDeclaredActivityAssociations.length === 0"
         :skills-disabled="declaredSkillAssociations.length === 0"
         @activities-selected="displayActivitiesModal"
         @skills-selected="displaySkillsModal"
       />
       <TraceAssociateElementsDropdown
+        :disabled="disabled"
         @skills-selected="displayAssociationModal"
         @activities-selected="displayAssociateActivitiesModal"
         @experiences-selected="displayAssociateExperiencesModal"

--- a/src/features/student/traces/views/StudentTraceView/components/overlays/dropdowns/DeleteTraceAssociatedElementsDropdown/DeleteTraceAssociatedElementsDropdown.test.ts
+++ b/src/features/student/traces/views/StudentTraceView/components/overlays/dropdowns/DeleteTraceAssociatedElementsDropdown/DeleteTraceAssociatedElementsDropdown.test.ts
@@ -72,4 +72,34 @@ BddTest().given('a delete trace associated elements dropdown', () => {
       expect(activitiesButton.attributes('disabled')).toBeDefined()
     })
   })
+
+  BddTest().when('the component is mounted with disabled=true', () => {
+    beforeEach(() => {
+      wrapper = mount(DeleteTraceAssociatedElementsDropdown, {
+        props: { disabled: true },
+        global: { stubs }
+      })
+    })
+
+    BddTest().then('the skills menu item should be disabled', () => {
+      expect(wrapper.find('[data-name="skills"]').attributes('disabled')).toBeDefined()
+    })
+
+    BddTest().then('the activities menu item should be disabled', () => {
+      expect(wrapper.find('[data-name="activities"]').attributes('disabled')).toBeDefined()
+    })
+  })
+
+  BddTest().when('the component is mounted with disabled=true and skillsDisabled=false', () => {
+    beforeEach(() => {
+      wrapper = mount(DeleteTraceAssociatedElementsDropdown, {
+        props: { disabled: true, skillsDisabled: false },
+        global: { stubs }
+      })
+    })
+
+    BddTest().then('the skills menu item should still be disabled', () => {
+      expect(wrapper.find('[data-name="skills"]').attributes('disabled')).toBeDefined()
+    })
+  })
 })

--- a/src/features/student/traces/views/StudentTraceView/components/overlays/dropdowns/DeleteTraceAssociatedElementsDropdown/DeleteTraceAssociatedElementsDropdown.vue
+++ b/src/features/student/traces/views/StudentTraceView/components/overlays/dropdowns/DeleteTraceAssociatedElementsDropdown/DeleteTraceAssociatedElementsDropdown.vue
@@ -6,9 +6,10 @@ import { useI18n } from 'vue-i18n'
 export interface DeleteTraceAssociatedElementsDropdownProps {
   skillsDisabled?: boolean
   activitiesDisabled?: boolean
+  disabled?: boolean
 }
 
-const { skillsDisabled = false, activitiesDisabled = false } = defineProps<DeleteTraceAssociatedElementsDropdownProps>()
+const { skillsDisabled = false, activitiesDisabled = false, disabled = false } = defineProps<DeleteTraceAssociatedElementsDropdownProps>()
 
 const emit = defineEmits<{
   (e: 'skillsSelected'): void
@@ -27,13 +28,13 @@ const menuItems = computed(() => [
     name: DeleteTraceAssociatedElementsDropdownEvents.SKILLS,
     icon: ICONS.SKILLS,
     label: t('student.traces.views.StudentTraceView.DeleteTraceAssociatedElementsDropdown.skills'),
-    disabled: skillsDisabled,
+    disabled: disabled || skillsDisabled,
   },
   {
     name: DeleteTraceAssociatedElementsDropdownEvents.ACTIVITIES,
     icon: ICONS.ACTIVITY,
     label: t('student.traces.views.StudentTraceView.DeleteTraceAssociatedElementsDropdown.activities'),
-    disabled: activitiesDisabled,
+    disabled: disabled || activitiesDisabled,
   }
 ])
 

--- a/src/features/student/traces/views/StudentTraceView/components/overlays/dropdowns/TraceAssociateElementsDropdown/TraceAssociateElementsDropdown.test.ts
+++ b/src/features/student/traces/views/StudentTraceView/components/overlays/dropdowns/TraceAssociateElementsDropdown/TraceAssociateElementsDropdown.test.ts
@@ -88,4 +88,25 @@ BddTest().given('a trace associate elements dropdown', () => {
       expect(wrapper.emitted('skillsSelected')).toHaveLength(1)
     })
   })
+
+  BddTest().when('the component is mounted with disabled=true', () => {
+    beforeEach(() => {
+      wrapper = mount(TraceAssociateElementsDropdown, {
+        props: { disabled: true },
+        global: { stubs }
+      })
+    })
+
+    BddTest().then('the activities menu item should be disabled', () => {
+      expect(wrapper.find('[data-name="activities"]').attributes('disabled')).toBeDefined()
+    })
+
+    BddTest().then('the experiences menu item should be disabled', () => {
+      expect(wrapper.find('[data-name="experiences"]').attributes('disabled')).toBeDefined()
+    })
+
+    BddTest().then('the skills menu item should be disabled', () => {
+      expect(wrapper.find('[data-name="skills"]').attributes('disabled')).toBeDefined()
+    })
+  })
 })

--- a/src/features/student/traces/views/StudentTraceView/components/overlays/dropdowns/TraceAssociateElementsDropdown/TraceAssociateElementsDropdown.vue
+++ b/src/features/student/traces/views/StudentTraceView/components/overlays/dropdowns/TraceAssociateElementsDropdown/TraceAssociateElementsDropdown.vue
@@ -3,6 +3,12 @@ import { ICONS } from '@/common/constants'
 import { AvDropdown } from '@avenirs-esr/avenirs-dsav'
 import { useI18n } from 'vue-i18n'
 
+export interface TraceAssociateElementsDropdownProps {
+  disabled?: boolean
+}
+
+const { disabled = false } = defineProps<TraceAssociateElementsDropdownProps>()
+
 const emit = defineEmits<{
   (e: 'activitiesSelected'): void
   (e: 'skillsSelected'): void
@@ -21,7 +27,8 @@ const menuItems = computed(() => [
   {
     name: TraceAssociateElementsDropdownEvents.ACTIVITIES,
     icon: ICONS.ACTIVITY,
-    label: t('student.traces.views.StudentTraceView.TraceAssociateElementsDropdown.activities')
+    label: t('student.traces.views.StudentTraceView.TraceAssociateElementsDropdown.activities'),
+    disabled,
   },
   ...(
     __DEMO_MODE__
@@ -29,13 +36,15 @@ const menuItems = computed(() => [
       : [{
           name: TraceAssociateElementsDropdownEvents.EXPERIENCES,
           icon: ICONS.EXPERIENCES,
-          label: t('student.traces.views.StudentTraceView.TraceAssociateElementsDropdown.experiences')
+          label: t('student.traces.views.StudentTraceView.TraceAssociateElementsDropdown.experiences'),
+          disabled,
         }]
   ),
   {
     name: TraceAssociateElementsDropdownEvents.SKILLS,
     icon: ICONS.SKILLS,
-    label: t('student.traces.views.StudentTraceView.TraceAssociateElementsDropdown.skills')
+    label: t('student.traces.views.StudentTraceView.TraceAssociateElementsDropdown.skills'),
+    disabled,
   }
 ])
 

--- a/src/features/student/traces/views/StudentUpdateTraceView/components/UpdateTabs/UpdateTabs.vue
+++ b/src/features/student/traces/views/StudentUpdateTraceView/components/UpdateTabs/UpdateTabs.vue
@@ -58,6 +58,7 @@ const associationCount = computed(() =>
         <TraceAssociations
           :associations="associations"
           :trace-id="trace.id"
+          :disabled="true"
         >
           <template #caption>
             <span class="caption-regular">


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> Ajout d'une prop `disabled` optionnelle sur `AssociationCard` qui remplace le `RouterLink` par une `div` via `:is`, met la bordure au survol à `transparent` et passe le curseur en `not-allowed`. Cette prop est propagée à travers toute la chaîne de composants (`UpdateTabs` → `TraceAssociations` → `AssociatedDeclaredSkillsCard` / `AssociatedDeclaredActivitiesCard` → `AssociatedSkillCard` / `AssociatedActivityCard` → `AssociationCard`) avec `disabled=true` depuis la vue de modification de trace. Les dropdowns `DeleteTraceAssociatedElementsDropdown` et `TraceAssociateElementsDropdown` reçoivent également une prop `disabled` qui désactive tous leurs items.

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1956

---

### Documentation
> Aucune mise à jour de documentation nécessaire.

---

### Target Branch
> `develop`

---

### Additional Notes
> Le `disabled` global sur `DeleteTraceAssociatedElementsDropdown` est combiné en `||` avec les props `skillsDisabled` / `activitiesDisabled` existants, préservant leur comportement individuel.

---

### Known Limitations or Side Effects
> Aucune.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process