### PR TITLE
feat(1533): Add edit button for unpublished activity

### DIFF
--- a/src/features/staff/activities/views/NationalActivityCatalogView/NationalActivityCatalogView.test.ts
+++ b/src/features/staff/activities/views/NationalActivityCatalogView/NationalActivityCatalogView.test.ts
@@ -14,10 +14,12 @@ import { mountComponent } from 'tests/utils'
 import { beforeEach, expect, vi } from 'vitest'
 
 const mockNavigateToStaffActivities = vi.fn()
+const mockNavigateToStaffActivitiesEditNationalActivity = vi.fn()
 
 vi.mock('@/common/composables/use-navigation/use-navigation', () => ({
   useNavigation: () => ({
     navigateToStaffActivities: mockNavigateToStaffActivities,
+    navigateToStaffActivitiesEditNationalActivity: mockNavigateToStaffActivitiesEditNationalActivity,
   }),
 }))
 
@@ -99,9 +101,9 @@ BddTest().given('a national activity catalog view', () => {
       await waitForLoaded()
     })
 
-    BddTest().then('it should render the delete button', () => {
-      expect(wrapper.findComponent(AvButtonStub).exists()).toBe(true)
-      expect(wrapper.findComponent(AvButtonStub).props('label')).toBe('Supprimer')
+    BddTest().then('it should render the edit and delete buttons', () => {
+      expect(wrapper.find('[data-testid="edit-draft-button"]').exists()).toBe(true)
+      expect(wrapper.find('[data-testid="delete-draft-button"]').exists()).toBe(true)
     })
 
     BddTest().then('it should render the confirmation modal closed', () => {
@@ -112,9 +114,19 @@ BddTest().given('a national activity catalog view', () => {
       expect(wrapper.findComponent(DeleteDraftActivityConfirmationModalStub).props('activityId')).toBe(mockedActivityContent.id)
     })
 
+    BddTest().and('the edit button is clicked', () => {
+      beforeEach(async () => {
+        await wrapper.find('[data-testid="edit-draft-button"]').trigger('click')
+      })
+
+      BddTest().then('it should navigate to the edit view', () => {
+        expect(mockNavigateToStaffActivitiesEditNationalActivity).toHaveBeenCalledWith({ id: mockedActivityContent.id })
+      })
+    })
+
     BddTest().and('the delete button is clicked', () => {
       beforeEach(async () => {
-        await wrapper.findComponent(AvButtonStub).trigger('click')
+        await wrapper.find('[data-testid="delete-draft-button"]').trigger('click')
       })
 
       BddTest().then('it should open the confirmation modal', () => {

--- a/src/features/staff/activities/views/NationalActivityCatalogView/NationalActivityCatalogView.vue
+++ b/src/features/staff/activities/views/NationalActivityCatalogView/NationalActivityCatalogView.vue
@@ -31,7 +31,7 @@ const isDraft = computed(() => status === EActivityStatus.DRAFT)
 
 const { showModal: showDeleteConfirmation, displayModal: displayDeleteConfirmation, hideModal: hideDeleteConfirmation } = useModal()
 
-const { navigateToStaffActivities } = useNavigation()
+const { navigateToStaffActivities, navigateToStaffActivitiesEditNationalActivity } = useNavigation()
 </script>
 
 <template>
@@ -42,8 +42,14 @@ const { navigateToStaffActivities } = useNavigation()
 
   <div
     v-if="isDraft"
-    class="av-row av-justify-end av-py-md"
+    class="av-row av-justify-end av-py-md av-gap-sm"
   >
+    <AvButton
+      :label="t('global.buttons.update')"
+      variant="FLAT"
+      data-testid="edit-draft-button"
+      @click="() => navigateToStaffActivitiesEditNationalActivity({ id })"
+    />
     <AvButton
       :label="t('global.buttons.delete')"
       variant="OUTLINED"


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
Add an "Edit" button in the NationalActivityCatalogView for unpublished (DRAFT) activities. On click, the user is redirected to EditNationalActivityView with the activity ID as a route parameter. The button is only visible when the activity status is DRAFT.>

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1532
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1533

### Target Branch
develop

---

### Additional Notes
<img width="1481" height="530" alt="Capture d’écran du 2026-06-23 15-52-05" src="https://github.com/user-attachments/assets/942b1fcf-e1c0-43eb-807d-a42c501f7283" />

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [x] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and detaiils for the update process