### PR TITLE
test(1596): add e2e tests for us 1254 edit national activity

### DIFF
--- a/e2e/framework/staff/activities/StaffNationalActivityCatalogPage.ts
+++ b/e2e/framework/staff/activities/StaffNationalActivityCatalogPage.ts
@@ -89,6 +89,28 @@ export class StaffNationalActivityCatalogPage extends BasePage {
     await expect(this.getContextTitle()).toBeVisible()
   }
 
+  getEditDraftButton () {
+    return this.page.getByTestId('edit-draft-button')
+  }
+
+  @Then('the edit draft button is visible')
+  async verifyEditDraftButtonVisible () {
+    await expect(this.getEditDraftButton()).toBeVisible()
+  }
+
+  @When('the user clicks on the edit draft button')
+  async clickEditDraftButton () {
+    await clickOnElement(this.getEditDraftButton())
+  }
+
+  @Then('the staff is redirected to the edit national activity page')
+  async verifyRedirectedToEditPage () {
+    const expectedPattern = STAFF_ROUTES.ACTIVITIES_EDIT_NATIONAL_ACTIVITY
+      .replace(':id', '[^/]+')
+
+    await expect(this.page).toHaveURL(new RegExp(expectedPattern))
+  }
+
   private getDeleteDraftButton () {
     return this.page.getByTestId('delete-draft-button')
   }

--- a/e2e/tests/staff/activities/national-activity-catalog.feature
+++ b/e2e/tests/staff/activities/national-activity-catalog.feature
@@ -23,11 +23,20 @@ Feature: Staff National Activity Catalog
   Scenario: The national activity context section is visible
     Then the national activity context section is visible
 
+  Scenario: The edit draft button is visible
+    Then the edit draft button is visible
+
   Scenario: The delete draft button is visible
     Then the delete draft button is visible
 
-  Rule: Delete draft activity
 
+  Rule: Edit draft activity
+
+    Scenario: Staff can navigate to edit page from catalog page
+      When the user clicks on the edit draft button
+      Then the staff is redirected to the edit national activity page
+
+  Rule: Delete draft activity
     
     Background:
       When the user clicks on the delete draft button


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
Add E2E tests for the edit draft activity button in NationalActivityCatalogView. Tests cover the visibility of the edit button and the navigation to the edit page on click.

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1596

---

### Target Branch
develop

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and detaiils for the update process

