### PR TITLE
fix(1965): replace Formation by activity in feedbacks list

### DIFF
--- a/src/features/staff/feedbacks/locales/en.json
+++ b/src/features/staff/feedbacks/locales/en.json
@@ -73,7 +73,7 @@
           },
           "FeedbacksTable": {
             "columns": {
-              "formation": "Formation",
+              "activity": "Activity",
               "iterations": "Number of iterations",
               "lastSaved": "Last saved",
               "receivedAt": "Request received date",

--- a/src/features/staff/feedbacks/locales/fr.json
+++ b/src/features/staff/feedbacks/locales/fr.json
@@ -73,7 +73,7 @@
           },
           "FeedbacksTable": {
             "columns": {
-              "formation": "Formation",
+              "activity": "Activité",
               "iterations": "Nombre d'itérations",
               "lastSaved": "Dernier enregistrement",
               "receivedAt": "Date de réception de la demande",

--- a/src/features/staff/feedbacks/views/FeedbacksView/components/FeedbacksTable/FeedbacksTable.vue
+++ b/src/features/staff/feedbacks/views/FeedbacksView/components/FeedbacksTable/FeedbacksTable.vue
@@ -66,33 +66,42 @@ const feedbacksTitle = computed(() => {
   }
 })
 
-const activityColumn: AvTableColumn<FeedbackStaffListItemDTO> = { key: 'activity', label: t('staff.feedbacks.views.FeedbacksView.FeedbacksTable.columns.formation') }
-const accessColumn: AvTableColumn<FeedbackStaffListItemDTO & { access?: string }> = { key: 'access', label: t('global.buttons.access') }
+const columns = computed<AvTableColumn<FeedbackStaffListItemDTO & { access?: string }>[]>(() => {
+  const activityColumn: AvTableColumn<FeedbackStaffListItemDTO & { access?: string }> = {
+    key: 'activity',
+    label: t('staff.feedbacks.views.FeedbacksView.FeedbacksTable.columns.activity'),
+  }
 
-const columns = computed<AvTableColumn<FeedbackStaffListItemDTO & { access?: string }>[]>(() => [
-  {
-    key: 'student',
-    label: t('staff.feedbacks.views.FeedbacksView.FeedbacksTable.columns.student'),
-  },
-  ...withActivity ? [activityColumn] : [],
-  {
-    key: 'createdAt',
-    label: t('staff.feedbacks.views.FeedbacksView.FeedbacksTable.columns.receivedAt'),
-  },
-  {
-    key: 'status',
-    label: t('staff.feedbacks.views.FeedbacksView.FeedbacksTable.columns.status'),
-  },
-  {
-    key: 'iteration',
-    label: t('staff.feedbacks.views.FeedbacksView.FeedbacksTable.columns.iterations'),
-  },
-  {
-    key: 'updatedAt',
-    label: t('staff.feedbacks.views.FeedbacksView.FeedbacksTable.columns.lastSaved'),
-  },
-  accessColumn,
-])
+  const accessColumn: AvTableColumn<FeedbackStaffListItemDTO & { access?: string }> = {
+    key: 'access',
+    label: t('global.buttons.access'),
+  }
+
+  return [
+    {
+      key: 'student',
+      label: t('staff.feedbacks.views.FeedbacksView.FeedbacksTable.columns.student'),
+    },
+    ...(withActivity ? [activityColumn] : []),
+    {
+      key: 'createdAt',
+      label: t('staff.feedbacks.views.FeedbacksView.FeedbacksTable.columns.receivedAt'),
+    },
+    {
+      key: 'status',
+      label: t('staff.feedbacks.views.FeedbacksView.FeedbacksTable.columns.status'),
+    },
+    {
+      key: 'iteration',
+      label: t('staff.feedbacks.views.FeedbacksView.FeedbacksTable.columns.iterations'),
+    },
+    {
+      key: 'updatedAt',
+      label: t('staff.feedbacks.views.FeedbacksView.FeedbacksTable.columns.lastSaved'),
+    },
+    accessColumn,
+  ]
+})
 </script>
 
 <template>


### PR DESCRIPTION


### Brief description of changes applied
<!-- Describe the changes introduced by this pull request. -->
Replace Formation by activity in feedbacks table
---

### Reference to an Issue, Feature, Task, User Story or another PR
<!-- Mention related issue numbers or links (e.g. Closes #123, Implements #456). -->
<!-- Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/### -->
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1965

