### PR TITLE
feat(1792): add activity feedbacks dashboard section

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "avenirs-cofolio-client",
       "version": "0.0.0",
       "dependencies": {
-        "@avenirs-esr/avenirs-dsav": "^0.1.254",
+        "@avenirs-esr/avenirs-dsav": "^0.1.257",
         "@tanstack/vue-form": "^1.15.0",
         "@tanstack/vue-query": "^5.74.9",
         "@vue-flow/core": "^1.48.0",
@@ -348,9 +348,9 @@
       "license": "ISC"
     },
     "node_modules/@avenirs-esr/avenirs-dsav": {
-      "version": "0.1.254",
-      "resolved": "https://registry.npmjs.org/@avenirs-esr/avenirs-dsav/-/avenirs-dsav-0.1.254.tgz",
-      "integrity": "sha512-MUm0cEjB4lCY/KnY/UX98OK7EdgAFa7an1T2AQ1cvt96oZxyeepCPGHmIa30OhbZQ6f2is+kkZYJSb9KucHnlQ==",
+      "version": "0.1.257",
+      "resolved": "https://registry.npmjs.org/@avenirs-esr/avenirs-dsav/-/avenirs-dsav-0.1.257.tgz",
+      "integrity": "sha512-D++vH2YDOG+7qhlNaQAoMCxrq6TVc8f3ELiyMZQ838cqBGzW9sHiEX0nI2Ia0hau4adTylIBdy71LR5K8vf5yg==",
       "dependencies": {
         "@tanstack/vue-table": "^8.21.3",
         "@tiptap/extension-character-count": "^3.20.2",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
-    "@avenirs-esr/avenirs-dsav": "^0.1.254",
+    "@avenirs-esr/avenirs-dsav": "^0.1.257",
     "@tanstack/vue-form": "^1.15.0",
     "@tanstack/vue-query": "^5.74.9",
     "@vue-flow/core": "^1.48.0",

--- a/src/common/utils/route/route.test.ts
+++ b/src/common/utils/route/route.test.ts
@@ -1,0 +1,95 @@
+import type { RouteLocationNormalizedLoadedGeneric } from 'vue-router'
+import { isRouteActive } from '@/common/utils/route/route'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+
+function buildRoute (overrides: Partial<RouteLocationNormalizedLoadedGeneric>): RouteLocationNormalizedLoadedGeneric {
+  return {
+    name: undefined,
+    matched: [],
+    ...overrides,
+  } as unknown as RouteLocationNormalizedLoadedGeneric
+}
+
+const routeA = { name: 'route-a' }
+const routeB = { name: 'route-b' }
+const routeC = { name: 'route-c' }
+
+BddTest().given('isRouteActive', () => {
+  BddTest().when('the current route name directly matches one of the provided routes', () => {
+    BddTest().then('it should return true', () => {
+      const route = buildRoute({ name: 'route-a', matched: [] })
+      expect(isRouteActive({ route, routes: [routeA, routeB] })).toBe(true)
+    })
+  })
+
+  BddTest().when('the current route name does not match any of the provided routes', () => {
+    BddTest().then('it should return false', () => {
+      const route = buildRoute({ name: 'route-c', matched: [] })
+      expect(isRouteActive({ route, routes: [routeA, routeB] })).toBe(false)
+    })
+  })
+
+  BddTest().when('the current route name is not a string (Symbol)', () => {
+    BddTest().then('it should skip the direct check and rely on matched routes', () => {
+      const route = buildRoute({
+        name: Symbol('route-a'),
+        matched: [{ name: 'route-a' }] as any,
+      })
+      expect(isRouteActive({ route, routes: [routeA] })).toBe(true)
+    })
+  })
+
+  BddTest().when('an ancestor matched route name matches one of the provided routes', () => {
+    BddTest().then('it should return true', () => {
+      const route = buildRoute({
+        name: 'route-child',
+        matched: [{ name: 'route-a' }, { name: 'route-child' }] as any,
+      })
+      expect(isRouteActive({ route, routes: [routeA] })).toBe(true)
+    })
+  })
+
+  BddTest().when('no matched route name matches any of the provided routes', () => {
+    BddTest().then('it should return false', () => {
+      const route = buildRoute({
+        name: 'route-child',
+        matched: [{ name: 'route-parent' }, { name: 'route-child' }] as any,
+      })
+      expect(isRouteActive({ route, routes: [routeA, routeB] })).toBe(false)
+    })
+  })
+
+  BddTest().when('a matched route name is not a string (Symbol)', () => {
+    BddTest().then('it should skip it and not match', () => {
+      const route = buildRoute({
+        name: 'route-child',
+        matched: [{ name: Symbol('route-a') }, { name: 'route-child' }] as any,
+      })
+      expect(isRouteActive({ route, routes: [routeA] })).toBe(false)
+    })
+  })
+
+  BddTest().when('the routes list is empty', () => {
+    BddTest().then('it should return false', () => {
+      const route = buildRoute({ name: 'route-a', matched: [] })
+      expect(isRouteActive({ route, routes: [] })).toBe(false)
+    })
+  })
+
+  BddTest().when('the matched list is empty and route name does not match', () => {
+    BddTest().then('it should return false', () => {
+      const route = buildRoute({ name: 'route-c', matched: [] })
+      expect(isRouteActive({ route, routes: [routeA, routeB] })).toBe(false)
+    })
+  })
+
+  BddTest().when('multiple routes are provided and one matches via matched ancestors', () => {
+    BddTest().then('it should return true for the matching one', () => {
+      const route = buildRoute({
+        name: 'route-leaf',
+        matched: [{ name: 'route-b' }, { name: 'route-leaf' }] as any,
+      })
+      expect(isRouteActive({ route, routes: [routeA, routeB, routeC] })).toBe(true)
+    })
+  })
+})

--- a/src/common/utils/route/route.ts
+++ b/src/common/utils/route/route.ts
@@ -1,0 +1,33 @@
+import type { RouteLocationNormalizedLoadedGeneric } from 'vue-router'
+
+interface IsRouteActiveParams {
+  /**
+   * The current route object, which contains information about the current route, including its name and matched routes.
+   */
+  route: RouteLocationNormalizedLoadedGeneric
+
+  /**
+   * An array of route objects, each containing a name property. These are the routes against which the current route will be checked for activity.
+   */
+  routes: Array<{ name: string }>
+}
+
+/**
+ * Checks if the current route is active based on a list of routes.
+ * @param param0 An object containing the current route and the list of routes to check against.
+ * @param param0.route The current route object, which contains information about the current route, including its name and matched routes.
+ * @param param0.routes An array of route objects, each containing a name property. These are the routes against which the current route will be checked for activity.
+ * @returns A boolean indicating whether the current route is active.
+ */
+export function isRouteActive ({ route, routes }: IsRouteActiveParams): boolean {
+  const routeNames = new Set(routes.map(avRoute => avRoute.name))
+
+  if (typeof route.name === 'string' && routeNames.has(route.name)) {
+    return true
+  }
+
+  return route.matched
+    .map(matchedRoute => matchedRoute.name)
+    .filter((name): name is string => typeof name === 'string')
+    .some(name => routeNames.has(name))
+}

--- a/src/features/staff/activities/routes/index.test.ts
+++ b/src/features/staff/activities/routes/index.test.ts
@@ -1,8 +1,9 @@
 import { ROUTES } from '@/common/constants'
-import { staffActivitiesEditNationalActivityRoute, staffActivitiesRoute, staffActivityCatalogRoute } from '@/features/staff/activities/routes'
+import { staffActivitiesEditNationalActivityRoute, staffActivitiesRoute, staffActivityCatalogRoute, staffActivityFeedbacksRoute } from '@/features/staff/activities/routes'
 import ActivitiesView from '@/features/staff/activities/views/ActivitiesView/ActivitiesView.vue'
 import EditNationalActivityView from '@/features/staff/activities/views/EditNationalActivityView/EditNationalActivityView.vue'
 import NationalActivityCatalogView from '@/features/staff/activities/views/NationalActivityCatalogView/NationalActivityCatalogView.vue'
+import ActivityFeedbacksView from '@/features/staff/feedbacks/views/ActivityFeedbacksView/ActivityFeedbacksView.vue'
 import { testRoute } from 'tests/utils'
 
 testRoute(
@@ -21,4 +22,10 @@ testRoute(
   staffActivityCatalogRoute,
   ROUTES.STAFF.ACTIVITY_CATALOG,
   NationalActivityCatalogView
+)
+
+testRoute(
+  staffActivityFeedbacksRoute,
+  ROUTES.STAFF.ACTIVITY_FEEDBACKS,
+  ActivityFeedbacksView
 )

--- a/src/features/staff/activities/routes/index.ts
+++ b/src/features/staff/activities/routes/index.ts
@@ -26,3 +26,19 @@ export const staffActivityCatalogRoute: AvRoute = {
   component: () =>
     import('@/features/staff/activities/views/NationalActivityCatalogView/NationalActivityCatalogView.vue'),
 }
+
+export const staffActivityFeedbacksRoute: AvRoute = {
+  ...ROUTES.STAFF.ACTIVITY_FEEDBACKS,
+  props: route => ({
+    activityId: route.params.id,
+  }),
+  component: () =>
+    import('@/features/staff/feedbacks/views/ActivityFeedbacksView/ActivityFeedbacksView.vue'),
+}
+
+export const staffActivitiesRoutes: AvRoute[] = [
+  staffActivitiesRoute,
+  staffActivitiesEditNationalActivityRoute,
+  staffActivityCatalogRoute,
+  staffActivityFeedbacksRoute
+]

--- a/src/features/staff/feedbacks/locales/en.json
+++ b/src/features/staff/feedbacks/locales/en.json
@@ -70,6 +70,9 @@
           "errors": {
             "fetchActivity": "Unable to load activity"
           },
+          "FeedbacksDashboardSection": {
+            "title": "Dashboard"
+          },
           "title": "All my feedback requests on the activity \"{activityTitle}\""
         },
         "FeedbacksView": {

--- a/src/features/staff/feedbacks/locales/fr.json
+++ b/src/features/staff/feedbacks/locales/fr.json
@@ -70,6 +70,11 @@
           "errors": {
             "fetchActivity": "Impossible de charger l'activité"
           },
+          "FeedbacksDashboardSection": {
+            "new": "nouvelle demande de feedback | nouvelles demandes de feedback",
+            "sent": "réponse envoyée | réponses envoyées",
+            "title": "Tableau de bord"
+          },
           "title": "Toutes mes demandes de feedback sur l'activité \"{activityTitle}\""
         },
         "FeedbacksView": {

--- a/src/features/staff/feedbacks/routes/index.test.ts
+++ b/src/features/staff/feedbacks/routes/index.test.ts
@@ -1,11 +1,9 @@
 import { ROUTES } from '@/common/constants'
 import {
-  staffActivityFeedbacksRoute,
   staffStudentActivityFeedbacksRoute,
   staffStudentFeedbacksRoute
 } from '@/features/staff/feedbacks/routes'
 import ActivityFeedbackDetailsView from '@/features/staff/feedbacks/views/ActivityFeedbackDetailsView/ActivityFeedbackDetailsView.vue'
-import ActivityFeedbacksView from '@/features/staff/feedbacks/views/ActivityFeedbacksView/ActivityFeedbacksView.vue'
 import FeedbacksView from '@/features/staff/feedbacks/views/FeedbacksView/FeedbacksView.vue'
 import { testRoute } from 'tests/utils'
 
@@ -19,10 +17,4 @@ testRoute(
   staffStudentFeedbacksRoute,
   ROUTES.STAFF.STUDENT_FEEDBACKS,
   FeedbacksView
-)
-
-testRoute(
-  staffActivityFeedbacksRoute,
-  ROUTES.STAFF.ACTIVITY_FEEDBACKS,
-  ActivityFeedbacksView
 )

--- a/src/features/staff/feedbacks/routes/index.ts
+++ b/src/features/staff/feedbacks/routes/index.ts
@@ -16,11 +16,7 @@ export const staffStudentFeedbacksRoute: AvRoute = {
     import('@/features/staff/feedbacks/views/FeedbacksView/FeedbacksView.vue'),
 }
 
-export const staffActivityFeedbacksRoute: AvRoute = {
-  ...ROUTES.STAFF.ACTIVITY_FEEDBACKS,
-  props: route => ({
-    activityId: route.params.id,
-  }),
-  component: () =>
-    import('@/features/staff/feedbacks/views/ActivityFeedbacksView/ActivityFeedbacksView.vue'),
-}
+export const staffFeedbacksRoutes: AvRoute[] = [
+  staffStudentActivityFeedbacksRoute,
+  staffStudentFeedbacksRoute,
+]

--- a/src/features/staff/feedbacks/views/ActivityFeedbackDetailsView/components/FeedbacksDashboardSection/FeedbacksDashboardSection.stub.ts
+++ b/src/features/staff/feedbacks/views/ActivityFeedbackDetailsView/components/FeedbacksDashboardSection/FeedbacksDashboardSection.stub.ts
@@ -1,0 +1,10 @@
+export const FeedbacksDashboardSectionStub = defineComponent({
+  name: 'FeedbacksDashboardSection',
+  props: {
+    activityId: {
+      type: String,
+      required: true,
+    },
+  },
+  template: '<div data-testid="feedbacks-dashboard-section-stub" />',
+})

--- a/src/features/staff/feedbacks/views/ActivityFeedbackDetailsView/components/FeedbacksDashboardSection/FeedbacksDashboardSection.test.ts
+++ b/src/features/staff/feedbacks/views/ActivityFeedbackDetailsView/components/FeedbacksDashboardSection/FeedbacksDashboardSection.test.ts
@@ -1,0 +1,102 @@
+import type { VueWrapper } from '@vue/test-utils'
+import { mockedFeedbackDashboard } from '@/__mocks__/fixtures/staffs/feedbacks.fixtures'
+import { getFeedbackDashboardErrorHandler } from '@/__mocks__/msw/handlers/staffs/feedbacks.handlers'
+import { server } from '@/__mocks__/msw/server'
+import { QuerySuspenseStub } from '@/common/components/QuerySuspense/QuerySuspense.stub'
+import FeedbacksDashboardSection from '@/features/staff/feedbacks/views/ActivityFeedbackDetailsView/components/FeedbacksDashboardSection/FeedbacksDashboardSection.vue'
+import { DashboardCardStub } from '@/features/staff/global/components/cards/DashboardCard/DashboardCard.stub'
+import { IconTitleCardContainerStub } from '@/features/staff/global/components/cards/IconTitleCardContainer/IconTitleCardContainer.stub'
+import { RI_ICONS } from '@avenirs-esr/avenirs-dsav'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { flushPromises } from '@vue/test-utils'
+import { mountComponent } from 'tests/utils'
+import { beforeEach, expect, vi } from 'vitest'
+
+BddTest().given('a FeedbacksDashboardSection component', () => {
+  let wrapper: VueWrapper<InstanceType<typeof FeedbacksDashboardSection>>
+
+  const stubs = {
+    QuerySuspense: QuerySuspenseStub,
+    DashboardCard: DashboardCardStub,
+    IconTitleCardContainer: IconTitleCardContainerStub,
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  BddTest().when('mounted with a valid activity id', () => {
+    beforeEach(async () => {
+      wrapper = mountComponent(FeedbacksDashboardSection, {
+        props: { activityId: 'activity-1' },
+        global: { stubs },
+      })
+      await flushPromises()
+    })
+
+    BddTest().then('it should render IconTitleCardContainer with the expected icon', () => {
+      const container = wrapper.findComponent(IconTitleCardContainerStub)
+      expect(container.exists()).toBe(true)
+      expect(container.props('titleIcon')).toBe(RI_ICONS.DASHBOARD_2_LINE)
+    })
+
+    BddTest().then('it should pass loading and error state to QuerySuspense', () => {
+      const querySuspense = wrapper.findComponent(QuerySuspenseStub)
+      expect(querySuspense.exists()).toBe(true)
+      expect(querySuspense.props('isLoading')).toBe(false)
+      expect(querySuspense.props('error')).toBeNull()
+    })
+
+    BddTest().then('it should render two DashboardCard components', () => {
+      expect(wrapper.findAllComponents(DashboardCardStub)).toHaveLength(2)
+    })
+
+    BddTest().then('it should pass the new feedback value to the first card', () => {
+      const cards = wrapper.findAllComponents(DashboardCardStub)
+      expect(cards[0].props('value')).toBe(`${mockedFeedbackDashboard.newFeedbacks}`)
+    })
+
+    BddTest().then('it should pass processed over total value to the second card', () => {
+      const cards = wrapper.findAllComponents(DashboardCardStub)
+      expect(cards[1].props('value')).toBe(`${mockedFeedbackDashboard.processedFeedbacks}/${mockedFeedbackDashboard.totalFeedbacks}`)
+    })
+  })
+
+  BddTest().when('mounted with an empty activity id', () => {
+    beforeEach(async () => {
+      wrapper = mountComponent(FeedbacksDashboardSection, {
+        props: { activityId: '' },
+        global: { stubs },
+      })
+      await flushPromises()
+    })
+
+    BddTest().then('it should fallback dashboard values to zero', () => {
+      const cards = wrapper.findAllComponents(DashboardCardStub)
+      expect(cards).toHaveLength(2)
+      expect(cards[0].props('value')).toBe('0')
+      expect(cards[1].props('value')).toBe('0/0')
+    })
+  })
+
+  BddTest().when('the dashboard request fails', () => {
+    beforeEach(async () => {
+      server.use(getFeedbackDashboardErrorHandler)
+      wrapper = mountComponent(FeedbacksDashboardSection, {
+        props: { activityId: 'activity-1' },
+        global: { stubs },
+      })
+      await flushPromises()
+    })
+
+    BddTest().then('it should pass an error to QuerySuspense', () => {
+      const querySuspense = wrapper.findComponent(QuerySuspenseStub)
+      expect(querySuspense.props('isLoading')).toBe(false)
+      expect(querySuspense.props('error')).toBeTruthy()
+    })
+
+    BddTest().then('it should not render dashboard cards in error state', () => {
+      expect(wrapper.findAllComponents(DashboardCardStub)).toHaveLength(0)
+    })
+  })
+})

--- a/src/features/staff/feedbacks/views/ActivityFeedbackDetailsView/components/FeedbacksDashboardSection/FeedbacksDashboardSection.vue
+++ b/src/features/staff/feedbacks/views/ActivityFeedbackDetailsView/components/FeedbacksDashboardSection/FeedbacksDashboardSection.vue
@@ -1,0 +1,50 @@
+<script lang="ts" setup>
+import { useGetFeedbackDashboard } from '@/api/avenir-esr'
+import QuerySuspense from '@/common/components/QuerySuspense/QuerySuspense.vue'
+import DashboardCard from '@/features/staff/global/components/cards/DashboardCard/DashboardCard.vue'
+import IconTitleCardContainer from '@/features/staff/global/components/cards/IconTitleCardContainer/IconTitleCardContainer.vue'
+import { MDI_ICONS, MS_ICONS, RI_ICONS } from '@avenirs-esr/avenirs-dsav'
+import { useI18n } from 'vue-i18n'
+
+export interface DashboardSectionProps {
+  activityId: string
+}
+
+const { activityId } = defineProps<DashboardSectionProps>()
+
+const { t } = useI18n()
+
+const { data: feedbackDashboard, isLoading, error } = useGetFeedbackDashboard({ activityId }, {
+  query: {
+    enabled: computed(() => !!activityId),
+  },
+})
+</script>
+
+<template>
+  <IconTitleCardContainer
+    :title-icon="RI_ICONS.DASHBOARD_2_LINE"
+    :title="t('staff.feedbacks.views.ActivityFeedbacksView.FeedbacksDashboardSection.title')"
+    data-testid="feedbacks-dashboard-section"
+  >
+    <QuerySuspense
+      :is-loading="isLoading"
+      :error="error"
+    >
+      <div class="av-row av-wrap av-w-full av-gap-sm">
+        <DashboardCard
+          :label="t('staff.feedbacks.views.ActivityFeedbacksView.FeedbacksDashboardSection.new', { count: feedbackDashboard?.newFeedbacks ?? 0 })"
+          :icon="MS_ICONS.FEEDBACK"
+          :value="`${feedbackDashboard?.newFeedbacks ?? 0}`"
+          data-testid="new-feedbacks-dashboard-card"
+        />
+        <DashboardCard
+          :label="t('staff.feedbacks.views.ActivityFeedbacksView.FeedbacksDashboardSection.sent', { count: feedbackDashboard?.processedFeedbacks ?? 0 })"
+          :icon="MDI_ICONS.CHECK_CIRCLE"
+          :value="`${feedbackDashboard?.processedFeedbacks ?? 0}/${feedbackDashboard?.totalFeedbacks ?? 0}`"
+          data-testid="processed-feedbacks-dashboard-card"
+        />
+      </div>
+    </QuerySuspense>
+  </IconTitleCardContainer>
+</template>

--- a/src/features/staff/feedbacks/views/ActivityFeedbacksView/ActivityFeedbacksView.test.ts
+++ b/src/features/staff/feedbacks/views/ActivityFeedbacksView/ActivityFeedbacksView.test.ts
@@ -5,6 +5,7 @@ import { server } from '@/__mocks__/msw/server'
 import { PageTitleStub } from '@/common/components/PageTitle/PageTitle.stub'
 import { QuerySuspenseStub } from '@/common/components/QuerySuspense/QuerySuspense.stub'
 import { ROUTES } from '@/common/constants'
+import { FeedbacksDashboardSectionStub } from '@/features/staff/feedbacks/views/ActivityFeedbackDetailsView/components/FeedbacksDashboardSection/FeedbacksDashboardSection.stub'
 import ActivityFeedbacksView from '@/features/staff/feedbacks/views/ActivityFeedbacksView/ActivityFeedbacksView.vue'
 import { ActivityFeedbacksCardStub } from '@/features/staff/feedbacks/views/ActivityFeedbacksView/components/ActivityFeedbacksCard/ActivityFeedbacksCard.stub'
 import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
@@ -18,6 +19,7 @@ BddTest().given('an ActivityFeedbacksView component', () => {
     PageTitle: PageTitleStub,
     QuerySuspense: QuerySuspenseStub,
     ActivityFeedbacksCard: ActivityFeedbacksCardStub,
+    FeedbacksDashboardSection: FeedbacksDashboardSectionStub
   }
 
   const mountView = () => mountComponent(ActivityFeedbacksView, {
@@ -41,6 +43,10 @@ BddTest().given('an ActivityFeedbacksView component', () => {
       expect(wrapper.findComponent(PageTitleStub).exists()).toBe(true)
     })
 
+    BddTest().then('it should render FeedbacksDashboardSection', () => {
+      expect(wrapper.findComponent(FeedbacksDashboardSectionStub).exists()).toBe(true)
+    })
+
     BddTest().then('it should pass the correct errorTitle to QuerySuspense', () => {
       expect(wrapper.findComponent(QuerySuspenseStub).props('errorTitle')).toBe('Impossible de charger l\'activité')
     })
@@ -52,9 +58,9 @@ BddTest().given('an ActivityFeedbacksView component', () => {
     BddTest().then('it should render PageTitle with correct breadcrumbs', () => {
       expect(wrapper.findComponent(PageTitleStub).props('breadcrumbLinks')).toEqual([
         { text: 'Accueil', to: ROUTES.STAFF.HOME },
-        { text: 'Suivi des apprenants' },
-        { text: 'Toutes mes demandes de feedback', to: ROUTES.STAFF.STUDENT_FEEDBACKS },
+        { text: 'Bibliothèque des activités', to: ROUTES.STAFF.ACTIVITIES },
         { text: mockedActivityContent.title },
+        { text: 'Toutes mes demandes de feedback' }
       ])
     })
 

--- a/src/features/staff/feedbacks/views/ActivityFeedbacksView/ActivityFeedbacksView.vue
+++ b/src/features/staff/feedbacks/views/ActivityFeedbacksView/ActivityFeedbacksView.vue
@@ -3,6 +3,7 @@ import { EActivityStatus, useGetActivityContent } from '@/api/avenir-esr'
 import { QuerySuspense } from '@/common/components'
 import PageTitle from '@/common/components/PageTitle/PageTitle.vue'
 import { ICONS, ROUTES } from '@/common/constants'
+import FeedbacksDashboardSection from '@/features/staff/feedbacks/views/ActivityFeedbackDetailsView/components/FeedbacksDashboardSection/FeedbacksDashboardSection.vue'
 import ActivityFeedbacksCard
   from '@/features/staff/feedbacks/views/ActivityFeedbacksView/components/ActivityFeedbacksCard/ActivityFeedbacksCard.vue'
 import { AvIconText } from '@avenirs-esr/avenirs-dsav'
@@ -22,9 +23,9 @@ const activityTitle = computed(() => activity.value?.title ?? '')
 
 const breadcrumbLinks = computed(() => [
   { text: t('staff.global.navigation.tabs.home'), to: ROUTES.STAFF.HOME },
-  { text: t('staff.global.navigation.tabs.studentTracking') },
-  { text: t('staff.global.navigation.tabs.studentFeedbacks'), to: ROUTES.STAFF.STUDENT_FEEDBACKS },
+  { text: t('staff.global.navigation.tabs.activities.header'), to: ROUTES.STAFF.ACTIVITIES },
   { text: activityTitle.value },
+  { text: t('staff.global.navigation.tabs.studentFeedbacks') },
 ])
 </script>
 
@@ -46,6 +47,7 @@ const breadcrumbLinks = computed(() => [
         class="n5 av-pl-2xl av-text-primary1 av-text-regular"
       >{{ activity?.title }}</span>
     </div>
+    <FeedbacksDashboardSection :activity-id="activityId" />
     <QuerySuspense
       :is-loading="isLoading"
       :error="error"

--- a/src/features/staff/global/components/cards/DashboardCard/DashboardCard.vue
+++ b/src/features/staff/global/components/cards/DashboardCard/DashboardCard.vue
@@ -46,13 +46,9 @@ defineProps<DashboardCardProps>()
 </template>
 
 <style scoped lang="scss">
-@use '@avenirs-esr/avenirs-dsav/mixins' as dsav;
-
 .dashboard-card {
-  @include dsav.min-width(md) {
-    width: 20rem;
-  }
-  min-height: 13rem;
+  width: 16.53125rem;
+  height: 16.0625rem;
 
   .icon-container {
     width: var(--dimension-sm);

--- a/src/features/staff/global/components/navigation/StaffNavigation/StaffNavigation.test.ts
+++ b/src/features/staff/global/components/navigation/StaffNavigation/StaffNavigation.test.ts
@@ -1,19 +1,35 @@
 import type { VueWrapper } from '@vue/test-utils'
 import { ICONS } from '@/common/constants'
 import StaffNavigation from '@/features/staff/global/components/navigation/StaffNavigation/StaffNavigation.vue'
-import { MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
+import router from '@/router'
+import { MDI_ICONS, registerNavigationLinkKey } from '@avenirs-esr/avenirs-dsav'
 import { AvNavigationStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
-import { mountWithRouter } from 'tests/utils'
-import { beforeEach, expect } from 'vitest'
+import { mountComponent } from 'tests/utils'
+import { beforeEach, expect, vi } from 'vitest'
 
 BddTest().given('a staff navigation', () => {
   let wrapper: VueWrapper<InstanceType<typeof StaffNavigation>>
 
   const stubs = { AvNavigation: AvNavigationStub }
 
+  const mountDefault = async () => {
+    const wrapper = mountComponent(StaffNavigation, {
+      global: {
+        stubs,
+        plugins: [router],
+        provide: {
+          [registerNavigationLinkKey]: vi.fn()
+        }
+      },
+    })
+
+    await wrapper.vm.$nextTick()
+    return wrapper
+  }
+
   BddTest().when('the component is mounted', () => {
     beforeEach(async () => {
-      wrapper = await mountWithRouter<typeof StaffNavigation>(StaffNavigation, { global: { stubs } })
+      wrapper = await mountDefault()
     })
 
     BddTest().then('it should render AvNavigation component', () => {
@@ -21,7 +37,7 @@ BddTest().given('a staff navigation', () => {
       expect(avNavigation.exists()).toBe(true)
     })
 
-    BddTest().then('it should include home navigation item with correct propertie', () => {
+    BddTest().then('it should include home navigation item with correct properties', () => {
       const avNavigation = wrapper.findComponent(AvNavigationStub)
       const navItems = avNavigation.props('navItems')
 
@@ -32,7 +48,7 @@ BddTest().given('a staff navigation', () => {
       })
     })
 
-    BddTest().then('it should include activities navigation item with correct propertie', () => {
+    BddTest().then('it should include activities navigation item with correct properties', () => {
       const avNavigation = wrapper.findComponent(AvNavigationStub)
       const navItems = avNavigation.props('navItems')
 
@@ -43,13 +59,18 @@ BddTest().given('a staff navigation', () => {
       })
     })
 
-    BddTest().then('it should include student tracking menu with feedback sub item', () => {
+    BddTest().then('it should include student tracking menu with correct title', () => {
       const avNavigation = wrapper.findComponent(AvNavigationStub)
       const navItems = avNavigation.props('navItems')
 
       expect(navItems[2]).toMatchObject({
         title: 'SUIVI DES APPRENANTS',
       })
+    })
+
+    BddTest().then('it should include feedback link in student tracking menu', () => {
+      const avNavigation = wrapper.findComponent(AvNavigationStub)
+      const navItems = avNavigation.props('navItems')
 
       expect(navItems[2].links).toHaveLength(1)
 

--- a/src/features/staff/global/components/navigation/StaffNavigation/StaffNavigation.vue
+++ b/src/features/staff/global/components/navigation/StaffNavigation/StaffNavigation.vue
@@ -1,18 +1,27 @@
 <script setup lang="ts">
 import { ICONS, ROUTES } from '@/common/constants'
+import { isRouteActive } from '@/common/utils/route/route'
+import { staffActivitiesRoutes } from '@/features/staff/activities/routes'
+import { staffFeedbacksRoutes } from '@/features/staff/feedbacks/routes'
 import { AvNavigation, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
 import { useId } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { useRoute } from 'vue-router'
 
 const { t } = useI18n()
+const route = useRoute()
 
 const studentTrackingMenu = computed(() => ({
   title: t('staff.global.navigation.tabs.studentTracking').toUpperCase(),
+  get active () {
+    return isRouteActive({ route, routes: staffFeedbacksRoutes })
+  },
   links: [
     {
       to: ROUTES.STAFF.STUDENT_FEEDBACKS,
       text: t('staff.global.navigation.tabs.studentFeedbacks'),
       icon: MDI_ICONS.PEOPLE_GROUP_OUTLINE,
+      highlight: isRouteActive({ route, routes: staffFeedbacksRoutes }),
     },
   ],
 }))
@@ -29,6 +38,7 @@ const navItems = computed(() => [
     to: ROUTES.STAFF.ACTIVITIES,
     text: t('staff.global.navigation.tabs.activities.header').toUpperCase(),
     icon: ICONS.ACTIVITY,
+    highlight: isRouteActive({ route, routes: staffActivitiesRoutes }),
   },
   studentTrackingMenu.value,
 ])

--- a/src/features/staff/global/routes/index.ts
+++ b/src/features/staff/global/routes/index.ts
@@ -1,8 +1,7 @@
 import type { RoutePageProps } from '@/common/types'
 import { ROUTES } from '@/common/constants'
-import { staffActivitiesEditNationalActivityRoute, staffActivitiesRoute, staffActivityCatalogRoute } from '@/features/staff/activities/routes'
+import { staffActivitiesRoutes } from '@/features/staff/activities/routes'
 import {
-  staffActivityFeedbacksRoute,
   staffStudentActivityFeedbacksRoute,
   staffStudentFeedbacksRoute
 } from '@/features/staff/feedbacks/routes'
@@ -47,12 +46,9 @@ export default [
         component: () =>
           import('@/common/views/PersonalDataView/PersonalDataView.vue'),
       },
-      staffActivitiesRoute,
-      staffActivitiesEditNationalActivityRoute,
-      staffActivityCatalogRoute,
+      ...staffActivitiesRoutes,
       staffStudentActivityFeedbacksRoute,
       staffStudentFeedbacksRoute,
-      staffActivityFeedbacksRoute
     ]
   }
 ]

--- a/src/features/student/global/components/navigation/StudentNavigation/StudentNavigation.vue
+++ b/src/features/student/global/components/navigation/StudentNavigation/StudentNavigation.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import { ICONS, ROUTES, studentPersonalCareerRoutes, studentProjectActivtiesRoutes, studentProjectTrajectoriesRoutes } from '@/common/constants'
+import { isRouteActive } from '@/common/utils/route/route'
 import { useStudentApcAccess } from '@/features/student/global/composables/use-student-apc-access/use-student-apc-access'
+import { studentToolsTracesRoutes } from '@/features/student/traces/routes'
 import { AvNavigation, ICONS_DATA_URL, MDI_ICONS, RI_ICONS } from '@avenirs-esr/avenirs-dsav'
 import { useId } from 'vue'
 import { useI18n } from 'vue-i18n'
@@ -14,21 +16,8 @@ const {
   showApcSubmenus,
 } = useStudentApcAccess()
 
-function isRouteActive (routes: Array<{ name: string }>): boolean {
-  const routeNames = new Set(routes.map(avRoute => avRoute.name))
-
-  if (typeof route.name === 'string' && routeNames.has(route.name)) {
-    return true
-  }
-
-  return route.matched
-    .map(matchedRoute => matchedRoute.name)
-    .filter((name): name is string => typeof name === 'string')
-    .some(name => routeNames.has(name))
-}
-
 const personalCareerNavigationTarget = computed(() => {
-  if (isRouteActive(studentPersonalCareerRoutes)) {
+  if (isRouteActive({ route, routes: studentPersonalCareerRoutes })) {
     return route.fullPath
   }
 
@@ -37,22 +26,27 @@ const personalCareerNavigationTarget = computed(() => {
 
 const projectActivitiesLink = computed(() => ({
   to: ROUTES.STUDENT.PROJECT_ACTIVITIES,
-  highlight: isRouteActive(studentProjectActivtiesRoutes),
+  highlight: isRouteActive({ route, routes: studentProjectActivtiesRoutes }),
 }))
 
 const projectTrajectoriesLink = computed(() => ({
   to: ROUTES.STUDENT.PROJECT_TRAJECTORIES,
-  highlight: isRouteActive(studentProjectTrajectoriesRoutes),
+  highlight: isRouteActive({ route, routes: studentProjectTrajectoriesRoutes }),
+}))
+
+const toolTracesLink = computed(() => ({
+  to: ROUTES.STUDENT.TOOLS_TRACES,
+  highlight: isRouteActive({ route, routes: studentToolsTracesRoutes }),
 }))
 
 const educationMenu = computed(() => {
   const menu: Record<string, any> = {
     get active () {
-      return isRouteActive([
+      return isRouteActive({ route, routes: [
         ROUTES.STUDENT.APC_UNAVAILABLE,
         ROUTES.STUDENT.EDUCATION_SKILLS,
         ROUTES.STUDENT.EDUCATION_SKILLS,
-      ])
+      ] })
     },
   }
 
@@ -93,15 +87,15 @@ const allToolsMenu
   = computed(() => ({
     title: t('student.global.navigation.tabs.tools.header').toUpperCase(),
     get active () {
-      return isRouteActive([
-        ROUTES.STUDENT.TOOLS_TRACES,
+      return isRouteActive({ route, routes: [
+        ...studentToolsTracesRoutes,
         ROUTES.STUDENT.TOOLS_PAGES,
         ROUTES.STUDENT.TOOLS_RESUMES
-      ])
+      ] })
     },
     links: [
       {
-        to: ROUTES.STUDENT.TOOLS_TRACES,
+        ...toolTracesLink.value,
         text: t('student.global.navigation.tabs.tools.items.traces'),
         icon: MDI_ICONS.ATTACH_FILE
       },
@@ -123,10 +117,14 @@ const demoModeToolsMenu
     {
       title: t('student.global.navigation.tabs.tools.header').toUpperCase(),
       get active () {
-        return isRouteActive([ROUTES.STUDENT.TOOLS_TRACES])
+        return isRouteActive({ route, routes: studentToolsTracesRoutes })
       },
       links: [
-        { to: ROUTES.STUDENT.TOOLS_TRACES, text: t('student.global.navigation.tabs.tools.items.traces'), icon: MDI_ICONS.ATTACH_FILE },
+        {
+          ...toolTracesLink.value,
+          text: t('student.global.navigation.tabs.tools.items.traces'),
+          icon: MDI_ICONS.ATTACH_FILE
+        },
       ],
     }
   ))
@@ -134,12 +132,12 @@ const demoModeToolsMenu
 const buildLifeProjectMenu = computed(() => ({
   title: t('student.global.navigation.tabs.project.header').toUpperCase(),
   get active () {
-    return isRouteActive([
+    return isRouteActive({ route, routes: [
       ROUTES.STUDENT.PROJECT_SKILLS,
       ...studentPersonalCareerRoutes,
       ...studentProjectActivtiesRoutes,
       ...studentProjectTrajectoriesRoutes
-    ])
+    ] })
   },
   links: [
     {

--- a/src/features/student/traces/routes/index.ts
+++ b/src/features/student/traces/routes/index.ts
@@ -42,3 +42,14 @@ export const studentToolsUpdateTraceRoute: AvRoute = {
   component: () =>
     import('@/features/student/traces/views/StudentUpdateTraceView/StudentUpdateTraceView.vue'),
 }
+
+export const studentToolsTracesRoutes: AvRoute[] = [
+  studentToolsTraceRoute,
+  studentToolsTracesRoute,
+  studentToolsUpdateTraceRoute,
+]
+
+export const studentTracesRoutes: AvRoute[] = [
+  studentTraceRoute,
+  studentUpdateTraceRoute,
+]


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
<!-- Describe the changes introduced by this pull request. -->

:sparkles: add activity feedbacks dashboard section
:recycle: update main nav highlights

---

### Reference to an Issue, Feature, Task, User Story or another PR
<!-- Mention related issue numbers or links (e.g. Closes #123, Implements #456). -->
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1792

---

### Documentation
<!-- Detail any updates made to documentation, configuration steps, or technical specs. -->

---

### Target Branch
<!-- Which branch is this PR targeting (e.g. `main`, `develop`)? -->

develop

---

### Additional Notes
<!-- Include any relevant context, technical details, or reasons behind certain decisions. -->

<img width="1905" height="926" alt="image" src="https://github.com/user-attachments/assets/64212a2c-ce50-479f-96fd-dc0cb265580d" />

---

### Known Limitations or Side Effects
<!-- List any limitations, known bugs, or side effects this PR may introduce. -->

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [ ] No unnecessary code (e.g., debug logs, commented code)
- [ ] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and detaiils for the update process

---

# Remember

**DO NOT** keep this template as is when you submit. Please remove or adjust the description when you submit your pull request.

Please do not submit a pull request to ask questions.

Do not submit pull requests without tests that verify or reproduce your intended use case. The pull request will
most likely be automatically closed immediately, unless the change is extremely trivial. 

