### PR TITLE
feat(1792): FeedbacksDashboardSection - add pending feedbacks card

### DIFF
--- a/src/features/staff/feedbacks/locales/en.json
+++ b/src/features/staff/feedbacks/locales/en.json
@@ -71,6 +71,9 @@
             "fetchActivity": "Unable to load activity"
           },
           "FeedbacksDashboardSection": {
+            "new": "new feedback request | new feedback requests",
+            "pending": "unprocessed feedback request | unprocessed feedback requests",
+            "sent": "sent feedback | sent feedbacks",
             "title": "Dashboard"
           },
           "title": "All my feedback requests on the activity \"{activityTitle}\""

--- a/src/features/staff/feedbacks/locales/fr.json
+++ b/src/features/staff/feedbacks/locales/fr.json
@@ -72,6 +72,7 @@
           },
           "FeedbacksDashboardSection": {
             "new": "nouvelle demande de feedback | nouvelles demandes de feedback",
+            "pending": "demande non traitée | demandes non traitées",
             "sent": "réponse envoyée | réponses envoyées",
             "title": "Tableau de bord"
           },

--- a/src/features/staff/feedbacks/views/ActivityFeedbackDetailsView/components/FeedbacksDashboardSection/FeedbacksDashboardSection.test.ts
+++ b/src/features/staff/feedbacks/views/ActivityFeedbackDetailsView/components/FeedbacksDashboardSection/FeedbacksDashboardSection.test.ts
@@ -47,8 +47,8 @@ BddTest().given('a FeedbacksDashboardSection component', () => {
       expect(querySuspense.props('error')).toBeNull()
     })
 
-    BddTest().then('it should render two DashboardCard components', () => {
-      expect(wrapper.findAllComponents(DashboardCardStub)).toHaveLength(2)
+    BddTest().then('it should render three DashboardCard components', () => {
+      expect(wrapper.findAllComponents(DashboardCardStub)).toHaveLength(3)
     })
 
     BddTest().then('it should pass the new feedback value to the first card', () => {
@@ -56,9 +56,14 @@ BddTest().given('a FeedbacksDashboardSection component', () => {
       expect(cards[0].props('value')).toBe(`${mockedFeedbackDashboard.newFeedbacks}`)
     })
 
-    BddTest().then('it should pass processed over total value to the second card', () => {
+    BddTest().then('it should pass the pending feedback value to the second card', () => {
       const cards = wrapper.findAllComponents(DashboardCardStub)
-      expect(cards[1].props('value')).toBe(`${mockedFeedbackDashboard.processedFeedbacks}/${mockedFeedbackDashboard.totalFeedbacks}`)
+      expect(cards[1].props('value')).toBe(`${mockedFeedbackDashboard.pendingFeedbacks}`)
+    })
+
+    BddTest().then('it should pass processed over total value to the third card', () => {
+      const cards = wrapper.findAllComponents(DashboardCardStub)
+      expect(cards[2].props('value')).toBe(`${mockedFeedbackDashboard.processedFeedbacks}/${mockedFeedbackDashboard.totalFeedbacks}`)
     })
   })
 
@@ -73,9 +78,10 @@ BddTest().given('a FeedbacksDashboardSection component', () => {
 
     BddTest().then('it should fallback dashboard values to zero', () => {
       const cards = wrapper.findAllComponents(DashboardCardStub)
-      expect(cards).toHaveLength(2)
+      expect(cards).toHaveLength(3)
       expect(cards[0].props('value')).toBe('0')
-      expect(cards[1].props('value')).toBe('0/0')
+      expect(cards[1].props('value')).toBe('0')
+      expect(cards[2].props('value')).toBe('0/0')
     })
   })
 

--- a/src/features/staff/feedbacks/views/ActivityFeedbackDetailsView/components/FeedbacksDashboardSection/FeedbacksDashboardSection.vue
+++ b/src/features/staff/feedbacks/views/ActivityFeedbackDetailsView/components/FeedbacksDashboardSection/FeedbacksDashboardSection.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
 import { useGetFeedbackDashboard } from '@/api/avenir-esr'
 import QuerySuspense from '@/common/components/QuerySuspense/QuerySuspense.vue'
+import { ICONS } from '@/common/constants'
 import DashboardCard from '@/features/staff/global/components/cards/DashboardCard/DashboardCard.vue'
 import IconTitleCardContainer from '@/features/staff/global/components/cards/IconTitleCardContainer/IconTitleCardContainer.vue'
 import { MDI_ICONS, MS_ICONS, RI_ICONS } from '@avenirs-esr/avenirs-dsav'
@@ -37,6 +38,12 @@ const { data: feedbackDashboard, isLoading, error } = useGetFeedbackDashboard({ 
           :icon="MS_ICONS.FEEDBACK"
           :value="`${feedbackDashboard?.newFeedbacks ?? 0}`"
           data-testid="new-feedbacks-dashboard-card"
+        />
+        <DashboardCard
+          :label="t('staff.feedbacks.views.ActivityFeedbacksView.FeedbacksDashboardSection.pending', { count: feedbackDashboard?.pendingFeedbacks ?? 0 })"
+          :icon="ICONS.FEEDBACK"
+          :value="`${feedbackDashboard?.pendingFeedbacks ?? 0}`"
+          data-testid="pending-feedbacks-dashboard-card"
         />
         <DashboardCard
           :label="t('staff.feedbacks.views.ActivityFeedbacksView.FeedbacksDashboardSection.sent', { count: feedbackDashboard?.processedFeedbacks ?? 0 })"


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
<!-- Describe the changes introduced by this pull request. -->

:sparkles: FeedbacksDashboardSection - add pending feedbacks card

---

### Reference to an Issue, Feature, Task, User Story or another PR
<!-- Mention related issue numbers or links (e.g. Closes #123, Implements #456). -->
Linked to https://github.com/avenirs-esr/AVENIRS-Project/issues/1792

---

### Documentation
<!-- Detail any updates made to documentation, configuration steps, or technical specs. -->

---

### Target Branch
<!-- Which branch is this PR targeting (e.g. `main`, `develop`)? -->

---

### Additional Notes
<!-- Include any relevant context, technical details, or reasons behind certain decisions. -->

<img width="1905" height="926" alt="image" src="https://github.com/user-attachments/assets/d8c2fe1a-3489-4347-9fdc-f211d72497fd" />


---

### Known Limitations or Side Effects
<!-- List any limitations, known bugs, or side effects this PR may introduce. -->

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [ ] No unnecessary code (e.g., debug logs, commented code)
- [ ] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and detaiils for the update process

---

# Remember

**DO NOT** keep this template as is when you submit. Please remove or adjust the description when you submit your pull request.

Please do not submit a pull request to ask questions.

Do not submit pull requests without tests that verify or reproduce your intended use case. The pull request will
most likely be automatically closed immediately, unless the change is extremely trivial. 

