### PR TITLE
refactor(1949): EditNationalActivityView - replace cancel button with exit button

### DIFF
--- a/src/features/staff/activities/locales/en.json
+++ b/src/features/staff/activities/locales/en.json
@@ -132,7 +132,6 @@
             "title": "Trace association"
           },
           "EditNationalActivityViewTabActions": {
-            "cancelLabel": "Cancel",
             "saveLabel": "Save for later"
           },
           "errors": {

--- a/src/features/staff/activities/locales/fr.json
+++ b/src/features/staff/activities/locales/fr.json
@@ -132,7 +132,6 @@
             "title": "Association de traces"
           },
           "EditNationalActivityViewTabActions": {
-            "cancelLabel": "Annuler",
             "saveLabel": "Enregistrer pour plus tard"
           },
           "errors": {

--- a/src/features/staff/activities/views/EditNationalActivityView/EditNationalActivityView.stub.ts
+++ b/src/features/staff/activities/views/EditNationalActivityView/EditNationalActivityView.stub.ts
@@ -41,7 +41,6 @@ export const EditNationalActivityViewFormWrapper = defineComponent({
       form,
       isUpdating: mockIsUpdating,
       save: mockSave,
-      cancel: mockCancel
     })
   },
 })
@@ -72,7 +71,6 @@ export const EditNationalActivityViewFormWrapperDirty = defineComponent({
       form,
       isUpdating: mockIsUpdating,
       save: mockSave,
-      cancel: mockCancel
     })
 
     onMounted(() => {

--- a/src/features/staff/activities/views/EditNationalActivityView/EditNationalActivityView.test.ts
+++ b/src/features/staff/activities/views/EditNationalActivityView/EditNationalActivityView.test.ts
@@ -196,6 +196,23 @@ BddTest().given('a national activity view', () => {
     })
   })
 
+  BddTest().when('the form is saved successfully after local changes', () => {
+    beforeEach(async () => {
+      await mountView()
+
+      const context = getContext(wrapper)
+      await context.form.setFieldValue('title', 'Updated title')
+      await wrapper.vm.$nextTick()
+
+      await context.form.handleSubmit()
+      await flushPromises()
+    })
+
+    BddTest().then('it should reset the dirty state', () => {
+      expect(getContext(wrapper).form.state.isDirty).toBe(false)
+    })
+  })
+
   BddTest().when('save is triggered with no pending changes', () => {
     beforeEach(async () => {
       await mountView()

--- a/src/features/staff/activities/views/EditNationalActivityView/EditNationalActivityView.vue
+++ b/src/features/staff/activities/views/EditNationalActivityView/EditNationalActivityView.vue
@@ -194,6 +194,10 @@ async function save (data?: ActivityDraftUpdateRequest) {
   }
 
   if (results.every(r => r.status === 'fulfilled')) {
+    form.reset({
+      ...form.state.values,
+      bannerAction: EditActivityFormDataBannerAction.NONE,
+    })
     addSuccessMessage(t('staff.activities.views.EditNationalActivityView.success.saveActivityContent'))
   }
   else {
@@ -217,11 +221,6 @@ async function save (data?: ActivityDraftUpdateRequest) {
   }
 }
 
-function cancel () {
-  bannerFile.value = null
-  form.reset(defaultValues)
-}
-
 function onNextStep () {
   activeTab.value = EditActivityTabIndex.PUBLICATION
 }
@@ -230,9 +229,7 @@ function onPublished () {
   navigateToStaffActivities(true)
 }
 
-watch([content, presentation], () => cancel())
-
-provideEditNationalActivityViewContext({ form, isUpdating, save, cancel })
+provideEditNationalActivityViewContext({ form, isUpdating, save })
 </script>
 
 <template>

--- a/src/features/staff/activities/views/EditNationalActivityView/EditNationalActivityViewContext.ts
+++ b/src/features/staff/activities/views/EditNationalActivityView/EditNationalActivityViewContext.ts
@@ -16,10 +16,6 @@ export interface EditNationalActivityViewContext {
    * A full update requires calling form.handleSubmit().
    */
   save: (data?: ActivityDraftUpdateRequest) => void
-  /**
-   * Cancels the editing of the activity draft, discarding any unsaved changes.
-   */
-  cancel: () => void
 }
 
 export const editNationalActivityViewContextKey: InjectionKey<EditNationalActivityViewContext> = Symbol('editNationalActivityViewContext')

--- a/src/features/staff/activities/views/EditNationalActivityView/components/EditNationalActivityViewTabActions/EditNationalActivityViewTabActions.test.ts
+++ b/src/features/staff/activities/views/EditNationalActivityView/components/EditNationalActivityViewTabActions/EditNationalActivityViewTabActions.test.ts
@@ -1,15 +1,31 @@
+import type { VueWrapper } from '@vue/test-utils'
+import { ROUTES } from '@/common/constants'
 import EditNationalActivityViewTabActions from '@/features/staff/activities/views/EditNationalActivityView/components/EditNationalActivityViewTabActions/EditNationalActivityViewTabActions.vue'
-import { EditNationalActivityViewFormWrapper, EditNationalActivityViewFormWrapperDirty, mockCancel, mockHandleSubmit } from '@/features/staff/activities/views/EditNationalActivityView/EditNationalActivityView.stub'
+import { EditNationalActivityViewFormWrapper, EditNationalActivityViewFormWrapperDirty, mockHandleSubmit } from '@/features/staff/activities/views/EditNationalActivityView/EditNationalActivityView.stub'
 import { AvButtonStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
-import { mount, type VueWrapper } from '@vue/test-utils'
+import { mountWithRouter } from 'tests/utils'
 import { beforeEach, expect, vi } from 'vitest'
 import { h } from 'vue'
+
+const mockRouterBack = vi.fn()
+const mockRouterPush = vi.fn()
+
+vi.mock('vue-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('vue-router')>()
+  return {
+    ...actual,
+    useRouter: vi.fn(() => ({
+      back: mockRouterBack,
+      push: mockRouterPush,
+    })),
+  }
+})
 
 BddTest().given('an EditNationalActivityViewTabActions component', () => {
   const stubs = { AvButton: AvButtonStub }
 
-  const mountWith = (FormWrapper: typeof EditNationalActivityViewFormWrapper): VueWrapper<InstanceType<typeof EditNationalActivityViewTabActions>> => {
-    const wrapper = mount(FormWrapper, {
+  const mountWith = async (FormWrapper: typeof EditNationalActivityViewFormWrapper): Promise<VueWrapper<InstanceType<typeof EditNationalActivityViewTabActions>>> => {
+    const wrapper = await mountWithRouter(FormWrapper, {
       slots: { default: h(EditNationalActivityViewTabActions) },
       global: { stubs },
     })
@@ -18,25 +34,27 @@ BddTest().given('an EditNationalActivityViewTabActions component', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    window.history.replaceState({}, '', '/')
   })
 
   BddTest().when('the form is pristine', () => {
     let actions: VueWrapper<InstanceType<typeof EditNationalActivityViewTabActions>>
 
-    beforeEach(() => {
-      actions = mountWith(EditNationalActivityViewFormWrapper)
+    beforeEach(async () => {
+      actions = await mountWith(EditNationalActivityViewFormWrapper)
     })
 
-    BddTest().then('it should render the cancel button', () => {
-      expect(actions.find('[data-testid="cancel-button"]').exists()).toBe(true)
+    BddTest().then('it should render the exit button', () => {
+      expect(actions.find('[data-testid="exit-button"]').exists()).toBe(true)
     })
 
     BddTest().then('it should render the save button', () => {
       expect(actions.find('[data-testid="save-button"]').exists()).toBe(true)
     })
 
-    BddTest().then('the cancel button should be disabled', () => {
-      expect(actions.find('[data-testid="cancel-button"]').attributes()).toHaveProperty('disabled')
+    BddTest().then('the exit button should not be loading', () => {
+      expect((actions.findComponent('[data-testid="exit-button"]') as VueWrapper<InstanceType<typeof AvButtonStub>>)
+        .props('isLoading')).toBe(false)
     })
 
     BddTest().then('the save button should be disabled', () => {
@@ -47,26 +65,38 @@ BddTest().given('an EditNationalActivityViewTabActions component', () => {
   BddTest().when('the form is dirty', () => {
     let actions: VueWrapper<InstanceType<typeof EditNationalActivityViewTabActions>>
 
-    beforeEach(() => {
-      actions = mountWith(EditNationalActivityViewFormWrapperDirty)
+    beforeEach(async () => {
+      actions = await mountWith(EditNationalActivityViewFormWrapperDirty)
     })
 
-    BddTest().then('the cancel button should be enabled', async () => {
+    BddTest().then('the exit button should be loading', async () => {
       await vi.waitFor(() => {
-        expect(actions.find('[data-testid="cancel-button"]').attributes()).not.toHaveProperty('disabled')
+        expect((actions.findComponent('[data-testid="exit-button"]') as VueWrapper<InstanceType<typeof AvButtonStub>>)
+          .props('isLoading')).toBe(true)
       })
     })
 
-    BddTest().and('the cancel button is clicked', () => {
+    BddTest().and('the exit button is clicked with a previous history entry', () => {
       beforeEach(async () => {
-        await vi.waitFor(() => {
-          expect(actions.find('[data-testid="cancel-button"]').attributes()).not.toHaveProperty('disabled')
-        })
-        await actions.find('[data-testid="cancel-button"]').trigger('click')
+        window.history.replaceState({ back: '/staff/activities' }, '', '/staff/activities/edit')
+        await actions.find('[data-testid="exit-button"]').trigger('click')
       })
 
-      BddTest().then('it should call cancel', () => {
-        expect(mockCancel).toHaveBeenCalledTimes(1)
+      BddTest().then('it should navigate back', () => {
+        expect(mockRouterBack).toHaveBeenCalledTimes(1)
+        expect(mockRouterPush).not.toHaveBeenCalled()
+      })
+    })
+
+    BddTest().and('the exit button is clicked without previous history entry', () => {
+      beforeEach(async () => {
+        window.history.replaceState({}, '', '/staff/activities/edit')
+        await actions.find('[data-testid="exit-button"]').trigger('click')
+      })
+
+      BddTest().then('it should navigate to staff activities', () => {
+        expect(mockRouterBack).not.toHaveBeenCalled()
+        expect(mockRouterPush).toHaveBeenCalledWith(ROUTES.STAFF.ACTIVITIES)
       })
     })
 
@@ -88,7 +118,7 @@ BddTest().given('an EditNationalActivityViewTabActions component', () => {
     let actions: VueWrapper<InstanceType<typeof EditNationalActivityViewTabActions>>
 
     beforeEach(async () => {
-      actions = mountWith(EditNationalActivityViewFormWrapper)
+      actions = await mountWith(EditNationalActivityViewFormWrapper)
       await actions.find('[data-testid="save-button"]').trigger('click')
     })
 

--- a/src/features/staff/activities/views/EditNationalActivityView/components/EditNationalActivityViewTabActions/EditNationalActivityViewTabActions.vue
+++ b/src/features/staff/activities/views/EditNationalActivityView/components/EditNationalActivityViewTabActions/EditNationalActivityViewTabActions.vue
@@ -1,11 +1,22 @@
 <script setup lang="ts">
+import { ROUTES } from '@/common/constants'
 import { useEditNationalActivityViewContext } from '@/features/staff/activities/views/EditNationalActivityView/EditNationalActivityViewContext'
 import { AvButton, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
 import { useI18n } from 'vue-i18n'
 
+const router = useRouter()
 const { t } = useI18n()
 
-const { form, isUpdating, cancel } = useEditNationalActivityViewContext()
+function goBack () {
+  if (window.history.state?.back) {
+    router.back()
+  }
+  else {
+    router.push(ROUTES.STAFF.ACTIVITIES)
+  }
+}
+
+const { form, isUpdating } = useEditNationalActivityViewContext()
 const isFormDirty = form.useStore(s => s.isDirty)
 const isFormValid = form.useStore(s => s.isValid && !s.isValidating && s.isDirty)
 </script>
@@ -14,11 +25,11 @@ const isFormValid = form.useStore(s => s.isValid && !s.isValidating && s.isDirty
   <div class="av-row av-gap-sm">
     <AvButton
       small
-      data-testid="cancel-button"
+      data-testid="exit-button"
       :icon="MDI_ICONS.CLOSE_CIRCLE_OUTLINE"
-      :label="t('staff.activities.views.EditNationalActivityView.EditNationalActivityViewTabActions.cancelLabel')"
-      :disabled="isUpdating || !isFormDirty"
-      @click="cancel()"
+      :label="t('global.buttons.exit')"
+      :is-loading="isUpdating || isFormDirty"
+      @click="goBack"
     />
     <AvButton
       small


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
<!-- Describe the changes introduced by this pull request. -->

:recycle: EditNationalActivityView - replace cancel button with exit button

---

### Reference to an Issue, Feature, Task, User Story or another PR
<!-- Mention related issue numbers or links (e.g. Closes #123, Implements #456). -->
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1949

---

### Documentation
<!-- Detail any updates made to documentation, configuration steps, or technical specs. -->

---

### Target Branch
<!-- Which branch is this PR targeting (e.g. `main`, `develop`)? -->

develop

---

### Additional Notes
<!-- Include any relevant context, technical details, or reasons behind certain decisions. -->


https://github.com/user-attachments/assets/22b92454-57c5-43e6-9e8c-b6bb0a3e1c0e



---

### Known Limitations or Side Effects
<!-- List any limitations, known bugs, or side effects this PR may introduce. -->

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [ ] No unnecessary code (e.g., debug logs, commented code)
- [ ] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and detaiils for the update process

---

# Remember

**DO NOT** keep this template as is when you submit. Please remove or adjust the description when you submit your pull request.

Please do not submit a pull request to ask questions.

Do not submit pull requests without tests that verify or reproduce your intended use case. The pull request will
most likely be automatically closed immediately, unless the change is extremely trivial. 

