### PR TITLE
feat(1788): add section activity consign

### DIFF
--- a/src/features/staff/feedbacks/components/cards/ActivityConsignCard/ActivityConsignCard.stub.ts
+++ b/src/features/staff/feedbacks/components/cards/ActivityConsignCard/ActivityConsignCard.stub.ts
@@ -1,0 +1,10 @@
+export const ActivityConsignCardStub = defineComponent({
+  name: 'ActivityConsignCard',
+  props: {
+    description: {
+      type: String,
+      required: false
+    }
+  },
+  template: '<div class="activity-consign-card" />'
+})

--- a/src/features/staff/feedbacks/components/cards/ActivityConsignCard/ActivityConsignCard.test.ts
+++ b/src/features/staff/feedbacks/components/cards/ActivityConsignCard/ActivityConsignCard.test.ts
@@ -1,0 +1,63 @@
+import type { ActivityConsignCardProps } from '@/features/staff/feedbacks/components/cards/ActivityConsignCard/ActivityConsignCard.vue'
+import type { VueWrapper } from '@vue/test-utils'
+import ActivityConsignCard from '@/features/staff/feedbacks/components/cards/ActivityConsignCard/ActivityConsignCard.vue'
+import { IconTitleCardContainerStub } from '@/features/staff/global/components/cards/IconTitleCardContainer/IconTitleCardContainer.stub'
+import { MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { mountComponent } from 'tests/utils'
+import { beforeEach, expect } from 'vitest'
+
+BddTest().given('an activity consign card', () => {
+  let wrapper: VueWrapper<InstanceType<typeof ActivityConsignCard>>
+
+  const stubs = {
+    IconTitleCardContainer: IconTitleCardContainerStub
+  }
+
+  const getContent = () =>
+    wrapper.find('[data-testid="activity-consign-card-content"]')
+
+  BddTest().when('the component is mounted with a description', () => {
+    const props: ActivityConsignCardProps = {
+      description: '<p>This is the activity consign</p>'
+    }
+
+    beforeEach(() => {
+      wrapper = mountComponent(ActivityConsignCard, {
+        props,
+        global: { stubs }
+      })
+    })
+
+    BddTest().then('it should render IconTitleCardContainer with the expected icon', () => {
+      const container = wrapper.findComponent(IconTitleCardContainerStub)
+
+      expect(container.exists()).toBe(true)
+      expect(container.props('title')).toBe('Consigne')
+      expect(container.props('titleIcon')).toBe(MDI_ICONS.FILE_DOCUMENT_BOX_MULTIPLE_OUTLINE)
+      expect(container.props('collapsed')).toBe(true)
+    })
+
+    BddTest().then('it should render the description content', () => {
+      const content = getContent()
+
+      expect(content.exists()).toBe(true)
+      expect(content.html()).toContain('This is the activity consign')
+    })
+  })
+
+  BddTest().when('the component is mounted without a description', () => {
+    beforeEach(() => {
+      wrapper = mountComponent(ActivityConsignCard, {
+        global: { stubs }
+      })
+    })
+
+    BddTest().then('it should render an empty content', () => {
+      const content = getContent()
+
+      expect(content.exists()).toBe(true)
+      expect(content.text()).toBe('')
+    })
+  })
+})

--- a/src/features/staff/feedbacks/components/cards/ActivityConsignCard/ActivityConsignCard.vue
+++ b/src/features/staff/feedbacks/components/cards/ActivityConsignCard/ActivityConsignCard.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import IconTitleCardContainer from '@/features/staff/global/components/cards/IconTitleCardContainer/IconTitleCardContainer.vue'
+import { MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
+import DOMPurify from 'dompurify'
+import { useI18n } from 'vue-i18n'
+
+export interface ActivityConsignCardProps {
+  description?: string
+}
+
+const { description } = defineProps<ActivityConsignCardProps>()
+
+const { t } = useI18n()
+
+const sanitizedContent = computed(() =>
+  DOMPurify.sanitize(description ?? '')
+)
+</script>
+
+<template>
+  <IconTitleCardContainer
+    :title-icon="MDI_ICONS.FILE_DOCUMENT_BOX_MULTIPLE_OUTLINE"
+    :title="t('staff.feedbacks.cards.ActivityConsignCard.title')"
+    collapsible
+    :collapsed="true"
+    data-testid="activity-consign-card"
+  >
+    <div
+      data-user-content
+      data-testid="activity-consign-card-content"
+      v-html="sanitizedContent"
+    />
+  </IconTitleCardContainer>
+</template>

--- a/src/features/staff/feedbacks/locales/en.json
+++ b/src/features/staff/feedbacks/locales/en.json
@@ -12,6 +12,9 @@
         }
       },
       "cards": {
+        "ActivityConsignCard": {
+          "title": "Instructions"
+        },
         "AssociatedElementSummaryCard": {
           "emptyState": "No elements associated with this feedback found",
           "title": "Summary of associated elements ({count})"

--- a/src/features/staff/feedbacks/locales/fr.json
+++ b/src/features/staff/feedbacks/locales/fr.json
@@ -12,6 +12,9 @@
         }
       },
       "cards": {
+        "ActivityConsignCard": {
+          "title": "Consigne"
+        },
         "AssociatedElementSummaryCard": {
           "emptyState": "Aucun élément associé à ce feedback trouvé",
           "title": "Récapitulatif des éléments associés ({count})"

--- a/src/features/staff/feedbacks/views/ActivityFeedbacksView/ActivityFeedbacksView.test.ts
+++ b/src/features/staff/feedbacks/views/ActivityFeedbacksView/ActivityFeedbacksView.test.ts
@@ -5,6 +5,7 @@ import { server } from '@/__mocks__/msw/server'
 import { PageTitleStub } from '@/common/components/PageTitle/PageTitle.stub'
 import { QuerySuspenseStub } from '@/common/components/QuerySuspense/QuerySuspense.stub'
 import { ROUTES } from '@/common/constants'
+import { ActivityConsignCardStub } from '@/features/staff/feedbacks/components/cards/ActivityConsignCard/ActivityConsignCard.stub'
 import { FeedbacksDashboardSectionStub } from '@/features/staff/feedbacks/views/ActivityFeedbackDetailsView/components/FeedbacksDashboardSection/FeedbacksDashboardSection.stub'
 import ActivityFeedbacksView from '@/features/staff/feedbacks/views/ActivityFeedbacksView/ActivityFeedbacksView.vue'
 import { ActivityFeedbacksCardStub } from '@/features/staff/feedbacks/views/ActivityFeedbacksView/components/ActivityFeedbacksCard/ActivityFeedbacksCard.stub'
@@ -19,7 +20,8 @@ BddTest().given('an ActivityFeedbacksView component', () => {
     PageTitle: PageTitleStub,
     QuerySuspense: QuerySuspenseStub,
     ActivityFeedbacksCard: ActivityFeedbacksCardStub,
-    FeedbacksDashboardSection: FeedbacksDashboardSectionStub
+    FeedbacksDashboardSection: FeedbacksDashboardSectionStub,
+    ActivityConsignCard: ActivityConsignCardStub
   }
 
   const mountView = () => mountComponent(ActivityFeedbacksView, {
@@ -70,6 +72,14 @@ BddTest().given('an ActivityFeedbacksView component', () => {
 
     BddTest().then('it should render ActivityFeedbacksCard', () => {
       expect(wrapper.findComponent(ActivityFeedbacksCardStub).exists()).toBe(true)
+    })
+
+    BddTest().then('it should render ActivityConsignCard', () => {
+      expect(wrapper.findComponent(ActivityConsignCardStub).exists()).toBe(true)
+    })
+
+    BddTest().then('it should pass the description to ActivityConsignCard', () => {
+      expect(wrapper.findComponent(ActivityConsignCardStub).props('description')).toBe(mockedActivityContent.description)
     })
 
     BddTest().then('it should pass the activity to ActivityFeedbacksCard', () => {

--- a/src/features/staff/feedbacks/views/ActivityFeedbacksView/ActivityFeedbacksView.vue
+++ b/src/features/staff/feedbacks/views/ActivityFeedbacksView/ActivityFeedbacksView.vue
@@ -3,9 +3,9 @@ import { EActivityStatus, useGetActivityContent } from '@/api/avenir-esr'
 import { QuerySuspense } from '@/common/components'
 import PageTitle from '@/common/components/PageTitle/PageTitle.vue'
 import { ICONS, ROUTES } from '@/common/constants'
+import ActivityConsignCard from '@/features/staff/feedbacks/components/cards/ActivityConsignCard/ActivityConsignCard.vue'
 import FeedbacksDashboardSection from '@/features/staff/feedbacks/views/ActivityFeedbackDetailsView/components/FeedbacksDashboardSection/FeedbacksDashboardSection.vue'
-import ActivityFeedbacksCard
-  from '@/features/staff/feedbacks/views/ActivityFeedbacksView/components/ActivityFeedbacksCard/ActivityFeedbacksCard.vue'
+import ActivityFeedbacksCard from '@/features/staff/feedbacks/views/ActivityFeedbacksView/components/ActivityFeedbacksCard/ActivityFeedbacksCard.vue'
 import { AvIconText } from '@avenirs-esr/avenirs-dsav'
 import { useI18n } from 'vue-i18n'
 
@@ -53,9 +53,15 @@ const breadcrumbLinks = computed(() => [
       :error="error"
       :error-title="t('staff.feedbacks.views.ActivityFeedbacksView.errors.fetchActivity')"
     >
-      <ActivityFeedbacksCard
-        :activity="activity!"
-      />
+      <div class="av-col av-gap-md">
+        <ActivityConsignCard
+          :description="activity?.description"
+        />
+
+        <ActivityFeedbacksCard
+          :activity="activity!"
+        />
+      </div>
     </QuerySuspense>
   </div>
 </template>


### PR DESCRIPTION


### Brief description of changes applied
<!-- Describe the changes introduced by this pull request. -->
create section instruction
create tests
added the card in ActivityFeedbacksView.vue 

---

### Reference to an Issue, Feature, Task, User Story or another PR
<!-- Mention related issue numbers or links (e.g. Closes #123, Implements #456). -->
<!-- Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/### -->
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1788

---

<img width="1639" height="835" alt="image" src="https://github.com/user-attachments/assets/fc2dc03b-baed-42f0-aefe-0d9a6aa241e8" />

