### PR TITLE
fix(1745): remove detail button from feedback associated element

### DIFF
--- a/src/features/staff/feedbacks/views/FeedbacksView/components/cards/AssociatedElementCard/AssociatedElementCard.test.ts
+++ b/src/features/staff/feedbacks/views/FeedbacksView/components/cards/AssociatedElementCard/AssociatedElementCard.test.ts
@@ -6,23 +6,9 @@ import { EAssociationContextType } from '@/api/avenir-esr'
 import { AssociatedElementTypeBadgeStub } from '@/features/staff/feedbacks/views/FeedbacksView/components/badges/AssociatedElementTypeBadge/AssociatedElementTypeBadge.stub'
 import AssociatedElementCard from '@/features/staff/feedbacks/views/FeedbacksView/components/cards/AssociatedElementCard/AssociatedElementCard.vue'
 import { FeedbackTraceActionsStub } from '@/features/staff/feedbacks/views/FeedbacksView/components/FeedbackTraceActions/FeedbackTraceActions.stub'
-import { AvButtonStub, AvCardStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { AvCardStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { mountComponent } from 'tests/utils'
-import { beforeEach, expect, vi } from 'vitest'
-
-const mockNavigateToStudentToolsTrace = vi.fn()
-const mockNavigateToStudentProjectSkill = vi.fn()
-
-vi.mock('@/common/composables', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@/common/composables')>()
-  return {
-    ...actual,
-    useNavigation: () => ({
-      navigateToStudentToolsTrace: mockNavigateToStudentToolsTrace,
-      navigateToStudentProjectSkill: mockNavigateToStudentProjectSkill,
-    }),
-  }
-})
+import { beforeEach, expect } from 'vitest'
 
 const mockedFeedbackTraceWithFile: FeedbackAssociatedElement = {
   type: EAssociationContextType.TRACE,
@@ -40,17 +26,12 @@ const mockedFeedbackDeclaredSkill: FeedbackAssociatedElement = {
 
 const stubs = {
   AvCard: AvCardStub,
-  AvButton: AvButtonStub,
   AssociatedElementTypeBadge: AssociatedElementTypeBadgeStub,
   FeedbackTraceActions: FeedbackTraceActionsStub,
 }
 
 BddTest().given('an AssociatedElementCard component', () => {
   let wrapper: VueWrapper<InstanceType<typeof AssociatedElementCard>>
-
-  beforeEach(() => {
-    vi.clearAllMocks()
-  })
 
   BddTest().when('the element is a TRACE with a file attachment', () => {
     beforeEach(() => {
@@ -77,15 +58,6 @@ BddTest().given('an AssociatedElementCard component', () => {
     BddTest().then('it should render FeedbackTraceActions', () => {
       expect(wrapper.findComponent(FeedbackTraceActionsStub).exists()).toBe(true)
     })
-
-    BddTest().then('it should render the detail button', () => {
-      expect(wrapper.find('[data-testid="associated-element-card-detail-button"]').exists()).toBe(true)
-    })
-
-    BddTest().then('it should navigate to trace detail when detail button is clicked', async () => {
-      await wrapper.find('[data-testid="associated-element-card-detail-button"]').trigger('click')
-      expect(mockNavigateToStudentToolsTrace).toHaveBeenCalledWith({ id: mockedFeedbackTraceWithFile.data.id })
-    })
   })
 
   BddTest().when('the element is a TRACE with a link', () => {
@@ -98,11 +70,6 @@ BddTest().given('an AssociatedElementCard component', () => {
 
     BddTest().then('it should render FeedbackTraceActions', () => {
       expect(wrapper.findComponent(FeedbackTraceActionsStub).exists()).toBe(true)
-    })
-
-    BddTest().then('it should navigate to trace detail when detail button is clicked', async () => {
-      await wrapper.find('[data-testid="associated-element-card-detail-button"]').trigger('click')
-      expect(mockNavigateToStudentToolsTrace).toHaveBeenCalledWith({ id: mockedFeedbackTraceWithLink.data.id })
     })
   })
 
@@ -122,11 +89,6 @@ BddTest().given('an AssociatedElementCard component', () => {
 
     BddTest().then('it should not render FeedbackTraceActions', () => {
       expect(wrapper.findComponent(FeedbackTraceActionsStub).exists()).toBe(false)
-    })
-
-    BddTest().then('it should navigate to skill detail when detail button is clicked', async () => {
-      await wrapper.find('[data-testid="associated-element-card-detail-button"]').trigger('click')
-      expect(mockNavigateToStudentProjectSkill).toHaveBeenCalledWith({ id: mockedFeedbackDeclaredSkill.data.id })
     })
   })
 })

--- a/src/features/staff/feedbacks/views/FeedbacksView/components/cards/AssociatedElementCard/AssociatedElementCard.vue
+++ b/src/features/staff/feedbacks/views/FeedbacksView/components/cards/AssociatedElementCard/AssociatedElementCard.vue
@@ -2,11 +2,9 @@
 import type { TraceDetailDTO } from '@/api/avenir-esr'
 import type { FeedbackAssociatedElement } from '@/features/staff/feedbacks/types/feedback.types'
 import { EAssociationContextType } from '@/api/avenir-esr'
-import { useNavigation } from '@/common/composables'
 import AssociatedElementTypeBadge from '@/features/staff/feedbacks/views/FeedbacksView/components/badges/AssociatedElementTypeBadge/AssociatedElementTypeBadge.vue'
 import FeedbackTraceActions from '@/features/staff/feedbacks/views/FeedbacksView/components/FeedbackTraceActions/FeedbackTraceActions.vue'
-import { AvButton, AvCard, CUIDA_ICONS } from '@avenirs-esr/avenirs-dsav'
-import { useI18n } from 'vue-i18n'
+import { AvCard } from '@avenirs-esr/avenirs-dsav'
 
 export interface AssociatedElementCardProps {
   feedbackAssociatedElement: FeedbackAssociatedElement
@@ -14,26 +12,12 @@ export interface AssociatedElementCardProps {
 
 const { feedbackAssociatedElement } = defineProps<AssociatedElementCardProps>()
 
-const { t } = useI18n()
-const { navigateToStudentToolsTrace, navigateToStudentProjectSkill } = useNavigation()
-
 const traceData = computed(() =>
   feedbackAssociatedElement.type === EAssociationContextType.TRACE
     ? (feedbackAssociatedElement.data as TraceDetailDTO)
     : null
 )
 const title = computed(() => feedbackAssociatedElement.data.title)
-
-function openDetail () {
-  switch (feedbackAssociatedElement.type) {
-    case EAssociationContextType.TRACE:
-      navigateToStudentToolsTrace({ id: feedbackAssociatedElement.data.id })
-      break
-    case EAssociationContextType.DECLARED_SKILL:
-      navigateToStudentProjectSkill({ id: feedbackAssociatedElement.data.id })
-      break
-  }
-}
 </script>
 
 <template>
@@ -61,12 +45,6 @@ function openDetail () {
         <FeedbackTraceActions
           v-if="traceData"
           :trace="traceData"
-        />
-        <AvButton
-          :icon="CUIDA_ICONS.VISIBILITY_ON_OUTLINE"
-          :label="t('global.detail')"
-          data-testid="associated-element-card-detail-button"
-          @click.stop="openDetail"
         />
       </div>
     </template>

--- a/src/features/staff/feedbacks/views/FeedbacksView/components/cards/AssociatedElementSummaryCard/AssociatedElementSummaryCard.vue
+++ b/src/features/staff/feedbacks/views/FeedbacksView/components/cards/AssociatedElementSummaryCard/AssociatedElementSummaryCard.vue
@@ -50,11 +50,13 @@ const associatedElements = computed<FeedbackAssociatedElement[]>(() => {
       :empty-state-message="t('staff.feedbacks.cards.AssociatedElementSummaryCard.emptyState')"
       :error="error"
     >
-      <AssociatedElementCard
-        v-for="element in associatedElements"
-        :key="element.data.id"
-        :feedback-associated-element="element"
-      />
+      <div class="av-col av-gap-sm">
+        <AssociatedElementCard
+          v-for="element in associatedElements"
+          :key="element.data.id"
+          :feedback-associated-element="element"
+        />
+      </div>
     </QuerySuspense>
   </AvCard>
 </template>


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
* Suppression du bouton "Détail" et du code de navigation inutilisé dans AssociatedElementCard
* Ajout d'un gap entre les éléments associés dans AssociatedElementSummaryCard
* Nettoyage des tests associés

---

### Reference to an Issue, Feature, Task, User Story or another PR
Related to https://github.com/avenirs-esr/AVENIRS-Project/issues/1745

<img width="1381" height="1131" alt="Capture d’écran du 2026-06-26 15-22-05" src="https://github.com/user-attachments/assets/d802e957-8880-4ae7-a7e6-c312fb6a3933" />


---

### Target Branch
develop