### PR TITLE
feat(1763): add FeedbacksHistoryTab with feedback history list

### DIFF
--- a/api-specs/avenir-esr.swagger.json
+++ b/api-specs/avenir-esr.swagger.json
@@ -541,6 +541,40 @@
         }
       }
     },
+    "/me/activity-progress/feedbacks/{declaredActivityId}/history": {
+      "get": {
+        "tags": [
+          "feedback-controller"
+        ],
+        "operationId": "getFeedbackHistory",
+        "parameters": [
+          {
+            "name": "declaredActivityId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/FeedbackOverviewDTO"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/me/traces": {
       "post": {
         "tags": [
@@ -5396,6 +5430,10 @@
             "type": "string",
             "format": "uuid"
           },
+          "declaredActivityId": {
+            "type": "string",
+            "format": "uuid"
+          },
           "activity": {
             "$ref": "#/components/schemas/ActivityContentDTO"
           },
@@ -5441,6 +5479,7 @@
         "required": [
           "activity",
           "createdAt",
+          "declaredActivityId",
           "id",
           "status",
           "student",

--- a/src/__mocks__/fixtures/staffs/feedbacks.fixtures.ts
+++ b/src/__mocks__/fixtures/staffs/feedbacks.fixtures.ts
@@ -1,12 +1,19 @@
 import { createMockedDeclaredSkillProgressDTO } from '@/__mocks__/fixtures/student/skills.fixtures'
 import { mockedTraceDetailedWithFile } from '@/__mocks__/fixtures/student/traces.fixtures'
-import { type ActivityContentDTO, EActivityThematic, EFeedbackStatus, type FeedbackDashboardDTO, type FeedbackDetailsDTO, type FeedbackStaffListItemDTO, type PagedResponseFeedbackStaffListItemDTO, type UserInfoDTO } from '@/api/avenir-esr'
+import { type ActivityContentDTO, EActivityThematic, EFeedbackStatus, type FeedbackDashboardDTO, type FeedbackDetailsDTO, type FeedbackOverviewDTO, type FeedbackStaffListItemDTO, type PagedResponseFeedbackStaffListItemDTO, type UserInfoDTO } from '@/api/avenir-esr'
 
 const mockedStudent: UserInfoDTO = {
   id: 'student-1',
   firstName: 'Lucas',
   lastName: 'Tessier',
   email: 'lucas.tessier@university.com',
+}
+
+const mockedStaff: UserInfoDTO = {
+  id: 'staff-1',
+  firstName: 'Marc',
+  lastName: 'Dupont',
+  email: 'marc.dupont@university.com',
 }
 
 const mockedActivity: ActivityContentDTO = {
@@ -55,6 +62,7 @@ const allFeedbacks: FeedbackStaffListItemDTO[] = [
 
 export const mockedFeedbackDetailsWithAssociations: FeedbackDetailsDTO = {
   id: 'feedback-with-associations',
+  declaredActivityId: 'declared-activity-id',
   activity: mockedActivity,
   feedback: 'This is a detailed feedback with associations',
   status: EFeedbackStatus.NEW,
@@ -77,6 +85,36 @@ export const mockedFeedbackDetailsSubmitted: FeedbackDetailsDTO = {
   status: EFeedbackStatus.SUBMITTED,
   id: 'feedback-submitted',
 }
+
+export const mockedFeedbackHistory: FeedbackOverviewDTO[] = [
+  {
+    id: 'feedback-overview-3',
+    staff: mockedStaff,
+    student: mockedStudent,
+    feedback: 'Votre travail est bien structuré, continuez dans cette direction.',
+    status: EFeedbackStatus.SUBMITTED,
+    createdAt: '2026-03-05T10:00:00Z',
+    updatedAt: '2026-05-09T10:00:00Z',
+  },
+  {
+    id: 'feedback-overview-2',
+    staff: mockedStaff,
+    student: mockedStudent,
+    feedback: 'Les références bibliographiques manquent de précision.',
+    status: EFeedbackStatus.SUBMITTED,
+    createdAt: '2026-01-20T10:00:00Z',
+    updatedAt: '2026-02-02T10:00:00Z',
+  },
+  {
+    id: 'feedback-overview-1',
+    staff: mockedStaff,
+    student: mockedStudent,
+    feedback: 'Il faudrait que vous puissiez citer vos références méthodologiques.',
+    status: EFeedbackStatus.IN_PROCESS,
+    createdAt: '2025-12-12T10:00:00Z',
+    updatedAt: '2026-02-07T10:00:00Z',
+  },
+]
 
 export const mockedFeedbackDashboard: FeedbackDashboardDTO = {
   totalFeedbacks: 20,

--- a/src/__mocks__/msw/handlers/staffs/feedbacks.handlers.ts
+++ b/src/__mocks__/msw/handlers/staffs/feedbacks.handlers.ts
@@ -3,13 +3,16 @@ import {
   mockedFeedbackDashboard,
   mockedFeedbackDetailsSubmitted,
   mockedFeedbackDetailsWithAssociations,
-  mockedFeedbackDetailsWithoutAssociations
+  mockedFeedbackDetailsWithoutAssociations,
+  mockedFeedbackHistory
 } from '@/__mocks__/fixtures/staffs/feedbacks.fixtures'
 import {
   type FeedbackDashboardDTO,
   type FeedbackDetailsDTO,
+  type FeedbackOverviewDTO,
   getGetFeedbackDashboardUrl,
   getGetFeedbackDetailsUrl,
+  getGetFeedbackHistoryUrl,
   getGetStaffFeedbacksUrl,
   getSubmitFeedbackUrl,
   getUpdateFeedbackUrl
@@ -65,6 +68,26 @@ export const getFeedbackDetailsWithAssociationsHandler = http.get(
   }
 )
 
+export function createGetFeedbackHistoryHandler (feedbacks: FeedbackOverviewDTO[] = mockedFeedbackHistory) {
+  return http.get(
+    `*${getGetFeedbackHistoryUrl(':declaredActivityId')}`,
+    () => HttpResponse.json<FeedbackOverviewDTO[]>(feedbacks, {
+      status: HttpStatusCode.OK,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  )
+}
+
+export const getFeedbackHistoryHandler = createGetFeedbackHistoryHandler()
+
+export const getFeedbackHistoryErrorHandler = http.get(
+  `*${getGetFeedbackHistoryUrl(':declaredActivityId')}`,
+  () => HttpResponse.json(
+    { message: 'Erreur lors de la récupération de l\'historique des feedbacks' },
+    { status: HttpStatusCode.INTERNAL_SERVER_ERROR, headers: { 'Content-Type': 'application/json' } }
+  )
+)
+
 export const getStaffFeedbacksHandler = http.get(
   `*${getGetStaffFeedbacksUrl()}`,
   ({ request }) => {
@@ -115,6 +138,7 @@ export const submitFeedbackHandler = http.put(`*${getSubmitFeedbackUrl(':feedbac
 
 export const feedbacksHandlers = [
   getFeedbackDashboardHandler,
+  getFeedbackHistoryHandler,
   getFeedbackDetailsWithAssociationsHandler,
   getStaffFeedbacksHandler,
   updateFeedbackHandler,

--- a/src/features/staff/feedbacks/locales/en.json
+++ b/src/features/staff/feedbacks/locales/en.json
@@ -46,6 +46,7 @@
           "WriteFeedbackFloatingPanel": {
             "tabs": {
               "history": {
+                "emptyState": "You have no previous feedback",
                 "title": "Feedback history ({count})"
               },
               "write": {

--- a/src/features/staff/feedbacks/locales/fr.json
+++ b/src/features/staff/feedbacks/locales/fr.json
@@ -46,7 +46,8 @@
           "WriteFeedbackFloatingPanel": {
             "tabs": {
               "history": {
-                "title": "Historique des feedabacks ({count})"
+                "emptyState": "Vous n'avez aucun feedback précédent",
+                "title": "Historique des feedbacks ({count})"
               },
               "write": {
                 "errors": {

--- a/src/features/staff/feedbacks/views/ActivityFeedbackDetailsView/components/interaction/tabs/FeedbacksHistoryTab/FeedbacksHistory.stub.ts
+++ b/src/features/staff/feedbacks/views/ActivityFeedbackDetailsView/components/interaction/tabs/FeedbacksHistoryTab/FeedbacksHistory.stub.ts
@@ -1,4 +1,25 @@
+import type { FeedbackOverviewDTO } from '@/api/avenir-esr'
+import type { PropType } from 'vue'
+
 export const FeedbacksHistoryTabStub = defineComponent({
   name: 'FeedbacksHistoryTab',
+  props: {
+    feedbacks: {
+      type: Array as PropType<FeedbackOverviewDTO[]>,
+      required: true,
+    },
+    maxIterations: {
+      type: Number,
+      required: false,
+    },
+    isLoading: {
+      type: Boolean,
+      default: false,
+    },
+    error: {
+      type: Object,
+      default: null,
+    },
+  },
   template: '<div data-testid="feedbacks-history-tab-stub" />',
 })

--- a/src/features/staff/feedbacks/views/ActivityFeedbackDetailsView/components/interaction/tabs/FeedbacksHistoryTab/FeedbacksHistoryTab.test.ts
+++ b/src/features/staff/feedbacks/views/ActivityFeedbackDetailsView/components/interaction/tabs/FeedbacksHistoryTab/FeedbacksHistoryTab.test.ts
@@ -1,18 +1,88 @@
+import type { VueWrapper } from '@vue/test-utils'
+import { mockedFeedbackHistory } from '@/__mocks__/fixtures/staffs/feedbacks.fixtures'
+import { QuerySuspenseStub } from '@/common/components/QuerySuspense/QuerySuspense.stub'
+import { BaseApiException } from '@/common/exceptions'
+import { FeedbackHistoryCardStub } from '@/features/staff/feedbacks/components/cards/FeedbackHistoryCard/FeedbackHistoryCard.stub'
 import FeedbacksHistoryTab from '@/features/staff/feedbacks/views/ActivityFeedbackDetailsView/components/interaction/tabs/FeedbacksHistoryTab/FeedbacksHistoryTab.vue'
 import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
-import { mount, type VueWrapper } from '@vue/test-utils'
+import { mountComponent } from 'tests/utils'
 import { beforeEach, expect } from 'vitest'
+
+const feedbacks = mockedFeedbackHistory
+
+const stubs = {
+  QuerySuspense: QuerySuspenseStub,
+  FeedbackHistoryCard: FeedbackHistoryCardStub,
+}
 
 BddTest().given('a feedback history tab', () => {
   let wrapper: VueWrapper<InstanceType<typeof FeedbacksHistoryTab>>
 
-  BddTest().when('the component is mounted', () => {
+  BddTest().when('the component is mounted with feedbacks', () => {
     beforeEach(() => {
-      wrapper = mount(FeedbacksHistoryTab)
+      wrapper = mountComponent(FeedbacksHistoryTab, {
+        props: { feedbacks, maxIterations: 3 },
+        global: { stubs },
+      })
     })
 
-    BddTest().then('it should render the feedback history tab', () => {
-      expect(wrapper.exists()).toBe(true)
+    BddTest().then('it should render a FeedbackHistoryCard for each feedback', () => {
+      expect(wrapper.findAllComponents(FeedbackHistoryCardStub)).toHaveLength(feedbacks.length)
+    })
+
+    BddTest().then('it should pass the descending iteration to each card', () => {
+      const cards = wrapper.findAllComponents(FeedbackHistoryCardStub)
+      expect(cards[0].props('iteration')).toBe(3)
+      expect(cards[1].props('iteration')).toBe(2)
+      expect(cards[2].props('iteration')).toBe(1)
+    })
+
+    BddTest().then('it should forward feedback and maxIterations to each card', () => {
+      const firstCard = wrapper.findAllComponents(FeedbackHistoryCardStub)[0]
+      expect(firstCard.props('feedback')).toEqual(feedbacks[0])
+      expect(firstCard.props('maxIterations')).toBe(3)
+    })
+  })
+
+  BddTest().when('the component is mounted with an empty list', () => {
+    beforeEach(() => {
+      wrapper = mountComponent(FeedbacksHistoryTab, {
+        props: { feedbacks: [] },
+        global: { stubs },
+      })
+    })
+
+    BddTest().then('it should render no card and show the empty state message', () => {
+      expect(wrapper.findAllComponents(FeedbackHistoryCardStub)).toHaveLength(0)
+      const emptyState = wrapper.find('[data-testid="query-suspense-empty"]')
+      expect(emptyState.exists()).toBe(true)
+      expect(emptyState.text()).toBe('Vous n\'avez aucun feedback précédent')
+    })
+  })
+
+  BddTest().when('the component is loading', () => {
+    beforeEach(() => {
+      wrapper = mountComponent(FeedbacksHistoryTab, {
+        props: { feedbacks: [], isLoading: true },
+        global: { stubs },
+      })
+    })
+
+    BddTest().then('it should show the loading state', () => {
+      expect(wrapper.find('[data-testid="query-suspense-loading"]').exists()).toBe(true)
+    })
+  })
+
+  BddTest().when('the component has an error', () => {
+    beforeEach(() => {
+      wrapper = mountComponent(FeedbacksHistoryTab, {
+        props: { feedbacks: [], error: new BaseApiException('error') },
+        global: { stubs },
+      })
+    })
+
+    BddTest().then('it should show the error state', () => {
+      expect(wrapper.find('[data-testid="query-suspense-error"]').exists()).toBe(true)
     })
   })
 })

--- a/src/features/staff/feedbacks/views/ActivityFeedbackDetailsView/components/interaction/tabs/FeedbacksHistoryTab/FeedbacksHistoryTab.vue
+++ b/src/features/staff/feedbacks/views/ActivityFeedbackDetailsView/components/interaction/tabs/FeedbacksHistoryTab/FeedbacksHistoryTab.vue
@@ -1,7 +1,43 @@
 <script lang="ts" setup>
+import type { FeedbackOverviewDTO } from '@/api/avenir-esr'
+import type { BaseApiException } from '@/common/exceptions'
+import QuerySuspense from '@/common/components/QuerySuspense/QuerySuspense.vue'
+import FeedbackHistoryCard from '@/features/staff/feedbacks/components/cards/FeedbackHistoryCard/FeedbackHistoryCard.vue'
+import { useI18n } from 'vue-i18n'
 
+export interface FeedbacksHistoryTabProps {
+  feedbacks: FeedbackOverviewDTO[]
+  maxIterations?: number
+  isLoading?: boolean
+  error?: BaseApiException | null
+}
+
+const {
+  feedbacks,
+  maxIterations,
+  isLoading = false,
+  error = null,
+} = defineProps<FeedbacksHistoryTabProps>()
+
+const { t } = useI18n()
 </script>
 
 <template>
-  Feedbacks history tab placeholder (TODO US#1672 Task#1763)
+  <QuerySuspense
+    :is-loading="isLoading"
+    :error="error"
+    :is-empty="feedbacks.length === 0"
+    :empty-state-message="t('staff.feedbacks.views.ActivityFeedbackDetailsView.WriteFeedbackFloatingPanel.tabs.history.emptyState')"
+    data-testid="feedbacks-history-tab"
+  >
+    <div class="av-col av-gap-sm">
+      <FeedbackHistoryCard
+        v-for="(feedback, index) in feedbacks"
+        :key="feedback.id"
+        :feedback="feedback"
+        :iteration="feedbacks.length - index"
+        :max-iterations="maxIterations"
+      />
+    </div>
+  </QuerySuspense>
 </template>

--- a/src/features/staff/feedbacks/views/ActivityFeedbackDetailsView/components/overlays/WriteFeedbackFloatingPanel/WriteFeedbackFloatingPanel.test.ts
+++ b/src/features/staff/feedbacks/views/ActivityFeedbackDetailsView/components/overlays/WriteFeedbackFloatingPanel/WriteFeedbackFloatingPanel.test.ts
@@ -1,37 +1,44 @@
-import type { FeedbackDetailsDTO } from '@/api/avenir-esr'
-import type { VueWrapper } from '@vue/test-utils'
-import { mockedActivityContent } from '@/__mocks__/fixtures/staffs/activities.fixtures'
+import { mockedFeedbackDetailsWithAssociations, mockedFeedbackHistory } from '@/__mocks__/fixtures/staffs/feedbacks.fixtures'
+import { createGetFeedbackHistoryHandler, getFeedbackHistoryErrorHandler } from '@/__mocks__/msw/handlers/staffs/feedbacks.handlers'
+import { server } from '@/__mocks__/msw/server'
+import { FeedbacksHistoryTabStub } from '@/features/staff/feedbacks/views/ActivityFeedbackDetailsView/components/interaction/tabs/FeedbacksHistoryTab/FeedbacksHistory.stub'
 import WriteFeedbackFloatingPanel from '@/features/staff/feedbacks/views/ActivityFeedbackDetailsView/components/overlays/WriteFeedbackFloatingPanel/WriteFeedbackFloatingPanel.vue'
 import { AvFloatingPanelStub, AvTabsStub, AvTabStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { flushPromises, type VueWrapper } from '@vue/test-utils'
 import { mountComponent } from 'tests/utils'
 import { beforeEach, expect } from 'vitest'
 
 BddTest().given('a write feedback floating panel', () => {
   let wrapper: VueWrapper<InstanceType<typeof WriteFeedbackFloatingPanel>>
 
-  const mockFeedback: FeedbackDetailsDTO = {
-    id: 'feedback-1',
-    feedback: 'Test feedback',
-    activity: mockedActivityContent
-  } as FeedbackDetailsDTO
+  const mockFeedback = mockedFeedbackDetailsWithAssociations
 
   const stubs = {
     AvTabs: AvTabsStub,
     AvTab: AvTabStub,
     AvFloatingPanel: AvFloatingPanelStub,
     WriteFeedbackTab: true,
-    FeedbacksHistoryTab: true,
+    FeedbacksHistoryTab: FeedbacksHistoryTabStub,
   }
 
-  BddTest().when('the component is mounted', () => {
-    beforeEach(() => {
-      wrapper = mountComponent(WriteFeedbackFloatingPanel, {
-        props: {
-          feedback: mockFeedback,
-          activityTitle: 'Test Activity'
-        },
-        global: { stubs }
-      })
+  const mountPanel = async () => {
+    const mounted = mountComponent(WriteFeedbackFloatingPanel, {
+      props: {
+        feedback: mockFeedback,
+        activityTitle: 'Test Activity'
+      },
+      global: { stubs }
+    })
+    await flushPromises()
+    return mounted
+  }
+
+  const getHistoryTab = () => wrapper.findComponent(FeedbacksHistoryTabStub)
+  const getHistoryTabTitle = () => wrapper.findAllComponents(AvTabStub)[1].props('title')
+
+  BddTest().when('the feedback history is loaded', () => {
+    beforeEach(async () => {
+      wrapper = await mountPanel()
     })
 
     BddTest().then('it should render the floating panel', () => {
@@ -42,10 +49,53 @@ BddTest().given('a write feedback floating panel', () => {
       expect(wrapper.findComponent(AvTabsStub).exists()).toBe(true)
     })
 
-    BddTest().then('it should render the write feedback tab with feedback prop', () => {
+    BddTest().then('it should render the write feedback tab with the feedback prop', () => {
       const writeFeedbackTab = wrapper.findComponent({ name: 'WriteFeedbackTab' })
       expect(writeFeedbackTab.exists()).toBe(true)
       expect(writeFeedbackTab.props('feedback')).toEqual(mockFeedback)
+    })
+
+    BddTest().then('it should pass the feedback history and max iterations to the history tab', () => {
+      const historyTab = getHistoryTab()
+      expect(historyTab.exists()).toBe(true)
+      expect(historyTab.props('feedbacks')).toEqual(mockedFeedbackHistory)
+      expect(historyTab.props('maxIterations')).toBe(mockFeedback.activity.feedbackAllowedIterations)
+    })
+
+    BddTest().then('it should forward the loaded state to the history tab', () => {
+      const historyTab = getHistoryTab()
+      expect(historyTab.props('isLoading')).toBe(false)
+      expect(historyTab.props('error')).toBe(null)
+    })
+
+    BddTest().then('it should display the history count in the tab title', () => {
+      expect(getHistoryTabTitle()).toContain(`(${mockedFeedbackHistory.length})`)
+    })
+  })
+
+  BddTest().when('the feedback history is empty', () => {
+    beforeEach(async () => {
+      server.use(createGetFeedbackHistoryHandler([]))
+      wrapper = await mountPanel()
+    })
+
+    BddTest().then('it should pass an empty list to the history tab', () => {
+      expect(getHistoryTab().props('feedbacks')).toEqual([])
+    })
+
+    BddTest().then('it should display a zero count in the tab title', () => {
+      expect(getHistoryTabTitle()).toContain('(0)')
+    })
+  })
+
+  BddTest().when('the feedback history fails to load', () => {
+    beforeEach(async () => {
+      server.use(getFeedbackHistoryErrorHandler)
+      wrapper = await mountPanel()
+    })
+
+    BddTest().then('it should forward the error to the history tab', () => {
+      expect(getHistoryTab().props('error')).toBeTruthy()
     })
   })
 })

--- a/src/features/staff/feedbacks/views/ActivityFeedbackDetailsView/components/overlays/WriteFeedbackFloatingPanel/WriteFeedbackFloatingPanel.vue
+++ b/src/features/staff/feedbacks/views/ActivityFeedbackDetailsView/components/overlays/WriteFeedbackFloatingPanel/WriteFeedbackFloatingPanel.vue
@@ -1,5 +1,6 @@
 <script lang="ts" setup>
 import type { FeedbackDetailsDTO } from '@/api/avenir-esr'
+import { useGetFeedbackHistory } from '@/api/avenir-esr'
 import { ICONS } from '@/common/constants'
 import FeedbacksHistoryTab from '@/features/staff/feedbacks/views/ActivityFeedbackDetailsView/components/interaction/tabs/FeedbacksHistoryTab/FeedbacksHistoryTab.vue'
 import WriteFeedbackTab from '@/features/staff/feedbacks/views/ActivityFeedbackDetailsView/components/interaction/tabs/WriteFeedbackTab/WriteFeedbackTab.vue'
@@ -11,7 +12,7 @@ export interface WriteFeedbackFloatingPanelProps {
   activityTitle: string
 }
 
-defineProps<WriteFeedbackFloatingPanelProps>()
+const { feedback, activityTitle } = defineProps<WriteFeedbackFloatingPanelProps>()
 
 enum WriteFeedbackFloatingPanelTabs {
   MY_FEEDBACK = 0,
@@ -26,6 +27,28 @@ const panelRef = ref<InstanceType<typeof AvFloatingPanel> | null>(null)
 function togglePanel () {
   panelRef.value?.toggleCollapsed()
 }
+
+const activityId = computed(() => feedback.declaredActivityId)
+
+const {
+  data: feedbackHistory,
+  isLoading: isHistoryLoading,
+  error: historyError,
+} = useGetFeedbackHistory(activityId, {
+  query: {
+    enabled: computed(() => !!activityId.value),
+  },
+})
+
+const feedbacks = computed(() => feedbackHistory.value ?? [])
+const feedbacksCount = computed(() => feedbacks.value.length)
+const maxIterations = computed(() => feedback.activity.feedbackAllowedIterations)
+
+const historyTabTitle = computed(() =>
+  t('staff.feedbacks.views.ActivityFeedbackDetailsView.WriteFeedbackFloatingPanel.tabs.history.title', {
+    count: feedbacksCount.value,
+  })
+)
 </script>
 
 <template>
@@ -55,10 +78,15 @@ function togglePanel () {
           />
         </AvTab>
         <AvTab
-          :title="t('staff.feedbacks.views.ActivityFeedbackDetailsView.WriteFeedbackFloatingPanel.tabs.history.title')"
+          :title="historyTabTitle"
           :name="WriteFeedbackFloatingPanelTabs.HISTORY"
         >
-          <FeedbacksHistoryTab />
+          <FeedbacksHistoryTab
+            :feedbacks="feedbacks"
+            :max-iterations="maxIterations"
+            :is-loading="isHistoryLoading"
+            :error="historyError"
+          />
         </AvTab>
       </AvTabs>
     </div>


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> Ce PR câble l'historique des feedbacks dans le `WriteFeedbackFloatingPanel` et finalise le `FeedbacksHistoryTab` :
> - Appel au `feedback-controller` via `getFeedbackHistory` (`useGetFeedbackHistory`) pour récupérer la liste des `FeedbackOverviewDTO` à partir du `declaredActivityId` de la demande courante.
> - Le nombre de feedbacks remontés est injecté dans le titre de l'onglet d'historique (clé `...WriteFeedbackFloatingPanel.tabs.history.title` avec `{count}`).
> - La liste (ainsi que `maxIterations`, l'état de chargement et l'erreur) est transmise au `FeedbacksHistoryTab`, qui instancie un `FeedbackHistoryCard` par feedback dans un `QuerySuspense` (gestion des états chargement / erreur / vide).
> - Affichage d'un message dédié « Vous n'avez aucun feedback précédent » lorsque la liste est vide.

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1763

---

### Documentation
> Aucune mise à jour de documentation nécessaire.
> - Ajout des clés i18n `tabs.history.emptyState` (FR/EN) et correction de la coquille `feedabacks` → `feedbacks`.
> - Synchronisation de la spec API (`api-specs/avenir-esr.swagger.json`) avec l'endpoint `getFeedbackHistory`.

---

### Target Branch
> `develop`

---

### Additional Notes
> - L'identifiant utilisé pour l'appel est `feedback.declaredActivityId` (et non `activity.id`), conformément au nouveau champ exposé par `FeedbackDetailsDTO`.
> - `maxIterations` est dérivé de `feedback.activity.feedbackAllowedIterations`.
> - L'itération de chaque carte est calculée par position (`feedbacks.length - index`), la plus récente en tête recevant le numéro le plus élevé.
> - Le `FeedbacksHistoryTab` réutilise le composant `FeedbackHistoryCard` (issue #1762) et le pattern `QuerySuspense` déjà en place dans la feature.

---

### Known Limitations or Side Effects
> Aucun. Le composant reste affiché tant que `showWriteFeedbackPanel` est vrai côté `ActivityFeedbackDetailsView`.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [x] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process
