### PR TITLE
feat(1785): integrate catalog preview on staff activity details page

### DIFF
--- a/src/common/activities/components/ActivityCatalogHeader/ActivityCatalogHeader.vue
+++ b/src/common/activities/components/ActivityCatalogHeader/ActivityCatalogHeader.vue
@@ -37,26 +37,28 @@ const {
         data-testid="activity-banner"
       >
     </Card>
-    <AvIconText
-      :icon="ICONS.ACTIVITY"
-      icon-color="var(--icon)"
-      :text="title"
-      text-color="var(--dark-background-primary1)"
-      typography-class="n2"
-      gap="var(--spacing-md)"
-      inline
-      wrap-anywhere
-      data-testid="activity-title"
-    />
-    <div class="av-row av-wrap av-gap-xs av-pl-5xl">
-      <ActivityThematicBadge
-        :thematic="thematic"
-        data-testid="activity-thematic-badge"
+    <div class="av-col av-gap-md">
+      <AvIconText
+        :icon="ICONS.ACTIVITY"
+        icon-color="var(--icon)"
+        :text="title"
+        text-color="var(--dark-background-primary1)"
+        typography-class="n2"
+        gap="var(--spacing-md)"
+        inline
+        wrap-anywhere
+        data-testid="activity-title"
       />
-      <DeclaredActivityStatusBadge
-        v-if="subscribedDeclaredActivity"
-        :status="EDeclaredActivityStatus.SUBSCRIBED"
-      />
+      <div class="av-row av-wrap av-gap-xs av-pl-5xl">
+        <ActivityThematicBadge
+          :thematic="thematic"
+          data-testid="activity-thematic-badge"
+        />
+        <DeclaredActivityStatusBadge
+          v-if="subscribedDeclaredActivity"
+          :status="EDeclaredActivityStatus.SUBSCRIBED"
+        />
+      </div>
     </div>
   </div>
 </template>

--- a/src/common/activities/components/ActivityCatalogPreviewCard/ActivityCatalogPreviewCard.vue
+++ b/src/common/activities/components/ActivityCatalogPreviewCard/ActivityCatalogPreviewCard.vue
@@ -28,7 +28,7 @@ const { t } = useI18n()
     <div class="av-col av-gap-sm">
       <div class="av-col av-row--md av-justify-between--md av-gap-xl">
         <div class="av-col av-flex-fill av-gap-md">
-          <span class="n4 av-text-primary1">{{ t('global.activities.components.ActivityCatalogPreviewCard.previewTitle') }}</span>
+          <span class="n4 av-text-primary1 av-text-regular">{{ t('global.activities.components.ActivityCatalogPreviewCard.previewTitle') }}</span>
           <span
             class="s2-regular av-text-text1"
             data-testid="activity-summary"
@@ -37,7 +37,7 @@ const { t } = useI18n()
           </span>
         </div>
         <div class="av-col av-flex-fill av-gap-md">
-          <span class="n4 av-text-primary1">{{ t('global.activities.components.ActivityCatalogPreviewCard.periodTitle') }}</span>
+          <span class="n4 av-text-primary1 av-text-regular">{{ t('global.activities.components.ActivityCatalogPreviewCard.periodTitle') }}</span>
           <span
             class="s2-bold av-text-primary1"
             data-testid="activity-execution-period-info"

--- a/src/features/staff/activities/locales/en.json
+++ b/src/features/staff/activities/locales/en.json
@@ -85,6 +85,11 @@
           "errors": {
             "fetchActivityContent": "Unable to load activity"
           },
+          "NationalActivityCatalogPreviewTab": {
+            "errors": {
+              "fetchActivityPresentation": "Unable to load activity preview"
+            }
+          },
           "NationalActivityContentTab": {
             "scheduleTitle": "Activity schedule",
             "title": "Activity content"
@@ -94,6 +99,10 @@
               "feedbackIterations": "0 iterations | {count} iteration | {count} iterations",
               "unlimitedIterations": "Unlimited iterations"
             }
+          },
+          "tabs": {
+            "content": "Content",
+            "preview": "Catalog Preview"
           },
           "title": "All activities available in my institution"
         },

--- a/src/features/staff/activities/locales/fr.json
+++ b/src/features/staff/activities/locales/fr.json
@@ -85,6 +85,11 @@
           "errors": {
             "fetchActivityContent": "Impossible de charger l'activité"
           },
+          "NationalActivityCatalogPreviewTab": {
+            "errors": {
+              "fetchActivityPresentation": "Impossible de charger l'aperçu de l'activité"
+            }
+          },
           "NationalActivityContentTab": {
             "scheduleTitle": "Déroulé de l'activité",
             "title": "Contenu de l'activité"
@@ -94,6 +99,10 @@
               "feedbackIterations": "{count} itération | {count} itérations",
               "unlimitedIterations": "Itérations illimitées"
             }
+          },
+          "tabs": {
+            "content": "Contenu",
+            "preview": "Extrait du catalogue"
           },
           "title": "Toutes les activités disponibles dans mon établissement"
         },

--- a/src/features/staff/activities/views/NationalActivityCatalogView/NationalActivityCatalogView.test.ts
+++ b/src/features/staff/activities/views/NationalActivityCatalogView/NationalActivityCatalogView.test.ts
@@ -7,14 +7,19 @@ import { PageTitleStub } from '@/common/components/PageTitle/PageTitle.stub'
 import { QuerySuspenseStub } from '@/common/components/QuerySuspense/QuerySuspense.stub'
 import { ROUTES } from '@/common/constants'
 import { DeleteDraftActivityConfirmationModalStub } from '@/features/staff/activities/components/modals/DeleteDraftActivityConfirmationModal/DeleteDraftActivityConfirmationModal.stub'
+import { NationalActivityCatalogPreviewTabStub } from '@/features/staff/activities/views/NationalActivityCatalogView/components/NationalActivityCatalogPreviewTab/NationalActivityCatalogPreviewTab.stub'
 import { NationalActivityContentTabStub } from '@/features/staff/activities/views/NationalActivityCatalogView/components/NationalActivityContentTab/NationalActivityContentTab.stub'
 import NationalActivityCatalogView from '@/features/staff/activities/views/NationalActivityCatalogView/NationalActivityCatalogView.vue'
-import { AvButtonStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { AvButtonStub, AvTabsStub, AvTabStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { mountComponent } from 'tests/utils'
 import { beforeEach, expect, vi } from 'vitest'
 
 const mockNavigateToStaffActivities = vi.fn()
 const mockNavigateToStaffActivitiesEditNationalActivity = vi.fn()
+
+vi.mock('@/common/composables/use-enum-route-query/use-enum-route-query', () => ({
+  useEnumRouteQuery: vi.fn(() => ref(0)),
+}))
 
 vi.mock('@/common/composables/use-navigation/use-navigation', () => ({
   useNavigation: () => ({
@@ -29,9 +34,12 @@ BddTest().given('a national activity catalog view', () => {
   const stubs = {
     PageTitle: PageTitleStub,
     QuerySuspense: QuerySuspenseStub,
+    NationalActivityCatalogPreviewTab: NationalActivityCatalogPreviewTabStub,
     NationalActivityContentTab: NationalActivityContentTabStub,
     AvButton: AvButtonStub,
     DeleteDraftActivityConfirmationModal: DeleteDraftActivityConfirmationModalStub,
+    AvTabs: AvTabsStub,
+    AvTab: AvTabStub,
   }
 
   const mountView = (status = EActivityStatus.DRAFT, id = mockedActivityContent.id) => mountComponent(NationalActivityCatalogView, {

--- a/src/features/staff/activities/views/NationalActivityCatalogView/NationalActivityCatalogView.vue
+++ b/src/features/staff/activities/views/NationalActivityCatalogView/NationalActivityCatalogView.vue
@@ -2,12 +2,14 @@
 import { EActivityStatus, useGetActivityContent } from '@/api/avenir-esr'
 import { QuerySuspense } from '@/common/components'
 import PageTitle from '@/common/components/PageTitle/PageTitle.vue'
+import { useEnumRouteQuery } from '@/common/composables/use-enum-route-query/use-enum-route-query'
 import { useModal } from '@/common/composables/use-modal/use-modal'
 import { useNavigation } from '@/common/composables/use-navigation/use-navigation'
 import { ROUTES } from '@/common/constants'
 import DeleteDraftActivityConfirmationModal from '@/features/staff/activities/components/modals/DeleteDraftActivityConfirmationModal/DeleteDraftActivityConfirmationModal.vue'
+import NationalActivityCatalogPreviewTab from '@/features/staff/activities/views/NationalActivityCatalogView/components/NationalActivityCatalogPreviewTab/NationalActivityCatalogPreviewTab.vue'
 import NationalActivityContentTab from '@/features/staff/activities/views/NationalActivityCatalogView/components/NationalActivityContentTab/NationalActivityContentTab.vue'
-import { AvButton, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
+import { AvButton, AvTab, AvTabs, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
 import { useI18n } from 'vue-i18n'
 
 interface NationalActivityCatalogViewProps {
@@ -32,6 +34,13 @@ const isDraft = computed(() => status === EActivityStatus.DRAFT)
 const { showModal: showDeleteConfirmation, displayModal: displayDeleteConfirmation, hideModal: hideDeleteConfirmation } = useModal()
 
 const { navigateToStaffActivities, navigateToStaffActivitiesEditNationalActivity } = useNavigation()
+
+enum NationalActivityCatalogTabs {
+  CONTENT = 0,
+  PREVIEW = 1,
+}
+
+const activeTab = useEnumRouteQuery('tab', NationalActivityCatalogTabs, NationalActivityCatalogTabs.CONTENT)
 </script>
 
 <template>
@@ -67,9 +76,26 @@ const { navigateToStaffActivities, navigateToStaffActivitiesEditNationalActivity
     :error="error"
     :error-title="t('staff.activities.views.NationalActivityCatalogView.errors.fetchActivityContent')"
   >
-    <div class="av-col av-flex-fill">
-      <NationalActivityContentTab :activity="activity!" />
-    </div>
+    <AvTabs
+      v-if="activity"
+      v-model="activeTab"
+    >
+      <AvTab
+        :title="t('staff.activities.views.NationalActivityCatalogView.tabs.content')"
+        :icon="MDI_ICONS.FILE_DOCUMENT_BOX_MULTIPLE_OUTLINE"
+      >
+        <NationalActivityContentTab :activity="activity" />
+      </AvTab>
+      <AvTab
+        :title="t('staff.activities.views.NationalActivityCatalogView.tabs.preview')"
+        :icon="MDI_ICONS.BOOK_OPEN_VARIANT"
+      >
+        <NationalActivityCatalogPreviewTab
+          :activity-id="activity.id"
+          :status="status"
+        />
+      </AvTab>
+    </AvTabs>
   </QuerySuspense>
 
   <DeleteDraftActivityConfirmationModal

--- a/src/features/staff/activities/views/NationalActivityCatalogView/components/NationalActivityCatalogPreviewTab/NationalActivityCatalogPreviewTab.stub.ts
+++ b/src/features/staff/activities/views/NationalActivityCatalogView/components/NationalActivityCatalogPreviewTab/NationalActivityCatalogPreviewTab.stub.ts
@@ -1,0 +1,17 @@
+import type { EActivityStatus } from '@/api/avenir-esr'
+import type { PropType } from 'vue'
+
+export const NationalActivityCatalogPreviewTabStub = defineComponent({
+  name: 'NationalActivityCatalogPreviewTab',
+  template: '<div data-testid="national-activity-catalog-preview-tab-stub"></div>',
+  props: {
+    activityId: {
+      type: String,
+      required: true,
+    },
+    status: {
+      type: String as PropType<EActivityStatus>,
+      required: true,
+    },
+  },
+})

--- a/src/features/staff/activities/views/NationalActivityCatalogView/components/NationalActivityCatalogPreviewTab/NationalActivityCatalogPreviewTab.test.ts
+++ b/src/features/staff/activities/views/NationalActivityCatalogView/components/NationalActivityCatalogPreviewTab/NationalActivityCatalogPreviewTab.test.ts
@@ -1,0 +1,77 @@
+import type { VueWrapper } from '@vue/test-utils'
+import { mockedActivityDetail } from '@/__mocks__/fixtures/student/activities.fixtures'
+import { EActivityStatus } from '@/api/avenir-esr'
+import { ActivityCatalogHeaderStub } from '@/common/activities/components/ActivityCatalogHeader/ActivityCatalogHeader.stub'
+import { ActivityCatalogPreviewCardStub } from '@/common/activities/components/ActivityCatalogPreviewCard/ActivityCatalogPreviewCard.stub'
+import { QuerySuspenseStub } from '@/common/components/QuerySuspense/QuerySuspense.stub'
+import NationalActivityCatalogPreviewTab from '@/features/staff/activities/views/NationalActivityCatalogView/components/NationalActivityCatalogPreviewTab/NationalActivityCatalogPreviewTab.vue'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { mountComponent } from 'tests/utils'
+import { beforeEach, expect, vi } from 'vitest'
+
+BddTest().given('a national activity catalog preview tab', () => {
+  let wrapper: VueWrapper<InstanceType<typeof NationalActivityCatalogPreviewTab>>
+
+  const stubs = {
+    ActivityCatalogHeader: ActivityCatalogHeaderStub,
+    ActivityCatalogPreviewCard: ActivityCatalogPreviewCardStub,
+    QuerySuspense: QuerySuspenseStub,
+  }
+
+  const mountTab = (activityId = 'activity-1') => mountComponent(NationalActivityCatalogPreviewTab, {
+    props: { activityId, status: EActivityStatus.DRAFT },
+    global: { stubs },
+  })
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    wrapper = mountTab()
+    await vi.waitFor(() => {
+      expect(wrapper.findComponent(ActivityCatalogHeaderStub).exists()).toBe(true)
+    })
+  })
+
+  BddTest().when('the component is mounted with a valid activityId', () => {
+    BddTest().then('it should render the container', () => {
+      expect(wrapper.find('[data-testid="national-activity-catalog-preview-tab"]').exists()).toBe(true)
+    })
+
+    BddTest().then('it should render ActivityCatalogHeader with the correct title', () => {
+      expect(wrapper.findComponent(ActivityCatalogHeaderStub).props('title')).toBe(mockedActivityDetail.title)
+    })
+
+    BddTest().then('it should render ActivityCatalogHeader with the correct thematic', () => {
+      expect(wrapper.findComponent(ActivityCatalogHeaderStub).props('thematic')).toBe(mockedActivityDetail.thematic)
+    })
+
+    BddTest().then('it should render ActivityCatalogHeader with the correct banner', () => {
+      expect(wrapper.findComponent(ActivityCatalogHeaderStub).props('banner')).toEqual(mockedActivityDetail.banner)
+    })
+
+    BddTest().then('it should render ActivityCatalogPreviewCard with the correct summary', () => {
+      expect(wrapper.findComponent(ActivityCatalogPreviewCardStub).props('summary')).toBe(mockedActivityDetail.summary)
+    })
+
+    BddTest().then('it should render ActivityCatalogPreviewCard with the correct executionPeriodInfo', () => {
+      expect(wrapper.findComponent(ActivityCatalogPreviewCardStub).props('executionPeriodInfo')).toBe(mockedActivityDetail.executionPeriodInfo)
+    })
+  })
+
+  BddTest().when('the component is mounted with an invalid activityId', () => {
+    beforeEach(() => {
+      wrapper = mountTab('INVALID_ACTIVITY_ID')
+    })
+
+    BddTest().then('it should render QuerySuspense with an error', async () => {
+      await vi.waitFor(() => {
+        expect(wrapper.findComponent(QuerySuspenseStub).props('error')).toBeTruthy()
+      })
+    })
+
+    BddTest().then('it should render QuerySuspense with the correct error title', async () => {
+      await vi.waitFor(() => {
+        expect(wrapper.findComponent(QuerySuspenseStub).props('errorTitle')).toBe('Impossible de charger l\'aperçu de l\'activité')
+      })
+    })
+  })
+})

--- a/src/features/staff/activities/views/NationalActivityCatalogView/components/NationalActivityCatalogPreviewTab/NationalActivityCatalogPreviewTab.vue
+++ b/src/features/staff/activities/views/NationalActivityCatalogView/components/NationalActivityCatalogPreviewTab/NationalActivityCatalogPreviewTab.vue
@@ -1,0 +1,46 @@
+<script setup lang="ts">
+import { type EActivityStatus, useGetActivityPresentation } from '@/api/avenir-esr'
+import ActivityCatalogHeader from '@/common/activities/components/ActivityCatalogHeader/ActivityCatalogHeader.vue'
+import ActivityCatalogPreviewCard from '@/common/activities/components/ActivityCatalogPreviewCard/ActivityCatalogPreviewCard.vue'
+import { QuerySuspense } from '@/common/components'
+import { useI18n } from 'vue-i18n'
+
+interface NationalActivityCatalogPreviewTabProps {
+  activityId: string
+  status: EActivityStatus
+}
+
+const { activityId, status } = defineProps<NationalActivityCatalogPreviewTabProps>()
+
+const { t } = useI18n()
+const {
+  data: presentation,
+  isLoading,
+  error
+} = useGetActivityPresentation(status, activityId)
+</script>
+
+<template>
+  <div data-testid="national-activity-catalog-preview-tab">
+    <QuerySuspense
+      :is-loading="isLoading"
+      :error="error"
+      :error-title="t('staff.activities.views.NationalActivityCatalogView.NationalActivityCatalogPreviewTab.errors.fetchActivityPresentation')"
+    >
+      <div
+        v-if="presentation"
+        class="av-col av-gap-lg"
+      >
+        <ActivityCatalogHeader
+          :banner="presentation.banner"
+          :title="presentation.title"
+          :thematic="presentation.thematic"
+        />
+        <ActivityCatalogPreviewCard
+          :summary="presentation.summary"
+          :execution-period-info="presentation.executionPeriodInfo"
+        />
+      </div>
+    </QuerySuspense>
+  </div>
+</template>

--- a/src/features/staff/activities/views/NationalActivityCatalogView/components/NationalActivityContentTab/NationalActivityContentTab.test.ts
+++ b/src/features/staff/activities/views/NationalActivityCatalogView/components/NationalActivityContentTab/NationalActivityContentTab.test.ts
@@ -41,7 +41,7 @@ BddTest().given('a national activity content tab', () => {
       const titleComponent = title.getComponent(AvIconTextStub)
       expect(titleComponent.props('text')).toBe(mockedActivityContent.title)
       expect(titleComponent.props('icon')).toBe(ICONS.ACTIVITY)
-      expect(title.attributes('typography-class')).toBe('n4')
+      expect(title.attributes('typography-class')).toBe('n4 av-text-regular')
     })
 
     BddTest().then('it should render the thematic badge with the activity thematic', () => {

--- a/src/features/staff/activities/views/NationalActivityCatalogView/components/NationalActivityContentTab/NationalActivityContentTab.vue
+++ b/src/features/staff/activities/views/NationalActivityCatalogView/components/NationalActivityContentTab/NationalActivityContentTab.vue
@@ -27,7 +27,7 @@ const { t } = useI18n()
       <AvIconText
         :icon="ICONS.ACTIVITY"
         :text="activity.title"
-        typography-class="n4"
+        typography-class="n4 av-text-regular"
         text-color="var(--dark-background-primary1)"
         icon-color="var(--icon)"
         data-testid="national-activity-content-tab-title"
@@ -45,13 +45,19 @@ const { t } = useI18n()
     >
       <div class="av-row--md av-justify-between--md av-gap-xl">
         <div class="av-col av-gap-sm">
-          <h4 data-testid="national-activity-content-tab-consign-title">
+          <h4
+            data-testid="national-activity-content-tab-consign-title"
+            class="av-text-primary1 av-text-regular"
+          >
             {{ t('staff.activities.interactions.formFields.ActivityConsignFormField.label') }}
           </h4>
           <ActivityDescriptionContent :description="activity.description" />
         </div>
         <div class="av-col av-gap-sm">
-          <h4 data-testid="national-activity-content-tab-context-title">
+          <h4
+            data-testid="national-activity-content-tab-context-title"
+            class="av-text-primary1 av-text-regular"
+          >
             {{ t('staff.activities.interactions.formFields.ActivityExecutionPeriodFormField.label') }}
           </h4>
           <ActivityExecutionPeriodList :execution-period-info="activity.executionPeriodInfo" />
@@ -62,10 +68,3 @@ const { t } = useI18n()
     <NationalActivitySettingDetails :activity="activity" />
   </div>
 </template>
-
-<style lang="scss" scoped>
-:deep(.n4) {
-  color: var(--dark-background-primary1);
-  font-weight: var(--font-weight-regular);
-}
-</style>


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
Integrates a catalog preview tab into the staff activity details page, allowing staff to view activity catalog information alongside activity content. This feature includes adding a new preview tab component, updating the activity view structure, and refactoring the ActivityCatalogHeader component.

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes #1785

---

### Documentation
- Added new translations for the preview tab in English and French
- New component: `NationalActivityCatalogPreviewTab` with complete test coverage
- Refactored `ActivityCatalogHeader` component with improved styling

---

### Target Branch
\`develop\`

---

### Additional Notes
The implementation follows the existing feature patterns with:
- New tab component properly scoped and tested
- Integration with existing NationalActivityCatalogView
- Comprehensive unit tests for tab functionality
- Proper i18n structure for translations

---

### Known Limitations or Side Effects
None identified.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [x] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [x] i18n handled (texts are translated)
- [x] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [x] Semantic Versioning respected
- [x] Add to \`CHANGELOG.md\` file all properties and database change and details for the update process

---