### PR TITLE
feat(1786): implement staff activity catalog preview e2e tests

### DIFF
--- a/e2e/framework/staff/activities/StaffNationalActivityCatalogPage.ts
+++ b/e2e/framework/staff/activities/StaffNationalActivityCatalogPage.ts
@@ -3,6 +3,7 @@ import { BasePage } from '@e2e/framework/shared/base/BasePage'
 import { STAFF_ROUTES } from '@e2e/framework/shared/constants/routes'
 import { clickOnElement } from '@e2e/framework/shared/utils/click'
 import { waitForPageLoad } from '@e2e/framework/shared/utils/waits'
+import { NationalActivityCatalogPreviewTabObject } from '@e2e/framework/staff/activities/componentObjects/NationalActivityCatalogPreviewTabObject'
 import { expect, type Page } from '@playwright/test'
 import { Fixture, Given, Then, When } from 'playwright-bdd/decorators'
 
@@ -30,6 +31,18 @@ export class StaffNationalActivityCatalogPage extends BasePage {
 
   private getContextTitle () {
     return this.page.getByTestId('national-activity-content-tab-context-title')
+  }
+
+  private getContentTabSelector () {
+    return this.page.getByTestId('national-activity-catalog-content-tab-item')
+  }
+
+  private getPreviewTabSelector () {
+    return this.page.getByTestId('national-activity-catalog-preview-tab-item')
+  }
+
+  private getPreviewTabObject () {
+    return new NationalActivityCatalogPreviewTabObject(this.page)
   }
 
   @Given('the staff navigates to the first national activity catalog page')
@@ -87,6 +100,51 @@ export class StaffNationalActivityCatalogPage extends BasePage {
   @Then('the national activity context section is visible')
   async verifyContextSectionVisible () {
     await expect(this.getContextTitle()).toBeVisible()
+  }
+
+  @Then('the national activity catalog content tab selector is visible')
+  async verifyContentTabSelectorVisible () {
+    await expect(this.getContentTabSelector()).toBeVisible()
+  }
+
+  @Then('the national activity catalog preview tab selector is visible')
+  async verifyPreviewTabSelectorVisible () {
+    await expect(this.getPreviewTabSelector()).toBeVisible()
+  }
+
+  @When('the user clicks on the national activity catalog preview tab')
+  async clickPreviewTab () {
+    await clickOnElement(this.getPreviewTabSelector())
+  }
+
+  @Then('the national activity catalog preview tab is displayed')
+  async verifyPreviewTabDisplayed () {
+    await this.getPreviewTabObject().isVisible()
+  }
+
+  @Then('the activity title is visible in the preview tab')
+  async verifyActivityTitleInPreviewTab () {
+    await this.getPreviewTabObject().verifyTitleVisible()
+  }
+
+  @Then('the activity banner is visible in the preview tab')
+  async verifyActivityBannerInPreviewTab () {
+    await this.getPreviewTabObject().verifyBannerVisible()
+  }
+
+  @Then('the activity thematic is visible in the preview tab')
+  async verifyActivityThematicInPreviewTab () {
+    await this.getPreviewTabObject().verifyThematicVisible()
+  }
+
+  @Then('the activity summary is visible in the preview tab')
+  async verifyActivitySummaryInPreviewTab () {
+    await this.getPreviewTabObject().verifySummaryVisible()
+  }
+
+  @Then('the execution context information is visible in the preview tab')
+  async verifyExecutionContextInPreviewTab () {
+    await this.getPreviewTabObject().verifyExecutionPeriodInfoVisible()
   }
 
   getEditDraftButton () {

--- a/e2e/framework/staff/activities/componentObjects/NationalActivityCatalogPreviewTabObject.ts
+++ b/e2e/framework/staff/activities/componentObjects/NationalActivityCatalogPreviewTabObject.ts
@@ -1,0 +1,49 @@
+import { BaseObject } from '@e2e/framework/shared/base/BaseObject'
+import { verifyTextLocator } from '@e2e/framework/shared/utils/text'
+import { expect, type Page } from '@playwright/test'
+
+export class NationalActivityCatalogPreviewTabObject extends BaseObject {
+  constructor (protected page: Page) {
+    super(page.getByTestId('national-activity-catalog-preview-tab'), page)
+  }
+
+  private getTitle () {
+    return this.getRoot().getByTestId('activity-title')
+  }
+
+  private getBanner () {
+    return this.getRoot().getByTestId('activity-banner')
+  }
+
+  private getThematic () {
+    return this.getRoot().getByTestId('activity-thematic-badge')
+  }
+
+  private getSummary () {
+    return this.getRoot().getByTestId('activity-summary')
+  }
+
+  private getExecutionPeriodInfo () {
+    return this.getRoot().getByTestId('activity-execution-period-info')
+  }
+
+  async verifyTitleVisible () {
+    await verifyTextLocator(this.getTitle())
+  }
+
+  async verifyBannerVisible () {
+    await expect(this.getBanner()).toBeVisible()
+  }
+
+  async verifyThematicVisible () {
+    await expect(this.getThematic()).toBeVisible()
+  }
+
+  async verifySummaryVisible () {
+    await verifyTextLocator(this.getSummary())
+  }
+
+  async verifyExecutionPeriodInfoVisible () {
+    await expect(this.getExecutionPeriodInfo()).toBeVisible()
+  }
+}

--- a/e2e/tests/staff/activities/national-activity-catalog.feature
+++ b/e2e/tests/staff/activities/national-activity-catalog.feature
@@ -29,6 +29,35 @@ Feature: Staff National Activity Catalog
   Scenario: The delete draft button is visible
     Then the delete draft button is visible
 
+  Scenario: The national activity catalog content tab selector is visible
+    Then the national activity catalog content tab selector is visible
+
+  Scenario: The national activity catalog preview tab selector is visible
+    Then the national activity catalog preview tab selector is visible
+
+  Rule: Catalog preview tab
+
+    Background:
+      When the user clicks on the national activity catalog preview tab
+
+    Scenario: The preview tab is displayed
+      Then the national activity catalog preview tab is displayed
+
+    Scenario: The activity title is visible in the preview tab
+      Then the activity title is visible in the preview tab
+
+    Scenario: The activity banner is visible in the preview tab
+      Then the activity banner is visible in the preview tab
+
+    Scenario: The activity thematic is visible in the preview tab
+      Then the activity thematic is visible in the preview tab
+
+    Scenario: The activity summary is visible in the preview tab
+      Then the activity summary is visible in the preview tab
+
+    Scenario: The execution context information is visible in the preview tab
+      Then the execution context information is visible in the preview tab
+
 
   Rule: Edit draft activity
 

--- a/src/features/staff/activities/views/NationalActivityCatalogView/NationalActivityCatalogView.vue
+++ b/src/features/staff/activities/views/NationalActivityCatalogView/NationalActivityCatalogView.vue
@@ -83,12 +83,14 @@ const activeTab = useEnumRouteQuery('tab', NationalActivityCatalogTabs, National
       <AvTab
         :title="t('staff.activities.views.NationalActivityCatalogView.tabs.content')"
         :icon="MDI_ICONS.FILE_DOCUMENT_BOX_MULTIPLE_OUTLINE"
+        data-testid="national-activity-catalog-content-tab-item"
       >
         <NationalActivityContentTab :activity="activity" />
       </AvTab>
       <AvTab
         :title="t('staff.activities.views.NationalActivityCatalogView.tabs.preview')"
         :icon="MDI_ICONS.BOOK_OPEN_VARIANT"
+        data-testid="national-activity-catalog-preview-tab-item"
       >
         <NationalActivityCatalogPreviewTab
           :activity-id="activity.id"


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
Implements E2E tests for staff activity catalog preview feature, including test page objects and feature file for national activity catalog preview tab.

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1786

Related to user story #1529

---

### Documentation
Added E2E test files:
- `StaffNationalActivityCatalogPage.ts` - Page object for staff national activity catalog
- `NationalActivityCatalogPreviewTabObject.ts` - Tab object for catalog preview
- `national-activity-catalog.feature` - BDD feature file with test scenarios

---

### Target Branch
develop

---

### Additional Notes
Tests verify:
- Page display and rendering
- Element visibility and structure
- Integration with backend catalog data

---

### Known Limitations or Side Effects
None identified

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [x] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [x] i18n handled (texts are translated)
- [x] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [x] Semantic Versioning respected
- [x] Add to `CHANGELOG.md` file all properties and database change and detaiils for the update process