### PR TITLE
test(1803): add e2e tests for us 1676 update feedback request

### DIFF
--- a/e2e/framework/student/lifeProject/activityDetails/StudentProjectActivityDetails.ts
+++ b/e2e/framework/student/lifeProject/activityDetails/StudentProjectActivityDetails.ts
@@ -148,19 +148,35 @@ export class StudentProjectActivityDetails extends BasePage {
     await this.getMyPerspectiveSection().verifyRequestFeedbackButtonHidden()
   }
 
-  @Then('the request feedback button is disabled')
-  async verifyRequestFeedbackButtonDisabled () {
-    await this.getMyPerspectiveSection().verifyRequestFeedbackButtonDisabled()
-  }
-
   @Then('the request feedback button is enabled')
   async verifyRequestFeedbackButtonEnabled () {
     await this.getMyPerspectiveSection().verifyRequestFeedbackButtonEnabled()
   }
 
+  @Then('the update feedback button is visible')
+  async verifyUpdateFeedbackButtonVisible () {
+    await this.getMyPerspectiveSection().verifyUpdateFeedbackButtonVisible()
+  }
+
+  @Then('the update feedback button is hidden')
+  async verifyUpdateFeedbackButtonHidden () {
+    await this.getMyPerspectiveSection().verifyUpdateFeedbackButtonHidden()
+  }
+
+  @Then('the update feedback button is enabled')
+  async verifyUpdateFeedbackButtonEnabled () {
+    await this.getMyPerspectiveSection().verifyUpdateFeedbackButtonEnabled()
+  }
+
   @When('the student clicks the request feedback button')
   async clickRequestFeedbackButton () {
     await this.getMyPerspectiveSection().clickRequestFeedbackButton()
+    await this.getMyPerspectiveSection().waitForRequestFeedbackConfirmModalVisible()
+  }
+
+  @When('the student clicks the update feedback button')
+  async clickUpdateFeedbackButton () {
+    await this.getMyPerspectiveSection().clickUpdateFeedbackButton()
     await this.getMyPerspectiveSection().waitForRequestFeedbackConfirmModalVisible()
   }
 
@@ -187,6 +203,11 @@ export class StudentProjectActivityDetails extends BasePage {
   @Then('the feedback hint is hidden')
   async verifyFeedbackHintHidden () {
     await this.getMyPerspectiveSection().verifyFeedbackHintHidden()
+  }
+
+  @Then('the updatable feedback hint is visible')
+  async verifyUpdatableFeedbackHintVisible () {
+    await this.getMyPerspectiveSection().verifyUpdatableFeedbackHintVisible()
   }
 
   @Then('the finished hint is visible')

--- a/e2e/framework/student/lifeProject/activityDetails/componentObjects/MyPerspectiveSectionObject.ts
+++ b/e2e/framework/student/lifeProject/activityDetails/componentObjects/MyPerspectiveSectionObject.ts
@@ -47,6 +47,10 @@ export class MyPerspectiveSectionObject extends BaseObject {
     return this.root.getByTestId('request-feedback-button')
   }
 
+  getUpdateFeedbackButton () {
+    return this.root.getByTestId('update-feedback-button')
+  }
+
   getRequestFeedbackConfirmModal () {
     return this.root.page().getByTestId('request-feedback-confirm-modal')
   }
@@ -57,6 +61,10 @@ export class MyPerspectiveSectionObject extends BaseObject {
 
   getFeedbackHint () {
     return this.root.getByTestId('actions-hint').and(this.root.locator('[data-type="feedback-pending"], [data-type="max-feedback-reached"]'))
+  }
+
+  getUpdatableFeedbackHint () {
+    return this.root.getByTestId('actions-hint').and(this.root.locator('[data-type="updatable-feedback"]'))
   }
 
   getFinishedHint () {
@@ -180,16 +188,28 @@ export class MyPerspectiveSectionObject extends BaseObject {
     await expect(this.getRequestFeedbackButton()).toBeHidden()
   }
 
-  async verifyRequestFeedbackButtonDisabled () {
-    await expect(this.getRequestFeedbackButton()).toBeDisabled()
-  }
-
   async verifyRequestFeedbackButtonEnabled () {
     await expect(this.getRequestFeedbackButton()).toBeEnabled()
   }
 
+  async verifyUpdateFeedbackButtonVisible () {
+    await expect(this.getUpdateFeedbackButton()).toBeVisible()
+  }
+
+  async verifyUpdateFeedbackButtonHidden () {
+    await expect(this.getUpdateFeedbackButton()).toBeHidden()
+  }
+
+  async verifyUpdateFeedbackButtonEnabled () {
+    await expect(this.getUpdateFeedbackButton()).toBeEnabled()
+  }
+
   async clickRequestFeedbackButton () {
     await clickOnElement(this.getRequestFeedbackButton())
+  }
+
+  async clickUpdateFeedbackButton () {
+    await clickOnElement(this.getUpdateFeedbackButton())
   }
 
   async waitForRequestFeedbackConfirmModalVisible () {
@@ -214,6 +234,10 @@ export class MyPerspectiveSectionObject extends BaseObject {
 
   async verifyFeedbackHintHidden () {
     await expect(this.getFeedbackHint()).toBeHidden()
+  }
+
+  async verifyUpdatableFeedbackHintVisible () {
+    await expect(this.getUpdatableFeedbackHint()).toBeVisible()
   }
 
   async verifyFinishedHintVisible () {

--- a/e2e/tests/student/lifeProject/activityDetails/activityDetails.feature
+++ b/e2e/tests/student/lifeProject/activityDetails/activityDetails.feature
@@ -96,6 +96,7 @@ Feature: Student Project Activity Detail Page
       And the student clicks the my perspective item in the activity side menu
       And the my perspective section is visible
       Then the request feedback button is hidden
+      And the update feedback button is hidden
       And the feedback hint is hidden
 
     @high @activity-details @feedback-request
@@ -113,13 +114,14 @@ Feature: Student Project Activity Detail Page
       Then the request feedback confirmation modal is hidden
 
     @high @activity-details @feedback-request
-    Scenario: Student with submitted activity has enabled feedback button and pending hint
+    Scenario: Student with submitted activity has enabled update feedback button and updatable feedback hint
       And the student clicks a library activity card with "SUBMITTED" status
       And the project activity details are loaded
       And the student clicks the my perspective item in the activity side menu
       And the my perspective section is visible
-      Then the request feedback button is enabled
-      And the feedback hint is visible
+      Then the update feedback button is visible
+      And the update feedback button is enabled
+      And the updatable feedback hint is visible
 
     @high @activity-details @feedback-request
     Scenario: Student with completed activity has no feedback button and finished hint is visible
@@ -128,6 +130,7 @@ Feature: Student Project Activity Detail Page
       And the student clicks the my perspective item in the activity side menu
       And the my perspective section is visible
       Then the request feedback button is hidden
+      And the update feedback button is hidden
       And the finished hint is visible
 
   Rule: Received feedbacks

--- a/src/__mocks__/fixtures/student/activities.fixtures.ts
+++ b/src/__mocks__/fixtures/student/activities.fixtures.ts
@@ -7,6 +7,7 @@ import {
   type DeclaredActivityViewDTO,
   EActivityThematic,
   EDeclaredActivityStatus,
+  EFeedbackStatus,
   EFileType,
   ETraceAuthorType,
   type PagedResponseAssociationSearchResultDeclaredActivityDTO,
@@ -342,7 +343,7 @@ export const mockedFinishedDeclaredActivityDetails: DeclaredActivityDetailsDTO =
   finishedAt: '2026-01-01T00:00:00Z',
 }
 
-export function createMockedDeclaredActivityDetails (id: string): DeclaredActivityDetailsDTO {
+export function createMockedDeclaredActivityDetails (id: string, options?: { withFeedback?: boolean }): DeclaredActivityDetailsDTO {
   const selectedActivity = allDeclaredActivities.find(activity => activity.id === id)
 
   const activity = selectedActivity
@@ -379,6 +380,16 @@ export function createMockedDeclaredActivityDetails (id: string): DeclaredActivi
       ? mockedFinishedDeclaredActivityDetails.finishedAt
       : '',
     reflection: mockedDeclaredActivityDetails.reflection,
+    feedbacks: options?.withFeedback
+      ? [{
+          id: 'feedback-new-1',
+          status: EFeedbackStatus.NEW,
+          createdAt: '2024-01-15T10:00:00Z',
+          updatedAt: '2024-01-16T10:00:00Z',
+          staff: { id: 'staff-1', firstName: 'Marc', lastName: 'Dupont', email: 'marc.dupont@university.com' },
+          student: { id: 'student-1', firstName: 'Lucas', lastName: 'Tessier', email: 'lucas.tessier@university.com' },
+        }]
+      : undefined,
   }
 }
 

--- a/src/__mocks__/msw/handlers/student/activities.handlers.ts
+++ b/src/__mocks__/msw/handlers/student/activities.handlers.ts
@@ -19,6 +19,7 @@ import {
   type DeclaredActivityAssociationsDTO,
   type DeclaredActivityDetailsDTO,
   EActivityStatus,
+  EDeclaredActivityStatus,
   EErrorCode,
   getAskForFeedbackUrl,
   getAssociateActivityWithDeclaredSkillsUrl,
@@ -168,7 +169,10 @@ export const declaredActivityDetailsHandler = http.get(`*${getGetDeclaredActivit
     )
   }
 
-  const baseDetails = createMockedDeclaredActivityDetails(declaredActivityId)
+  const tempDetails = createMockedDeclaredActivityDetails(declaredActivityId)
+  const baseDetails = createMockedDeclaredActivityDetails(declaredActivityId, {
+    withFeedback: tempDetails.status === EDeclaredActivityStatus.SUBMITTED,
+  })
   const overrides = declaredActivityDetailsOverrides.get(declaredActivityId)
 
   return HttpResponse.json<DeclaredActivityDetailsDTO>(

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/interactions/RequestFeedback/RequestFeedback.vue
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/interactions/RequestFeedback/RequestFeedback.vue
@@ -44,7 +44,7 @@ function handleConfirm () {
     data-testid="request-feedback"
   >
     <AvButton
-      data-testid="request-feedback-button"
+      :data-testid="feedbackStatus === EFeedbackStatus.NEW ? 'update-feedback-button' : 'request-feedback-button'"
       v-bind="requestFeedbackConfig"
       :disabled="disabled"
       :is-loading="isLoading"


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
Update e2e tests to reflect new feedback request button behavior: SUBMITTED activity now shows an enabled "Update" button instead of a disabled "Send" button. Added data-status attribute on the button and updated MSW handler to return a NEW feedback for SUBMITTED activities.

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1803

---

### Target Branch
develop

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [x] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [x] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and detaiils for the update process