### PR TITLE
fix(2061): make toggler labels configurable

### DIFF
--- a/src/common/components/Toggle/Toggle.test.ts
+++ b/src/common/components/Toggle/Toggle.test.ts
@@ -1,32 +1,51 @@
-import Toggle from '@/common/components/Toggle/Toggle.vue'
-import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import type { VueWrapper } from '@vue/test-utils'
+import Toggle, { type ToggleProps } from '@/common/components/Toggle/Toggle.vue'
+import { AvToggleStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { mount } from '@vue/test-utils'
-import { expect } from 'vitest'
-
-const AvToggleStub = {
-  name: 'AvToggle',
-  props: ['activeText', 'inactiveText', 'modelValue'],
-  template: `<div class="av-toggle-stub">
-    <span data-test="active-text">{{ activeText }}</span>
-    <span data-test="inactive-text">{{ inactiveText }}</span>
-  </div>`
-}
 
 BddTest().given('a Toggle component', () => {
-  BddTest().when('the component is mounted', () => {
-    BddTest().then('it should render an AvToggle with correct translated labels', () => {
-      const wrapper = mount(Toggle, {
-        props: {
-          modelValue: true,
-          description: 'test'
-        },
-        global: {
-          stubs: { AvToggle: AvToggleStub }
-        }
-      })
+  let wrapper: VueWrapper<InstanceType<typeof Toggle>>
 
-      expect(wrapper.find('[data-test="active-text"]').text()).toBe('Oui')
-      expect(wrapper.find('[data-test="inactive-text"]').text()).toBe('Non')
+  const stubs = {
+    AvToggle: AvToggleStub
+  }
+
+  function mountDefault (props: Partial<ToggleProps> = {}) {
+    wrapper = mount(Toggle, {
+      props: {
+        modelValue: true,
+        description: 'test',
+        ...props
+      },
+      global: { stubs }
+    })
+  }
+
+  const getToggle = () => wrapper.findComponent(AvToggleStub)
+
+  BddTest().when('the component is mounted', () => {
+    beforeEach(() => mountDefault())
+
+    BddTest().then('it should render with default props', () => {
+      const toggle = getToggle()
+      expect(toggle.props('description')).toBe('test')
+      expect(toggle.props('activeText')).toBe('Oui')
+      expect(toggle.props('inactiveText')).toBe('Non')
+    })
+  })
+
+  BddTest().when('the component is mounted with custom props', () => {
+    beforeEach(() => mountDefault({
+      description: 'Some description',
+      activeText: 'Activé',
+      inactiveText: 'Désactivé'
+    }))
+
+    BddTest().then('it should render with custom props', () => {
+      const toggle = getToggle()
+      expect(toggle.props('description')).toBe('Some description')
+      expect(toggle.props('activeText')).toBe('Activé')
+      expect(toggle.props('inactiveText')).toBe('Désactivé')
     })
   })
 })

--- a/src/common/components/Toggle/Toggle.vue
+++ b/src/common/components/Toggle/Toggle.vue
@@ -3,7 +3,7 @@ import { AvToggle, type AvToggleProps } from '@avenirs-esr/avenirs-dsav'
 import { type ComputedRef, useAttrs } from 'vue'
 import { useI18n } from 'vue-i18n'
 
-export interface ToggleProps extends Omit<AvToggleProps, 'activeText' | 'inactiveText'> { }
+export interface ToggleProps extends AvToggleProps { }
 
 const props = defineProps<ToggleProps>()
 const { t } = useI18n()
@@ -12,8 +12,8 @@ const attrs = useAttrs()
 const avToggleProps: ComputedRef<AvToggleProps> = computed(() => ({
   ...attrs,
   ...props,
-  activeText: t('global.avToggle.activeText'),
-  inactiveText: t('global.avToggle.inactiveText')
+  activeText: props.activeText ?? t('global.avToggle.activeText'),
+  inactiveText: props.inactiveText ?? t('global.avToggle.inactiveText')
 }))
 </script>
 


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
- Add support for customizable `activeText` and `inactiveText` props in the shared Toggle component, using the current labels as defaults

---

### Reference to an Issue, Feature, Task, User Story or another PR
- Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/2061

---

**Modified areas:**
- `src/common/components/Toggle/Toggle.test.ts`
- `src/common/components/Toggle/Toggle.vue`

---

### Target Branch
`develop`

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process