### PR TITLE
feat(activities): adapt swagger and FE to draft update endpoint refactor

### DIFF
--- a/api-specs/avenir-esr.swagger.json
+++ b/api-specs/avenir-esr.swagger.json
@@ -1811,23 +1811,15 @@
         }
       }
     },
-    "/me/activities/{activityStatus}/{activityId}": {
+    "/me/activities/{activityDraftId}": {
       "patch": {
         "tags": [
           "activity-controller"
         ],
-        "operationId": "updateActivity",
+        "operationId": "updateActivityDraft",
         "parameters": [
           {
-            "name": "activityStatus",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/EActivityStatus"
-            }
-          },
-          {
-            "name": "activityId",
+            "name": "activityDraftId",
             "in": "path",
             "required": true,
             "schema": {

--- a/src/__mocks__/msw/handlers/staffs/activities.handlers.ts
+++ b/src/__mocks__/msw/handlers/staffs/activities.handlers.ts
@@ -2,7 +2,7 @@ import type { ActivityContentDTO, ActivityDraftCreationResponse, ActivityDraftUp
 import { createMockedBannerUploadResponse, createMockedPagedResponseActivityStaffOverviewDTO, mockedActivityContent, mockedActivityDraftCreationResponse, mockedActivityDraftUpdateResponse } from '@/__mocks__/fixtures/staffs/activities.fixtures'
 import { mockedActivityDetail } from '@/__mocks__/fixtures/student/activities.fixtures'
 import { createEmptyPaginatedDatasetResponse, isEmptyDataSetRequest } from '@/__mocks__/msw/utils'
-import { EActivityStatus, EErrorCode, EFileCategory, getCreateActivityDraftUrl, getDeleteActivityDraftUrl, getGetActivityContentUrl, getGetActivityPresentationUrl, getGetStaffActivityLibraryUrl, getGetStaffActivityWorkingSpaceUrl, getPublishActivityDraftUrl, getUpdateActivityUrl, getUploadFileUrl } from '@/api/avenir-esr'
+import { EActivityStatus, EErrorCode, EFileCategory, getCreateActivityDraftUrl, getDeleteActivityDraftUrl, getGetActivityContentUrl, getGetActivityPresentationUrl, getGetStaffActivityLibraryUrl, getGetStaffActivityWorkingSpaceUrl, getPublishActivityDraftUrl, getUpdateActivityDraftUrl, getUploadFileUrl } from '@/api/avenir-esr'
 import { ErrorCodes } from '@/common/constants/error-codes'
 import { HttpStatusCode } from '@/common/utils/http/http-status'
 import { http, HttpResponse } from 'msw'
@@ -130,14 +130,14 @@ export const staffsActivitiesHandlers = [
       headers: { 'Content-Type': 'application/json' },
     })
   }),
-  http.patch(`*${getUpdateActivityUrl(EActivityStatus.DRAFT, ':activityId')}`, ({ params }) => {
-    const activityId: string | undefined = params.activityId as string | undefined
+  http.patch(`*${getUpdateActivityDraftUrl(':activityDraftId')}`, ({ params }) => {
+    const activityDraftId: string | undefined = params.activityDraftId as string | undefined
 
-    if (!activityId) {
+    if (!activityDraftId) {
       return HttpResponse.json({ error: 'Activity ID is required', code: ErrorCodes.NOT_BLANK }, { status: 400 })
     }
 
-    if (activityId === 'INVALID_ACTIVITY_ID') {
+    if (activityDraftId === 'INVALID_ACTIVITY_ID') {
       return HttpResponse.json(
         { code: EErrorCode.ACTIVITY_NOT_FOUND, message: 'Activity not found' },
         { status: 404, headers: { 'Content-Type': 'application/json' } }

--- a/src/features/staff/activities/views/EditNationalActivityView/EditNationalActivityView.vue
+++ b/src/features/staff/activities/views/EditNationalActivityView/EditNationalActivityView.vue
@@ -10,7 +10,7 @@ import {
   useDeleteFile,
   useGetActivityContent,
   useGetActivityPresentation,
-  useUpdateActivity,
+  useUpdateActivityDraft,
   useUploadFile
 } from '@/api/avenir-esr'
 import { QuerySuspense } from '@/common/components'
@@ -94,7 +94,7 @@ const defaultValues: EditActivityFormData = reactive({
 
 const { mutateAsync: uploadBannerMutation } = useUploadFile()
 const { mutateAsync: deleteBannerMutation } = useDeleteFile()
-const { mutateAsync: updateActivity } = useUpdateActivity()
+const { mutateAsync: updateActivity } = useUpdateActivityDraft()
 
 const form = useForm({
   defaultValues,
@@ -162,8 +162,7 @@ async function saveBanner (action: EditActivityFormDataBannerAction) {
 
 async function saveActivity (data: ActivityDraftUpdateRequest) {
   await updateActivity({
-    activityStatus: EActivityStatus.DRAFT,
-    activityId: id,
+    activityDraftId: id,
     data,
   })
 }


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> Adapts the frontend to the backend refactor of the activity draft update endpoint: `PATCH /me/activities/{activityStatus}/{activityId}` becomes `PATCH /me/activities/{activityDraftId}` (`updateActivity` → `updateActivityDraft`). Updates the swagger spec, the MSW mock handler (and fixes a stale `params.activityId` reference that broke the mock after the rename), and `EditNationalActivityView.vue` to use the new `useUpdateActivityDraft` hook and `activityDraftId` param.

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/2092

---

### Documentation
> Swagger spec (`api-specs/avenir-esr.swagger.json`) updated to reflect the new endpoint shape.

---

### Target Branch
> `develop`

---

### Additional Notes
> While fixing the mock handler, found and fixed a bug where it still read `params.activityId` instead of `params.activityDraftId`, which caused `EditNationalActivityView.test.ts` to fail (mutation always returned 400). Also verified that the remaining pre-existing test failures in the repo (timezone-dependent `date.test.ts` assertions, and flaky trace-creation tests) are unrelated to this change.

---

### Known Limitations or Side Effects
> None identified.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [x] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process