### PR TITLE
feat(2098): rename 'Ma prise de revcul' to 'Ma réflexion' in activity 

### DIFF
--- a/e2e/framework/student/lifeProject/activityDetails/StudentProjectActivityDetails.ts
+++ b/e2e/framework/student/lifeProject/activityDetails/StudentProjectActivityDetails.ts
@@ -83,7 +83,7 @@ export class StudentProjectActivityDetails extends BasePage {
 
   @When('the student clicks the my perspective item in the activity side menu')
   async clickMyPerspectiveItemInSideMenu () {
-    await this.getActivityDetailedSideNavigation().getByText('Ma prise de recul').click()
+    await this.getActivityDetailedSideNavigation().getByText('Ma réflexion').click()
   }
 
   @Then('the my perspective section is visible')

--- a/src/features/student/buildProject/locales/en.json
+++ b/src/features/student/buildProject/locales/en.json
@@ -98,7 +98,7 @@
               "triggerLabel": "Manage my activity"
             },
             "ActivityDetailedSideNavigation": {
-              "myPerspective": "My perspective"
+              "myReflection": "My reflection"
             },
             "AssociatedTracesCard": {
               "title": "My associated trace ({count}) | My associated traces ({count})"

--- a/src/features/student/buildProject/locales/fr.json
+++ b/src/features/student/buildProject/locales/fr.json
@@ -97,7 +97,7 @@
               "triggerLabel": "Gérer mon activité"
             },
             "ActivityDetailedSideNavigation": {
-              "myPerspective": "Ma prise de recul"
+              "myReflection": "Ma réflexion"
             },
             "AssociatedTracesCard": {
               "title": "Ma trace associée ({count}) | Mes traces associées ({count})"

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/ProjectActivityDetailedLayout/ProjectActivityDetailedLayout.test.ts
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/ProjectActivityDetailedLayout/ProjectActivityDetailedLayout.test.ts
@@ -134,7 +134,7 @@ BddTest().given('a project activity detailed layout component', () => {
         },
         {
           id: ProjectActivityDetailedSections.MY_PERSPECTIVE,
-          label: 'Ma prise de recul',
+          label: 'Ma réflexion',
           icon: MS_ICONS.FEATURED_PLAY_LIST_OUTLINE,
         },
       ])

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/ProjectActivityDetailedLayout/ProjectActivityDetailedLayout.vue
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/ProjectActivityDetailedLayout/ProjectActivityDetailedLayout.vue
@@ -36,7 +36,7 @@ const items = computed(() => [
     ? [
         {
           id: ProjectActivityDetailedSections.MY_PERSPECTIVE,
-          label: t('student.buildProject.activities.views.ProjectActivityDetailedView.ActivityDetailedSideNavigation.myPerspective'),
+          label: t('student.buildProject.activities.views.ProjectActivityDetailedView.ActivityDetailedSideNavigation.myReflection'),
           icon: MS_ICONS.FEATURED_PLAY_LIST_OUTLINE,
         }
       ]


### PR DESCRIPTION


## 📝 Pull Request Description

### Brief description of changes applied
<!-- Describe the changes introduced by this pull request. -->
Rename 'Ma prise de revcul' to 'Ma réflexion' in activity sidebar


---

### Reference to an Issue, Feature, Task, User Story or another PR
<!-- Mention related issue numbers or links (e.g. Closes #123, Implements #456). -->
<!-- Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/### -->
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/2093
---
<img width="379" height="615" alt="image" src="https://github.com/user-attachments/assets/c1b127bf-923a-49ba-9d14-5234ac9f8d2d" />


