### PR TITLE
fix(2076): update feedback request button states and status handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,54 @@ npm install @avenirs-esr/avenirs-dsav
 
 ## Contributing
 
+### Business Rules
+
+**IMPORTANT**: When a component relies on an important business rule (a non-trivial condition that decides whether an action is allowed, a value that must be derived from domain data, etc.), that rule **MUST** be extracted into a dedicated `rules` file rather than being inlined in the component.
+
+#### Why?
+
+- Business rules are the part of the code most likely to change and to be reused across components
+- Keeping them in the component buries domain logic inside presentation concerns
+- Extracted rules are pure functions that are trivial to unit test in isolation
+- A single source of truth prevents the same rule from being re-implemented (and drifting) in several places
+
+#### Where do they live?
+
+Activity-related rules live in `src/common/activities/rules/activities.rules.ts`. More generally, put rules in a `rules/` folder scoped to the domain they belong to (`src/common/{domain}/rules/{domain}.rules.ts`, or inside the relevant feature when the rule is feature-specific).
+
+#### Pattern
+
+Each rule is an exported, documented pure function that takes the domain DTO(s) and returns a primitive/derived value:
+
+```typescript
+// src/common/activities/rules/activities.rules.ts
+import { type DeclaredActivityDetailsDTO, EFeedbackStatus } from '@/api/avenir-esr'
+
+export function computeRemainingFeedbacks (declaredActivityDetails: DeclaredActivityDetailsDTO) {
+  return declaredActivityDetails.activity.feedbackAllowedIterations - (declaredActivityDetails.feedbacks?.length ?? 0)
+}
+
+export function canCreateFeedbackRequest (declaredActivityDetails: DeclaredActivityDetailsDTO, remainingFeedbacks: number) {
+  const lastFeedback = declaredActivityDetails.feedbacks?.at(0)
+  return remainingFeedbacks !== 0 && lastFeedback?.status !== EFeedbackStatus.IN_PROCESS
+}
+```
+
+The component just consumes the rule (typically wrapped in a `computed`):
+
+```typescript
+import { canCreateFeedbackRequest, computeRemainingFeedbacks } from '@/common/activities/rules/activities.rules'
+
+const remainingFeedbacks = computed(() => computeRemainingFeedbacks(declaredActivityDetails))
+const isRequestFeedbackDisabled = computed(() => !canCreateFeedbackRequest(declaredActivityDetails, remainingFeedbacks.value))
+```
+
+Rules must be:
+- **Pure** — no side effects, no API calls, no store access
+- **Unit tested** — co-located `*.rules.test.ts` following the project's BDD testing conventions
+
+Reference implementation: `src/common/activities/rules/activities.rules.ts` used by `PerspectiveTabActions.vue`.
+
 ### Stub Files and Barrel Exports
 
 **IMPORTANT**: Stub files (`.stub.ts`) should **NEVER** be exported from feature barrel files (`index.ts`).

--- a/src/common/activities/rules/activities.rules.test.ts
+++ b/src/common/activities/rules/activities.rules.test.ts
@@ -1,0 +1,148 @@
+import type { DeclaredActivityDetailsDTO, FeedbackOverviewDTO, UserInfoDTO } from '@/api/avenir-esr'
+import { mockedDeclaredActivityDetails } from '@/__mocks__/fixtures/student/activities.fixtures'
+import { EFeedbackStatus } from '@/api/avenir-esr'
+import { canCreateFeedbackRequest, computeRemainingFeedbacks } from '@/common/activities/rules/activities.rules'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { expect } from 'vitest'
+
+const baseUser: UserInfoDTO = {
+  id: 'user-1',
+  firstName: 'Jean',
+  lastName: 'Dupont',
+  email: 'jean.dupont@example.com'
+}
+
+function buildFeedback (status: EFeedbackStatus, id = 'feedback-1'): FeedbackOverviewDTO {
+  return {
+    id,
+    staff: baseUser,
+    student: baseUser,
+    status,
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z'
+  }
+}
+
+function buildDeclaredActivityDetails (
+  feedbackAllowedIterations: number,
+  feedbacks?: FeedbackOverviewDTO[]
+): DeclaredActivityDetailsDTO {
+  return {
+    ...mockedDeclaredActivityDetails,
+    activity: {
+      ...mockedDeclaredActivityDetails.activity,
+      feedbackAllowedIterations
+    },
+    feedbacks
+  }
+}
+
+BddTest().given('computeRemainingFeedbacks', () => {
+  BddTest().when('the activity has no feedbacks yet', () => {
+    BddTest().and('the feedbacks list is undefined', () => {
+      BddTest().then('it should return the full allowed iterations count', () => {
+        const declaredActivityDetails = buildDeclaredActivityDetails(3, undefined)
+        expect(computeRemainingFeedbacks(declaredActivityDetails)).toBe(3)
+      })
+    })
+
+    BddTest().and('the feedbacks list is empty', () => {
+      BddTest().then('it should return the full allowed iterations count', () => {
+        const declaredActivityDetails = buildDeclaredActivityDetails(3, [])
+        expect(computeRemainingFeedbacks(declaredActivityDetails)).toBe(3)
+      })
+    })
+  })
+
+  BddTest().when('the activity has some feedbacks', () => {
+    BddTest().then('it should subtract the number of feedbacks from the allowed iterations', () => {
+      const declaredActivityDetails = buildDeclaredActivityDetails(3, [
+        buildFeedback(EFeedbackStatus.SUBMITTED, 'feedback-1'),
+        buildFeedback(EFeedbackStatus.SUBMITTED, 'feedback-2')
+      ])
+      expect(computeRemainingFeedbacks(declaredActivityDetails)).toBe(1)
+    })
+
+    BddTest().and('all allowed iterations have been used', () => {
+      BddTest().then('it should return zero', () => {
+        const declaredActivityDetails = buildDeclaredActivityDetails(2, [
+          buildFeedback(EFeedbackStatus.SUBMITTED, 'feedback-1'),
+          buildFeedback(EFeedbackStatus.SUBMITTED, 'feedback-2')
+        ])
+        expect(computeRemainingFeedbacks(declaredActivityDetails)).toBe(0)
+      })
+    })
+
+    BddTest().and('more feedbacks exist than the allowed iterations', () => {
+      BddTest().then('it should return a negative number', () => {
+        const declaredActivityDetails = buildDeclaredActivityDetails(1, [
+          buildFeedback(EFeedbackStatus.SUBMITTED, 'feedback-1'),
+          buildFeedback(EFeedbackStatus.SUBMITTED, 'feedback-2')
+        ])
+        expect(computeRemainingFeedbacks(declaredActivityDetails)).toBe(-1)
+      })
+    })
+  })
+})
+
+BddTest().given('canCreateFeedbackRequest', () => {
+  BddTest().when('there are no remaining feedbacks', () => {
+    BddTest().then('it should return false regardless of the last feedback status', () => {
+      const declaredActivityDetails = buildDeclaredActivityDetails(1, [
+        buildFeedback(EFeedbackStatus.SUBMITTED)
+      ])
+      expect(canCreateFeedbackRequest(declaredActivityDetails, 0)).toBe(false)
+    })
+  })
+
+  BddTest().when('there are remaining feedbacks', () => {
+    BddTest().and('there is no existing feedback', () => {
+      BddTest().then('it should return true when the feedbacks list is empty', () => {
+        const declaredActivityDetails = buildDeclaredActivityDetails(3, [])
+        expect(canCreateFeedbackRequest(declaredActivityDetails, 3)).toBe(true)
+      })
+
+      BddTest().then('it should return true when the feedbacks list is undefined', () => {
+        const declaredActivityDetails = buildDeclaredActivityDetails(3, undefined)
+        expect(canCreateFeedbackRequest(declaredActivityDetails, 3)).toBe(true)
+      })
+    })
+
+    BddTest().and('the last feedback is being processed', () => {
+      BddTest().then('it should return false', () => {
+        const declaredActivityDetails = buildDeclaredActivityDetails(3, [
+          buildFeedback(EFeedbackStatus.IN_PROCESS)
+        ])
+        expect(canCreateFeedbackRequest(declaredActivityDetails, 2)).toBe(false)
+      })
+    })
+
+    BddTest().and('the last feedback is submitted', () => {
+      BddTest().then('it should return true', () => {
+        const declaredActivityDetails = buildDeclaredActivityDetails(3, [
+          buildFeedback(EFeedbackStatus.SUBMITTED)
+        ])
+        expect(canCreateFeedbackRequest(declaredActivityDetails, 2)).toBe(true)
+      })
+    })
+
+    BddTest().and('the last feedback is new', () => {
+      BddTest().then('it should return true', () => {
+        const declaredActivityDetails = buildDeclaredActivityDetails(3, [
+          buildFeedback(EFeedbackStatus.NEW)
+        ])
+        expect(canCreateFeedbackRequest(declaredActivityDetails, 2)).toBe(true)
+      })
+    })
+
+    BddTest().and('the most recent feedback is first in the list and being processed', () => {
+      BddTest().then('it should consider only the first feedback and return false', () => {
+        const declaredActivityDetails = buildDeclaredActivityDetails(3, [
+          buildFeedback(EFeedbackStatus.IN_PROCESS, 'feedback-recent'),
+          buildFeedback(EFeedbackStatus.SUBMITTED, 'feedback-old')
+        ])
+        expect(canCreateFeedbackRequest(declaredActivityDetails, 1)).toBe(false)
+      })
+    })
+  })
+})

--- a/src/common/activities/rules/activities.rules.ts
+++ b/src/common/activities/rules/activities.rules.ts
@@ -1,0 +1,10 @@
+import { type DeclaredActivityDetailsDTO, EFeedbackStatus } from '@/api/avenir-esr'
+
+export function computeRemainingFeedbacks (declaredActivityDetails: DeclaredActivityDetailsDTO) {
+  return declaredActivityDetails.activity.feedbackAllowedIterations - (declaredActivityDetails.feedbacks?.length ?? 0)
+}
+
+export function canCreateFeedbackRequest (declaredActivityDetails: DeclaredActivityDetailsDTO, remainingFeedbacks: number) {
+  const lastFeedback = declaredActivityDetails.feedbacks?.at(0)
+  return remainingFeedbacks !== 0 && lastFeedback?.status !== EFeedbackStatus.IN_PROCESS
+}

--- a/src/features/student/buildProject/locales/en.json
+++ b/src/features/student/buildProject/locales/en.json
@@ -168,7 +168,6 @@
               "error": "An error occurred while requesting feedback. Please try again later.",
               "feedbackPending": "Your request is being processed",
               "maximumFeedbackReached": "You have reached the maximum number of requests allowed",
-              "requestFeedbackBadge": "Sent on {date}",
               "requestFeedbackButton": {
                 "requestFeedbackLabel": "Ask for feedback",
                 "updateFeedbackLabel": "Update my feedback request"

--- a/src/features/student/buildProject/locales/fr.json
+++ b/src/features/student/buildProject/locales/fr.json
@@ -168,7 +168,6 @@
               "error": "Une erreur est survenue lors de la demande de feedback. Veuillez réessayer plus tard.",
               "feedbackPending": "Votre demande est en cours de traitement",
               "maximumFeedbackReached": "Vous avez atteint le nombre maximal de demande autorisé",
-              "requestFeedbackBadge": "Envoyée le {date}",
               "requestFeedbackButton": {
                 "requestFeedbackLabel": "Demander un feedback",
                 "updateFeedbackLabel": "Mettre à jour ma demande de feedback"

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/cards/MyPerspectiveCard/MyPerspectiveCard.test.ts
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/cards/MyPerspectiveCard/MyPerspectiveCard.test.ts
@@ -1,5 +1,5 @@
 import type { MyPerspectiveCardProps } from '@/features/student/buildProject/views/ProjectActivityDetailedView/components/cards/MyPerspectiveCard/MyPerspectiveCard.vue'
-import { EDeclaredActivityStatus, EFeedbackStatus } from '@/api/avenir-esr'
+import { EDeclaredActivityStatus } from '@/api/avenir-esr'
 import { CardStub } from '@/common/components/cards/Card/Card.stub'
 import { RichTextEditorStub } from '@/common/components/interaction/inputs/RichTextEditor/RichTextEditor.stub'
 import MyPerspectiveCard from '@/features/student/buildProject/views/ProjectActivityDetailedView/components/cards/MyPerspectiveCard/MyPerspectiveCard.vue'
@@ -385,12 +385,11 @@ BddTest().given('a my perspective card', () => {
     })
   })
 
-  BddTest().when('the component is mounted with a submitted activity and an unread feedback', () => {
+  BddTest().when('the component is mounted with a submitted activity ', () => {
     const props: MyPerspectiveCardProps = {
       activityId: 'activity-1',
       perspective: '<p>This is my perspective</p>',
       activityStatus: EDeclaredActivityStatus.SUBMITTED,
-      lastFeedbackStatus: EFeedbackStatus.NEW,
     }
 
     beforeEach(() => {
@@ -402,26 +401,6 @@ BddTest().given('a my perspective card', () => {
       const editButton = getEditButton()
       expect(editButton.exists()).toBe(true)
       expect(editButton.attributes('disabled')).toBeUndefined()
-    })
-  })
-
-  BddTest().when('the component is mounted with a submitted activity and a read feedback', () => {
-    const props: MyPerspectiveCardProps = {
-      activityId: 'activity-1',
-      perspective: '<p>This is my perspective</p>',
-      activityStatus: EDeclaredActivityStatus.SUBMITTED,
-      lastFeedbackStatus: EFeedbackStatus.IN_PROCESS,
-    }
-
-    beforeEach(() => {
-      vi.clearAllMocks()
-      wrapper = mountComponent(MyPerspectiveCard, { props, global: { stubs } })
-    })
-
-    BddTest().then('it should render the edit button as disabled', () => {
-      const editButton = getEditButton()
-      expect(editButton.exists()).toBe(true)
-      expect(editButton.attributes('disabled')).toBeDefined()
     })
   })
 })

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/cards/MyPerspectiveCard/MyPerspectiveCard.vue
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/cards/MyPerspectiveCard/MyPerspectiveCard.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { EActivityStatus, EDeclaredActivityStatus, EFeedbackStatus, invalidateGetActivityPresentation, invalidateGetDeclaredActivityDetails, useUpdateReflection } from '@/api/avenir-esr'
+import type { EFeedbackStatus } from '@/api/avenir-esr'
+import { EActivityStatus, EDeclaredActivityStatus, invalidateGetActivityPresentation, invalidateGetDeclaredActivityDetails, useUpdateReflection } from '@/api/avenir-esr'
 import Card from '@/common/components/cards/Card/Card.vue'
 import { useApiErrors } from '@/common/composables/use-api-errors/use-api-errors'
 import { useFormValidators } from '@/common/composables/use-form-validators/use-form-validators'
@@ -22,7 +23,7 @@ export interface MyPerspectiveCardProps {
   lastFeedbackStatus?: EFeedbackStatus
 }
 
-const { activityId, perspective, activityStatus, lastFeedbackStatus } = defineProps<MyPerspectiveCardProps>()
+const { activityId, perspective, activityStatus } = defineProps<MyPerspectiveCardProps>()
 
 const RichTextEditor = defineAsyncComponent(() => import('@/common/components/interaction/inputs/RichTextEditor/RichTextEditor.vue'))
 
@@ -127,7 +128,7 @@ watch(content, () => {
             :icon="MDI_ICONS.PENCIL_OUTLINE"
             variant="OUTLINED"
             small
-            :disabled="(activityStatus === EDeclaredActivityStatus.SUBMITTED && lastFeedbackStatus !== EFeedbackStatus.NEW) || activityStatus === EDeclaredActivityStatus.COMPLETED"
+            :disabled="activityStatus === EDeclaredActivityStatus.COMPLETED"
             data-testid="my-perspective-card-edit-button"
             @click="readonly = false"
           />

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/interactions/PerspectiveTabActions/PerspectiveTabActions.vue
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/interactions/PerspectiveTabActions/PerspectiveTabActions.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
 import type { BaseApiException } from '@/common/exceptions/base-api-exception/base-api.exception'
 import { type DeclaredActivityDetailsDTO, EActivityStatus, EDeclaredActivityStatus, EFeedbackStatus, invalidateGetActivityPresentation, invalidateGetDeclaredActivityDetails, useAskForFeedback, useFinish } from '@/api/avenir-esr'
+import { canCreateFeedbackRequest, computeRemainingFeedbacks } from '@/common/activities/rules/activities.rules'
 import { useApiErrors } from '@/common/composables/use-api-errors/use-api-errors'
 import { useTaskLoading } from '@/common/composables/use-task-loading/use-task-loading'
 import FinishDeclaredActivity
@@ -26,12 +27,14 @@ const { isLoading: isTaskLoading, withTaskLoading } = useTaskLoading()
 const { mutate: mutateFinish, isPending: isFinishPending } = useFinish()
 const { mutate: mutateAskForFeedback, isPending: isFeedbackPending } = useAskForFeedback()
 
-const remainingFeedbacks = computed(() => declaredActivityDetails.activity.feedbackAllowedIterations - (declaredActivityDetails.feedbacks?.length ?? 0))
+const remainingFeedbacks = computed(() => computeRemainingFeedbacks(declaredActivityDetails))
 
 const isDeclaredActivityInProgress = computed(() => declaredActivityDetails.status === EDeclaredActivityStatus.IN_PROGRESS)
 const isDeclaredActivitySubmitted = computed(() => declaredActivityDetails.status === EDeclaredActivityStatus.SUBMITTED)
 
 const lastFeedback = computed(() => declaredActivityDetails.feedbacks?.at(0))
+
+const isRequestFeedbackDisabled = computed(() => !canCreateFeedbackRequest(declaredActivityDetails, remainingFeedbacks.value))
 
 const actionsHintInfo = computed(() => {
   if (declaredActivityDetails.status === EDeclaredActivityStatus.SUBSCRIBED) {
@@ -126,7 +129,7 @@ function requestFeedback () {
         v-if="isDeclaredActivityInProgress || isDeclaredActivitySubmitted"
         :feedback-created-at="lastFeedback?.createdAt"
         :feedback-status="lastFeedback?.status "
-        :disabled="remainingFeedbacks === 0 || lastFeedback?.status === EFeedbackStatus.IN_PROCESS"
+        :disabled="isRequestFeedbackDisabled"
         :is-loading="isFeedbackPending || isFinishPending || isLoading"
         :remaining-feedbacks="remainingFeedbacks"
         @request-feedback="requestFeedback"

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/interactions/PerspectiveTabActions/PerspectiveTabActions.vue
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/interactions/PerspectiveTabActions/PerspectiveTabActions.vue
@@ -158,7 +158,7 @@ function requestFeedback () {
 
 @include dsav.min-width(md) {
   span[data-type="updatable-feedback"] {
-    width: 38%;
+    width: 40%;
   }
 }
 </style>

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/interactions/PerspectiveTabActions/PerspectiveTabActions.vue
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/interactions/PerspectiveTabActions/PerspectiveTabActions.vue
@@ -31,7 +31,7 @@ const remainingFeedbacks = computed(() => declaredActivityDetails.activity.feedb
 const isDeclaredActivityInProgress = computed(() => declaredActivityDetails.status === EDeclaredActivityStatus.IN_PROGRESS)
 const isDeclaredActivitySubmitted = computed(() => declaredActivityDetails.status === EDeclaredActivityStatus.SUBMITTED)
 
-const lastFeedback = computed(() => declaredActivityDetails.feedbacks?.at(-1))
+const lastFeedback = computed(() => declaredActivityDetails.feedbacks?.at(0))
 
 const actionsHintInfo = computed(() => {
   if (declaredActivityDetails.status === EDeclaredActivityStatus.SUBSCRIBED) {
@@ -126,7 +126,7 @@ function requestFeedback () {
         v-if="isDeclaredActivityInProgress || isDeclaredActivitySubmitted"
         :feedback-created-at="lastFeedback?.createdAt"
         :feedback-status="lastFeedback?.status "
-        :disabled="remainingFeedbacks === 0"
+        :disabled="remainingFeedbacks === 0 || lastFeedback?.status === EFeedbackStatus.IN_PROCESS"
         :is-loading="isFeedbackPending || isFinishPending || isLoading"
         :remaining-feedbacks="remainingFeedbacks"
         @request-feedback="requestFeedback"
@@ -140,7 +140,7 @@ function requestFeedback () {
     <div class="av-row av-justify-end">
       <span
         v-if="actionsHintInfo"
-        class="caption-regular av-text-text2"
+        class="caption-regular av-text-text2 av-text-right"
         data-testid="actions-hint"
         :data-type="actionsHintInfo.type"
       >
@@ -149,3 +149,13 @@ function requestFeedback () {
     </div>
   </div>
 </template>
+
+<style lang="scss" scoped>
+@use '@avenirs-esr/avenirs-dsav/mixins' as dsav;
+
+@include dsav.min-width(md) {
+  span[data-type="updatable-feedback"] {
+    width: 38%;
+  }
+}
+</style>

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/interactions/RequestFeedback/RequestFeedback.test.ts
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/interactions/RequestFeedback/RequestFeedback.test.ts
@@ -98,9 +98,9 @@ BddTest().given('a RequestFeedback component', () => {
       })
     })
 
-    BddTest().then('it should render the badge and not the button', () => {
-      expect(wrapper.findComponent(AvBadgeStub).exists()).toBe(true)
-      expect(wrapper.findComponent(AvButtonStub).exists()).toBe(false)
+    BddTest().then('it should render the button as disabled', () => {
+      expect(wrapper.findComponent(AvButtonStub).exists()).toBe(true)
+      expect(wrapper.findComponent(AvBadgeStub).exists()).toBe(false)
     })
   })
 

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/interactions/RequestFeedback/RequestFeedback.vue
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/interactions/RequestFeedback/RequestFeedback.vue
@@ -4,7 +4,7 @@ import { EFeedbackStatus } from '@/api/avenir-esr'
 import { ConfirmationModal } from '@/common/components'
 import { useModal } from '@/common/composables'
 import { formatDateLocalized } from '@/common/utils'
-import { AvBadge, AvButton, type AvButtonProps, MDI_ICONS, MS_ICONS } from '@avenirs-esr/avenirs-dsav'
+import { AvButton, type AvButtonProps, MS_ICONS } from '@avenirs-esr/avenirs-dsav'
 import { useI18n } from 'vue-i18n'
 
 export interface RequestFeedbackProps {
@@ -44,26 +44,12 @@ function handleConfirm () {
     data-testid="request-feedback"
   >
     <AvButton
-      v-if="feedbackStatus !== EFeedbackStatus.IN_PROCESS"
       data-testid="request-feedback-button"
       v-bind="requestFeedbackConfig"
       :disabled="disabled"
-
       :is-loading="isLoading"
       @click="displayModal"
     />
-    <div
-      v-else
-      class="av-row av-w-full av-justify-end"
-    >
-      <AvBadge
-        :label="t('student.buildProject.activities.views.ProjectActivityDetailedView.requestFeedbackActivity.requestFeedbackBadge', { date: feedbackCreatedAt ? formatDateLocalized(feedbackCreatedAt, locale as AvLocale) : '' })"
-        color="var(--light-foreground-primary1)"
-        background-color="var(--light-background-primary1)"
-        :icon="MDI_ICONS.CHECK_CIRCLE"
-        data-testid="finish-declared-activity-finished-badge"
-      />
-    </div>
   </div>
   <ConfirmationModal
     :show="showModal"


### PR DESCRIPTION
## 📝 Pull Request Description
### Brief description of changes applied
Fix feedback request button states and status handling. The button now correctly reflects the feedback status with different labels, icons and variants depending on whether a feedback is NEW or not. The button is disabled when a feedback is IN_PROCESS or when the maximum number of feedbacks is reached.

---
### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/2076

---
### Target Branch
develop

---
### Additional Notes
- `RequestFeedback` button shows update label/icon when feedback status is NEW
- Button is disabled when `lastFeedback.status === IN_PROCESS` or `remainingFeedbacks === 0`
- `RequestFeedback` is only shown for `IN_PROGRESS` and `SUBMITTED` statuses
- Updated unit tests accordingly

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and detaiils for the update process


https://github.com/user-attachments/assets/fade33d8-738f-4204-9733-2dcd0926fb45


