### PR TITLE
test(1781): add e2e tests for us 1668 notification settings

### DIFF
--- a/e2e/framework/shared/componentObjects/NotificationsDropdown.ts
+++ b/e2e/framework/shared/componentObjects/NotificationsDropdown.ts
@@ -1,0 +1,81 @@
+import { clickOnElement } from '@e2e/framework/shared/utils/click'
+import { expect, type Page } from '@playwright/test'
+
+export class NotificationsDropdown {
+  constructor (private page: Page) {}
+
+  private getTriggerButton () {
+    return this.page.getByTestId('notifications-popover-trigger')
+  }
+
+  private getDropdownBody () {
+    return this.page.getByTestId('notifications-popover-body')
+  }
+
+  private getTitle () {
+    return this.page.getByTestId('notifications-popover-body-title')
+  }
+
+  private getDisabledMessage () {
+    return this.page.getByTestId('notifications-popover-disabled')
+  }
+
+  private getToggleInput () {
+    return this.page.getByTestId('notification-preference-toggle-input')
+  }
+
+  private getToggleLabel () {
+    return this.page.getByTestId('notification-preference-toggle-label')
+  }
+
+  private getExitButton () {
+    return this.page.getByTestId('notifications-popover-body-close')
+  }
+
+  async open () {
+    await clickOnElement(this.getTriggerButton())
+    await expect(this.getDropdownBody()).toBeVisible()
+  }
+
+  async close () {
+    await clickOnElement(this.getExitButton())
+  }
+
+  async activateToggle () {
+    const isChecked = await this.getToggleInput().isChecked()
+    if (!isChecked) {
+      await clickOnElement(this.getToggleLabel())
+    }
+  }
+
+  async deactivateToggle () {
+    const isChecked = await this.getToggleInput().isChecked()
+    if (isChecked) {
+      await clickOnElement(this.getToggleLabel())
+    }
+  }
+
+  async verifyTitleVisible () {
+    await expect(this.getTitle()).toBeVisible()
+  }
+
+  async verifyToggleEnabled () {
+    await expect(this.getToggleInput()).toBeChecked()
+  }
+
+  async verifyToggleDisabled () {
+    await expect(this.getToggleInput()).not.toBeChecked()
+  }
+
+  async verifyDisabledMessageVisible () {
+    await expect(this.getDisabledMessage()).toBeVisible()
+  }
+
+  async verifyExitButtonVisible () {
+    await expect(this.getExitButton()).toBeVisible()
+  }
+
+  async verifyClosed () {
+    await expect(this.getDropdownBody()).toBeHidden()
+  }
+}

--- a/e2e/framework/staff/home/StaffHomePage.ts
+++ b/e2e/framework/staff/home/StaffHomePage.ts
@@ -1,6 +1,7 @@
 import type { test } from '@e2e/framework/shared/fixtures/fixtures'
 import type { Page } from '@playwright/test'
 import { BasePage } from '@e2e/framework/shared/base/BasePage'
+import { NotificationsDropdown } from '@e2e/framework/shared/componentObjects/NotificationsDropdown'
 import { UserProfileDropdown } from '@e2e/framework/shared/componentObjects/UserProfileDropdown'
 import { t } from '@e2e/framework/shared/utils/i18n'
 import { StaffOverviewWidget } from '@e2e/framework/staff/home/componentObjects/StaffOverviewWidget'
@@ -18,6 +19,10 @@ export class StaffHomePage extends BasePage {
 
   getStaffProfileDropdown () {
     return new UserProfileDropdown(this.page)
+  }
+
+  getStaffNotificationsDropdown () {
+    return new NotificationsDropdown(this.page)
   }
 
   @Given('the staff profile overview widget is visible')
@@ -58,5 +63,55 @@ export class StaffHomePage extends BasePage {
   @Then('the staff logout confirmation modal is visible')
   async verifyStaffLogoutConfirmationModalVisible () {
     await this.getStaffProfileDropdown().verifyLogoutConfirmationModalVisible()
+  }
+
+  @Given('the staff opens the notifications dropdown')
+  async openStaffNotificationsDropdown () {
+    await this.getStaffNotificationsDropdown().open()
+  }
+
+  @Then('the staff notifications dropdown title is displayed')
+  async verifyStaffNotificationsDropdownTitle () {
+    await this.getStaffNotificationsDropdown().verifyTitleVisible()
+  }
+
+  @Then('the staff notifications toggle is enabled')
+  async verifyStaffNotificationsToggleEnabled () {
+    await this.getStaffNotificationsDropdown().verifyToggleEnabled()
+  }
+
+  @Then('the staff notifications toggle is disabled')
+  async verifyStaffNotificationsToggleDisabled () {
+    await this.getStaffNotificationsDropdown().verifyToggleDisabled()
+  }
+
+  @When('the staff activates the notifications toggle')
+  async activateStaffNotificationsToggle () {
+    await this.getStaffNotificationsDropdown().activateToggle()
+  }
+
+  @When('the staff deactivates the notifications toggle')
+  async deactivateStaffNotificationsToggle () {
+    await this.getStaffNotificationsDropdown().deactivateToggle()
+  }
+
+  @Then('the staff notifications disabled message is displayed')
+  async verifyStaffNotificationsDisabledMessage () {
+    await this.getStaffNotificationsDropdown().verifyDisabledMessageVisible()
+  }
+
+  @Then('the staff exit button is displayed')
+  async verifyStaffNotificationsExitButton () {
+    await this.getStaffNotificationsDropdown().verifyExitButtonVisible()
+  }
+
+  @When('the staff clicks the exit button on the notifications dropdown')
+  async clickStaffNotificationsExitButton () {
+    await this.getStaffNotificationsDropdown().close()
+  }
+
+  @Then('the staff notifications dropdown is closed')
+  async verifyStaffNotificationsDropdownClosed () {
+    await this.getStaffNotificationsDropdown().verifyClosed()
   }
 }

--- a/e2e/framework/student/home/StudentHomePage.ts
+++ b/e2e/framework/student/home/StudentHomePage.ts
@@ -1,5 +1,6 @@
 import type { test } from '@e2e/framework/shared/fixtures/fixtures'
 import { BasePage } from '@e2e/framework/shared/base/BasePage'
+import { NotificationsDropdown } from '@e2e/framework/shared/componentObjects/NotificationsDropdown'
 import { UserProfileDropdown } from '@e2e/framework/shared/componentObjects/UserProfileDropdown'
 import { t } from '@e2e/framework/shared/utils/i18n'
 import { waitForPageLoad } from '@e2e/framework/shared/utils/waits'
@@ -58,6 +59,10 @@ class StudentHomePage extends BasePage {
 
   getStudentProfileDropdown () {
     return new UserProfileDropdown(this.page)
+  }
+
+  getStudentNotificationsDropdown () {
+    return new NotificationsDropdown(this.page)
   }
 
   @Given('the profile overview widget is visible')
@@ -338,5 +343,55 @@ class StudentHomePage extends BasePage {
   @Then('the student logout confirmation modal is visible')
   async verifyStudentLogoutConfirmationModalVisible () {
     await this.getStudentProfileDropdown().verifyLogoutConfirmationModalVisible()
+  }
+
+  @Given('the student opens the notifications dropdown')
+  async openStudentNotificationsDropdown () {
+    await this.getStudentNotificationsDropdown().open()
+  }
+
+  @Then('the student notifications dropdown title is displayed')
+  async verifyStudentNotificationsDropdownTitle () {
+    await this.getStudentNotificationsDropdown().verifyTitleVisible()
+  }
+
+  @Then('the student notifications toggle is enabled')
+  async verifyStudentNotificationsToggleEnabled () {
+    await this.getStudentNotificationsDropdown().verifyToggleEnabled()
+  }
+
+  @Then('the student notifications toggle is disabled')
+  async verifyStudentNotificationsToggleDisabled () {
+    await this.getStudentNotificationsDropdown().verifyToggleDisabled()
+  }
+
+  @When('the student activates the notifications toggle')
+  async activateStudentNotificationsToggle () {
+    await this.getStudentNotificationsDropdown().activateToggle()
+  }
+
+  @When('the student deactivates the notifications toggle')
+  async deactivateStudentNotificationsToggle () {
+    await this.getStudentNotificationsDropdown().deactivateToggle()
+  }
+
+  @Then('the student notifications disabled message is displayed')
+  async verifyStudentNotificationsDisabledMessage () {
+    await this.getStudentNotificationsDropdown().verifyDisabledMessageVisible()
+  }
+
+  @Then('the student exit button is displayed')
+  async verifyStudentNotificationsExitButton () {
+    await this.getStudentNotificationsDropdown().verifyExitButtonVisible()
+  }
+
+  @When('the student clicks the exit button on the notifications dropdown')
+  async clickStudentNotificationsExitButton () {
+    await this.getStudentNotificationsDropdown().close()
+  }
+
+  @Then('the student notifications dropdown is closed')
+  async verifyStudentNotificationsDropdownClosed () {
+    await this.getStudentNotificationsDropdown().verifyClosed()
   }
 }

--- a/e2e/tests/staff/home.feature
+++ b/e2e/tests/staff/home.feature
@@ -42,6 +42,35 @@ Feature: Staff Home Page
       When the user click on the ACTIVITIES link
       Then the page navigates to activities page
 
+  Rule: Notifications preferences
+        Background:
+          Given the staff opens the notifications dropdown
+
+          @high @notifications @dataset-full
+          Scenario: Notifications dropdown displays title and disabled state by default
+            Then the staff notifications dropdown title is displayed
+            And the staff notifications toggle is disabled
+            And the staff notifications disabled message is displayed
+            And the staff exit button is displayed
+
+          @high @notifications @dataset-full
+          Scenario: Staff can disable notifications
+            Given the staff activates the notifications toggle
+            When the staff deactivates the notifications toggle
+            Then the staff notifications toggle is disabled
+            And the staff notifications disabled message is displayed
+
+          @medium @notifications @dataset-full
+          Scenario: Staff can enable notifications
+            Given the staff deactivates the notifications toggle
+            When the staff activates the notifications toggle
+            Then the staff notifications toggle is enabled
+
+          @medium @notifications @dataset-full
+          Scenario: Staff can close the notifications dropdown
+            When the staff clicks the exit button on the notifications dropdown
+            Then the staff notifications dropdown is closed
+
   Rule: Logout
 
     @high @logout

--- a/e2e/tests/student/home.feature
+++ b/e2e/tests/student/home.feature
@@ -98,6 +98,35 @@ Feature: Student Home Page
       Then the profile button is visible
       And the language switcher is visible
 
+  Rule: Notifications preferences
+      Background:
+        Given the student opens the notifications dropdown
+
+        @high @notifications @dataset-full
+        Scenario: Notifications dropdown displays title and disabled state by default
+          Then the student notifications dropdown title is displayed
+          And the student notifications toggle is disabled
+          And the student notifications disabled message is displayed
+          And the student exit button is displayed
+
+        @high @notifications @dataset-full
+        Scenario: Student can enable notifications
+          Given the student deactivates the notifications toggle
+          When the student activates the notifications toggle
+          Then the student notifications toggle is enabled
+
+        @medium @notifications @dataset-full
+        Scenario: Student can disable notifications
+          Given the student activates the notifications toggle
+          When the student deactivates the notifications toggle
+          Then the student notifications toggle is disabled
+          And the student notifications disabled message is displayed
+
+        @medium @notifications @dataset-full
+        Scenario: Student can close the notifications dropdown
+          When the student clicks the exit button on the notifications dropdown
+          Then the student notifications dropdown is closed
+
   Rule: Logout
 
     @high @logout

--- a/src/__mocks__/fixtures/staffs/user.fixtures.ts
+++ b/src/__mocks__/fixtures/staffs/user.fixtures.ts
@@ -34,5 +34,5 @@ export const mockedStaffQuickLinks: QuickLinksDTO = {
   lastname: 'Dupont',
   hasUnseenNotification: true,
   unreadNotifications: 10,
-  notificationEnabled: true
+  notificationEnabled: false
 }

--- a/src/__mocks__/msw/handlers/staffs/user.handlers.ts
+++ b/src/__mocks__/msw/handlers/staffs/user.handlers.ts
@@ -1,4 +1,4 @@
-import { mockedStaffProfileOverview } from '@/__mocks__/fixtures/staffs/user.fixtures'
+import { mockedStaffProfileOverview, mockedStaffQuickLinks } from '@/__mocks__/fixtures/staffs/user.fixtures'
 import { quickLinksState } from '@/__mocks__/msw/common/quickLinks.state'
 import {
   EUserCategory,
@@ -40,3 +40,16 @@ export const staffUserHandlers = [
     })
   }),
 ]
+
+export const getStaffQuickLinksEnabledHandler = http.get<PathParams, QuickLinksDTO>(
+  `*${getGetQuickLinksUrl(EUserCategory.STAFF)}`,
+  () => {
+    return HttpResponse.json<QuickLinksDTO>(
+      { ...mockedStaffQuickLinks, notificationEnabled: true },
+      {
+        status: HttpStatusCode.OK,
+        headers: { 'Content-Type': 'application/json' },
+      },
+    )
+  },
+)

--- a/src/common/notifications/components/NotificationsPopover/NotificationsPopover.test.ts
+++ b/src/common/notifications/components/NotificationsPopover/NotificationsPopover.test.ts
@@ -1,3 +1,5 @@
+import { getStaffQuickLinksEnabledHandler } from '@/__mocks__/msw/handlers/staffs/user.handlers'
+import { server } from '@/__mocks__/msw/server'
 import { EUserCategory } from '@/api/avenir-esr'
 import NotificationsPopover from '@/common/notifications/components/NotificationsPopover/NotificationsPopover.vue'
 import { NotificationsPopoverBodyStub } from '@/common/notifications/components/NotificationsPopoverBody/NotificationsPopoverBody.stub'
@@ -35,7 +37,10 @@ BddTest().given('a notifications popover', () => {
   const getBody = () => wrapper.findComponent(NotificationsPopoverBodyStub)
 
   BddTest().when('notifications are enabled', () => {
-    beforeEach(() => mountDefault(EUserCategory.STAFF))
+    beforeEach(() => {
+      server.use(getStaffQuickLinksEnabledHandler)
+      return mountDefault(EUserCategory.STAFF)
+    })
 
     BddTest().then('it should render trigger with unread counter', () => {
       const trigger = getTrigger()

--- a/src/common/notifications/components/NotificationsPopoverBody/NotificationsPopoverBody.test.ts
+++ b/src/common/notifications/components/NotificationsPopoverBody/NotificationsPopoverBody.test.ts
@@ -1,4 +1,6 @@
-import { EUserCategory } from '@/api/avenir-esr'
+import { getStaffQuickLinksEnabledHandler } from '@/__mocks__/msw/handlers/staffs/user.handlers'
+import { server } from '@/__mocks__/msw/server'
+import { EUserCategory, getGetNotificationsUrl, type PagedResponseNotificationDTO } from '@/api/avenir-esr'
 import { QuerySuspenseStub } from '@/common/components/QuerySuspense/QuerySuspense.stub'
 import NotificationsPopoverBody from '@/common/notifications/components/NotificationsPopoverBody/NotificationsPopoverBody.vue'
 import { NotificationsPopoverEmptyOrDisabledStub } from '@/common/notifications/components/NotificationsPopoverEmptyOrDisabled/NotificationsPopoverEmptyOrDisabled.stub'
@@ -7,6 +9,7 @@ import { NotificationsPopoverPreferenceToggleStub } from '@/common/notifications
 import { MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
 import { AvButtonStub, AvIconTextStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { flushPromises, type VueWrapper } from '@vue/test-utils'
+import { http, HttpResponse } from 'msw'
 import { mountComponent } from 'tests/utils'
 
 BddTest().given('a notifications popover body', () => {
@@ -35,8 +38,23 @@ BddTest().given('a notifications popover body', () => {
   const getPreferenceToggle = () => wrapper.findComponent(NotificationsPopoverPreferenceToggleStub)
   const getCloseButton = () => wrapper.findComponent('[data-testid="notifications-popover-body-close"]') as VueWrapper<InstanceType<typeof AvButtonStub>>
 
+  afterEach(() => {
+    server.resetHandlers()
+  })
+
   BddTest().when('notifications are enabled', () => {
-    beforeEach(() => mountDefault(EUserCategory.STAFF))
+    beforeEach(() => {
+      server.use(
+        getStaffQuickLinksEnabledHandler,
+        http.get<never, PagedResponseNotificationDTO>(`*${getGetNotificationsUrl(EUserCategory.STAFF)}`, () => {
+          return HttpResponse.json<PagedResponseNotificationDTO>({
+            data: [],
+            page: { page: 0, pageSize: 10, totalElements: 0, totalPages: 0 },
+          })
+        }),
+      )
+      return mountDefault(EUserCategory.STAFF)
+    })
 
     BddTest().then('it should render title with unseen notification counter', () => {
       const title = getTitle()

--- a/src/common/notifications/components/NotificationsPopoverEmptyOrDisabled/NotificationsPopoverEmptyOrDisabled.test.ts
+++ b/src/common/notifications/components/NotificationsPopoverEmptyOrDisabled/NotificationsPopoverEmptyOrDisabled.test.ts
@@ -1,3 +1,5 @@
+import { getStaffQuickLinksEnabledHandler } from '@/__mocks__/msw/handlers/staffs/user.handlers'
+import { server } from '@/__mocks__/msw/server'
 import { EUserCategory } from '@/api/avenir-esr'
 import NotificationsPopoverEmptyOrDisabled from '@/common/notifications/components/NotificationsPopoverEmptyOrDisabled/NotificationsPopoverEmptyOrDisabled.vue'
 import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
@@ -34,7 +36,10 @@ BddTest().given('a notifications popover empty or disabled', () => {
   })
 
   BddTest().when('notifications enabled', () => {
-    beforeEach(() => mountDefault(EUserCategory.STAFF))
+    beforeEach(() => {
+      server.use(getStaffQuickLinksEnabledHandler)
+      return mountDefault(EUserCategory.STAFF)
+    })
 
     BddTest().then('it should render default slot content', () => {
       const noNotifications = getNoNotifications()
@@ -48,9 +53,12 @@ BddTest().given('a notifications popover empty or disabled', () => {
   })
 
   BddTest().when('a slot is provided', () => {
-    beforeEach(() => mountDefault(EUserCategory.STAFF, {
-      default: '<div data-testid="custom-slot">Custom content</div>'
-    }))
+    beforeEach(() => {
+      server.use(getStaffQuickLinksEnabledHandler)
+      return mountDefault(EUserCategory.STAFF, {
+        default: '<div data-testid="custom-slot">Custom content</div>'
+      })
+    })
 
     BddTest().then('it should render the slot content', () => {
       const slot = getCustomSlot()


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
Added E2E tests (Playwright + Cucumber/BDD) for enabling/disabling feedback request notifications, for both staff and student. New shared NotificationsDropdown component object, new steps in StaffHomePage.ts / StudentHomePage.ts, and a new Notifications preferences Rule in both home features. Covers: default disabled state, enabling, disabling, and closing the dropdown via the exit button.

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1781

---

### Target Branch
develop

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [ ] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and detaiils for the update process