### PR TITLE
fix(1804): fix update feedback confirmation modal text

### DIFF
--- a/src/common/activities/rules/activities.rules.ts
+++ b/src/common/activities/rules/activities.rules.ts
@@ -1,7 +1,12 @@
 import { type DeclaredActivityDetailsDTO, EFeedbackStatus } from '@/api/avenir-esr'
 
 export function computeRemainingFeedbacks (declaredActivityDetails: DeclaredActivityDetailsDTO) {
-  return declaredActivityDetails.activity.feedbackAllowedIterations - (declaredActivityDetails.feedbacks?.length ?? 0)
+  const { feedbackAllowedIterations } = declaredActivityDetails.activity
+  const usedFeedbacks = declaredActivityDetails.feedbacks?.length ?? 0
+
+  return feedbackAllowedIterations === -1
+    ? -1
+    : feedbackAllowedIterations - usedFeedbacks
 }
 
 export function canCreateFeedbackRequest (declaredActivityDetails: DeclaredActivityDetailsDTO, remainingFeedbacks: number) {

--- a/src/features/student/buildProject/locales/en.json
+++ b/src/features/student/buildProject/locales/en.json
@@ -171,7 +171,9 @@
               },
               "requestFeedbackConfirmModal": {
                 "description": "Are you sure you want to submit your activity? You have 1 feedback request available for this activity. | Are you sure you want to submit your activity? You have {count} feedback requests available for this activity.",
+                "descriptionUnlimited": "Are you sure you want to submit your activity? You have an unlimited number of feedback requests available for this activity.",
                 "title": "Ask for feedback"
+
               },
               "success": "Your activity has been successfully submitted. You will be notified when your referent advisor has responded.",
               "updatableFeedback": "Feedback request sent on {date}. You can update your request, this does not constitute a new iteration."

--- a/src/features/student/buildProject/locales/fr.json
+++ b/src/features/student/buildProject/locales/fr.json
@@ -171,6 +171,7 @@
               },
               "requestFeedbackConfirmModal": {
                 "description": "Êtes-vous certain(e) de vouloir soumettre votre activité ? Vous disposez encore de 1 demande de feedback pour cette activité. | Êtes-vous certain(e) de vouloir soumettre votre activité ? Vous disposez encore de {count} demandes de feedback pour cette activité.",
+                "descriptionUnlimited": "Êtes-vous certain(e) de vouloir soumettre votre activité ? Vous disposez d'un nombre illimité de demandes de feedback pour cette activité.",
                 "title": "Demander un feedback"
               },
               "success": "Votre activité a été soumise avec succès. Vous serez notifié lorsque que votre conseiller référent vous aura répondu.",

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/interactions/RequestFeedback/RequestFeedback.vue
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/interactions/RequestFeedback/RequestFeedback.vue
@@ -32,6 +32,16 @@ const requestFeedbackConfig = computed(() => ({
   variant: (feedbackStatus === EFeedbackStatus.NEW ? 'FLAT' : 'OUTLINED') as AvButtonProps['variant'],
 }))
 
+const feedbackDescription = computed(() => {
+  if (remainingFeedbacks === -1) {
+    return t('student.buildProject.activities.views.ProjectActivityDetailedView.requestFeedbackActivity.requestFeedbackConfirmModal.descriptionUnlimited')
+  }
+  return t(
+    'student.buildProject.activities.views.ProjectActivityDetailedView.requestFeedbackActivity.requestFeedbackConfirmModal.description',
+    { count: remainingFeedbacks },
+  )
+})
+
 function handleConfirm () {
   hideModal()
   emit('requestFeedback')
@@ -55,7 +65,7 @@ function handleConfirm () {
     :show="showModal"
     data-testid="request-feedback-confirm-modal"
     :title="t('student.buildProject.activities.views.ProjectActivityDetailedView.requestFeedbackActivity.requestFeedbackConfirmModal.title')"
-    :description="t('student.buildProject.activities.views.ProjectActivityDetailedView.requestFeedbackActivity.requestFeedbackConfirmModal.description', { count: remainingFeedbacks })"
+    :description="feedbackDescription"
     :is-loading="isLoading"
     @close="hideModal"
     @confirm="handleConfirm"


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
Handle the "unlimited feedbacks" case (`-1`) in the feedback request confirmation modal: show a dedicated message instead of the regular count.

---

### Reference to an Issue, Feature, Task, User Story or another PR
Related to https://github.com/avenirs-esr/AVENIRS-Project/issues/1804

---

### Target Branch
develop

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [x] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and detaiils for the update process