### PR TITLE
fix(notifications): adapt notification cards to the new parameters DTO

### DIFF
--- a/api-specs/avenir-esr.swagger.json
+++ b/api-specs/avenir-esr.swagger.json
@@ -6294,6 +6294,57 @@
           "type"
         ]
       },
+      "ActivityModifiedParameters": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/NotificationParameters"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "activityTitle": {
+                "type": "string"
+              },
+              "updatedFields": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "ACTIVITY_TITLE",
+                    "THEMATIC",
+                    "FILES_AND_LINKS",
+                    "BANNER",
+                    "SUMMARY",
+                    "DESCRIPTION",
+                    "EXECUTION_PERIOD"
+                  ]
+                }
+              }
+            }
+          }
+        ]
+      },
+      "AskForFeedbackParameters": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/NotificationParameters"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "studentFirstName": {
+                "type": "string"
+              },
+              "studentLastName": {
+                "type": "string"
+              },
+              "activityTitle": {
+                "type": "string"
+              }
+            }
+          }
+        ]
+      },
       "NotificationDTO": {
         "type": "object",
         "properties": {
@@ -6317,10 +6368,14 @@
             "format": "uuid"
           },
           "parameters": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/ActivityModifiedParameters"
+              },
+              {
+                "$ref": "#/components/schemas/AskForFeedbackParameters"
+              }
+            ]
           },
           "seen": {
             "type": "boolean"
@@ -6332,6 +6387,9 @@
           "seen",
           "type"
         ]
+      },
+      "NotificationParameters": {
+        "type": "object"
       },
       "PagedResponseNotificationDTO": {
         "type": "object",

--- a/src/features/staff/global/components/cards/ActivityFeedbackNotificationCard/ActivityFeedbackNotificationCard.test.ts
+++ b/src/features/staff/global/components/cards/ActivityFeedbackNotificationCard/ActivityFeedbackNotificationCard.test.ts
@@ -21,7 +21,11 @@ BddTest().given('an ActivityFeedbackNotificationCard', () => {
   const mockedNotification: NotificationDTO = {
     ...mockedStaffNotification,
     elementId: crypto.randomUUID(),
-    parameters: ['John', 'Doe', 'Math Exam'],
+    parameters: {
+      studentFirstName: 'John',
+      studentLastName: 'Doe',
+      activityTitle: 'Math Exam',
+    },
   }
 
   const getContent = () =>
@@ -61,10 +65,10 @@ BddTest().given('an ActivityFeedbackNotificationCard', () => {
 
     BddTest().then('it should render the translated sentence with interpolated parameters', () => {
       const content = getContent()
-      const [studentFirstName, studentLastName, activityName] = mockedNotification.parameters!
+      const { studentFirstName, studentLastName, activityTitle } = mockedNotification.parameters!
 
       expect(content.exists()).toBe(true)
-      expect(content.text()).toBe(`Vous avez reçus une nouvelle demande de feedback de ${studentLastName} ${studentFirstName} sur l'activité ${activityName}.`)
+      expect(content.text()).toBe(`Vous avez reçus une nouvelle demande de feedback de ${studentLastName} ${studentFirstName} sur l'activité ${activityTitle}.`)
     })
   })
 

--- a/src/features/staff/global/components/cards/ActivityFeedbackNotificationCard/ActivityFeedbackNotificationCard.vue
+++ b/src/features/staff/global/components/cards/ActivityFeedbackNotificationCard/ActivityFeedbackNotificationCard.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { NotificationDTO } from '@/api/avenir-esr'
+import type { AskForFeedbackParameters, NotificationDTO } from '@/api/avenir-esr'
 import { ROUTES } from '@/common/constants'
 import NotificationCard from '@/common/notifications/components/NotificationCard/NotificationCard.vue'
 import { I18nT } from 'vue-i18n'
@@ -11,7 +11,7 @@ const emit = defineEmits<{
   (e: 'seen', id: string): void
 }>()
 
-const parameters = computed(() => n.parameters !== undefined && n.parameters.length >= 3 ? n.parameters : ['', '', ''])
+const parameters = computed(() => n.parameters as AskForFeedbackParameters | undefined)
 const to = computed(() => n.elementId !== undefined
   ? ({
       name: ROUTES.STAFF.ACTIVITY_FEEDBACK_DETAILS.name,
@@ -37,11 +37,11 @@ const to = computed(() => n.elementId !== undefined
         tag="span"
       >
         <template #studentName>
-          <span class="av-text-bold">{{ parameters[1] }} {{ parameters[0] }}</span>
+          <span class="av-text-bold">{{ parameters?.studentLastName }} {{ parameters?.studentFirstName }}</span>
         </template>
 
         <template #activityName>
-          <span class="av-text-bold">{{ parameters[2] }}</span>
+          <span class="av-text-bold">{{ parameters?.activityTitle }}</span>
         </template>
       </I18nT>
     </span>

--- a/src/features/student/global/components/cards/ActivityModifiedNotificationCard/ActivityModifiedNotificationCard.test.ts
+++ b/src/features/student/global/components/cards/ActivityModifiedNotificationCard/ActivityModifiedNotificationCard.test.ts
@@ -1,6 +1,7 @@
 import type { NotificationDTO } from '@/api/avenir-esr'
 import type { VueWrapper } from '@vue/test-utils'
 import { mockedStudentNotification } from '@/__mocks__/fixtures/student/notifications.fixtures'
+import { ActivityModifiedParametersUpdatedFieldsItem } from '@/api/avenir-esr'
 import { ROUTES } from '@/common/constants'
 import { NotificationCardStub } from '@/common/notifications/components/NotificationCard/NotificationCard.stub'
 import ActivityModifiedNotificationCard from '@/features/student/global/components/cards/ActivityModifiedNotificationCard/ActivityModifiedNotificationCard.vue'
@@ -21,7 +22,10 @@ BddTest().given('an ActivityModifiedNotificationCard', () => {
   const mockedNotification: NotificationDTO = {
     ...mockedStudentNotification,
     elementId: crypto.randomUUID(),
-    parameters: ['Math Exam', 'TITLE'],
+    parameters: {
+      activityTitle: 'Math Exam',
+      updatedFields: [ActivityModifiedParametersUpdatedFieldsItem.ACTIVITY_TITLE],
+    },
   }
 
   const getContent = () => wrapper.find('[data-testid="activity-modified-notification-card-content"]')
@@ -60,22 +64,29 @@ BddTest().given('an ActivityModifiedNotificationCard', () => {
       const content = getContent()
 
       expect(content.exists()).toBe(true)
-      expect(content.text()).toBe(`L'activité "${mockedNotification.parameters![0]}" a été mise à jour. La section suivante a été modifiée : Titre.`)
+      expect(content.text()).toBe(`L'activité "${mockedNotification.parameters!.activityTitle}" a été mise à jour. La section suivante a été modifiée : Titre.`)
     })
   })
 
-  BddTest().when('notification parameters contains more than 2 elements', () => {
+  BddTest().when('notification parameters contains more than one updated field', () => {
     beforeEach(() => {
       mountDefault({
         ...mockedNotification,
-        parameters: [...mockedNotification.parameters!, 'THEMATIC', 'MODALITIES'],
+        parameters: {
+          ...mockedNotification.parameters,
+          updatedFields: [
+            ActivityModifiedParametersUpdatedFieldsItem.ACTIVITY_TITLE,
+            ActivityModifiedParametersUpdatedFieldsItem.THEMATIC,
+            ActivityModifiedParametersUpdatedFieldsItem.FILES_AND_LINKS,
+          ],
+        },
       })
     })
 
     BddTest().then('it should render the sentence with interpolated parameters', () => {
       const content = getContent()
       expect(content.exists()).toBe(true)
-      expect(content.text()).toBe(`L'activité "${mockedNotification.parameters![0]}" a été mise à jour. Les sections suivantes ont été modifiées : Titre, Thématique, Modalités.`)
+      expect(content.text()).toBe(`L'activité "${mockedNotification.parameters!.activityTitle}" a été mise à jour. Les sections suivantes ont été modifiées : Titre, Thématique, Fichiers et liens.`)
     })
   })
 

--- a/src/features/student/global/components/cards/ActivityModifiedNotificationCard/ActivityModifiedNotificationCard.vue
+++ b/src/features/student/global/components/cards/ActivityModifiedNotificationCard/ActivityModifiedNotificationCard.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { NotificationDTO } from '@/api/avenir-esr'
+import type { ActivityModifiedParameters, NotificationDTO } from '@/api/avenir-esr'
 import { ROUTES } from '@/common/constants'
 import NotificationCard from '@/common/notifications/components/NotificationCard/NotificationCard.vue'
 import { I18nT, useI18n } from 'vue-i18n'
@@ -20,8 +20,9 @@ const to = computed(() => notification.elementId
     })
   : undefined)
 
-const activityName = computed(() => notification.parameters?.[0] ?? '')
-const sectionTypes = computed(() => notification.parameters?.slice(1) ?? [])
+const parameters = computed(() => notification.parameters as ActivityModifiedParameters | undefined)
+const activityName = computed(() => parameters.value?.activityTitle ?? '')
+const sectionTypes = computed(() => parameters.value?.updatedFields ?? [])
 const sectionCount = computed(() => Math.max(sectionTypes.value.length, 1))
 </script>
 
@@ -51,7 +52,7 @@ const sectionCount = computed(() => Math.max(sectionTypes.value.length, 1))
             v-for="(type, index) in sectionTypes"
             :key="index"
           >
-            <span class="av-text-bold">{{ t(`global.activities.contentSectionTypes.${type}`) }}</span>
+            <span class="av-text-bold">{{ t(`student.global.cards.ActivityModifiedNotificationCard.updatedFields.${type}`) }}</span>
             <template v-if="index < sectionCount - 1">, </template>
           </template>
         </template>

--- a/src/features/student/global/locales/en.json
+++ b/src/features/student/global/locales/en.json
@@ -6,7 +6,16 @@
       },
       "cards": {
         "ActivityModifiedNotificationCard": {
-          "content": "The activity \"{activityName}\" has been updated. The following section has been modified: {sectionTypes}. | The activity \"{activityName}\" has been updated. The following sections have been modified: {sectionTypes}."
+          "content": "The activity \"{activityName}\" has been updated. The following section has been modified: {sectionTypes}. | The activity \"{activityName}\" has been updated. The following sections have been modified: {sectionTypes}.",
+          "updatedFields": {
+            "ACTIVITY_TITLE": "Title",
+            "BANNER": "Banner",
+            "DESCRIPTION": "Description",
+            "EXECUTION_PERIOD": "Execution period",
+            "FILES_AND_LINKS": "Files and links",
+            "SUMMARY": "Summary",
+            "THEMATIC": "Theme"
+          }
         },
         "SelectedAssociateItemContainer": {
           "label": "My selected elements ({count})"

--- a/src/features/student/global/locales/fr.json
+++ b/src/features/student/global/locales/fr.json
@@ -6,7 +6,16 @@
       },
       "cards": {
         "ActivityModifiedNotificationCard": {
-          "content": "L'activité \"{activityName}\" a été mise à jour. La section suivante a été modifiée : {sectionTypes}. | L'activité \"{activityName}\" a été mise à jour. Les sections suivantes ont été modifiées : {sectionTypes}."
+          "content": "L'activité \"{activityName}\" a été mise à jour. La section suivante a été modifiée : {sectionTypes}. | L'activité \"{activityName}\" a été mise à jour. Les sections suivantes ont été modifiées : {sectionTypes}.",
+          "updatedFields": {
+            "ACTIVITY_TITLE": "Titre",
+            "BANNER": "Image de présentation",
+            "DESCRIPTION": "Consigne",
+            "EXECUTION_PERIOD": "Période de réalisation",
+            "FILES_AND_LINKS": "Fichiers et liens",
+            "SUMMARY": "Extrait",
+            "THEMATIC": "Thématique"
+          }
         },
         "SelectedAssociateItemContainer": {
           "label": "Mes éléments sélectionnés ({count})"


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> `NotificationDTO.parameters` changed from a positional `string[]` to a typed object (`ActivityModifiedParameters` for `ACTIVITY_MODIFIED` notifications, `AskForFeedbackParameters` for `ASK_FOR_FEEDBACK` notifications). This PR adapts `ActivityModifiedNotificationCard` and `ActivityFeedbackNotificationCard` to read the new named fields (`activityTitle`, `updatedFields`, `studentFirstName`, `studentLastName`) instead of array indices, and adds a dedicated `updatedFields` translation block scoped to the notification card so it doesn't collide with the unrelated activity-editing content section translations.

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/2119

---

### Documentation
> Updated `api-specs/avenir-esr.swagger.json` to reflect the new `NotificationDTO.parameters` schema (`ActivityModifiedParameters` / `AskForFeedbackParameters` / `NotificationParameters`).

---

### Target Branch
> `develop`

---

### Additional Notes
> The `updatedFields` translations live under `student.global.cards.ActivityModifiedNotificationCard.updatedFields` (feature-local locale) rather than the shared `global.activities.contentSectionTypes` namespace, since the latter is used by the unrelated activity-editing screens (`ContentSectionId` enum) and shares some key names by coincidence, not by design.

---

### Known Limitations or Side Effects
> None known.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [x] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [x] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [x] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process