### PR TITLE
feat(2037): add trace association limit card

### DIFF
--- a/src/features/student/buildProject/locales/en.json
+++ b/src/features/student/buildProject/locales/en.json
@@ -100,6 +100,11 @@
             "ActivityDetailedSideNavigation": {
               "myReflection": "My reflection"
             },
+            "AssociationLimitCard": {
+              "count": "1 trace | {count} traces",
+              "title": "Association limit",
+              "unlimited": "Unlimited traces"
+            },
             "AssociatedTracesCard": {
               "title": "My associated trace ({count}) | My associated traces ({count})"
             },

--- a/src/features/student/buildProject/locales/fr.json
+++ b/src/features/student/buildProject/locales/fr.json
@@ -99,6 +99,11 @@
             "ActivityDetailedSideNavigation": {
               "myReflection": "Ma réflexion"
             },
+            "AssociationLimitCard": {
+              "count": "1 trace | {count} traces",
+              "title": "Limite d'association",
+              "unlimited": "Traces illimitées"
+            },
             "AssociatedTracesCard": {
               "title": "Ma trace associée ({count}) | Mes traces associées ({count})"
             },

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/MyPerspectiveSection/MyPerspectiveSection.vue
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/MyPerspectiveSection/MyPerspectiveSection.vue
@@ -55,6 +55,7 @@ const traceAssociationsDisabled = computed(() =>
         :declared-activity-id="declaredActivityDetails.id"
         :associations="declaredActivityAssociations"
         :count-associations="associationsCount"
+        :trace-allowed-associations="declaredActivityDetails.activity.traceAllowedAssociations"
         :error="error"
         :is-loading="isPending"
         :trace-associations-disabled="traceAssociationsDisabled"

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/cards/TraceAssociationLimitCard/TraceAssociationLimitCard.stub.ts
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/cards/TraceAssociationLimitCard/TraceAssociationLimitCard.stub.ts
@@ -1,0 +1,10 @@
+export const TraceAssociationLimitCardStub = defineComponent({
+  name: 'TraceAssociationLimitCard',
+  props: {
+    traceAllowedAssociations: {
+      type: Number,
+      required: true,
+    },
+  },
+  template: '<div data-testid="trace-association-limit-card" />',
+})

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/cards/TraceAssociationLimitCard/TraceAssociationLimitCard.test.ts
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/cards/TraceAssociationLimitCard/TraceAssociationLimitCard.test.ts
@@ -1,0 +1,88 @@
+import type { TraceAssociationLimitCardProps } from '@/features/student/buildProject/views/ProjectActivityDetailedView/components/cards/TraceAssociationLimitCard/TraceAssociationLimitCard.vue'
+import type { VueWrapper } from '@vue/test-utils'
+import { CardStub } from '@/common/components/cards/Card/Card.stub'
+import TraceAssociationLimitCard from '@/features/student/buildProject/views/ProjectActivityDetailedView/components/cards/TraceAssociationLimitCard/TraceAssociationLimitCard.vue'
+import { MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
+import { AvBadgeStub, AvIconTextStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { mountComponent } from 'tests/utils'
+import { beforeEach, expect } from 'vitest'
+
+BddTest().given('a TraceAssociationLimitCard component', () => {
+  let wrapper: VueWrapper<InstanceType<typeof TraceAssociationLimitCard>>
+
+  const stubs = {
+    Card: CardStub,
+    AvIconText: AvIconTextStub,
+    AvBadge: AvBadgeStub,
+  }
+
+  const getCard = () => wrapper.findComponent(CardStub)
+  const getTitle = () =>
+    wrapper.findComponent(AvIconTextStub)
+
+  const getBadge = () =>
+    wrapper.findComponent(AvBadgeStub)
+
+  BddTest().when('the trace association limit is 7', () => {
+    const props: TraceAssociationLimitCardProps = {
+      traceAllowedAssociations: 7,
+    }
+
+    beforeEach(() => {
+      wrapper = mountComponent(TraceAssociationLimitCard, {
+        props,
+        global: { stubs },
+      })
+    })
+
+    BddTest().then('it should render the card', () => {
+      expect(getCard().exists()).toBe(true)
+      expect(getCard().props('backgroundColor')).toBe('var(--card2)')
+      expect(getCard().props('titleBackground')).toBe('var(--card2)')
+    })
+
+    BddTest().then('it should render the title', () => {
+      expect(getTitle().props('text')).toBe('Limite d\'association')
+      expect(getTitle().props('icon')).toBe(MDI_ICONS.ALERT_OUTLINE)
+    })
+
+    BddTest().then('it should render the badge', () => {
+      expect(getBadge().props('label')).toBe('7 traces')
+      expect(getBadge().props('icon')).toBe(MDI_ICONS.ATTACH_FILE)
+    })
+  })
+
+  BddTest().when('the trace association limit is unlimited', () => {
+    const props: TraceAssociationLimitCardProps = {
+      traceAllowedAssociations: -1,
+    }
+
+    beforeEach(() => {
+      wrapper = mountComponent(TraceAssociationLimitCard, {
+        props,
+        global: { stubs },
+      })
+    })
+
+    BddTest().then('it should display "Traces illimitées"', () => {
+      expect(getBadge().props('label')).toBe('Traces illimitées')
+    })
+  })
+
+  BddTest().when('trace associations are disabled', () => {
+    const props: TraceAssociationLimitCardProps = {
+      traceAllowedAssociations: 0,
+    }
+
+    beforeEach(() => {
+      wrapper = mountComponent(TraceAssociationLimitCard, {
+        props,
+        global: { stubs },
+      })
+    })
+
+    BddTest().then('it should not render the card', () => {
+      expect(getCard().exists()).toBe(false)
+    })
+  })
+})

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/cards/TraceAssociationLimitCard/TraceAssociationLimitCard.vue
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/cards/TraceAssociationLimitCard/TraceAssociationLimitCard.vue
@@ -1,0 +1,59 @@
+<script setup lang="ts">
+import Card from '@/common/components/cards/Card/Card.vue'
+import { AvBadge, AvIconText, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
+import { useI18n } from 'vue-i18n'
+
+export interface TraceAssociationLimitCardProps {
+  traceAllowedAssociations: number
+}
+
+const { traceAllowedAssociations } = defineProps<TraceAssociationLimitCardProps>()
+
+const { t } = useI18n()
+
+const translationKey = 'student.buildProject.activities.views.ProjectActivityDetailedView.AssociationLimitCard'
+
+const associationLimitLabel = computed(() => {
+  const key = 'student.buildProject.activities.views.ProjectActivityDetailedView.AssociationLimitCard'
+
+  if (traceAllowedAssociations === -1) {
+    return t(`${key}.unlimited`)
+  }
+
+  return t(`${key}.count`, {
+    count: traceAllowedAssociations,
+  })
+})
+</script>
+
+<template>
+  <Card
+    v-if="traceAllowedAssociations !== 0"
+    background-color="var(--card2)"
+    title-background="var(--card2)"
+    data-testid="association-limit-card"
+  >
+    <template #body>
+      <AvIconText
+        typography-class="n6"
+        :icon="MDI_ICONS.ALERT_OUTLINE"
+        icon-color="var(--text1)"
+        :text="t(`${translationKey}.title`)"
+        text-color="var(--text1)"
+        gap="var(--spacing-sm)"
+        data-testid="association-limit-card-title"
+      />
+    </template>
+
+    <template #footer>
+      <AvBadge
+        data-testid="association-limit-card-badge"
+        :label="associationLimitLabel"
+        :icon="MDI_ICONS.ATTACH_FILE"
+        color="var(--text1)"
+        background-color="var(--light-background-neutral)"
+        border-color="transparent"
+      />
+    </template>
+  </Card>
+</template>

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/tabs/AssociatedElementsTab/AssociatedElementsTab.test.ts
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/tabs/AssociatedElementsTab/AssociatedElementsTab.test.ts
@@ -1,5 +1,7 @@
 import { mockedDeclaredActivityAssociations } from '@/__mocks__/fixtures/student/activities.fixtures'
 import { AssociatedTracesCardStub } from '@/features/student/buildProject/views/ProjectActivityDetailedView/components/cards/AssociatedTracesCard/AssociatedTracesCard.stub'
+import { TraceAssociationLimitCardStub }
+  from '@/features/student/buildProject/views/ProjectActivityDetailedView/components/cards/TraceAssociationLimitCard/TraceAssociationLimitCard.stub'
 import {
   AssociateDeclaredSkillsToActivityModalStub
 } from '@/features/student/buildProject/views/ProjectActivityDetailedView/components/modals/AssociateDeclaredSkillToActivityModal/AssociateDeclaredSkillToActivityModal.stub'
@@ -32,14 +34,16 @@ BddTest().given('an associated elements tab', () => {
     AssociateTracesModal: AssociateTracesModalStub,
     AssociatedTracesCard: AssociatedTracesCardStub,
     AssociateDeclaredSkillToActivityModal: AssociateDeclaredSkillsToActivityModalStub,
-    AssociatedDeclaredSkillsCard: AssociatedDeclaredSkillsCardStub
+    AssociatedDeclaredSkillsCard: AssociatedDeclaredSkillsCardStub,
+    TraceAssociationLimitCard: TraceAssociationLimitCardStub
   }
 
   BddTest().when('the component is mounted with associations and traceAssociationsEnabled not set', () => {
     const props: AssociatedElementsTabProps = {
       associations: mockedDeclaredActivityAssociations,
       declaredActivityId: 'declared-activity-1',
-      countAssociations: 9
+      countAssociations: 9,
+      traceAllowedAssociations: 7
     }
 
     beforeEach(() => {
@@ -66,6 +70,13 @@ BddTest().given('an associated elements tab', () => {
       expect(associatedDeclaredSkillsCard.exists()).toBe(true)
       expect(associatedDeclaredSkillsCard.props('associatedDeclaredSkills'))
         .toEqual(props.associations.declaredSkillAssociations)
+    })
+
+    BddTest().then('it should render the trace association limit card', () => {
+      const card = wrapper.findComponent(TraceAssociationLimitCardStub)
+
+      expect(card.exists()).toBe(true)
+      expect(card.props('traceAllowedAssociations')).toBe(props.traceAllowedAssociations)
     })
 
     BddTest().then('it should render the associated traces card', () => {
@@ -275,6 +286,7 @@ BddTest().given('an associated elements tab', () => {
       associations: mockedDeclaredActivityAssociations,
       declaredActivityId: 'declared-activity-1',
       countAssociations: 9,
+      traceAllowedAssociations: 7,
       traceAssociationsDisabled: false
     }
 
@@ -293,6 +305,7 @@ BddTest().given('an associated elements tab', () => {
       associations: mockedDeclaredActivityAssociations,
       declaredActivityId: 'declared-activity-1',
       countAssociations: 9,
+      traceAllowedAssociations: 7,
       traceAssociationsDisabled: true
     }
 
@@ -311,6 +324,7 @@ BddTest().given('an associated elements tab', () => {
       associations: mockedDeclaredActivityAssociations,
       declaredActivityId: 'declared-activity-1',
       countAssociations: 9,
+      traceAllowedAssociations: 7,
       traceAssociationsDisabled: false,
       maxTraceAssociationsReached: true
     }

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/tabs/AssociatedElementsTab/AssociatedElementsTab.vue
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/tabs/AssociatedElementsTab/AssociatedElementsTab.vue
@@ -5,6 +5,8 @@ import { QuerySuspense } from '@/common/components'
 import { useModal } from '@/common/composables'
 import AssociatedTracesCard
   from '@/features/student/buildProject/views/ProjectActivityDetailedView/components/cards/AssociatedTracesCard/AssociatedTracesCard.vue'
+import TraceAssociationLimitCard
+  from '@/features/student/buildProject/views/ProjectActivityDetailedView/components/cards/TraceAssociationLimitCard/TraceAssociationLimitCard.vue'
 import AssociateDeclaredSkillToActivityModal
   from '@/features/student/buildProject/views/ProjectActivityDetailedView/components/modals/AssociateDeclaredSkillToActivityModal/AssociateDeclaredSkillToActivityModal.vue'
 import ActivityAssociateElementsDropdown
@@ -22,6 +24,7 @@ export interface AssociatedElementsTabProps {
   associations: DeclaredActivityAssociationsDTO
   declaredActivityId: string
   countAssociations: number
+  traceAllowedAssociations: number
   error?: BaseApiException | null
   isLoading?: boolean
   traceAssociationsDisabled?: boolean
@@ -30,6 +33,7 @@ export interface AssociatedElementsTabProps {
 
 const {
   associations,
+  traceAllowedAssociations,
   traceAssociationsDisabled = false,
   maxTraceAssociationsReached = false
 } = defineProps<AssociatedElementsTabProps>()
@@ -78,6 +82,11 @@ const skillsAssociations = computed(() => {
       >
         {{ t('student.buildProject.activities.views.ProjectActivityDetailedView.MyPerspectiveSection.AssociatedElementsTab.maxTraceAssociationsReached') }}
       </span>
+    </div>
+    <div class="av-col av-gap-md">
+      <TraceAssociationLimitCard
+        :trace-allowed-associations="traceAllowedAssociations"
+      />
     </div>
 
     <QuerySuspense


### PR DESCRIPTION


### Brief description of changes applied
<!-- Describe the changes introduced by this pull request. -->
create traceAssociationLimitCard 
add tests
integrate the card in AssociatedEmentsTab
---

### Reference to an Issue, Feature, Task, User Story or another PR
<!-- Mention related issue numbers or links (e.g. Closes #123, Implements #456). -->
<!-- Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/### -->
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/2037
---
<img width="1618" height="577" alt="image" src="https://github.com/user-attachments/assets/51907663-1173-40c1-b16f-10487d4c591b" />
