### PR TITLE
feat(1986): create DeleteDeclaredSkillAssociatedActivitiesModal

### DIFF
--- a/api-specs/avenir-esr.swagger.json
+++ b/api-specs/avenir-esr.swagger.json
@@ -2647,6 +2647,38 @@
             }
           }
         }
+      },
+      "delete": {
+        "tags": [
+          "declared-skill-progress-controller"
+        ],
+        "operationId": "deleteDeclaredSkillAssociations",
+        "parameters": [
+          {
+            "name": "declaredSkillProgressId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AssociationsDeleteRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
       }
     },
     "/me/declared/skill-progress/search-for-association": {

--- a/src/__mocks__/msw/handlers/student/skills.handlers.ts
+++ b/src/__mocks__/msw/handlers/student/skills.handlers.ts
@@ -20,6 +20,7 @@ import {
   EExternalSkillType,
   getAssociateDeclaredSkillWithDeclaredActivitiesUrl,
   getCreateDeclaredSkillProgressUrl,
+  getDeleteDeclaredSkillAssociationsUrl,
   getDeleteDeclaredSkillProgressUrl,
   getGetAdditionalSkillConfigUrl,
   getGetAllSkillsUrl,
@@ -387,4 +388,26 @@ export const skillsHandlers = [
       })
     }
   ),
+  http.delete(`*${getDeleteDeclaredSkillAssociationsUrl(':declaredSkillProgressId')}`, ({ params }) => {
+    const { declaredSkillProgressId } = params
+
+    if (declaredSkillProgressId === INVALID_DECLARED_SKILL_ID) {
+      return HttpResponse.json(
+        { code: ErrorCodes.DECLARED_SKILL_PROGRESS_NOT_FOUND, message: 'Declared skill progress not found' },
+        { status: 404 }
+      )
+    }
+
+    return new HttpResponse(null, { status: 204 })
+  }),
 ]
+
+export const deleteDeclaredSkillAssociationsErrorHandler = http.delete(
+  `*${getDeleteDeclaredSkillAssociationsUrl(':declaredSkillProgressId')}`,
+  () => {
+    return HttpResponse.json(
+      { message: 'Internal Server Error', code: ErrorCodes.SERVER },
+      { status: 500 }
+    )
+  }
+)

--- a/src/features/student/declaredSkills/components/overlays/modals/DeleteDeclaredSkillAssociatedActivitiesModal/DeleteDeclaredSkillAssociatedActivitiesModal.stub.ts
+++ b/src/features/student/declaredSkills/components/overlays/modals/DeleteDeclaredSkillAssociatedActivitiesModal/DeleteDeclaredSkillAssociatedActivitiesModal.stub.ts
@@ -1,0 +1,22 @@
+import type { DeclaredActivityAssociationDTO } from '@/api/avenir-esr'
+import type { PropType } from 'vue'
+
+export const DeleteDeclaredSkillAssociatedActivitiesModalStub = defineComponent({
+  name: 'DeleteDeclaredSkillAssociatedActivitiesModal',
+  props: {
+    show: {
+      type: Boolean,
+      required: true,
+    },
+    declaredSkillProgressId: {
+      type: String,
+      required: true,
+    },
+    associations: {
+      type: Array as PropType<DeclaredActivityAssociationDTO[]>,
+      required: true,
+    },
+  },
+  emits: ['cancel', 'deleted'],
+  template: '<div data-testid="delete-declared-skill-associated-activities-modal-stub" />',
+})

--- a/src/features/student/declaredSkills/components/overlays/modals/DeleteDeclaredSkillAssociatedActivitiesModal/DeleteDeclaredSkillAssociatedActivitiesModal.test.ts
+++ b/src/features/student/declaredSkills/components/overlays/modals/DeleteDeclaredSkillAssociatedActivitiesModal/DeleteDeclaredSkillAssociatedActivitiesModal.test.ts
@@ -1,0 +1,181 @@
+import { createMockedDeclaredActivitiesAssociations } from '@/__mocks__/fixtures/student/skills.fixtures'
+import { deleteDeclaredSkillAssociationsErrorHandler } from '@/__mocks__/msw/handlers/student/skills.handlers'
+import { server } from '@/__mocks__/msw/server'
+import { EDeclaredActivityStatus } from '@/api/avenir-esr'
+import DeleteDeclaredSkillAssociatedActivitiesModal, {
+  type DeleteDeclaredSkillAssociatedActivitiesModalProps
+} from '@/features/student/declaredSkills/components/overlays/modals/DeleteDeclaredSkillAssociatedActivitiesModal/DeleteDeclaredSkillAssociatedActivitiesModal.vue'
+import { CompactCardSelectorStub } from '@/features/student/global/components/cards/CompactCardSelector/CompactCardSelector.stub'
+import { DeleteAssociationsModalStub } from '@/features/student/global/components/overlays/modals/DeleteAssociationsModal/DeleteAssociationsModal.stub'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { mountComponent } from 'tests/utils'
+import { beforeEach, expect, vi } from 'vitest'
+
+const mockAddSuccessMessage = vi.fn()
+const mockAddErrorMessage = vi.fn()
+
+vi.mock('@/store', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/store')>()
+  return {
+    ...actual,
+    useToasterStore: () => ({
+      addSuccessMessage: mockAddSuccessMessage,
+      addErrorMessage: mockAddErrorMessage,
+    }),
+  }
+})
+
+BddTest().given('a delete declared skill associated activities modal', () => {
+  let wrapper: ReturnType<typeof mountComponent<typeof DeleteDeclaredSkillAssociatedActivitiesModal>>
+
+  const stubs = {
+    DeleteAssociationsModal: DeleteAssociationsModalStub,
+    CompactCardSelector: CompactCardSelectorStub,
+  }
+
+  const associations = createMockedDeclaredActivitiesAssociations(4)
+  associations[1].declaredActivity.status = EDeclaredActivityStatus.SUBSCRIBED
+  associations[2].declaredActivity.status = EDeclaredActivityStatus.SUBMITTED
+  associations[3].declaredActivity.status = EDeclaredActivityStatus.COMPLETED
+
+  const props: DeleteDeclaredSkillAssociatedActivitiesModalProps = {
+    show: true,
+    declaredSkillProgressId: 'skill-1',
+    associations,
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  BddTest().when('the modal is shown', () => {
+    beforeEach(() => {
+      wrapper = mountComponent(DeleteDeclaredSkillAssociatedActivitiesModal, { props, global: { stubs } })
+    })
+
+    BddTest().then('it should render the delete associations modal', () => {
+      const confirmModal = wrapper.findComponent(DeleteAssociationsModalStub)
+      expect(confirmModal.exists()).toBe(true)
+    })
+
+    BddTest().then('it should render the compact card selector', () => {
+      const selector = wrapper.findComponent(CompactCardSelectorStub)
+      expect(selector.exists()).toBe(true)
+    })
+
+    BddTest().then('it should only expose deletable associations excluding submitted and completed activities', () => {
+      const selector = wrapper.findComponent(CompactCardSelectorStub)
+      expect(selector.props('elements')).toEqual([
+        { id: 'declared-activity-association-1', title: 'Activité déclarée associée 1' },
+        { id: 'declared-activity-association-2', title: 'Activité déclarée associée 2' },
+      ])
+    })
+
+    BddTest().then('it should initialize selectedIds as empty', () => {
+      const selector = wrapper.findComponent(CompactCardSelectorStub)
+      expect(selector.props('modelValue')).toEqual([])
+    })
+
+    BddTest().and('the user selects associations from the compact card selector', () => {
+      beforeEach(() => {
+        const selector = wrapper.findComponent(CompactCardSelectorStub)
+        selector.vm.$emit('update:modelValue', ['declared-activity-association-1', 'declared-activity-association-2'])
+      })
+
+      BddTest().then('the selectedIds should be updated accordingly', () => {
+        const selector = wrapper.findComponent(CompactCardSelectorStub)
+        expect(selector.props('modelValue')).toEqual(['declared-activity-association-1', 'declared-activity-association-2'])
+      })
+    })
+
+    BddTest().and('the delete associations modal emits cancel', () => {
+      beforeEach(() => {
+        const confirmModal = wrapper.findComponent(DeleteAssociationsModalStub)
+        confirmModal.vm.$emit('cancel')
+      })
+
+      BddTest().then('the modal should emit cancel', () => {
+        expect(wrapper.emitted('cancel')).toBeTruthy()
+      })
+
+      BddTest().then('the selectedIds should be reset', () => {
+        const selector = wrapper.findComponent(CompactCardSelectorStub)
+        expect(selector.props('modelValue')).toEqual([])
+      })
+    })
+
+    BddTest().and('the delete associations modal emits confirmDelete successfully', () => {
+      beforeEach(() => {
+        const confirmModal = wrapper.findComponent(DeleteAssociationsModalStub)
+        confirmModal.vm.$emit('confirmDelete')
+      })
+
+      BddTest().then('the modal should emit deleted', async () => {
+        await vi.waitFor(() => {
+          expect(wrapper.emitted('deleted')).toBeTruthy()
+        })
+      })
+
+      BddTest().then('it should add a success toaster message', async () => {
+        await vi.waitFor(() => {
+          expect(mockAddSuccessMessage).toHaveBeenCalledWith({
+            timeout: 2000,
+            description: 'Les associations sélectionnées ont été supprimées avec succès',
+          })
+        })
+      })
+
+      BddTest().then('it should not add an error toaster message', async () => {
+        await vi.waitFor(() => {
+          expect(mockAddErrorMessage).not.toHaveBeenCalled()
+        })
+      })
+
+      BddTest().then('the selectedIds should be reset', async () => {
+        await vi.waitFor(() => {
+          const selector = wrapper.findComponent(CompactCardSelectorStub)
+          expect(selector.props('modelValue')).toEqual([])
+        })
+      })
+    })
+  })
+
+  BddTest().when('deleting associated activities fails', () => {
+    beforeEach(() => {
+      server.use(deleteDeclaredSkillAssociationsErrorHandler)
+
+      wrapper = mountComponent(DeleteDeclaredSkillAssociatedActivitiesModal, {
+        props,
+        global: { stubs }
+      })
+    })
+
+    BddTest().and('the delete associations modal emits confirmDelete', () => {
+      beforeEach(() => {
+        const confirmModal = wrapper.findComponent(DeleteAssociationsModalStub)
+        confirmModal.vm.$emit('confirmDelete')
+      })
+
+      BddTest().then('it should add an error toaster message', async () => {
+        await vi.waitFor(() => {
+          expect(mockAddErrorMessage).toHaveBeenCalledWith({
+            title: 'Une erreur est survenue. Veuillez réessayer ultérieurement.',
+            description: expect.any(String),
+          })
+        })
+      })
+
+      BddTest().then('it should not add a success toaster message', async () => {
+        await vi.waitFor(() => {
+          expect(mockAddSuccessMessage).not.toHaveBeenCalled()
+        })
+      })
+
+      BddTest().then('the modal should not emit deleted', async () => {
+        await vi.waitFor(() => {
+          expect(wrapper.emitted('deleted')).toBeFalsy()
+        })
+      })
+    })
+  })
+})

--- a/src/features/student/declaredSkills/components/overlays/modals/DeleteDeclaredSkillAssociatedActivitiesModal/DeleteDeclaredSkillAssociatedActivitiesModal.vue
+++ b/src/features/student/declaredSkills/components/overlays/modals/DeleteDeclaredSkillAssociatedActivitiesModal/DeleteDeclaredSkillAssociatedActivitiesModal.vue
@@ -1,0 +1,91 @@
+<script lang="ts" setup>
+import type { BaseApiException } from '@/common/exceptions'
+import { type DeclaredActivityAssociationDTO, invalidateGetDeclaredSkillProgressDetails, invalidateGetDeclaredSkillWithDeclaredActivities, useDeleteDeclaredSkillAssociations } from '@/api/avenir-esr'
+import { useApiErrors } from '@/common/composables/use-api-errors/use-api-errors'
+import { useTaskLoading } from '@/common/composables/use-task-loading/use-task-loading'
+import { ICONS } from '@/common/constants'
+import { isDeletableDeclaredActivityAssociation } from '@/features/student/declaredSkills/rules/declared-activity-association.rules'
+import CompactCardSelector from '@/features/student/global/components/cards/CompactCardSelector/CompactCardSelector.vue'
+import DeleteAssociationsModal from '@/features/student/global/components/overlays/modals/DeleteAssociationsModal/DeleteAssociationsModal.vue'
+import { useToasterStore } from '@/store'
+import { useQueryClient } from '@tanstack/vue-query'
+import { useI18n } from 'vue-i18n'
+
+export interface DeleteDeclaredSkillAssociatedActivitiesModalProps {
+  show: boolean
+  declaredSkillProgressId: string
+  associations: DeclaredActivityAssociationDTO[]
+}
+
+const { declaredSkillProgressId, associations } = defineProps<DeleteDeclaredSkillAssociatedActivitiesModalProps>()
+
+const emit = defineEmits<{
+  (e: 'cancel'): void
+  (e: 'deleted'): void
+}>()
+
+const { t } = useI18n()
+const { getErrorMessage } = useApiErrors()
+const { addErrorMessage, addSuccessMessage } = useToasterStore()
+const { isLoading, withTaskLoading } = useTaskLoading()
+const queryClient = useQueryClient()
+
+const selectedIds = ref<string[]>([])
+
+const selectableElements = computed(() => associations.filter(isDeletableDeclaredActivityAssociation).map(({ associationId, declaredActivity }) => ({
+  id: associationId,
+  title: declaredActivity.title,
+})))
+
+const { mutate: deleteDeclaredSkillAssociations } = useDeleteDeclaredSkillAssociations({
+  mutation: {
+    onError: (error: BaseApiException) => {
+      addErrorMessage({
+        title: t('global.error.generic'),
+        description: getErrorMessage(error),
+      })
+    },
+    onSuccess: async () => {
+      await withTaskLoading(() => Promise.all([
+        invalidateGetDeclaredSkillWithDeclaredActivities(queryClient, declaredSkillProgressId),
+        invalidateGetDeclaredSkillProgressDetails(queryClient, declaredSkillProgressId),
+      ]))
+      addSuccessMessage({
+        timeout: 2000,
+        description: t('student.global.overlays.modals.DeleteAssociationsModal.success', { count: selectedIds.value.length }),
+      })
+      selectedIds.value = []
+      emit('deleted')
+    }
+  }
+})
+
+function onConfirmDelete () {
+  deleteDeclaredSkillAssociations({
+    declaredSkillProgressId,
+    data: { idsToDelete: selectedIds.value }
+  })
+}
+
+function onCancel () {
+  selectedIds.value = []
+  emit('cancel')
+}
+</script>
+
+<template>
+  <DeleteAssociationsModal
+    :show="show"
+    :associations="selectableElements"
+    :selected-association-ids="selectedIds"
+    :is-loading="isLoading"
+    @cancel="onCancel"
+    @confirm-delete="onConfirmDelete"
+  >
+    <CompactCardSelector
+      v-model="selectedIds"
+      :elements="selectableElements"
+      :icon="ICONS.ACTIVITY"
+    />
+  </DeleteAssociationsModal>
+</template>

--- a/src/features/student/declaredSkills/rules/declared-activity-association.rules.test.ts
+++ b/src/features/student/declaredSkills/rules/declared-activity-association.rules.test.ts
@@ -1,0 +1,43 @@
+import type { DeclaredActivityAssociationDTO } from '@/api/avenir-esr'
+import { EActivityThematic, EDeclaredActivityStatus } from '@/api/avenir-esr'
+import { isDeletableDeclaredActivityAssociation } from '@/features/student/declaredSkills/rules/declared-activity-association.rules'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { beforeEach, expect } from 'vitest'
+
+function createAssociation (status: EDeclaredActivityStatus): DeclaredActivityAssociationDTO {
+  return {
+    associationId: 'assoc-1',
+    declaredActivity: {
+      id: 'activity-1',
+      activityId: 'act-1',
+      title: 'Activité 1',
+      thematic: EActivityThematic.PROGRAMS,
+      status,
+      summary: 'Summary 1',
+      description: '<p>Description 1</p>',
+    }
+  }
+}
+
+BddTest().given('the isDeletableDeclaredActivityAssociation rule', () => {
+  const testCases: { status: EDeclaredActivityStatus, expected: boolean }[] = [
+    { status: EDeclaredActivityStatus.SUBSCRIBED, expected: true },
+    { status: EDeclaredActivityStatus.IN_PROGRESS, expected: true },
+    { status: EDeclaredActivityStatus.SUBMITTED, expected: false },
+    { status: EDeclaredActivityStatus.COMPLETED, expected: false },
+  ]
+
+  testCases.forEach(({ status, expected }) => {
+    BddTest().when(`the association declared activity has status: ${status}`, () => {
+      let result: boolean
+
+      beforeEach(() => {
+        result = isDeletableDeclaredActivityAssociation(createAssociation(status))
+      })
+
+      BddTest().then(`it should return ${expected}`, () => {
+        expect(result).toBe(expected)
+      })
+    })
+  })
+})

--- a/src/features/student/declaredSkills/rules/declared-activity-association.rules.ts
+++ b/src/features/student/declaredSkills/rules/declared-activity-association.rules.ts
@@ -1,0 +1,7 @@
+import { type DeclaredActivityAssociationDTO, EDeclaredActivityStatus } from '@/api/avenir-esr'
+
+const NOT_DELETABLE_DECLARED_ACTIVITY_STATUS = new Set([EDeclaredActivityStatus.SUBMITTED, EDeclaredActivityStatus.COMPLETED])
+
+export function isDeletableDeclaredActivityAssociation (association: DeclaredActivityAssociationDTO) {
+  return !NOT_DELETABLE_DECLARED_ACTIVITY_STATUS.has(association.declaredActivity.status)
+}


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied

This PR implements the DeleteDeclaredSkillAssociatedActivitiesModal component that allows users to select and delete activity associations linked to a declared skill. The modal provides a checkbox-based interface for selecting multiple activities and includes a dynamic delete button with confirmation flow.

**Key features implemented:**
- Display list of selectable associated activities (checkboxes)
- Exclude activities with `SUBMITTED` or `COMPLETED` status via `deletableDeclaredActivityAssociations` computed property
- Dynamic "Delete selected associations (n)" button - disabled when no selection
- Confirmation flow using `useModal()` composable
- Integration with `useDeleteDeclaredSkillAssociations` mutation
- Automatic invalidation of `useGetDeclaredSkillWithDeclaredActivities` query after deletion

---

### Reference to an Issue, Feature, Task, User Story or another PR

Closes [#1986](https://github.com/avenirs-esr/AVENIRS-Project/issues/1986)

**Depends on:** #1972 (BE endpoint for DELETE /me/declared/skills/{skillId}/associations)

---

### Documentation

- Component stub file included for testing purposes
- Full unit test coverage included
- MSW handler added to support API mocking during tests

---

### Target Branch

`develop`

---

### Additional Notes

- Component follows the feature-based architecture pattern defined in the codebase
- Uses TanStack Vue Query for server state management
- Implements BDD-style test structure with proper isolation
- Modal state managed through the `useModal` composable
- Design aligns with Figma node-id: `40022241-132010`

---

### Known Limitations or Side Effects

- Requires backend endpoint from #1972 to be merged and deployed before this feature can be fully functional
- Modal only displays activities that are not in SUBMITTED or COMPLETED status

---

## ✅ Checklist

- [x] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests)
- [x] i18n handled (texts are translated)
- [x] No unnecessary code (no debug logs or commented code)
- [x] Code style and formatting rules respected (linting, conventions)
- [x] Feature follows existing architecture patterns