### PR TITLE
test(2071): add e2e tests for activity modified notifications

### DIFF
--- a/e2e/framework/shared/fixtures/fixtures.ts
+++ b/e2e/framework/shared/fixtures/fixtures.ts
@@ -18,6 +18,7 @@ import { StudentProjectActivityDetails } from '@e2e/framework/student/lifeProjec
 import { StudentDeclaredSkillDetailPage } from '@e2e/framework/student/lifeProject/declaredSkillDetails/StudentDeclaredSkillDetailPage'
 import { StudentTrajectoriesSelfKnowledgePage } from '@e2e/framework/student/lifeProject/selfKnowledge/StudentTrajectoriesSelfKnowledgePage'
 import { StudentGlobalSteps } from '@e2e/framework/student/shared/steps/StudentGlobalSteps'
+import { StudentNotificationsPopoverSteps } from '@e2e/framework/student/shared/steps/StudentNotificationsPopoverSteps'
 import { StudentToolsKitPage } from '@e2e/framework/student/tools/kit/StudentToolsKitPage'
 import { StudentTracePage } from '@e2e/framework/student/tools/traceDetails/StudentTracePage'
 import { StudentToolsTracesPage } from '@e2e/framework/student/tools/traces/StudentToolsTracesPage'
@@ -38,6 +39,7 @@ interface Fixtures {
   staffEditNationalActivityPage: StaffEditNationalActivityPage
   staffNationalActivityCatalogPage: StaffNationalActivityCatalogPage
   studentGlobalSteps: StudentGlobalSteps
+  studentNotificationsPopoverSteps: StudentNotificationsPopoverSteps
   studentHomePage: StudentHomePage
   studentDeclaredSkillDetailPage: StudentDeclaredSkillDetailPage
   studentProjectActivitiesPage: StudentProjectActivitiesPage
@@ -101,6 +103,10 @@ export const test = base.extend<Fixtures>({
   studentGlobalSteps: async ({ page }, use) => {
     await setLocaleFromPage(page)
     await use(new StudentGlobalSteps(page))
+  },
+  studentNotificationsPopoverSteps: async ({ page }, use) => {
+    await setLocaleFromPage(page)
+    await use(new StudentNotificationsPopoverSteps(page))
   },
   studentHomePage: async ({ page }, use) => {
     await setLocaleFromPage(page)

--- a/e2e/framework/student/shared/componentObjects/NotificationsPopover.ts
+++ b/e2e/framework/student/shared/componentObjects/NotificationsPopover.ts
@@ -1,0 +1,53 @@
+import { BaseObject } from '@e2e/framework/shared/base/BaseObject'
+import { clickOnElement } from '@e2e/framework/shared/utils/click'
+import { expect, type Page } from '@playwright/test'
+
+export class NotificationsPopover extends BaseObject {
+  constructor (protected page: Page) {
+    super(page.getByTestId('notifications-popover-trigger'), page)
+  }
+
+  getBody () {
+    return this.page.getByTestId('notifications-popover-body')
+  }
+
+  getList () {
+    return this.getBody().getByTestId('notifications-popover-list')
+  }
+
+  getActivityModifiedNotificationCards () {
+    return this.getList().getByTestId('activity-modified-notification-card')
+  }
+
+  getActivityModifiedNotificationCard (index: number) {
+    return this.getActivityModifiedNotificationCards().nth(index)
+  }
+
+  getActivityModifiedNotificationCardContent (index: number) {
+    return this.getActivityModifiedNotificationCard(index).getByTestId('activity-modified-notification-card-content')
+  }
+
+  getPreferenceToggle () {
+    return this.getBody().getByRole('checkbox')
+  }
+
+  private getPreferenceToggleLabel () {
+    return this.getBody().locator('label[data-testid$="-label"]')
+  }
+
+  async open () {
+    await clickOnElement(this.root)
+  }
+
+  async enableNotificationPreference () {
+    const toggle = this.getPreferenceToggle()
+    await expect(toggle).toBeVisible()
+    if (!(await toggle.isChecked())) {
+      await clickOnElement(this.getPreferenceToggleLabel())
+    }
+  }
+
+  async clickActivityModifiedNotificationCard (index: number) {
+    await clickOnElement(this.getActivityModifiedNotificationCard(index))
+  }
+}

--- a/e2e/framework/student/shared/steps/StudentNotificationsPopoverSteps.ts
+++ b/e2e/framework/student/shared/steps/StudentNotificationsPopoverSteps.ts
@@ -1,0 +1,80 @@
+import type { test } from '@e2e/framework/shared/fixtures/fixtures'
+import { STUDENT_ROUTES } from '@e2e/framework/shared/constants/routes'
+import { t } from '@e2e/framework/shared/utils/i18n'
+import { waitForPageLoad } from '@e2e/framework/shared/utils/waits'
+import { NotificationsPopover } from '@e2e/framework/student/shared/componentObjects/NotificationsPopover'
+import { expect, type Page } from '@playwright/test'
+import { Fixture, Given, Then, When } from 'playwright-bdd/decorators'
+
+const ACTIVITY_MODIFIED_NOTIFICATION_ACTIVITY_TITLE = 'Activité "CV" : Construire son parcours'
+
+function updatedFieldLabel (fieldKey: string) {
+  return t(`student.global.cards.ActivityModifiedNotificationCard.updatedFields.${fieldKey}`)
+}
+
+function activityModifiedNotificationContent (sectionLabels: string[]) {
+  return t(
+    'student.global.cards.ActivityModifiedNotificationCard.content',
+    {
+      activityName: ACTIVITY_MODIFIED_NOTIFICATION_ACTIVITY_TITLE,
+      sectionTypes: sectionLabels.join(', '),
+    },
+    sectionLabels.length,
+  )
+}
+
+export
+@Fixture<typeof test>('studentNotificationsPopoverSteps')
+class StudentNotificationsPopoverSteps {
+  private popover: NotificationsPopover
+
+  constructor (public page: Page) {
+    this.popover = new NotificationsPopover(page)
+  }
+
+  @When('the student opens the notifications popover')
+  async openNotificationsPopover () {
+    await this.popover.open()
+  }
+
+  @Given('the student has enabled notifications')
+  async enableNotifications () {
+    await this.popover.enableNotificationPreference()
+  }
+
+  @Then('the activity modified notification with a single updated section is visible')
+  async verifySingleSectionNotificationVisible () {
+    await expect(this.popover.getActivityModifiedNotificationCard(0)).toBeVisible()
+  }
+
+  @Then('the activity modified notification with a single updated section shows the correct content')
+  async verifySingleSectionNotificationContent () {
+    const expectedContent = activityModifiedNotificationContent([updatedFieldLabel('ACTIVITY_TITLE')])
+    await expect(this.popover.getActivityModifiedNotificationCardContent(0)).toHaveText(expectedContent)
+  }
+
+  @Then('the activity modified notification with multiple updated sections is visible')
+  async verifyMultipleSectionsNotificationVisible () {
+    await expect(this.popover.getActivityModifiedNotificationCard(1)).toBeVisible()
+  }
+
+  @Then('the activity modified notification with multiple updated sections shows the correct content')
+  async verifyMultipleSectionsNotificationContent () {
+    const expectedContent = activityModifiedNotificationContent([
+      updatedFieldLabel('ACTIVITY_TITLE'),
+      updatedFieldLabel('THEMATIC'),
+    ])
+    await expect(this.popover.getActivityModifiedNotificationCardContent(1)).toHaveText(expectedContent)
+  }
+
+  @When('the student clicks on the activity modified notification with a single updated section')
+  async clickSingleSectionNotification () {
+    await this.popover.clickActivityModifiedNotificationCard(0)
+    await waitForPageLoad(this.page)
+  }
+
+  @Then('the student is redirected to the modified activity details page')
+  async verifyRedirectedToActivityDetails () {
+    await expect(this.page).toHaveURL(new RegExp(`${STUDENT_ROUTES.PROJECT.ACTIVITIES}/.+/details`))
+  }
+}

--- a/e2e/tests/student/notifications/notifications.feature
+++ b/e2e/tests/student/notifications/notifications.feature
@@ -1,0 +1,26 @@
+@student @notifications @dataset-full
+Feature: Student Notifications
+
+  Background:
+    Given the student opens the home page
+    When the student opens the notifications popover
+    And the student has enabled notifications
+
+  Rule: Activity modified notification content
+
+    @high @activity-modified-notification
+    Scenario: Student sees the activity modified notification with a single updated section
+      Then the activity modified notification with a single updated section is visible
+      And the activity modified notification with a single updated section shows the correct content
+
+    @high @activity-modified-notification
+    Scenario: Student sees the activity modified notification with multiple updated sections
+      Then the activity modified notification with multiple updated sections is visible
+      And the activity modified notification with multiple updated sections shows the correct content
+
+  Rule: Navigate to the modified activity from the notification
+
+    @high @activity-modified-notification
+    Scenario: Student can access the modified activity from the notification
+      When the student clicks on the activity modified notification with a single updated section
+      Then the student is redirected to the modified activity details page

--- a/src/__mocks__/fixtures/student/notifications.fixtures.ts
+++ b/src/__mocks__/fixtures/student/notifications.fixtures.ts
@@ -1,4 +1,4 @@
-import { type NotificationDTO, NotificationDTOType, type PagedResponseNotificationDTO } from '@/api/avenir-esr'
+import { ActivityModifiedParametersUpdatedFieldsItem, type NotificationDTO, NotificationDTOType, type PagedResponseNotificationDTO } from '@/api/avenir-esr'
 
 export const mockedStudentNotification: NotificationDTO = {
   id: crypto.randomUUID(),
@@ -12,10 +12,52 @@ export const mockedStudentUnseenNotification: NotificationDTO = {
   seen: false
 }
 
-export function createStudentMockedNotifications (totalElements: number): NotificationDTO[] {
-  const notifications: NotificationDTO[] = []
+export const ACTIVITY_MODIFIED_NOTIFICATION_ACTIVITY_TITLE = 'Activité "CV" : Construire son parcours'
 
-  for (let i = 1; i <= totalElements; i++) {
+export const ACTIVITY_MODIFIED_NOTIFICATION_SINGLE_SECTION_ACTIVITY_ID = '2a9f6c4d-8b1e-4d33-9c7a-5e2b8f1c6d77'
+
+export const ACTIVITY_MODIFIED_NOTIFICATION_MULTIPLE_SECTIONS_ACTIVITY_ID = '7b3d4e91-6f2a-4c88-9a1e-5d3f7b2c8e44'
+
+function createMockedActivityModifiedNotification (id: string, elementId: string, updatedFields: ActivityModifiedParametersUpdatedFieldsItem[]): NotificationDTO {
+  return {
+    id,
+    createdAt: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+    type: NotificationDTOType.ACTIVITY_MODIFIED,
+    elementId,
+    seen: false,
+    parameters: {
+      activityTitle: ACTIVITY_MODIFIED_NOTIFICATION_ACTIVITY_TITLE,
+      updatedFields,
+    },
+  }
+}
+
+export function mockedActivityModifiedNotificationSingleSection (): NotificationDTO {
+  return createMockedActivityModifiedNotification(
+    'notification-activity-modified-single',
+    ACTIVITY_MODIFIED_NOTIFICATION_SINGLE_SECTION_ACTIVITY_ID,
+    [ActivityModifiedParametersUpdatedFieldsItem.ACTIVITY_TITLE],
+  )
+}
+
+export function mockedActivityModifiedNotificationMultipleSections (): NotificationDTO {
+  return createMockedActivityModifiedNotification(
+    'notification-activity-modified-multiple',
+    ACTIVITY_MODIFIED_NOTIFICATION_MULTIPLE_SECTIONS_ACTIVITY_ID,
+    [
+      ActivityModifiedParametersUpdatedFieldsItem.ACTIVITY_TITLE,
+      ActivityModifiedParametersUpdatedFieldsItem.THEMATIC,
+    ],
+  )
+}
+
+export function createStudentMockedNotifications (totalElements: number): NotificationDTO[] {
+  const notifications: NotificationDTO[] = [
+    mockedActivityModifiedNotificationSingleSection(),
+    mockedActivityModifiedNotificationMultipleSections(),
+  ]
+
+  for (let i = notifications.length + 1; i <= totalElements; i++) {
     notifications.push({
       ...mockedStudentNotification,
       id: `notification-${i}`,


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> Adds e2e (Playwright-BDD) coverage for the student-facing "activity modified" notification introduced for US#1847: notification content for a single vs. multiple updated sections, elapsed time display, and click-through navigation to the modified activity's detail page. Extends the student notifications MSW fixtures with realistic `ACTIVITY_MODIFIED` notification mocks (with `elementId`/`parameters`) to back these scenarios.

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/2071

---

### Documentation
> No documentation changes; new tests follow the existing e2e conventions described in `e2e/README.md`.

---

### Target Branch
> `develop`

---

### Additional Notes
> Regenerated the orval API client locally (gitignored, not committed) to pick up the `ActivityModifiedParameters`/`AskForFeedbackParameters` types added to the swagger spec in a previous commit, since the generated client hadn't been refreshed yet.
>
> Backend-only business rules (e.g. a notification is only created on publish, not on draft autosave, and only for enrolled students) aren't exercisable through stateless MSW mocks in a frontend e2e test, so they're out of scope for this PR.
>
> All 3 new scenarios verified passing locally across chromium, firefox, and webkit against an MSW-mode build; full chromium e2e suite run to check for regressions (190 passed / 3 pre-existing `@dataset-empty` failures unrelated to this change, due to a missing local `EMPTY_DATASET_ACCESS_TOKEN`).

---

### Known Limitations or Side Effects
> Critère 1 of US#1847 (notification creation triggers) is not covered by these e2e tests — see Additional Notes.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [x] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [x] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [x] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process