### PR TITLE
refactor(2125): make feedback management panel sticky and rename label

### DIFF
--- a/src/features/staff/feedbacks/locales/en.json
+++ b/src/features/staff/feedbacks/locales/en.json
@@ -43,7 +43,7 @@
             "placeholder": "Select a student"
           },
           "title": "All my feedback requests ({count}) on the activity \"{activityTitle}\"",
-          "WriteFeedbackFloatingPanel": {
+          "FeedbackManagementFloatingPanel": {
             "tabs": {
               "history": {
                 "emptyState": "You have no previous feedback",

--- a/src/features/staff/feedbacks/locales/fr.json
+++ b/src/features/staff/feedbacks/locales/fr.json
@@ -43,7 +43,7 @@
             "placeholder": "Sélectionner un étudiant"
           },
           "title": "Toutes mes demandes de feedback ({count}) sur l'activité \"{activityTitle}\"",
-          "WriteFeedbackFloatingPanel": {
+          "FeedbackManagementFloatingPanel": {
             "tabs": {
               "history": {
                 "emptyState": "Vous n'avez aucun feedback précédent",

--- a/src/features/staff/feedbacks/views/ActivityFeedbackDetailsView/ActivityFeedbackDetailsView.test.ts
+++ b/src/features/staff/feedbacks/views/ActivityFeedbackDetailsView/ActivityFeedbackDetailsView.test.ts
@@ -2,7 +2,7 @@ import { PageTitleStub } from '@/common/components/PageTitle/PageTitle.stub'
 import { QuerySuspenseStub } from '@/common/components/QuerySuspense/QuerySuspense.stub'
 import { StudentPerspectiveCardStub } from '@/features/staff/feedbacks/components/cards/StudentPerspectiveCard/StudentPerspectiveCard.stub'
 import ActivityFeedbackDetailsView from '@/features/staff/feedbacks/views/ActivityFeedbackDetailsView/ActivityFeedbackDetailsView.vue'
-import { WriteFeedbackFloatingPanelStub } from '@/features/staff/feedbacks/views/ActivityFeedbackDetailsView/components/overlays/WriteFeedbackFloatingPanel/WriteFeedbackFloatingPanel.stub'
+import { FeedbackManagementFloatingPanelStub } from '@/features/staff/feedbacks/views/ActivityFeedbackDetailsView/components/overlays/FeedbackManagementFloatingPanel/FeedbackManagementFloatingPanel.stub'
 import { ActivityFeedbackStudentSelectStub } from '@/features/staff/feedbacks/views/ActivityFeedbackDetailsView/components/selects/ActivityFeedbackStudentSelect/ActivityFeedbackStudentSelect.stub'
 import {
   AssociatedElementSummaryCardStub
@@ -19,7 +19,7 @@ BddTest().given('an activity feedback details view', () => {
     PageTitle: PageTitleStub,
     QuerySuspense: QuerySuspenseStub,
     ActivityFeedbackStudentSelect: ActivityFeedbackStudentSelectStub,
-    WriteFeedbackFloatingPanel: WriteFeedbackFloatingPanelStub,
+    FeedbackManagementFloatingPanel: FeedbackManagementFloatingPanelStub,
     StudentPerspectiveCard: StudentPerspectiveCardStub,
     AssociatedElementSummaryCard: AssociatedElementSummaryCardStub,
   }
@@ -73,7 +73,7 @@ BddTest().given('an activity feedback details view', () => {
     })
 
     BddTest().then('it should render the write feedback floating panel', () => {
-      expect(wrapper.findComponent(WriteFeedbackFloatingPanelStub).exists()).toBe(true)
+      expect(wrapper.findComponent(FeedbackManagementFloatingPanelStub).exists()).toBe(true)
     })
   })
 
@@ -88,7 +88,7 @@ BddTest().given('an activity feedback details view', () => {
     })
 
     BddTest().then('it should not render the write feedback floating panel', () => {
-      expect(wrapper.findComponent(WriteFeedbackFloatingPanelStub).exists()).toBe(false)
+      expect(wrapper.findComponent(FeedbackManagementFloatingPanelStub).exists()).toBe(false)
     })
   })
 
@@ -125,7 +125,7 @@ BddTest().given('an activity feedback details view', () => {
     })
 
     BddTest().then('it should not render the write feedback floating panel', () => {
-      expect(wrapper.findComponent(WriteFeedbackFloatingPanelStub).exists()).toBe(false)
+      expect(wrapper.findComponent(FeedbackManagementFloatingPanelStub).exists()).toBe(false)
     })
   })
 })

--- a/src/features/staff/feedbacks/views/ActivityFeedbackDetailsView/ActivityFeedbackDetailsView.vue
+++ b/src/features/staff/feedbacks/views/ActivityFeedbackDetailsView/ActivityFeedbackDetailsView.vue
@@ -10,8 +10,8 @@ import PageTitle from '@/common/components/PageTitle/PageTitle.vue'
 import QuerySuspense from '@/common/components/QuerySuspense/QuerySuspense.vue'
 import { ROUTES } from '@/common/constants'
 import StudentPerspectiveCard from '@/features/staff/feedbacks/components/cards/StudentPerspectiveCard/StudentPerspectiveCard.vue'
-import WriteFeedbackFloatingPanel
-  from '@/features/staff/feedbacks/views/ActivityFeedbackDetailsView/components/overlays/WriteFeedbackFloatingPanel/WriteFeedbackFloatingPanel.vue'
+import FeedbackManagementFloatingPanel
+  from '@/features/staff/feedbacks/views/ActivityFeedbackDetailsView/components/overlays/FeedbackManagementFloatingPanel/FeedbackManagementFloatingPanel.vue'
 import ActivityFeedbackStudentSelect
   from '@/features/staff/feedbacks/views/ActivityFeedbackDetailsView/components/selects/ActivityFeedbackStudentSelect/ActivityFeedbackStudentSelect.vue'
 import AssociatedElementSummaryCard
@@ -113,7 +113,7 @@ const pageTitle = computed(() =>
     />
   </div>
 
-  <WriteFeedbackFloatingPanel
+  <FeedbackManagementFloatingPanel
     v-if="showWriteFeedbackPanel && feedback"
     :feedback="feedback"
     :activity-title="activityTitle"

--- a/src/features/staff/feedbacks/views/ActivityFeedbackDetailsView/components/interaction/inputs/FeedbackTextarea/FeedbackTextarea.vue
+++ b/src/features/staff/feedbacks/views/ActivityFeedbackDetailsView/components/interaction/inputs/FeedbackTextarea/FeedbackTextarea.vue
@@ -19,7 +19,7 @@ const inputProps = computed(() => ({
   labelVisible: false,
   textareaMinHeight: 'var(--dimension-8xl)',
   maxlength: FEEDBACK_MAX_LENGTH,
-  label: label ?? t('staff.feedbacks.views.ActivityFeedbackDetailsView.WriteFeedbackFloatingPanel.tabs.write.inputs.FeedbackTextarea.label')
+  label: label ?? t('staff.feedbacks.views.ActivityFeedbackDetailsView.FeedbackManagementFloatingPanel.tabs.write.inputs.FeedbackTextarea.label')
 }))
 </script>
 

--- a/src/features/staff/feedbacks/views/ActivityFeedbackDetailsView/components/interaction/tabs/FeedbacksHistoryTab/FeedbacksHistoryTab.vue
+++ b/src/features/staff/feedbacks/views/ActivityFeedbackDetailsView/components/interaction/tabs/FeedbacksHistoryTab/FeedbacksHistoryTab.vue
@@ -27,7 +27,7 @@ const { t } = useI18n()
     :is-loading="isLoading"
     :error="error"
     :is-empty="feedbacks.length === 0"
-    :empty-state-message="t('staff.feedbacks.views.ActivityFeedbackDetailsView.WriteFeedbackFloatingPanel.tabs.history.emptyState')"
+    :empty-state-message="t('staff.feedbacks.views.ActivityFeedbackDetailsView.FeedbackManagementFloatingPanel.tabs.history.emptyState')"
     data-testid="feedbacks-history-tab"
   >
     <div class="av-col av-gap-sm">

--- a/src/features/staff/feedbacks/views/ActivityFeedbackDetailsView/components/interaction/tabs/WriteFeedbackTab/WriteFeedbackTab.vue
+++ b/src/features/staff/feedbacks/views/ActivityFeedbackDetailsView/components/interaction/tabs/WriteFeedbackTab/WriteFeedbackTab.vue
@@ -45,12 +45,12 @@ function submitFeedback () {
     {
       onSuccess: async () => {
         await withTaskLoading(() => invalidateGetFeedbackDetails(queryClient, EUserCategory.STAFF, feedback.id))
-        addSuccessMessage(t('staff.feedbacks.views.ActivityFeedbackDetailsView.WriteFeedbackFloatingPanel.tabs.write.success.sendFeedback'))
+        addSuccessMessage(t('staff.feedbacks.views.ActivityFeedbackDetailsView.FeedbackManagementFloatingPanel.tabs.write.success.sendFeedback'))
         emit('feedbackSent')
       },
       onError: (error) => {
         addErrorMessage({
-          title: t('staff.feedbacks.views.ActivityFeedbackDetailsView.WriteFeedbackFloatingPanel.tabs.write.errors.saveFeedback'),
+          title: t('staff.feedbacks.views.ActivityFeedbackDetailsView.FeedbackManagementFloatingPanel.tabs.write.errors.saveFeedback'),
           description: getErrorMessage(error)
         })
       },

--- a/src/features/staff/feedbacks/views/ActivityFeedbackDetailsView/components/overlays/FeedbackManagementFloatingPanel/FeedbackManagementFloatingPanel.stub.ts
+++ b/src/features/staff/feedbacks/views/ActivityFeedbackDetailsView/components/overlays/FeedbackManagementFloatingPanel/FeedbackManagementFloatingPanel.stub.ts
@@ -1,8 +1,8 @@
 import type { FeedbackDetailsDTO } from '@/api/avenir-esr'
 import type { PropType } from 'vue'
 
-export const WriteFeedbackFloatingPanelStub = defineComponent({
-  name: 'WriteFeedbackFloatingPanel',
+export const FeedbackManagementFloatingPanelStub = defineComponent({
+  name: 'FeedbackManagementFloatingPanel',
   props: {
     feedback: {
       type: Object as PropType<FeedbackDetailsDTO>,

--- a/src/features/staff/feedbacks/views/ActivityFeedbackDetailsView/components/overlays/FeedbackManagementFloatingPanel/FeedbackManagementFloatingPanel.test.ts
+++ b/src/features/staff/feedbacks/views/ActivityFeedbackDetailsView/components/overlays/FeedbackManagementFloatingPanel/FeedbackManagementFloatingPanel.test.ts
@@ -2,14 +2,14 @@ import { mockedFeedbackDetailsWithAssociations, mockedFeedbackHistory } from '@/
 import { createGetFeedbackHistoryHandler, getFeedbackHistoryErrorHandler } from '@/__mocks__/msw/handlers/staffs/feedbacks.handlers'
 import { server } from '@/__mocks__/msw/server'
 import { FeedbacksHistoryTabStub } from '@/features/staff/feedbacks/views/ActivityFeedbackDetailsView/components/interaction/tabs/FeedbacksHistoryTab/FeedbacksHistory.stub'
-import WriteFeedbackFloatingPanel from '@/features/staff/feedbacks/views/ActivityFeedbackDetailsView/components/overlays/WriteFeedbackFloatingPanel/WriteFeedbackFloatingPanel.vue'
+import FeedbackManagementFloatingPanel from '@/features/staff/feedbacks/views/ActivityFeedbackDetailsView/components/overlays/FeedbackManagementFloatingPanel/FeedbackManagementFloatingPanel.vue'
 import { AvFloatingPanelStub, AvTabsStub, AvTabStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { flushPromises, type VueWrapper } from '@vue/test-utils'
 import { mountComponent } from 'tests/utils'
 import { beforeEach, expect } from 'vitest'
 
 BddTest().given('a write feedback floating panel', () => {
-  let wrapper: VueWrapper<InstanceType<typeof WriteFeedbackFloatingPanel>>
+  let wrapper: VueWrapper<InstanceType<typeof FeedbackManagementFloatingPanel>>
 
   const mockFeedback = mockedFeedbackDetailsWithAssociations
 
@@ -22,12 +22,12 @@ BddTest().given('a write feedback floating panel', () => {
   }
 
   const mountPanel = async () => {
-    const mounted = mountComponent(WriteFeedbackFloatingPanel, {
+    const mounted = mountComponent(FeedbackManagementFloatingPanel, {
       props: {
         feedback: mockFeedback,
-        activityTitle: 'Test Activity'
+        activityTitle: 'Test Activity',
       },
-      global: { stubs }
+      global: { stubs },
     })
     await flushPromises()
     return mounted

--- a/src/features/staff/feedbacks/views/ActivityFeedbackDetailsView/components/overlays/FeedbackManagementFloatingPanel/FeedbackManagementFloatingPanel.vue
+++ b/src/features/staff/feedbacks/views/ActivityFeedbackDetailsView/components/overlays/FeedbackManagementFloatingPanel/FeedbackManagementFloatingPanel.vue
@@ -1,26 +1,26 @@
 <script lang="ts" setup>
 import type { FeedbackDetailsDTO } from '@/api/avenir-esr'
-import { useGetFeedbackHistory } from '@/api/avenir-esr'
+import { EFeedbackStatus, useGetFeedbackHistory } from '@/api/avenir-esr'
 import { ICONS } from '@/common/constants'
 import FeedbacksHistoryTab from '@/features/staff/feedbacks/views/ActivityFeedbackDetailsView/components/interaction/tabs/FeedbacksHistoryTab/FeedbacksHistoryTab.vue'
 import WriteFeedbackTab from '@/features/staff/feedbacks/views/ActivityFeedbackDetailsView/components/interaction/tabs/WriteFeedbackTab/WriteFeedbackTab.vue'
 import { AvFloatingPanel, AvTab, AvTabs } from '@avenirs-esr/avenirs-dsav'
 import { useI18n } from 'vue-i18n'
 
-export interface WriteFeedbackFloatingPanelProps {
+export interface FeedbackManagementFloatingPanelProps {
   feedback: FeedbackDetailsDTO
   activityTitle: string
 }
 
-const { feedback, activityTitle } = defineProps<WriteFeedbackFloatingPanelProps>()
+const { feedback, activityTitle } = defineProps<FeedbackManagementFloatingPanelProps>()
 
-enum WriteFeedbackFloatingPanelTabs {
+enum FeedbackManagementFloatingPanelTabs {
   MY_FEEDBACK = 0,
   HISTORY = 1,
 }
 
 const { t } = useI18n()
-const activeTab = ref(WriteFeedbackFloatingPanelTabs.MY_FEEDBACK)
+const activeTab = ref(FeedbackManagementFloatingPanelTabs.MY_FEEDBACK)
 
 const panelRef = ref<InstanceType<typeof AvFloatingPanel> | null>(null)
 
@@ -43,9 +43,10 @@ const {
 const feedbacks = computed(() => feedbackHistory.value ?? [])
 const feedbacksCount = computed(() => feedbacks.value.length)
 const maxIterations = computed(() => feedback.activity.feedbackAllowedIterations)
+const isFeedbackSubmitted = computed(() => feedback.status === EFeedbackStatus.SUBMITTED)
 
 const historyTabTitle = computed(() =>
-  t('staff.feedbacks.views.ActivityFeedbackDetailsView.WriteFeedbackFloatingPanel.tabs.history.title', {
+  t('staff.feedbacks.views.ActivityFeedbackDetailsView.FeedbackManagementFloatingPanel.tabs.history.title', {
     count: feedbacksCount.value,
   })
 )
@@ -54,7 +55,7 @@ const historyTabTitle = computed(() =>
 <template>
   <AvFloatingPanel
     ref="panelRef"
-    :title="t('staff.feedbacks.views.ActivityFeedbackDetailsView.WriteFeedbackFloatingPanel.title')"
+    :title="t('staff.feedbacks.views.ActivityFeedbackDetailsView.FeedbackManagementFloatingPanel.title')"
     :subtitle="activityTitle"
     :icon="ICONS.FEEDBACK"
     width="35rem"
@@ -68,18 +69,19 @@ const historyTabTitle = computed(() =>
         :lazy-render="false"
       >
         <AvTab
-          :title="t('staff.feedbacks.views.ActivityFeedbackDetailsView.WriteFeedbackFloatingPanel.tabs.write.title')"
-          :name="WriteFeedbackFloatingPanelTabs.MY_FEEDBACK"
+          :title="t('staff.feedbacks.views.ActivityFeedbackDetailsView.FeedbackManagementFloatingPanel.tabs.write.title')"
+          :name="FeedbackManagementFloatingPanelTabs.MY_FEEDBACK"
         >
           <WriteFeedbackTab
             :feedback="feedback"
-            @cancel="togglePanel"
+            :readonly="isFeedbackSubmitted"
             @feedback-sent="togglePanel"
+            @cancel="togglePanel"
           />
         </AvTab>
         <AvTab
           :title="historyTabTitle"
-          :name="WriteFeedbackFloatingPanelTabs.HISTORY"
+          :name="FeedbackManagementFloatingPanelTabs.HISTORY"
           data-testid="history-tab-button"
         >
           <FeedbacksHistoryTab

--- a/src/features/staff/feedbacks/views/ActivityFeedbackDetailsView/composables/use-write-feedback-form/use-write-feedback-form.ts
+++ b/src/features/staff/feedbacks/views/ActivityFeedbackDetailsView/composables/use-write-feedback-form/use-write-feedback-form.ts
@@ -28,7 +28,7 @@ export function useWriteFeedbackForm ({ feedback, onFeedbackSaved, onCancel }: U
   const { isLoading, withTaskLoading } = useTaskLoading()
   const onSendFeedbackError = (error: BaseApiException) => {
     addErrorMessage({
-      title: t('staff.feedbacks.views.ActivityFeedbackDetailsView.WriteFeedbackFloatingPanel.tabs.write.errors.saveFeedback'),
+      title: t('staff.feedbacks.views.ActivityFeedbackDetailsView.FeedbackManagementFloatingPanel.tabs.write.errors.saveFeedback'),
       description: getErrorMessage(error)
     })
   }


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
- Made the "Feedback management" panel (renamed from "Write feedback") sticky while scrolling on the feedback details page.
- Fixed the panel disappearing when the feedback status became `SUBMITTED`.
- Fixed the panel auto-collapsing right after sending a feedback.
- Added a `readOnly` state, propagated through `WriteFeedbackFloatingPanel` → `WriteFeedbackTab` → `FeedbackFormField`, disabling the form and submit button once a feedback is submitted, while keeping the panel visible.
- Renamed the panel label: "Rédiger un feedback" → "Gestion du feedback" (i18n keys updated, FR/EN).

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/2125

---

### Target Branch
develop

---

### Additional Notes
<img width="1439" height="692" alt="Capture d’écran 2026-07-13 à 17 50 21" src="https://github.com/user-attachments/assets/7b4213ab-7bd3-4c5e-9c1e-5aaaaff817f3" />

<img width="1439" height="803" alt="Capture d’écran 2026-07-13 à 17 51 08" src="https://github.com/user-attachments/assets/4749f9df-2961-418e-a1ae-b3fe8df31212" />

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [x] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [ ] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and detaiils for the update process