### PR TITLE
fix(2132): StaffNotificationsPopover - add empty state message

### DIFF
--- a/src/features/staff/user/components/overlays/StaffNotificationsPopover/StaffNotificationsPopover.test.ts
+++ b/src/features/staff/user/components/overlays/StaffNotificationsPopover/StaffNotificationsPopover.test.ts
@@ -31,11 +31,35 @@ BddTest().given('a StaffNotificationsPopover', () => {
   const getPopover = () => wrapper.findComponent(NotificationsPopoverStub)
   const getCards = () => wrapper.findAllComponents(ActivityFeedbackNotificationCardStub)
 
-  BddTest().when('the component is rendered', () => {
+  BddTest().when('the component is mounted', () => {
     beforeEach(() => mountDefault())
 
     BddTest().then('it should render NotificationsPopover with correct props', () => {
       expect(getPopover().exists()).toBe(true)
+    })
+  })
+
+  BddTest().when('the component is mounted without notifications', () => {
+    beforeEach(() => {
+      wrapper = mountComponent(StaffNotificationsPopover, {
+        props: {
+          notificationsEnabled: true,
+          unseenNotifications: 0
+        },
+        attrs: {
+          notifications: []
+        },
+        global: { stubs }
+      })
+    })
+
+    BddTest().then('it should render NotificationsPopover with correct props', () => {
+      expect(getPopover().exists()).toBe(true)
+    })
+
+    BddTest().then('it should render the empty state message', () => {
+      expect(wrapper.text()).toContain('Vous recevrez une notification dans les cas suivants :')
+      expect(wrapper.text()).toContain('Un apprenant vous enverra une demande de feedback')
     })
   })
 

--- a/src/features/staff/user/components/overlays/StaffNotificationsPopover/StaffNotificationsPopover.vue
+++ b/src/features/staff/user/components/overlays/StaffNotificationsPopover/StaffNotificationsPopover.vue
@@ -2,10 +2,27 @@
 import { EUserCategory, NotificationDTOType } from '@/api/avenir-esr'
 import NotificationsPopover from '@/common/notifications/components/NotificationsPopover/NotificationsPopover.vue'
 import ActivityFeedbackNotificationCard from '@/features/staff/global/components/cards/ActivityFeedbackNotificationCard/ActivityFeedbackNotificationCard.vue'
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
 </script>
 
 <template>
   <NotificationsPopover :user-category="EUserCategory.STAFF">
+    <template #empty>
+      <span
+        class="b2-light"
+        data-testid="staff-notifications-popover-contexts-header"
+      >
+        {{ t('global.notifications.NotificationsPopover.contexts.header') }}
+      </span>
+      <ul
+        class="b2-regular av-pl-lg"
+        data-testid="staff-notifications-popover-contexts"
+      >
+        <li><span>{{ t('staff.user.overlays.StaffNotificationsPopover.contexts.feedback') }}</span></li>
+      </ul>
+    </template>
     <template #default="{ notification: n, onRedirect, onSeen }">
       <ActivityFeedbackNotificationCard
         v-if="n.type === NotificationDTOType.ASK_FOR_FEEDBACK"

--- a/src/features/staff/user/locales/en.json
+++ b/src/features/staff/user/locales/en.json
@@ -1,0 +1,13 @@
+{
+  "staff": {
+    "user": {
+      "overlays": {
+        "StaffNotificationsPopover": {
+          "contexts": {
+            "feedback": "A student will send you a feedback request"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/features/staff/user/locales/fr.json
+++ b/src/features/staff/user/locales/fr.json
@@ -1,0 +1,13 @@
+{
+  "staff": {
+    "user": {
+      "overlays": {
+        "StaffNotificationsPopover": {
+          "contexts": {
+            "feedback": "Un apprenant vous enverra une demande de feedback"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/features/student/user/components/overlays/StudentNotificationsPopover/StudentNotificationsPopover.vue
+++ b/src/features/student/user/components/overlays/StudentNotificationsPopover/StudentNotificationsPopover.vue
@@ -14,7 +14,7 @@ const { t } = useI18n()
         class="b2-light"
         data-testid="student-notifications-popover-contexts-header"
       >
-        {{ t('student.user.overlays.StudentNotificationsPopover.contexts.header') }}
+        {{ t('global.notifications.NotificationsPopover.contexts.header') }}
       </span>
       <ul
         class="b2-regular av-pl-lg"

--- a/src/features/student/user/locales/en.json
+++ b/src/features/student/user/locales/en.json
@@ -22,7 +22,6 @@
           "contexts": {
             "assessedSkill": "A third party will have assessed you on a skill",
             "comingUpEvent": "An event is coming up",
-            "header": "You will receive a notification in the following cases:",
             "staffMessage": "A staff will send you a message",
             "validatedTrace": "A trace has been validated"
           }

--- a/src/features/student/user/locales/fr.json
+++ b/src/features/student/user/locales/fr.json
@@ -22,7 +22,6 @@
           "contexts": {
             "assessedSkill": "Un tiers vous aura évalué sur une compétence",
             "comingUpEvent": "Un événement a lieu prochainement",
-            "header": "Vous recevrez une notification dans les cas suivants :",
             "staffMessage": "Un enseignant vous enverra un message",
             "validatedTrace": "Une trace a été validée"
           }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -360,6 +360,9 @@
     },
     "notifications": {
       "NotificationsPopover": {
+        "contexts": {
+          "header": "You will receive a notification in the following cases:"
+        },
         "header": "No unread notifications | {count} unread notification | {count} unread notifications",
         "markAsSeenError": "An error occurred while marking the notification as read",
         "notifications": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -360,6 +360,9 @@
     },
     "notifications": {
       "NotificationsPopover": {
+        "contexts": {
+          "header": "Vous recevrez une notification dans les cas suivants :"
+        },
         "header": "Aucune notification non lue | {count} notification non lue | {count} notifications non lues",
         "markAsSeenError": "Une erreur est survenue pendant le marquage à lu de la notification",
         "notifications": {


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
<!-- Describe the changes introduced by this pull request. -->

:bug: StaffNotificationsPopover - add empty state message

---

### Reference to an Issue, Feature, Task, User Story or another PR
<!-- Mention related issue numbers or links (e.g. Closes #123, Implements #456). -->
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/2132

---

### Target Branch
<!-- Which branch is this PR targeting (e.g. `main`, `develop`)? -->

develop

---

### Additional Notes
<!-- Include any relevant context, technical details, or reasons behind certain decisions. -->

<img width="1904" height="926" alt="image" src="https://github.com/user-attachments/assets/0f6d59ea-72f4-405d-9a73-f7a22fe0cc79" />

---

### Known Limitations or Side Effects
<!-- List any limitations, known bugs, or side effects this PR may introduce. -->

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [ ] No unnecessary code (e.g., debug logs, commented code)
- [ ] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and detaiils for the update process

---