### PR TITLE
feat(1987): integrate DeleteDeclaredSkillAssociatedActivitiesModal

### DIFF
--- a/src/features/student/buildProject/locales/en.json
+++ b/src/features/student/buildProject/locales/en.json
@@ -90,10 +90,6 @@
             "unsubscribe": "Unsubscribe"
           },
           "ProjectActivityDetailedView": {
-            "ActivityAssociateElementsDropdown": {
-              "skills": "one/many skill(s)",
-              "traces": "one/many trace(s)"
-            },
             "ActivityDetailedDropdown": {
               "triggerLabel": "Manage my activity"
             },
@@ -112,10 +108,6 @@
               "confirmTitle": "Are you sure you want to associate these items?",
               "success": "You have associated {count} trace. Find it in the category \"My associated traces\". | You have associated {count} traces. Find them in the category \"My associated traces\".",
               "title": "Which trace(s) would you like to associate?"
-            },
-            "DeleteActivityAssociatedElementsDropdown": {
-              "skills": "one/many associated skill(s)",
-              "traces": "one/many associated trace(s)"
             },
             "DeleteActivityAssociatedElementsModal": {
               "success": "The selected associations have been successfully deleted.",

--- a/src/features/student/buildProject/locales/fr.json
+++ b/src/features/student/buildProject/locales/fr.json
@@ -89,10 +89,6 @@
             "title": "Toutes les activités disponibles"
           },
           "ProjectActivityDetailedView": {
-            "ActivityAssociateElementsDropdown": {
-              "skills": "une/des compétence(s)",
-              "traces": "une/des trace(s)"
-            },
             "ActivityDetailedDropdown": {
               "triggerLabel": "Gérer mon activité"
             },
@@ -111,10 +107,6 @@
               "confirmTitle": "Êtes-vous certain(e) de vouloir associer ces éléments ?",
               "success": "Vous avez associé {count} trace. Retrouvez-la dans la catégorie \"Mes traces associées\". | Vous avez associé {count} traces. Retrouvez-les dans la catégorie \"Mes traces associées\".",
               "title": "Quelle(s) trace(s) souhaitez-vous associer ?"
-            },
-            "DeleteActivityAssociatedElementsDropdown": {
-              "skills": "une/des compétence(s) associée(s)",
-              "traces": "une/des trace(s) associée(s)"
             },
             "DeleteActivityAssociatedElementsModal": {
               "success": "Les associations sélectionnées ont été supprimées avec succès.",

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/overlays/dropdowns/ActivityAssociateElementsDropdown/ActivityAssociateElementsDropdown.vue
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/overlays/dropdowns/ActivityAssociateElementsDropdown/ActivityAssociateElementsDropdown.vue
@@ -25,13 +25,13 @@ const menuItems = computed(() => [
   {
     name: ActivityAssociateElementsDropdownEvents.TRACES,
     icon: ICONS.TRACES,
-    label: t('student.buildProject.activities.views.ProjectActivityDetailedView.ActivityAssociateElementsDropdown.traces'),
+    label: t('global.associations.elementsToAssociate.traces'),
     disabled: tracesDisabled
   },
   {
     name: ActivityAssociateElementsDropdownEvents.SKILLS,
     icon: ICONS.SKILLS,
-    label: t('student.buildProject.activities.views.ProjectActivityDetailedView.ActivityAssociateElementsDropdown.skills')
+    label: t('global.associations.elementsToAssociate.skills')
   }
 ])
 

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/overlays/dropdowns/DeleteActivityAssociatedElementsDropdown/DeleteActivityAssociatedElementsDropdown.vue
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/overlays/dropdowns/DeleteActivityAssociatedElementsDropdown/DeleteActivityAssociatedElementsDropdown.vue
@@ -25,12 +25,12 @@ const menuItems = computed(() => [
   {
     name: DeleteActivityAssociatedElementsDropdownEvents.SKILLS,
     icon: ICONS.SKILLS,
-    label: t('student.buildProject.activities.views.ProjectActivityDetailedView.DeleteActivityAssociatedElementsDropdown.skills'),
+    label: t('global.associations.elementsToAssociate.skills'),
   },
   {
     name: DeleteActivityAssociatedElementsDropdownEvents.TRACES,
     icon: ICONS.TRACES,
-    label: t('student.buildProject.activities.views.ProjectActivityDetailedView.DeleteActivityAssociatedElementsDropdown.traces'),
+    label: t('global.associations.elementsToAssociate.traces'),
     disabled: tracesDisabled
   }
 ])

--- a/src/features/student/declaredSkills/locales/en.json
+++ b/src/features/student/declaredSkills/locales/en.json
@@ -82,12 +82,6 @@
               "title": "Declared skill {skill}"
             }
           },
-          "DeclaredSkillAssociateElementsDropdown": {
-            "activities": "one/many activity(ies)"
-          },
-          "DeleteDeclaredSkillAssociatedElementsDropdown": {
-            "activities": "one/many activity(ies)"
-          },
           "declaredSkillDetails": {
             "levelTitle": "Self-positioning",
             "skillTitle": "Title:"

--- a/src/features/student/declaredSkills/locales/en.json
+++ b/src/features/student/declaredSkills/locales/en.json
@@ -85,6 +85,9 @@
           "DeclaredSkillAssociateElementsDropdown": {
             "activities": "one/many activity(ies)"
           },
+          "DeleteDeclaredSkillAssociatedElementsDropdown": {
+            "activities": "one/many activity(ies)"
+          },
           "declaredSkillDetails": {
             "levelTitle": "Self-positioning",
             "skillTitle": "Title:"

--- a/src/features/student/declaredSkills/locales/fr.json
+++ b/src/features/student/declaredSkills/locales/fr.json
@@ -82,12 +82,6 @@
               "title": "Compétence déclarée {skill}"
             }
           },
-          "DeclaredSkillAssociateElementsDropdown": {
-            "activities": "une/des activité(s)"
-          },
-          "DeleteDeclaredSkillAssociatedElementsDropdown": {
-            "activities": "une/des activité(s)"
-          },
           "declaredSkillDetails": {
             "levelTitle": "Auto-positionnement",
             "skillTitle": "Intitulé :"

--- a/src/features/student/declaredSkills/locales/fr.json
+++ b/src/features/student/declaredSkills/locales/fr.json
@@ -85,6 +85,9 @@
           "DeclaredSkillAssociateElementsDropdown": {
             "activities": "une/des activité(s)"
           },
+          "DeleteDeclaredSkillAssociatedElementsDropdown": {
+            "activities": "une/des activité(s)"
+          },
           "declaredSkillDetails": {
             "levelTitle": "Auto-positionnement",
             "skillTitle": "Intitulé :"

--- a/src/features/student/declaredSkills/views/StudentDeclaredSkillView/components/StudentDeclaredSkillAssociations/StudentDeclaredSkillAssociations.test.ts
+++ b/src/features/student/declaredSkills/views/StudentDeclaredSkillView/components/StudentDeclaredSkillAssociations/StudentDeclaredSkillAssociations.test.ts
@@ -1,12 +1,16 @@
 import type { TraceAssociationDTO } from '@/api/avenir-esr'
 import type { VueWrapper } from '@vue/test-utils'
 import { mockedTraceDeclaredActivityAssociations, mockedTraceOverview } from '@/__mocks__/fixtures/student'
+import { createMockedDeclaredActivitiesAssociations } from '@/__mocks__/fixtures/student/skills.fixtures'
+import { EDeclaredActivityStatus } from '@/api/avenir-esr'
 import { QuerySuspenseStub } from '@/common/components/QuerySuspense/QuerySuspense.stub'
 import { ErrorCodes } from '@/common/constants'
 import { AssociatedDeclaredActivitiesCardStub } from '@/features/student/buildProject/components/cards/AssociatedDeclaredActivitiesCard/AssociatedDeclaredActivitiesCard.stub'
 import { AssociatedTracesCardStub } from '@/features/student/buildProject/views/ProjectActivityDetailedView/components/cards/AssociatedTracesCard/AssociatedTracesCard.stub'
 import { AssociateActivitiesToDeclaredSkillModalStub } from '@/features/student/declaredSkills/components/overlays/modals/AssociateActivitiesToDeclaredSkillModal/AssociateActivitiesToDeclaredSkillModal.stub'
+import { DeleteDeclaredSkillAssociatedActivitiesModalStub } from '@/features/student/declaredSkills/components/overlays/modals/DeleteDeclaredSkillAssociatedActivitiesModal/DeleteDeclaredSkillAssociatedActivitiesModal.stub'
 import { DeclaredSkillAssociateElementsDropdownStub } from '@/features/student/declaredSkills/views/StudentDeclaredSkillView/components/overlays/dropdowns/DeclaredSkillAssociateElementsDropdown/DeclaredSkillAssociateElementsDropdown.stub'
+import { DeleteDeclaredSkillAssociatedElementsDropdownStub } from '@/features/student/declaredSkills/views/StudentDeclaredSkillView/components/overlays/dropdowns/DeleteDeclaredSkillAssociatedElementsDropdown/DeleteDeclaredSkillAssociatedElementsDropdown.stub'
 import StudentDeclaredSkillAssociations
   from '@/features/student/declaredSkills/views/StudentDeclaredSkillView/components/StudentDeclaredSkillAssociations/StudentDeclaredSkillAssociations.vue'
 import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
@@ -25,7 +29,9 @@ const stubs = {
   AssociatedTracesCard: AssociatedTracesCardStub,
   AssociatedDeclaredActivitiesCard: AssociatedDeclaredActivitiesCardStub,
   DeclaredSkillAssociateElementsDropdown: DeclaredSkillAssociateElementsDropdownStub,
-  AssociateActivitiesToDeclaredSkillModal: AssociateActivitiesToDeclaredSkillModalStub
+  DeleteDeclaredSkillAssociatedElementsDropdown: DeleteDeclaredSkillAssociatedElementsDropdownStub,
+  AssociateActivitiesToDeclaredSkillModal: AssociateActivitiesToDeclaredSkillModalStub,
+  DeleteDeclaredSkillAssociatedActivitiesModal: DeleteDeclaredSkillAssociatedActivitiesModalStub
 }
 
 BddTest().given('a student declared skill associations component', () => {
@@ -147,6 +153,107 @@ BddTest().given('a student declared skill associations component', () => {
         expect(wrapper.emitted('associated')).toBeTruthy()
         expect(wrapper.emitted('associated')).toHaveLength(1)
       })
+    })
+  })
+
+  BddTest().when('the component is rendered with deletable declared activities', () => {
+    const associatedDeclaredActivities = createMockedDeclaredActivitiesAssociations(3)
+    associatedDeclaredActivities[1].declaredActivity.status = EDeclaredActivityStatus.SUBMITTED
+    associatedDeclaredActivities[2].declaredActivity.status = EDeclaredActivityStatus.COMPLETED
+
+    beforeEach(() => {
+      wrapper = mountComponent(StudentDeclaredSkillAssociations, {
+        props: {
+          declaredSkillId,
+          associatedTraces: mockedAssociatedTraces,
+          associatedDeclaredActivities,
+          countAssociations: 3
+        },
+        global: { stubs }
+      })
+    })
+
+    BddTest().then('it should render the delete declared skill associated elements dropdown', () => {
+      const dropdown = wrapper.findComponent(DeleteDeclaredSkillAssociatedElementsDropdownStub)
+      expect(dropdown.exists()).toBe(true)
+    })
+
+    BddTest().then('it should enable the delete dropdown activities when a deletable activity exists', () => {
+      const dropdown = wrapper.findComponent(DeleteDeclaredSkillAssociatedElementsDropdownStub)
+      expect(dropdown.props('activitiesDisabled')).toBe(false)
+    })
+
+    BddTest().then('it should render the delete activities modal hidden by default', () => {
+      const modal = wrapper.findComponent(DeleteDeclaredSkillAssociatedActivitiesModalStub)
+      expect(modal.exists()).toBe(true)
+      expect(modal.props('show')).toBe(false)
+      expect(modal.props('declaredSkillProgressId')).toBe(declaredSkillId)
+      expect(modal.props('associations')).toEqual(associatedDeclaredActivities)
+    })
+
+    BddTest().and('the delete dropdown emits activitiesSelected', () => {
+      beforeEach(() => {
+        const dropdown = wrapper.findComponent(DeleteDeclaredSkillAssociatedElementsDropdownStub)
+        dropdown.vm.$emit('activitiesSelected')
+      })
+
+      BddTest().then('the delete activities modal should be shown', () => {
+        const modal = wrapper.findComponent(DeleteDeclaredSkillAssociatedActivitiesModalStub)
+        expect(modal.props('show')).toBe(true)
+      })
+    })
+
+    BddTest().and('the delete activities modal emits cancel', () => {
+      beforeEach(() => {
+        const dropdown = wrapper.findComponent(DeleteDeclaredSkillAssociatedElementsDropdownStub)
+        dropdown.vm.$emit('activitiesSelected')
+
+        const modal = wrapper.findComponent(DeleteDeclaredSkillAssociatedActivitiesModalStub)
+        modal.vm.$emit('cancel')
+      })
+
+      BddTest().then('the delete activities modal should be hidden', () => {
+        const modal = wrapper.findComponent(DeleteDeclaredSkillAssociatedActivitiesModalStub)
+        expect(modal.props('show')).toBe(false)
+      })
+    })
+
+    BddTest().and('the delete activities modal emits deleted', () => {
+      beforeEach(() => {
+        const dropdown = wrapper.findComponent(DeleteDeclaredSkillAssociatedElementsDropdownStub)
+        dropdown.vm.$emit('activitiesSelected')
+
+        const modal = wrapper.findComponent(DeleteDeclaredSkillAssociatedActivitiesModalStub)
+        modal.vm.$emit('deleted')
+      })
+
+      BddTest().then('the delete activities modal should be hidden', () => {
+        const modal = wrapper.findComponent(DeleteDeclaredSkillAssociatedActivitiesModalStub)
+        expect(modal.props('show')).toBe(false)
+      })
+    })
+  })
+
+  BddTest().when('the component is rendered with only non-deletable declared activities', () => {
+    const associatedDeclaredActivities = createMockedDeclaredActivitiesAssociations(2)
+    associatedDeclaredActivities[0].declaredActivity.status = EDeclaredActivityStatus.SUBMITTED
+    associatedDeclaredActivities[1].declaredActivity.status = EDeclaredActivityStatus.COMPLETED
+
+    beforeEach(() => {
+      wrapper = mountComponent(StudentDeclaredSkillAssociations, {
+        props: {
+          declaredSkillId,
+          associatedTraces: [],
+          associatedDeclaredActivities,
+          countAssociations: 2
+        },
+        global: { stubs }
+      })
+    })
+
+    BddTest().then('it should disable the delete dropdown activities', () => {
+      const dropdown = wrapper.findComponent(DeleteDeclaredSkillAssociatedElementsDropdownStub)
+      expect(dropdown.props('activitiesDisabled')).toBe(true)
     })
   })
 

--- a/src/features/student/declaredSkills/views/StudentDeclaredSkillView/components/StudentDeclaredSkillAssociations/StudentDeclaredSkillAssociations.vue
+++ b/src/features/student/declaredSkills/views/StudentDeclaredSkillView/components/StudentDeclaredSkillAssociations/StudentDeclaredSkillAssociations.vue
@@ -9,8 +9,13 @@ import AssociatedTracesCard
   from '@/features/student/buildProject/views/ProjectActivityDetailedView/components/cards/AssociatedTracesCard/AssociatedTracesCard.vue'
 import AssociateActivitiesToDeclaredSkillModal
   from '@/features/student/declaredSkills/components/overlays/modals/AssociateActivitiesToDeclaredSkillModal/AssociateActivitiesToDeclaredSkillModal.vue'
+import DeleteDeclaredSkillAssociatedActivitiesModal
+  from '@/features/student/declaredSkills/components/overlays/modals/DeleteDeclaredSkillAssociatedActivitiesModal/DeleteDeclaredSkillAssociatedActivitiesModal.vue'
+import { isDeletableDeclaredActivityAssociation } from '@/features/student/declaredSkills/rules/declared-activity-association.rules'
 import DeclaredSkillAssociateElementsDropdown
   from '@/features/student/declaredSkills/views/StudentDeclaredSkillView/components/overlays/dropdowns/DeclaredSkillAssociateElementsDropdown/DeclaredSkillAssociateElementsDropdown.vue'
+import DeleteDeclaredSkillAssociatedElementsDropdown
+  from '@/features/student/declaredSkills/views/StudentDeclaredSkillView/components/overlays/dropdowns/DeleteDeclaredSkillAssociatedElementsDropdown/DeleteDeclaredSkillAssociatedElementsDropdown.vue'
 import { useI18n } from 'vue-i18n'
 
 interface StudentDeclaredSkillAssociationsProps {
@@ -41,6 +46,15 @@ const {
   hideModal: hideAssociateActivitiesModal
 } = useModal()
 
+const {
+  showModal: showDeleteActivitiesModal,
+  displayModal: displayDeleteActivitiesModal,
+  hideModal: hideDeleteActivitiesModal
+} = useModal()
+
+const deletableDeclaredActivityAssociations = computed(() =>
+  associatedDeclaredActivities.filter(isDeletableDeclaredActivityAssociation))
+
 function onAssociated () {
   hideAssociateActivitiesModal()
   emit('associated')
@@ -54,6 +68,10 @@ function onAssociated () {
       data-testid="declared-skill-associations"
     >
       <div class="av-row av-flex-fill av-justify-end av-gap-md">
+        <DeleteDeclaredSkillAssociatedElementsDropdown
+          :activities-disabled="deletableDeclaredActivityAssociations.length === 0"
+          @activities-selected="displayDeleteActivitiesModal"
+        />
         <DeclaredSkillAssociateElementsDropdown
           @activities-selected="displayAssociateActivitiesModal"
         />
@@ -78,5 +96,13 @@ function onAssociated () {
     :declared-skill-id="declaredSkillId"
     @cancel="hideAssociateActivitiesModal"
     @associated="onAssociated"
+  />
+
+  <DeleteDeclaredSkillAssociatedActivitiesModal
+    :show="showDeleteActivitiesModal"
+    :declared-skill-progress-id="declaredSkillId"
+    :associations="associatedDeclaredActivities"
+    @cancel="hideDeleteActivitiesModal"
+    @deleted="hideDeleteActivitiesModal"
   />
 </template>

--- a/src/features/student/declaredSkills/views/StudentDeclaredSkillView/components/overlays/dropdowns/DeclaredSkillAssociateElementsDropdown/DeclaredSkillAssociateElementsDropdown.vue
+++ b/src/features/student/declaredSkills/views/StudentDeclaredSkillView/components/overlays/dropdowns/DeclaredSkillAssociateElementsDropdown/DeclaredSkillAssociateElementsDropdown.vue
@@ -17,7 +17,7 @@ const menuItems = computed(() => [
   {
     name: DeclaredSkillAssociateElementsDropdownEvents.ACTIVITIES,
     icon: ICONS.ACTIVITY,
-    label: t('student.declaredSkills.views.StudentDeclaredSkillView.DeclaredSkillAssociateElementsDropdown.activities')
+    label: t('global.associations.elementsToAssociate.activities')
   }
 ])
 

--- a/src/features/student/declaredSkills/views/StudentDeclaredSkillView/components/overlays/dropdowns/DeleteDeclaredSkillAssociatedElementsDropdown/DeleteDeclaredSkillAssociatedElementsDropdown.stub.ts
+++ b/src/features/student/declaredSkills/views/StudentDeclaredSkillView/components/overlays/dropdowns/DeleteDeclaredSkillAssociatedElementsDropdown/DeleteDeclaredSkillAssociatedElementsDropdown.stub.ts
@@ -1,0 +1,15 @@
+export const DeleteDeclaredSkillAssociatedElementsDropdownStub = defineComponent({
+  name: 'DeleteDeclaredSkillAssociatedElementsDropdown',
+  props: {
+    activitiesDisabled: {
+      type: Boolean,
+      default: false
+    },
+    disabled: {
+      type: Boolean,
+      default: false
+    }
+  },
+  emits: ['activitiesSelected'],
+  template: '<div class="delete-declared-skill-associated-elements-dropdown-stub" />'
+})

--- a/src/features/student/declaredSkills/views/StudentDeclaredSkillView/components/overlays/dropdowns/DeleteDeclaredSkillAssociatedElementsDropdown/DeleteDeclaredSkillAssociatedElementsDropdown.test.ts
+++ b/src/features/student/declaredSkills/views/StudentDeclaredSkillView/components/overlays/dropdowns/DeleteDeclaredSkillAssociatedElementsDropdown/DeleteDeclaredSkillAssociatedElementsDropdown.test.ts
@@ -1,0 +1,65 @@
+import DeleteDeclaredSkillAssociatedElementsDropdown from '@/features/student/declaredSkills/views/StudentDeclaredSkillView/components/overlays/dropdowns/DeleteDeclaredSkillAssociatedElementsDropdown/DeleteDeclaredSkillAssociatedElementsDropdown.vue'
+import { AvDropdownStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { beforeEach, expect } from 'vitest'
+
+BddTest().given('a delete declared skill associated elements dropdown', () => {
+  let wrapper: VueWrapper<InstanceType<typeof DeleteDeclaredSkillAssociatedElementsDropdown>>
+
+  const stubs = {
+    AvDropdown: AvDropdownStub
+  }
+
+  BddTest().when('the component is mounted', () => {
+    beforeEach(() => {
+      wrapper = mount(DeleteDeclaredSkillAssociatedElementsDropdown, { global: { stubs } })
+    })
+
+    BddTest().then('it should render the dropdown with a single menu item', () => {
+      const dropdown = wrapper.findComponent({ name: 'AvDropdown' })
+      expect(dropdown.exists()).toBe(true)
+      expect(dropdown.props('items')).toHaveLength(1)
+    })
+
+    BddTest().then('it should pass correct props to dropdown', () => {
+      const dropdown = wrapper.findComponent({ name: 'AvDropdown' })
+      expect(dropdown.props('triggerAriaLabel')).toBe('Supprimer...')
+      expect(dropdown.props('triggerLabel')).toBe('Supprimer...')
+    })
+
+    BddTest().and('the activities button is clicked', () => {
+      BddTest().then('it should emit the activitiesSelected event', async () => {
+        const activitiesButton = wrapper.find('[data-name="activities"]')
+        await activitiesButton.trigger('click')
+        expect(wrapper.emitted('activitiesSelected')).toHaveLength(1)
+      })
+    })
+  })
+
+  BddTest().when('the component is mounted with activities disabled', () => {
+    beforeEach(() => {
+      wrapper = mount(DeleteDeclaredSkillAssociatedElementsDropdown, {
+        props: { activitiesDisabled: true },
+        global: { stubs }
+      })
+    })
+
+    BddTest().then('the activities menu item should be disabled', () => {
+      const activitiesButton = wrapper.find('[data-name="activities"]')
+      expect(activitiesButton.attributes('disabled')).toBeDefined()
+    })
+  })
+
+  BddTest().when('the component is mounted with disabled=true', () => {
+    beforeEach(() => {
+      wrapper = mount(DeleteDeclaredSkillAssociatedElementsDropdown, {
+        props: { disabled: true },
+        global: { stubs }
+      })
+    })
+
+    BddTest().then('the activities menu item should be disabled', () => {
+      expect(wrapper.find('[data-name="activities"]').attributes('disabled')).toBeDefined()
+    })
+  })
+})

--- a/src/features/student/declaredSkills/views/StudentDeclaredSkillView/components/overlays/dropdowns/DeleteDeclaredSkillAssociatedElementsDropdown/DeleteDeclaredSkillAssociatedElementsDropdown.vue
+++ b/src/features/student/declaredSkills/views/StudentDeclaredSkillView/components/overlays/dropdowns/DeleteDeclaredSkillAssociatedElementsDropdown/DeleteDeclaredSkillAssociatedElementsDropdown.vue
@@ -24,7 +24,7 @@ const menuItems = computed(() => [
   {
     name: DeleteDeclaredSkillAssociatedElementsDropdownEvents.ACTIVITIES,
     icon: ICONS.ACTIVITY,
-    label: t('student.declaredSkills.views.StudentDeclaredSkillView.DeleteDeclaredSkillAssociatedElementsDropdown.activities'),
+    label: t('global.associations.elementsToAssociate.activities'),
     disabled: disabled || activitiesDisabled,
   }
 ])

--- a/src/features/student/declaredSkills/views/StudentDeclaredSkillView/components/overlays/dropdowns/DeleteDeclaredSkillAssociatedElementsDropdown/DeleteDeclaredSkillAssociatedElementsDropdown.vue
+++ b/src/features/student/declaredSkills/views/StudentDeclaredSkillView/components/overlays/dropdowns/DeleteDeclaredSkillAssociatedElementsDropdown/DeleteDeclaredSkillAssociatedElementsDropdown.vue
@@ -1,0 +1,51 @@
+<script lang="ts" setup>
+import { ICONS } from '@/common/constants'
+import { AvDropdown, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
+import { useI18n } from 'vue-i18n'
+
+export interface DeleteDeclaredSkillAssociatedElementsDropdownProps {
+  activitiesDisabled?: boolean
+  disabled?: boolean
+}
+
+const { activitiesDisabled = false, disabled = false } = defineProps<DeleteDeclaredSkillAssociatedElementsDropdownProps>()
+
+const emit = defineEmits<{
+  (e: 'activitiesSelected'): void
+}>()
+
+enum DeleteDeclaredSkillAssociatedElementsDropdownEvents {
+  ACTIVITIES = 'activities',
+}
+
+const { t } = useI18n()
+
+const menuItems = computed(() => [
+  {
+    name: DeleteDeclaredSkillAssociatedElementsDropdownEvents.ACTIVITIES,
+    icon: ICONS.ACTIVITY,
+    label: t('student.declaredSkills.views.StudentDeclaredSkillView.DeleteDeclaredSkillAssociatedElementsDropdown.activities'),
+    disabled: disabled || activitiesDisabled,
+  }
+])
+
+function handleItemSelected (itemName: string) {
+  switch (itemName) {
+    case DeleteDeclaredSkillAssociatedElementsDropdownEvents.ACTIVITIES:
+      emit('activitiesSelected')
+      break
+  }
+}
+</script>
+
+<template>
+  <AvDropdown
+    data-testid="delete-declared-skill-associated-elements-dropdown"
+    :items="menuItems"
+    :trigger-aria-label="`${t('global.buttons.delete')}...`"
+    :trigger-label="`${t('global.buttons.delete')}...`"
+    :trigger-icon="MDI_ICONS.TRASH_CAN_OUTLINE"
+    width="max-content"
+    @item-selected="handleItemSelected"
+  />
+</template>

--- a/src/features/student/traces/locales/en.json
+++ b/src/features/student/traces/locales/en.json
@@ -281,10 +281,6 @@
           "ConfirmAssociateActivitiesModal": {
             "title": "Are you sure you want to associate this activity? | Are you sure you want to associate these activities?"
           },
-          "DeleteTraceAssociatedElementsDropdown": {
-            "activities": "one/many associated activity(ies)",
-            "skills": "one/many associated skill(s)"
-          },
           "errors": {
             "delete": "An error occurred while deleting the trace",
             "download": "An error occurred while downloading the trace",
@@ -303,11 +299,6 @@
           "tabs": {
             "associations": "My associated elements ({count})",
             "details": "My trace"
-          },
-          "TraceAssociateElementsDropdown": {
-            "activities": "one/many activity(ies)",
-            "experiences": "one/many experience(s)",
-            "skills": "one/many skill(s)"
           }
         },
         "StudentUpdateTraceView": {

--- a/src/features/student/traces/locales/fr.json
+++ b/src/features/student/traces/locales/fr.json
@@ -281,10 +281,6 @@
           "ConfirmAssociateActivitiesModal": {
             "title": "Êtes-vous certain(e) de vouloir associer cette activité ? | Êtes-vous certain(e) de vouloir associer ces activités ?"
           },
-          "DeleteTraceAssociatedElementsDropdown": {
-            "activities": "une/des activité(s) associée(s)",
-            "skills": "une/des compétence(s) associée(s)"
-          },
           "empty": {
             "associations": "Aucune association pour cette trace."
           },
@@ -304,12 +300,7 @@
             "associations": "Mes éléments associés ({count})",
             "details": "Ma trace"
           },
-          "title": "Trace {trace}",
-          "TraceAssociateElementsDropdown": {
-            "activities": "une/des activité(s)",
-            "experiences": "une/des expérience(s)",
-            "skills": "une/des compétence(s)"
-          }
+          "title": "Trace {trace}"
         },
         "StudentUpdateTraceView": {
           "associations": "Mes éléments associés ({count})",

--- a/src/features/student/traces/views/StudentTraceView/components/overlays/dropdowns/DeleteTraceAssociatedElementsDropdown/DeleteTraceAssociatedElementsDropdown.vue
+++ b/src/features/student/traces/views/StudentTraceView/components/overlays/dropdowns/DeleteTraceAssociatedElementsDropdown/DeleteTraceAssociatedElementsDropdown.vue
@@ -27,13 +27,13 @@ const menuItems = computed(() => [
   {
     name: DeleteTraceAssociatedElementsDropdownEvents.SKILLS,
     icon: ICONS.SKILLS,
-    label: t('student.traces.views.StudentTraceView.DeleteTraceAssociatedElementsDropdown.skills'),
+    label: t('global.associations.elementsToAssociate.skills'),
     disabled: disabled || skillsDisabled,
   },
   {
     name: DeleteTraceAssociatedElementsDropdownEvents.ACTIVITIES,
     icon: ICONS.ACTIVITY,
-    label: t('student.traces.views.StudentTraceView.DeleteTraceAssociatedElementsDropdown.activities'),
+    label: t('global.associations.elementsToAssociate.activities'),
     disabled: disabled || activitiesDisabled,
   }
 ])

--- a/src/features/student/traces/views/StudentTraceView/components/overlays/dropdowns/TraceAssociateElementsDropdown/TraceAssociateElementsDropdown.vue
+++ b/src/features/student/traces/views/StudentTraceView/components/overlays/dropdowns/TraceAssociateElementsDropdown/TraceAssociateElementsDropdown.vue
@@ -27,7 +27,7 @@ const menuItems = computed(() => [
   {
     name: TraceAssociateElementsDropdownEvents.ACTIVITIES,
     icon: ICONS.ACTIVITY,
-    label: t('student.traces.views.StudentTraceView.TraceAssociateElementsDropdown.activities'),
+    label: t('global.associations.elementsToAssociate.activities'),
     disabled,
   },
   ...(
@@ -36,14 +36,14 @@ const menuItems = computed(() => [
       : [{
           name: TraceAssociateElementsDropdownEvents.EXPERIENCES,
           icon: ICONS.EXPERIENCES,
-          label: t('student.traces.views.StudentTraceView.TraceAssociateElementsDropdown.experiences'),
+          label: t('global.associations.elementsToAssociate.experiences'),
           disabled,
         }]
   ),
   {
     name: TraceAssociateElementsDropdownEvents.SKILLS,
     icon: ICONS.SKILLS,
-    label: t('student.traces.views.StudentTraceView.TraceAssociateElementsDropdown.skills'),
+    label: t('global.associations.elementsToAssociate.skills'),
     disabled,
   }
 ])

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -46,6 +46,14 @@
       }
     },
     "application": "Application",
+    "associations": {
+      "elementsToAssociate": {
+        "activities": "one/many activity(ies)",
+        "experiences": "one/many experience(s)",
+        "skills": "one/many skill(s)",
+        "traces": "one/many trace(s)"
+      }
+    },
     "audio": "Audio",
     "AvAutoComplete": {
       "clearLabel": "Clear the input",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -46,6 +46,14 @@
       }
     },
     "application": "Application",
+    "associations": {
+      "elementsToAssociate": {
+        "activities": "une/des activité(s)",
+        "experiences": "une/des expérience(s)",
+        "skills": "une/des compétence(s)",
+        "traces": "une/des trace(s)"
+      }
+    },
     "audio": "Audio",
     "AvAutoComplete": {
       "clearLabel": "Effacer la saisie",


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
Integrate the `DeleteDeclaredSkillAssociatedElementsDropdown` component into the `StudentDeclaredSkillAssociations` view to enable deletion of associated activities and skills within declared skills management.

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1987

---

### Documentation
- Added new i18n translations for `student.declaredSkills` feature (both EN and FR locales)
- Component includes proper TypeScript typing and JSDoc documentation
- Stubs provided for parent component testing

---

### Target Branch
`develop`

---

### Additional Notes
- The `DeleteDeclaredSkillAssociatedElementsDropdown` component was created in the previous commit (1986)
- This PR integrates it into the existing `StudentDeclaredSkillAssociations` component
- Full test coverage included for the new component and integration tests for the parent
- i18n strings properly ordered alphabetically in locale files

---

### Known Limitations or Side Effects
None identified.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [x] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [x] i18n handled (texts are translated)
- [x] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [x] Semantic Versioning respected
- [x] Add to `CHANGELOG.md` file all properties and database change and details for the update process