### PR TITLE
fix(2099): fix finish activity button display states based on declare…

### DIFF
--- a/e2e/framework/student/lifeProject/activityDetails/StudentProjectActivityDetails.ts
+++ b/e2e/framework/student/lifeProject/activityDetails/StudentProjectActivityDetails.ts
@@ -127,6 +127,26 @@ export class StudentProjectActivityDetails extends BasePage {
     await this.getMyPerspectiveSection().verifyFinishButtonVisible()
   }
 
+  @Then('the finish activity button is enabled')
+  async verifyFinishActivityButtonEnabled () {
+    await this.getMyPerspectiveSection().verifyFinishButtonEnabled()
+  }
+
+  @Then('the finish activity button is disabled')
+  async verifyFinishActivityButtonDisabled () {
+    await this.getMyPerspectiveSection().verifyFinishButtonDisabled()
+  }
+
+  @Then('the finish activity badge is visible')
+  async verifyFinishActivityBadgeVisible () {
+    await this.getMyPerspectiveSection().verifyFinishBadgeVisible()
+  }
+
+  @Then('the finish activity badge is hidden')
+  async verifyFinishActivityBadgeHidden () {
+    await this.getMyPerspectiveSection().verifyFinishBadgeHidden()
+  }
+
   @When('the student clicks the finish activity button')
   async clickFinishActivityButton () {
     await this.getMyPerspectiveSection().clickFinishButton()

--- a/e2e/framework/student/lifeProject/activityDetails/componentObjects/MyPerspectiveSectionObject.ts
+++ b/e2e/framework/student/lifeProject/activityDetails/componentObjects/MyPerspectiveSectionObject.ts
@@ -39,6 +39,10 @@ export class MyPerspectiveSectionObject extends BaseObject {
     return this.root.getByTestId('finish-declared-activity-button')
   }
 
+  getFinishBadge () {
+    return this.root.getByTestId('finish-declared-activity-finished-badge')
+  }
+
   getFinishConfirmationModal () {
     return this.root.page().getByTestId('finish-declared-activity-confirm-modal')
   }
@@ -158,6 +162,22 @@ export class MyPerspectiveSectionObject extends BaseObject {
 
   async verifyFinishButtonVisible () {
     await expect(this.getFinishButton()).toBeVisible()
+  }
+
+  async verifyFinishButtonEnabled () {
+    await expect(this.getFinishButton()).toBeEnabled()
+  }
+
+  async verifyFinishButtonDisabled () {
+    await expect(this.getFinishButton()).toBeDisabled()
+  }
+
+  async verifyFinishBadgeVisible () {
+    await expect(this.getFinishBadge()).toBeVisible()
+  }
+
+  async verifyFinishBadgeHidden () {
+    await expect(this.getFinishBadge()).toBeHidden()
   }
 
   async verifyFinishButtonHidden () {

--- a/e2e/tests/student/lifeProject/activityDetails/activityDetails.feature
+++ b/e2e/tests/student/lifeProject/activityDetails/activityDetails.feature
@@ -78,14 +78,44 @@ Feature: Student Project Activity Detail Page
   Rule: Finish declared activity
 
     @high @activity-details @finish-activity
-    Scenario: Student can finish an in progress activity
+    Scenario: Student with in progress activity can finish it
       And the student clicks a library activity card with "IN_PROGRESS" status
       And the project activity details are loaded
       And the student clicks the my perspective item in the activity side menu
       And the my perspective section is visible
       Then the finish activity button is visible
+      And the finish activity button is enabled
+      And the finish activity badge is hidden
       When the student clicks the finish activity button
       Then the finish activity confirmation modal is visible
+
+    @high @activity-details @finish-activity
+    Scenario: Student with submitted activity has disabled finish button
+      And the student clicks a library activity card with "SUBMITTED" status
+      And the project activity details are loaded
+      And the student clicks the my perspective item in the activity side menu
+      And the my perspective section is visible
+      Then the finish activity button is visible
+      And the finish activity button is disabled
+      And the finish activity badge is hidden
+
+    @high @activity-details @finish-activity
+    Scenario: Student with completed activity sees finished badge
+      And the student clicks a library activity card with "COMPLETED" status
+      And the project activity details are loaded
+      And the student clicks the my perspective item in the activity side menu
+      And the my perspective section is visible
+      Then the finish activity button is hidden
+      And the finish activity badge is visible
+
+    @high @activity-details @finish-activity
+    Scenario: Student with subscribed activity has no finish button and no badge
+      And the student clicks a library activity card with "SUBSCRIBED" status
+      And the project activity details are loaded
+      And the student clicks the my perspective item in the activity side menu
+      And the my perspective section is visible
+      Then the finish activity button is hidden
+    And the finish activity badge is hidden
 
   Rule: Request feedback
 

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/FinishDeclaredActivity/FinishDeclaredActivity.test.ts
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/FinishDeclaredActivity/FinishDeclaredActivity.test.ts
@@ -14,12 +14,23 @@ BddTest().given('a FinishDeclaredActivity component', () => {
     FinishDeclaredActivityConfirmModal: FinishDeclaredActivityConfirmModalStub,
   }
 
-  BddTest().when('the component is mounted without completed status', () => {
+  BddTest().when('the component is mounted with subscribed status', () => {
     beforeEach(() => {
       wrapper = mountComponent(FinishDeclaredActivity, {
-        props: {
-          status: EDeclaredActivityStatus.IN_PROGRESS,
-        },
+        props: { status: EDeclaredActivityStatus.SUBSCRIBED },
+        global: { stubs },
+      })
+    })
+
+    BddTest().then('it should not render the finish declared activity block', () => {
+      expect(wrapper.find('[data-testid="finish-declared-activity"]').exists()).toBe(false)
+    })
+  })
+
+  BddTest().when('the component is mounted with in progress status', () => {
+    beforeEach(() => {
+      wrapper = mountComponent(FinishDeclaredActivity, {
+        props: { status: EDeclaredActivityStatus.IN_PROGRESS },
         global: { stubs },
       })
     })
@@ -28,16 +39,17 @@ BddTest().given('a FinishDeclaredActivity component', () => {
       expect(wrapper.find('[data-testid="finish-declared-activity"]').exists()).toBe(true)
     })
 
-    BddTest().then('it should render the finish button with correct props', () => {
+    BddTest().then('it should render the finish button as enabled with correct props', () => {
       const button = wrapper.findComponent(AvButtonStub)
       expect(button.exists()).toBe(true)
       expect(button.props('label')).toBe('Terminer l\'activité')
       expect(button.props('variant')).toBe('FLAT')
       expect(button.props('icon')).toBeDefined()
+      expect(button.props('disabled')).toBe(false)
     })
 
     BddTest().then('it should not render the completed badge', () => {
-      expect(wrapper.find('[data-testid="av-badge-stub"]').exists()).toBe(false)
+      expect(wrapper.findComponent(AvBadgeStub).exists()).toBe(false)
     })
 
     BddTest().then('it should render the confirmation modal closed by default', () => {
@@ -88,12 +100,33 @@ BddTest().given('a FinishDeclaredActivity component', () => {
     })
   })
 
+  BddTest().when('the component is mounted with submitted status', () => {
+    beforeEach(() => {
+      wrapper = mountComponent(FinishDeclaredActivity, {
+        props: { status: EDeclaredActivityStatus.SUBMITTED },
+        global: { stubs },
+      })
+    })
+
+    BddTest().then('it should render the finish declared activity block', () => {
+      expect(wrapper.find('[data-testid="finish-declared-activity"]').exists()).toBe(true)
+    })
+
+    BddTest().then('it should render the finish button as disabled', () => {
+      const button = wrapper.findComponent(AvButtonStub)
+      expect(button.exists()).toBe(true)
+      expect(button.props('disabled')).toBe(true)
+    })
+
+    BddTest().then('it should not render the completed badge', () => {
+      expect(wrapper.findComponent(AvBadgeStub).exists()).toBe(false)
+    })
+  })
+
   BddTest().when('the component is mounted with completed status', () => {
     beforeEach(() => {
       wrapper = mountComponent(FinishDeclaredActivity, {
-        props: {
-          status: EDeclaredActivityStatus.COMPLETED,
-        },
+        props: { status: EDeclaredActivityStatus.COMPLETED },
         global: { stubs },
       })
     })
@@ -111,32 +144,6 @@ BddTest().given('a FinishDeclaredActivity component', () => {
       expect(badge.exists()).toBe(true)
       expect(badge.props('label')).toBe('Terminée')
       expect(badge.props('icon')).toBeDefined()
-    })
-
-    BddTest().then('it should render the confirmation modal closed by default', () => {
-      const confirmModal = wrapper.findComponent(FinishDeclaredActivityConfirmModalStub)
-      expect(confirmModal.exists()).toBe(true)
-      expect(confirmModal.props('show')).toBe(false)
-    })
-  })
-
-  BddTest().when('the component is mounted without status', () => {
-    beforeEach(() => {
-      wrapper = mountComponent(FinishDeclaredActivity, {
-        global: { stubs },
-      })
-    })
-
-    BddTest().then('it should not render the finish declared activity block', () => {
-      expect(wrapper.find('[data-testid="finish-declared-activity"]').exists()).toBe(false)
-    })
-
-    BddTest().then('it should not render the finish button', () => {
-      expect(wrapper.findComponent(AvButtonStub).exists()).toBe(false)
-    })
-
-    BddTest().then('it should not render the completed badge', () => {
-      expect(wrapper.findComponent(AvBadgeStub).exists()).toBe(false)
     })
 
     BddTest().then('it should render the confirmation modal closed by default', () => {

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/FinishDeclaredActivity/FinishDeclaredActivity.vue
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/FinishDeclaredActivity/FinishDeclaredActivity.vue
@@ -27,24 +27,26 @@ function handleConfirm () {
 
 const isCompleted = computed(() => status === EDeclaredActivityStatus.COMPLETED)
 const isInProgress = computed(() => status === EDeclaredActivityStatus.IN_PROGRESS)
+const isSubscribed = computed(() => status === EDeclaredActivityStatus.SUBSCRIBED)
 </script>
 
 <template>
   <div
-    v-if="isInProgress || isCompleted"
+    v-if="!isSubscribed"
     class="av-col av-align-end av-items-end av-pt-md"
     data-testid="finish-declared-activity"
   >
     <AvButton
-      v-if="isInProgress"
+      v-if="!isCompleted"
       data-testid="finish-declared-activity-button"
       :label="t('student.buildProject.activities.views.ProjectActivityDetailedView.FinishDeclaredActivity.finishButton')"
       variant="FLAT"
       :icon="MDI_ICONS.CHECK_CIRCLE_OUTLINE"
+      :disabled="!isInProgress"
       @click="displayModal"
     />
     <div
-      v-if="isCompleted"
+      v-else
       class="av-col av-align-end"
     >
       <AvBadge


### PR DESCRIPTION
### Brief description of changes applied
Fix the display states of the "Finish activity" button based on the declared activity status:
- SUBSCRIBED: button hidden
- IN_PROGRESS: button visible and enabled
- SUBMITTED: button visible but disabled
- COMPLETED: button hidden

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/2099

---

### Target Branch
develop

---

### Additional Notes


https://github.com/user-attachments/assets/34390f11-6051-4142-b4d7-5ad81db7294a


https://github.com/user-attachments/assets/4f129e10-94e3-491c-be79-e8e1b285ef58


---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [ ] No unnecessary code (e.g., debug logs, commented code)
- [ ] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and detaiils for the update process