### PR TITLE
feat(2007): add e2e for delete declared skill associated activities modal

### DIFF
--- a/e2e/framework/student/lifeProject/declaredSkillDetails/StudentDeclaredSkillDetailPage.ts
+++ b/e2e/framework/student/lifeProject/declaredSkillDetails/StudentDeclaredSkillDetailPage.ts
@@ -104,4 +104,74 @@ class StudentDeclaredSkillDetailPage extends BasePage {
   async verifyAllActivityItemsHaveTitles () {
     await this.getDeclaredSkillAssociations().verifyAllActivityItemsHaveTitles()
   }
+
+  @Then('the delete associations dropdown is visible')
+  async verifyDeleteAssociationsDropdownVisible () {
+    await this.getDeclaredSkillAssociations().verifyDeleteAssociationsDropdownVisible()
+  }
+
+  @When('the student opens the delete associations dropdown')
+  async openDeleteAssociationsDropdown () {
+    await this.getDeclaredSkillAssociations().openDeleteAssociationsDropdown()
+  }
+
+  @When('the student selects the activities delete option')
+  async selectDeleteActivitiesOption () {
+    await this.getDeclaredSkillAssociations().selectDeleteActivitiesOption()
+  }
+
+  @Then('the delete associations modal is visible')
+  async verifyDeleteAssociationsModalVisible () {
+    await this.getDeclaredSkillAssociations().verifyDeleteAssociationsModalVisible()
+  }
+
+  @Then('the delete associations modal contains items to delete')
+  async verifyDeleteAssociationsModalItemsNotEmpty () {
+    await this.getDeclaredSkillAssociations().verifyDeleteAssociationsModalItemsNotEmpty()
+  }
+
+  @Then('the delete associations modal confirm button is visible')
+  async verifyDeleteAssociationsModalConfirmButtonVisible () {
+    await this.getDeclaredSkillAssociations().verifyDeleteAssociationsModalConfirmButtonVisible()
+  }
+
+  @Then('the delete associations modal cancel button is visible')
+  async verifyDeleteAssociationsModalCancelButtonVisible () {
+    await this.getDeclaredSkillAssociations().verifyDeleteAssociationsModalCancelButtonVisible()
+  }
+
+  @When('the student cancels the delete associations modal')
+  async cancelDeleteAssociationsModal () {
+    await this.getDeclaredSkillAssociations().cancelDeleteAssociationsModal()
+  }
+
+  @Then('the delete associations modal is hidden')
+  async verifyDeleteAssociationsModalHidden () {
+    await this.getDeclaredSkillAssociations().verifyDeleteAssociationsModalHidden()
+  }
+
+  @When('the student selects the first activity to delete')
+  async selectFirstDeleteAssociationsModalItem () {
+    await this.getDeclaredSkillAssociations().selectFirstDeleteAssociationsModalItem()
+  }
+
+  @When('the student confirms the delete associations modal')
+  async confirmDeleteAssociationsModal () {
+    await this.getDeclaredSkillAssociations().confirmDeleteAssociationsModal()
+  }
+
+  @Then('the delete associations confirmation modal is visible')
+  async verifyDeleteAssociationsConfirmModalVisible () {
+    await this.getDeclaredSkillAssociations().verifyDeleteAssociationsConfirmModalVisible()
+  }
+
+  @When('the student cancels the delete associations confirmation modal')
+  async cancelDeleteAssociationsConfirmModal () {
+    await this.getDeclaredSkillAssociations().cancelDeleteAssociationsConfirmModal()
+  }
+
+  @Then('the delete associations confirmation modal is hidden')
+  async verifyDeleteAssociationsConfirmModalHidden () {
+    await this.getDeclaredSkillAssociations().verifyDeleteAssociationsConfirmModalHidden()
+  }
 }

--- a/e2e/framework/student/lifeProject/declaredSkillDetails/componentObjects/DeclaredSkillAssociationsObject.ts
+++ b/e2e/framework/student/lifeProject/declaredSkillDetails/componentObjects/DeclaredSkillAssociationsObject.ts
@@ -1,5 +1,7 @@
 import { BaseObject } from '@e2e/framework/shared/base/BaseObject'
+import { clickOnElement } from '@e2e/framework/shared/utils/click'
 import { verifyTextLocator } from '@e2e/framework/shared/utils/text'
+import { waitForPageLoad } from '@e2e/framework/shared/utils/waits'
 import { expect, type Locator } from '@playwright/test'
 
 export class DeclaredSkillAssociationsObject extends BaseObject {
@@ -93,5 +95,103 @@ export class DeclaredSkillAssociationsObject extends BaseObject {
       const titleLocator = items.nth(i).getByTestId('floating-icon-card-title')
       await verifyTextLocator(titleLocator)
     }
+  }
+
+  getDeleteAssociationsDropdown () {
+    return this.root.getByTestId('delete-declared-skill-associated-elements-dropdown')
+  }
+
+  getDeleteActivitiesOption () {
+    return this.root.page().getByTestId('activities')
+  }
+
+  getDeleteAssociationsModal () {
+    return this.root.page().getByTestId('delete-associations-modal-header')
+  }
+
+  getDeleteAssociationsModalItems () {
+    return this.root.page().getByTestId('compact-card-selector-item')
+  }
+
+  getDeleteAssociationsModalItemSelectors () {
+    return this.root.page().getByTestId('selector-overlay')
+  }
+
+  getDeleteAssociationsModalConfirmButton () {
+    return this.root.page().getByTestId('confirm-button')
+  }
+
+  getDeleteAssociationsModalCancelButton () {
+    return this.root.page().getByTestId('cancel-button')
+  }
+
+  getDeleteAssociationsConfirmModal () {
+    return this.root.page().getByTestId('delete-associations-confirm-modal__header')
+  }
+
+  getDeleteAssociationsConfirmModalContainer () {
+    return this.root.page().locator('dialog').filter({ has: this.getDeleteAssociationsConfirmModal() })
+  }
+
+  getDeleteAssociationsConfirmModalCancelButton () {
+    return this.getDeleteAssociationsConfirmModalContainer().getByTestId('cancel-button')
+  }
+
+  async verifyDeleteAssociationsDropdownVisible () {
+    await expect(this.getDeleteAssociationsDropdown()).toBeVisible()
+  }
+
+  async openDeleteAssociationsDropdown () {
+    await clickOnElement(this.getDeleteAssociationsDropdown())
+    await waitForPageLoad(this.root.page())
+  }
+
+  async selectDeleteActivitiesOption () {
+    await clickOnElement(this.getDeleteActivitiesOption())
+  }
+
+  async verifyDeleteAssociationsModalVisible () {
+    await expect(this.getDeleteAssociationsModal()).toBeVisible()
+  }
+
+  async verifyDeleteAssociationsModalHidden () {
+    await expect(this.getDeleteAssociationsModal()).toBeHidden()
+  }
+
+  async verifyDeleteAssociationsModalItemsNotEmpty () {
+    const count = await this.getDeleteAssociationsModalItems().count()
+    expect(count).toBeGreaterThan(0)
+  }
+
+  async verifyDeleteAssociationsModalConfirmButtonVisible () {
+    await expect(this.getDeleteAssociationsModalConfirmButton()).toBeVisible()
+  }
+
+  async verifyDeleteAssociationsModalCancelButtonVisible () {
+    await expect(this.getDeleteAssociationsModalCancelButton()).toBeVisible()
+  }
+
+  async selectFirstDeleteAssociationsModalItem () {
+    await clickOnElement(this.getDeleteAssociationsModalItemSelectors().first())
+  }
+
+  async confirmDeleteAssociationsModal () {
+    await clickOnElement(this.getDeleteAssociationsModalConfirmButton())
+  }
+
+  async verifyDeleteAssociationsConfirmModalVisible () {
+    await expect(this.getDeleteAssociationsConfirmModal()).toBeVisible()
+  }
+
+  async verifyDeleteAssociationsConfirmModalHidden () {
+    await expect(this.getDeleteAssociationsConfirmModal()).toBeHidden()
+  }
+
+  async cancelDeleteAssociationsConfirmModal () {
+    await clickOnElement(this.getDeleteAssociationsConfirmModalCancelButton())
+  }
+
+  async cancelDeleteAssociationsModal () {
+    await clickOnElement(this.getDeleteAssociationsModalCancelButton())
   }
 }

--- a/e2e/tests/student/lifeProject/declaredSkillDetails/declaredSkillDetails.feature
+++ b/e2e/tests/student/lifeProject/declaredSkillDetails/declaredSkillDetails.feature
@@ -33,3 +33,41 @@ Feature: Student Life Project Declared Skill Detail Page
       When the student expands the activity associations card
       Then the activity association items are not empty
       And each activity association item has a defined title
+
+  Rule: Declared skill association deletion
+
+    Background:
+      When the student opens the declared skill associations tab
+      Then the declared skill associations are loaded
+
+    @high @declared-skill-details @declared-skill-associations @dataset-full
+    Scenario: Student can see the delete associations dropdown
+      Then the delete associations dropdown is visible
+
+  Rule: Delete associated activities modal
+
+    Background:
+      When the student opens the declared skill associations tab
+      And the declared skill associations are loaded
+      And the student opens the delete associations dropdown
+      And the student selects the activities delete option
+
+    @high @declared-skill-details @declared-skill-associations @dataset-full
+    Scenario: Student can see the delete activities modal content
+      Then the delete associations modal is visible
+      And the delete associations modal contains items to delete
+      And the delete associations modal confirm button is visible
+      And the delete associations modal cancel button is visible
+
+    @high @declared-skill-details @declared-skill-associations @dataset-full
+    Scenario: Student can cancel the delete activities modal
+      When the student cancels the delete associations modal
+      Then the delete associations modal is hidden
+
+    @high @declared-skill-details @declared-skill-associations @dataset-full
+    Scenario: Student can open and cancel the delete confirmation modal
+      When the student selects the first activity to delete
+      And the student confirms the delete associations modal
+      Then the delete associations confirmation modal is visible
+      When the student cancels the delete associations confirmation modal
+      Then the delete associations confirmation modal is hidden


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> _Describe the changes introduced by this pull request._

Adds end-to-end (Playwright-BDD) coverage for the delete-associations flow on the declared skill detail page. The tests verify the UI surface only — no real deletions:
- the "Supprimer..." delete-associations dropdown is visible on the associations tab;
- opening the dropdown and selecting the activities option opens the delete modal;
- the modal shows items to delete and both a **Confirmer** and an **Annuler** button;
- clicking **Annuler** closes the modal.

Implemented by extending the existing E2E artifacts (no new fixtures/PageObjects):
- `declaredSkillDetails.feature` — new `Rule: Declared skill association deletion` (dropdown visibility) and `Rule: Delete activities modal` (modal content + cancel), with the shared dropdown-open steps factored into the latter's `Background`.
- `DeclaredSkillAssociationsObject.ts` — `data-testid`-only locators and `verify*`/action methods for the dropdown, teleported modal, its items and confirm/cancel buttons.
- `StudentDeclaredSkillDetailPage.ts` — matching `@When`/`@Then` step definitions delegating to the ComponentObject.

---

### Reference to an Issue, Feature, Task, User Story or another PR
> _Mention related issue numbers or links (e.g. Closes #123, Implements #456)._

Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/2007

---

### Documentation
> _Detail any updates made to documentation, configuration steps, or technical specs._

Added `references/component-interactions.md` to the `e2e-generator` skill documenting verified locators and interaction recipes for recurring DSAV overlays (AvDropdown, AvModal, AvCancelConfirmButtons, ConfirmationModal, DeleteAssociationsModal/ConfirmModal, CompactCardSelector) and the Teleport gotcha, and registered it in the skill's `SKILL.md`.

---

### Target Branch
> _Which branch is this PR targeting (e.g. `main`, `develop`)?_

`develop`

---

### Additional Notes
> _Include any relevant context, technical details, or reasons behind certain decisions._

- All locators use `data-testid` only; text/role/aria selectors are avoided per the E2E conventions.
- `AvModal` and the `AvDropdown` popover teleport to `body`, so the modal/item locators are resolved from the page (`this.root.page()`), not scoped under the component root. Hidden state is asserted with `toBeHidden()` since the nodes detach when the overlay closes.
- Only `@dataset-full` scenarios are added, each tagged `@high @declared-skill-details @declared-skill-associations @dataset-full`.
- All assertions live in the ComponentObject `verify*()` methods; step defs only delegate.

---

### Known Limitations or Side Effects
> _List any limitations, known bugs, or side effects this PR may introduce._

- The "contains items to delete" assertion depends on the `@dataset-full` dataset having at least one deletable (non-`SUBMITTED`/`COMPLETED`) declared-activity association; it currently does, as the scenario passes.
- Coverage stops at the first modal — the real deletion / second confirmation-modal path and toaster assertions are out of scope.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [x] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [x] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and detaiils for the update process
