### PR TITLE
fix(2138): simplify StudentNotificationsPopover contexts message

### DIFF
--- a/src/features/student/user/components/overlays/StudentNotificationsPopover/StudentNotificationsPopover.test.ts
+++ b/src/features/student/user/components/overlays/StudentNotificationsPopover/StudentNotificationsPopover.test.ts
@@ -48,11 +48,8 @@ BddTest().given('a StudentNotificationsPopover', () => {
     BddTest().then('it should render all context items', () => {
       const contexts = getContexts()
       expect(contexts.exists()).toBe(true)
-      expect(contexts.element.children.length).toBe(4)
-      expect(contexts.element.children[0].textContent).toBe('Un enseignant vous enverra un message')
-      expect(contexts.element.children[1].textContent).toBe('Un tiers vous aura évalué sur une compétence')
-      expect(contexts.element.children[2].textContent).toBe('Une trace a été validée')
-      expect(contexts.element.children[3].textContent).toBe('Un événement a lieu prochainement')
+      expect(contexts.element.children.length).toBe(1)
+      expect(contexts.element.children[0].textContent).toBe('Une activité à laquelle vous êtes inscrit(e) a été modifiée')
     })
   })
 

--- a/src/features/student/user/components/overlays/StudentNotificationsPopover/StudentNotificationsPopover.vue
+++ b/src/features/student/user/components/overlays/StudentNotificationsPopover/StudentNotificationsPopover.vue
@@ -20,10 +20,7 @@ const { t } = useI18n()
         class="b2-regular av-pl-lg"
         data-testid="student-notifications-popover-contexts"
       >
-        <li><span>{{ t('student.user.overlays.StudentNotificationsPopover.contexts.staffMessage') }}</span></li>
-        <li><span>{{ t('student.user.overlays.StudentNotificationsPopover.contexts.assessedSkill') }}</span></li>
-        <li><span>{{ t('student.user.overlays.StudentNotificationsPopover.contexts.validatedTrace') }}</span></li>
-        <li><span>{{ t('student.user.overlays.StudentNotificationsPopover.contexts.comingUpEvent') }}</span></li>
+        <li><span>{{ t('student.user.overlays.StudentNotificationsPopover.contexts.activityModified') }}</span></li>
       </ul>
     </template>
 

--- a/src/features/student/user/locales/en.json
+++ b/src/features/student/user/locales/en.json
@@ -20,10 +20,7 @@
         },
         "StudentNotificationsPopover": {
           "contexts": {
-            "assessedSkill": "A third party will have assessed you on a skill",
-            "comingUpEvent": "An event is coming up",
-            "staffMessage": "A staff will send you a message",
-            "validatedTrace": "A trace has been validated"
+            "activityModified": "An activity you are enrolled in has been modified"
           }
         },
         "UpdateProfileDrawer": {

--- a/src/features/student/user/locales/fr.json
+++ b/src/features/student/user/locales/fr.json
@@ -20,10 +20,7 @@
         },
         "StudentNotificationsPopover": {
           "contexts": {
-            "assessedSkill": "Un tiers vous aura évalué sur une compétence",
-            "comingUpEvent": "Un événement a lieu prochainement",
-            "staffMessage": "Un enseignant vous enverra un message",
-            "validatedTrace": "Une trace a été validée"
+            "activityModified": "Une activité à laquelle vous êtes inscrit(e) a été modifiée"
           }
         },
         "UpdateProfileDrawer": {


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> Remplace les 4 lignes de contexte du popover de notifications étudiant par un unique message générique : « Une activité dans laquelle vous êtes inscrit a été modifiée ». Les clés i18n `staffMessage`, `assessedSkill`, `validatedTrace` et `comingUpEvent` sont supprimées (fr/en) et remplacées par une nouvelle clé `activityModified`.

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/2138

---

### Documentation
> Aucune documentation technique impactée.

---

### Target Branch
> `develop`

---

### Additional Notes
> Le test unitaire associé (`StudentNotificationsPopover.test.ts`) a été mis à jour pour vérifier le nouveau contenu unique.

---

### Known Limitations or Side Effects
> Aucun effet de bord connu.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [x] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [x] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process