### PR TITLE
feat(2143): add valorized traces containers to student kit view

### DIFF
--- a/api-specs/avenir-esr.swagger.json
+++ b/api-specs/avenir-esr.swagger.json
@@ -5292,6 +5292,9 @@
           "isAssociated": {
             "type": "boolean"
           },
+          "isValorized": {
+            "type": "boolean"
+          },
           "fileTypes": {
             "type": "array",
             "items": {

--- a/src/__mocks__/msw/handlers/student/traces.handlers.ts
+++ b/src/__mocks__/msw/handlers/student/traces.handlers.ts
@@ -65,8 +65,23 @@ export function createTracesSummaryHandler (payload: TracesSummaryDTO) {
   })
 }
 
-export function createTracesViewHandler (payload: PagedResponseTraceViewDTO) {
-  return http.post(`*${getTracesViewUrl()}`, () => {
+export function createTracesViewHandler (
+  payload: PagedResponseTraceViewDTO,
+  onRequest?: (traceFilter: TraceFilter, params: TracesViewParams) => void
+) {
+  return http.post(`*${getTracesViewUrl()}`, async ({ request }) => {
+    if (onRequest) {
+      const traceFilter = await request.json() as TraceFilter
+      const searchParams = new URL(request.url).searchParams
+      onRequest(traceFilter, {
+        keyword: searchParams.get('keyword') ?? undefined,
+        page: searchParams.has('page') ? Number(searchParams.get('page')) : undefined,
+        pageSize: searchParams.has('pageSize') ? Number(searchParams.get('pageSize')) : undefined,
+        fromDate: searchParams.get('fromDate') ?? undefined,
+        toDate: searchParams.get('toDate') ?? undefined,
+      })
+    }
+
     return HttpResponse.json<PagedResponseTraceViewDTO>(payload, {
       status: 200,
       headers: {
@@ -483,6 +498,16 @@ export const tracesHandlers = [
   }),
   lockedDeclaredActivitiesHandler
 ]
+
+export const tracesViewErrorHandler = http.post(
+  `*${getTracesViewUrl()}`,
+  () => {
+    return HttpResponse.json(
+      { message: 'Internal Server Error', code: ErrorCodes.SERVER },
+      { status: 500 }
+    )
+  }
+)
 
 export const deleteTraceAssociationsErrorHandler = http.delete(
   `*${getDeleteTraceAssociationsUrl(':traceId')}`,

--- a/src/features/student/kit/components/cards/ValorizedElementsCardContainer/ValorizedElementsCardContainer.stub.ts
+++ b/src/features/student/kit/components/cards/ValorizedElementsCardContainer/ValorizedElementsCardContainer.stub.ts
@@ -1,0 +1,14 @@
+export const ValorizedElementsCardContainerStub = defineComponent({
+  name: 'ValorizedElementsCardContainer',
+  props: {
+    title: { type: String, required: true },
+    error: { type: Object, default: null },
+    isLoading: { type: Boolean, default: false },
+  },
+  template: `
+    <div data-testid="valorized-elements-card-container-stub">
+      <div data-testid="valorized-elements-card-container-title">{{ title }}</div>
+      <slot />
+    </div>
+  `,
+})

--- a/src/features/student/kit/components/cards/ValorizedElementsCardContainer/ValorizedElementsCardContainer.test.ts
+++ b/src/features/student/kit/components/cards/ValorizedElementsCardContainer/ValorizedElementsCardContainer.test.ts
@@ -1,0 +1,81 @@
+import { CardStub } from '@/common/components/cards/Card/Card.stub'
+import { QuerySuspenseStub } from '@/common/components/QuerySuspense/QuerySuspense.stub'
+import { BaseApiException } from '@/common/exceptions'
+import ValorizedElementsCardContainer, {
+  type ValorizedElementsCardContainerProps
+} from '@/features/student/kit/components/cards/ValorizedElementsCardContainer/ValorizedElementsCardContainer.vue'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { beforeEach, expect } from 'vitest'
+
+BddTest().given('a valorized elements card container', () => {
+  let wrapper: VueWrapper<InstanceType<typeof ValorizedElementsCardContainer>>
+
+  const stubs = {
+    Card: CardStub,
+    QuerySuspense: QuerySuspenseStub
+  }
+
+  const props: ValorizedElementsCardContainerProps = {
+    title: 'Mes traces associées (3)'
+  }
+
+  BddTest().when('the component is mounted', () => {
+    beforeEach(() => {
+      wrapper = mount(ValorizedElementsCardContainer, { props, global: { stubs } })
+    })
+
+    BddTest().then('it should render the card as collapsible', () => {
+      const card = wrapper.findComponent(CardStub)
+      expect(card.exists()).toBe(true)
+      expect(card.props('collapsible')).toBe(true)
+    })
+
+    BddTest().then('it should render the title', () => {
+      expect(wrapper.find('[data-testid="card-stub-title"]').text()).toBe(props.title)
+    })
+
+    BddTest().then('it should render the slot content', () => {
+      wrapper = mount(ValorizedElementsCardContainer, {
+        props,
+        global: { stubs },
+        slots: { default: '<p data-testid="slot-content">Contenu</p>' },
+      })
+      expect(wrapper.find('[data-testid="slot-content"]').exists()).toBe(true)
+    })
+
+    BddTest().then('it should not be loading and not have an error by default', () => {
+      const querySuspense = wrapper.findComponent(QuerySuspenseStub)
+      expect(querySuspense.props('isLoading')).toBe(false)
+      expect(querySuspense.props('error')).toBe(null)
+    })
+  })
+
+  BddTest().when('it is loading', () => {
+    beforeEach(() => {
+      wrapper = mount(ValorizedElementsCardContainer, {
+        props: { ...props, isLoading: true },
+        global: { stubs },
+      })
+    })
+
+    BddTest().then('it should forward isLoading to QuerySuspense', () => {
+      expect(wrapper.findComponent(QuerySuspenseStub).props('isLoading')).toBe(true)
+    })
+  })
+
+  BddTest().when('an error occurred', () => {
+    const error = new BaseApiException('error', 500)
+
+    beforeEach(() => {
+      wrapper = mount(ValorizedElementsCardContainer, {
+        props: { ...props, error },
+        global: { stubs },
+      })
+    })
+
+    BddTest().then('it should forward the error to QuerySuspense', () => {
+      expect(wrapper.findComponent(QuerySuspenseStub).props('error')).toEqual(error)
+    })
+  })
+})

--- a/src/features/student/kit/components/cards/ValorizedElementsCardContainer/ValorizedElementsCardContainer.vue
+++ b/src/features/student/kit/components/cards/ValorizedElementsCardContainer/ValorizedElementsCardContainer.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import type { BaseApiException } from '@/common/exceptions'
+import Card from '@/common/components/cards/Card/Card.vue'
+import QuerySuspense from '@/common/components/QuerySuspense/QuerySuspense.vue'
+
+export interface ValorizedElementsCardContainerProps {
+  title: string
+  error?: BaseApiException | null
+  isLoading?: boolean
+}
+
+const { title, error = null, isLoading = false } = defineProps<ValorizedElementsCardContainerProps>()
+</script>
+
+<template>
+  <Card
+    collapsible
+    border-color="var(--stroke)"
+    background-color="var(--card)"
+    title-background="var(--card)"
+  >
+    <template #title>
+      <span class="s1-regular">
+        {{ title }}
+      </span>
+    </template>
+    <QuerySuspense
+      :error="error"
+      :is-loading="isLoading"
+    >
+      <slot />
+    </QuerySuspense>
+  </Card>
+</template>

--- a/src/features/student/kit/locales/en.json
+++ b/src/features/student/kit/locales/en.json
@@ -8,7 +8,13 @@
             "profile": "An error occurred while retrieving your profile. Please try again later."
           },
           "subtitle": "Ready-to-use CoFolio raw material",
-          "title": "My ready-to-use kit"
+          "title": "My ready-to-use kit",
+          "valorizedAssociatedTracesContainer": {
+            "title": "My associated trace (1) | My associated traces ({count})"
+          },
+          "valorizedNonAssociatedTracesContainer": {
+            "title": "My non-associated trace (1) | My non-associated traces ({count})"
+          }
         }
       }
     }

--- a/src/features/student/kit/locales/fr.json
+++ b/src/features/student/kit/locales/fr.json
@@ -8,7 +8,13 @@
             "profile": "Une erreur est survenue lors de la récupération de votre profil. Veuillez réessayer plus tard."
           },
           "subtitle": "Matière brute CoFolio prête à l'emploi",
-          "title": "Mon kit prêt à l'emploi"
+          "title": "Mon kit prêt à l'emploi",
+          "valorizedAssociatedTracesContainer": {
+            "title": "Ma trace associée (1) | Mes traces associées ({count})"
+          },
+          "valorizedNonAssociatedTracesContainer": {
+            "title": "Ma trace non associée (1) | Mes traces non associées ({count})"
+          }
         }
       }
     }

--- a/src/features/student/kit/views/StudentToolsKitView/StudentToolsKitView.test.ts
+++ b/src/features/student/kit/views/StudentToolsKitView/StudentToolsKitView.test.ts
@@ -3,6 +3,8 @@ import { server } from '@/__mocks__/msw/server'
 import { ProfileCardStub } from '@/common/components/ProfileCard/ProfileCard.stub'
 import { QuerySuspenseStub } from '@/common/components/QuerySuspense/QuerySuspense.stub'
 import { ROUTES } from '@/common/constants/route-names'
+import { ValorizedAssociatedTracesContainerStub } from '@/features/student/kit/views/StudentToolsKitView/components/ValorizedAssociatedTracesContainer/ValorizedAssociatedTracesContainer.stub'
+import { ValorizedNonAssociatedTracesContainerStub } from '@/features/student/kit/views/StudentToolsKitView/components/ValorizedNonAssociatedTracesContainer/ValorizedNonAssociatedTracesContainer.stub'
 import StudentToolsKitView from '@/features/student/kit/views/StudentToolsKitView/StudentToolsKitView.vue'
 import { AvBreadcrumbStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { flushPromises, type VueWrapper } from '@vue/test-utils'
@@ -14,7 +16,9 @@ BddTest().given('a student tools kit view', () => {
   const stubs = {
     AvBreadcrumb: AvBreadcrumbStub,
     ProfileCard: ProfileCardStub,
-    QuerySuspense: QuerySuspenseStub
+    QuerySuspense: QuerySuspenseStub,
+    ValorizedAssociatedTracesContainer: ValorizedAssociatedTracesContainerStub,
+    ValorizedNonAssociatedTracesContainer: ValorizedNonAssociatedTracesContainerStub
   }
 
   BddTest().when('the view is mounted with a server error', async () => {
@@ -47,6 +51,11 @@ BddTest().given('a student tools kit view', () => {
     BddTest().then('it should not display the profile card', () => {
       expect(wrapper.findComponent(ProfileCardStub).exists()).toBe(false)
     })
+
+    BddTest().then('it should display the valorized associated and non associated traces containers', () => {
+      expect(wrapper.findComponent(ValorizedAssociatedTracesContainerStub).exists()).toBe(true)
+      expect(wrapper.findComponent(ValorizedNonAssociatedTracesContainerStub).exists()).toBe(true)
+    })
   })
 
   BddTest().when('the view is mounted with a successful response', async () => {
@@ -77,6 +86,11 @@ BddTest().given('a student tools kit view', () => {
 
     BddTest().then('it should not display the error message', () => {
       expect(wrapper.find('[data-testid="query-suspense-error"]').exists()).toBe(false)
+    })
+
+    BddTest().then('it should display the valorized associated and non associated traces containers', () => {
+      expect(wrapper.findComponent(ValorizedAssociatedTracesContainerStub).exists()).toBe(true)
+      expect(wrapper.findComponent(ValorizedNonAssociatedTracesContainerStub).exists()).toBe(true)
     })
   })
 })

--- a/src/features/student/kit/views/StudentToolsKitView/StudentToolsKitView.vue
+++ b/src/features/student/kit/views/StudentToolsKitView/StudentToolsKitView.vue
@@ -5,6 +5,8 @@ import ProfileCard from '@/common/components/ProfileCard/ProfileCard.vue'
 import QuerySuspense from '@/common/components/QuerySuspense/QuerySuspense.vue'
 import { useApiErrors } from '@/common/composables/use-api-errors/use-api-errors'
 import { ROUTES } from '@/common/constants'
+import ValorizedAssociatedTracesContainer from '@/features/student/kit/views/StudentToolsKitView/components/ValorizedAssociatedTracesContainer/ValorizedAssociatedTracesContainer.vue'
+import ValorizedNonAssociatedTracesContainer from '@/features/student/kit/views/StudentToolsKitView/components/ValorizedNonAssociatedTracesContainer/ValorizedNonAssociatedTracesContainer.vue'
 import { AvBreadcrumb } from '@avenirs-esr/avenirs-dsav'
 import { useI18n } from 'vue-i18n'
 
@@ -75,6 +77,9 @@ const breadcrumbLinks = computed(() => [
           :bio="studentSummary!.bio"
         />
       </QuerySuspense>
+
+      <ValorizedAssociatedTracesContainer />
+      <ValorizedNonAssociatedTracesContainer />
     </div>
   </div>
 </template>

--- a/src/features/student/kit/views/StudentToolsKitView/components/ValorizedAssociatedTracesContainer/ValorizedAssociatedTracesContainer.stub.ts
+++ b/src/features/student/kit/views/StudentToolsKitView/components/ValorizedAssociatedTracesContainer/ValorizedAssociatedTracesContainer.stub.ts
@@ -1,0 +1,4 @@
+export const ValorizedAssociatedTracesContainerStub = defineComponent({
+  name: 'ValorizedAssociatedTracesContainer',
+  template: '<div data-testid="valorized-associated-traces-container-stub" />',
+})

--- a/src/features/student/kit/views/StudentToolsKitView/components/ValorizedAssociatedTracesContainer/ValorizedAssociatedTracesContainer.test.ts
+++ b/src/features/student/kit/views/StudentToolsKitView/components/ValorizedAssociatedTracesContainer/ValorizedAssociatedTracesContainer.test.ts
@@ -1,0 +1,88 @@
+import type { PagedResponseTraceViewDTO, TraceFilter, TracesViewParams } from '@/api/avenir-esr'
+import { createTracesViewHandler, tracesViewErrorHandler } from '@/__mocks__/msw/handlers/student/traces.handlers'
+import { server } from '@/__mocks__/msw/server'
+import { ValorizedElementsCardContainerStub } from '@/features/student/kit/components/cards/ValorizedElementsCardContainer/ValorizedElementsCardContainer.stub'
+import ValorizedAssociatedTracesContainer from '@/features/student/kit/views/StudentToolsKitView/components/ValorizedAssociatedTracesContainer/ValorizedAssociatedTracesContainer.vue'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { flushPromises, type VueWrapper } from '@vue/test-utils'
+import { mountComponent } from 'tests/utils'
+
+BddTest().given('a valorized associated traces container', () => {
+  let wrapper: VueWrapper<InstanceType<typeof ValorizedAssociatedTracesContainer>>
+  let requestedTraceFilter: TraceFilter
+  let requestedParams: TracesViewParams
+
+  const stubs = {
+    ValorizedElementsCardContainer: ValorizedElementsCardContainerStub
+  }
+
+  const mountAssociatedTracesContainer = async () => {
+    wrapper = mountComponent(ValorizedAssociatedTracesContainer, { global: { stubs } })
+    await flushPromises()
+  }
+
+  BddTest().when('the traces view request succeeds with 3 traces', () => {
+    beforeEach(async () => {
+      const mockedTracesData: PagedResponseTraceViewDTO = {
+        data: [],
+        page: { page: 0, pageSize: 100, totalElements: 3, totalPages: 1 }
+      }
+
+      server.use(createTracesViewHandler(mockedTracesData, (traceFilter, params) => {
+        requestedTraceFilter = traceFilter
+        requestedParams = params
+      }))
+
+      await mountAssociatedTracesContainer()
+    })
+
+    BddTest().then('it should fetch traces with isAssociated true, isValorized true and pageSize 100', () => {
+      expect(requestedTraceFilter).toEqual({ isAssociated: true, isValorized: true })
+      expect(requestedParams.pageSize).toBe(100)
+    })
+
+    BddTest().then('it should render the title with the total elements count', () => {
+      const container = wrapper.findComponent(ValorizedElementsCardContainerStub)
+      expect(container.exists()).toBe(true)
+      expect(container.props('title')).toBe('Mes traces associées (3)')
+    })
+
+    BddTest().then('it should not be loading and have no error once fetched', () => {
+      const container = wrapper.findComponent(ValorizedElementsCardContainerStub)
+      expect(container.props('isLoading')).toBe(false)
+      expect(container.props('error')).toBe(null)
+    })
+
+    BddTest().then('it should render the placeholder body', () => {
+      expect(wrapper.find('[data-testid="valorized-associated-traces-container-placeholder"]').exists()).toBe(true)
+    })
+  })
+
+  BddTest().when('the traces view request succeeds with a single trace', () => {
+    beforeEach(async () => {
+      const mockedTracesData: PagedResponseTraceViewDTO = {
+        data: [],
+        page: { page: 0, pageSize: 100, totalElements: 1, totalPages: 1 }
+      }
+      server.use(createTracesViewHandler(mockedTracesData))
+
+      await mountAssociatedTracesContainer()
+    })
+
+    BddTest().then('it should render the title in the singular form', () => {
+      expect(wrapper.findComponent(ValorizedElementsCardContainerStub).props('title')).toBe('Ma trace associée (1)')
+    })
+  })
+
+  BddTest().when('the traces view request fails', () => {
+    beforeEach(async () => {
+      server.use(tracesViewErrorHandler)
+
+      await mountAssociatedTracesContainer()
+    })
+
+    BddTest().then('it should forward the error to the card container', () => {
+      expect(wrapper.findComponent(ValorizedElementsCardContainerStub).props('error')).toBeTruthy()
+    })
+  })
+})

--- a/src/features/student/kit/views/StudentToolsKitView/components/ValorizedAssociatedTracesContainer/ValorizedAssociatedTracesContainer.vue
+++ b/src/features/student/kit/views/StudentToolsKitView/components/ValorizedAssociatedTracesContainer/ValorizedAssociatedTracesContainer.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import { useTracesView } from '@/api/avenir-esr'
+import ValorizedElementsCardContainer from '@/features/student/kit/components/cards/ValorizedElementsCardContainer/ValorizedElementsCardContainer.vue'
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
+
+const { data, error, isFetching } = useTracesView(
+  { isAssociated: true, isValorized: true },
+  { pageSize: 100 }
+)
+
+const totalElements = computed(() => data.value?.page?.totalElements ?? 0)
+</script>
+
+<template>
+  <ValorizedElementsCardContainer
+    :title="t('student.kit.views.StudentToolsKitView.valorizedAssociatedTracesContainer.title', { count: totalElements })"
+    :error="error"
+    :is-loading="isFetching"
+    data-testid="valorized-associated-traces-container"
+  >
+    <div data-testid="valorized-associated-traces-container-placeholder">
+      Placeholder
+    </div>
+  </ValorizedElementsCardContainer>
+</template>

--- a/src/features/student/kit/views/StudentToolsKitView/components/ValorizedNonAssociatedTracesContainer/ValorizedNonAssociatedTracesContainer.stub.ts
+++ b/src/features/student/kit/views/StudentToolsKitView/components/ValorizedNonAssociatedTracesContainer/ValorizedNonAssociatedTracesContainer.stub.ts
@@ -1,0 +1,4 @@
+export const ValorizedNonAssociatedTracesContainerStub = defineComponent({
+  name: 'ValorizedNonAssociatedTracesContainer',
+  template: '<div data-testid="valorized-non-associated-traces-container-stub" />',
+})

--- a/src/features/student/kit/views/StudentToolsKitView/components/ValorizedNonAssociatedTracesContainer/ValorizedNonAssociatedTracesContainer.test.ts
+++ b/src/features/student/kit/views/StudentToolsKitView/components/ValorizedNonAssociatedTracesContainer/ValorizedNonAssociatedTracesContainer.test.ts
@@ -1,0 +1,102 @@
+import type { PagedResponseTraceViewDTO, TraceFilter, TracesViewParams } from '@/api/avenir-esr'
+import { createTracesViewHandler, tracesViewErrorHandler } from '@/__mocks__/msw/handlers/student/traces.handlers'
+import { server } from '@/__mocks__/msw/server'
+import { ValorizedElementsCardContainerStub } from '@/features/student/kit/components/cards/ValorizedElementsCardContainer/ValorizedElementsCardContainer.stub'
+import ValorizedNonAssociatedTracesContainer from '@/features/student/kit/views/StudentToolsKitView/components/ValorizedNonAssociatedTracesContainer/ValorizedNonAssociatedTracesContainer.vue'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { flushPromises, type VueWrapper } from '@vue/test-utils'
+import { mountComponent } from 'tests/utils'
+
+BddTest().given('a valorized non associated traces container', () => {
+  let wrapper: VueWrapper<InstanceType<typeof ValorizedNonAssociatedTracesContainer>>
+  let requestedTraceFilter: TraceFilter
+  let requestedParams: TracesViewParams
+
+  const stubs = {
+    ValorizedElementsCardContainer: ValorizedElementsCardContainerStub
+  }
+
+  const mountNonAssociatedTracesContainer = async () => {
+    wrapper = mountComponent(ValorizedNonAssociatedTracesContainer, { global: { stubs } })
+    await flushPromises()
+  }
+
+  BddTest().when('the traces view request succeeds with 0 traces', () => {
+    beforeEach(async () => {
+      const mockedTracesData: PagedResponseTraceViewDTO = {
+        data: [],
+        page: { page: 0, pageSize: 100, totalElements: 0, totalPages: 0 }
+      }
+
+      server.use(createTracesViewHandler(mockedTracesData, (traceFilter, params) => {
+        requestedTraceFilter = traceFilter
+        requestedParams = params
+      }))
+
+      await mountNonAssociatedTracesContainer()
+    })
+
+    BddTest().then('it should fetch traces with isAssociated false, isValorized true and pageSize 100', () => {
+      expect(requestedTraceFilter).toEqual({ isAssociated: false, isValorized: true })
+      expect(requestedParams.pageSize).toBe(100)
+    })
+
+    BddTest().then('it should render the title in the plural form with a 0 count', () => {
+      expect(wrapper.findComponent(ValorizedElementsCardContainerStub).props('title')).toBe('Mes traces non associées (0)')
+    })
+
+    BddTest().then('it should not be loading and have no error once fetched', () => {
+      const container = wrapper.findComponent(ValorizedElementsCardContainerStub)
+      expect(container.props('isLoading')).toBe(false)
+      expect(container.props('error')).toBe(null)
+    })
+
+    BddTest().then('it should render the placeholder body', () => {
+      expect(wrapper.find('[data-testid="valorized-non-associated-traces-container-placeholder"]').exists()).toBe(true)
+    })
+  })
+
+  BddTest().when('the traces view request succeeds with 5 traces', () => {
+    beforeEach(async () => {
+      const mockedTracesData: PagedResponseTraceViewDTO = {
+        data: [],
+        page: { page: 0, pageSize: 100, totalElements: 5, totalPages: 1 }
+      }
+      server.use(createTracesViewHandler(mockedTracesData))
+
+      await mountNonAssociatedTracesContainer()
+    })
+
+    BddTest().then('it should render the title in the plural form', () => {
+      expect(wrapper.findComponent(ValorizedElementsCardContainerStub).props('title')).toBe('Mes traces non associées (5)')
+    })
+  })
+
+  BddTest().when('the traces view request succeeds with 1 trace', () => {
+    beforeEach(async () => {
+      const mockedTracesData: PagedResponseTraceViewDTO = {
+        data: [],
+        page: { page: 0, pageSize: 100, totalElements: 1, totalPages: 1 }
+      }
+      server.use(createTracesViewHandler(mockedTracesData))
+
+      await mountNonAssociatedTracesContainer()
+    })
+
+    BddTest().then('it should render the title in the singular form', () => {
+      expect(wrapper.findComponent(ValorizedElementsCardContainerStub).props('title')).toBe('Ma trace non associée (1)')
+    })
+  })
+
+  BddTest().when('the traces view request fails', () => {
+    beforeEach(async () => {
+      server.use(tracesViewErrorHandler)
+
+      await mountNonAssociatedTracesContainer()
+    })
+
+    BddTest().then('it should forward the error to the card container', () => {
+      expect(wrapper.findComponent(ValorizedElementsCardContainerStub).props('error')).toBeTruthy()
+    })
+  })
+})

--- a/src/features/student/kit/views/StudentToolsKitView/components/ValorizedNonAssociatedTracesContainer/ValorizedNonAssociatedTracesContainer.vue
+++ b/src/features/student/kit/views/StudentToolsKitView/components/ValorizedNonAssociatedTracesContainer/ValorizedNonAssociatedTracesContainer.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import { useTracesView } from '@/api/avenir-esr'
+import ValorizedElementsCardContainer from '@/features/student/kit/components/cards/ValorizedElementsCardContainer/ValorizedElementsCardContainer.vue'
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
+
+const { data, error, isFetching } = useTracesView(
+  { isAssociated: false, isValorized: true },
+  { pageSize: 100 }
+)
+
+const totalElements = computed(() => data.value?.page?.totalElements ?? 0)
+</script>
+
+<template>
+  <ValorizedElementsCardContainer
+    :title="t('student.kit.views.StudentToolsKitView.valorizedNonAssociatedTracesContainer.title', { count: totalElements })"
+    :error="error"
+    :is-loading="isFetching"
+    data-testid="valorized-non-associated-traces-container"
+  >
+    <div data-testid="valorized-non-associated-traces-container-placeholder">
+      Placeholder
+    </div>
+  </ValorizedElementsCardContainer>
+</template>


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> Ajout de deux composants `AvCard` collapsible dans la vue Student Tools Kit : `ValorizedAssociatedTracesContainer` et `ValorizedNonAssociatedTracesContainer`. Chaque carte récupère les traces valorisées (filtre `isValorized: true`) via `useTracesView`, respectivement associées (`isAssociated: true`) et non associées (`isAssociated: false`), avec une pagination `pageSize: 100`. Le titre de chaque carte affiche le nombre total de traces avec gestion du singulier/pluriel ("Ma trace associée (1)" / "Mes traces associées (n)"). Le corps de chaque carte reste un placeholder en attendant l'implémentation du contenu.

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/2143

---

### Documentation
> Aucune mise à jour de documentation nécessaire.

---

### Target Branch
> `develop`

---

### Additional Notes
> Le champ `isValorized` a été ajouté au filtre `TraceFilter` dans la spec Swagger (`api-specs/avenir-esr.swagger.json`) pour permettre ce filtrage côté frontend.

---

### Known Limitations or Side Effects
> Le corps des deux cartes est un placeholder ; le contenu réel (liste des traces) sera implémenté dans un développement ultérieur.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [x] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [x] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [x] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process