### PR TITLE
feat(2047): add AssociateElementsDrawerSection in AddDeclaredSkillDrawer

### DIFF
--- a/src/features/student/declaredSkills/components/overlays/AddDeclaredSkillDrawer/AddDeclaredSkillDrawer.test.ts
+++ b/src/features/student/declaredSkills/components/overlays/AddDeclaredSkillDrawer/AddDeclaredSkillDrawer.test.ts
@@ -5,6 +5,8 @@ import {
   DeclaredSkillLevelRadioButtonSetFormFieldStub,
 } from '@/features/student/declaredSkills/components/interactions/formFields/DeclaredSkillLevelRadioButtonSetFormField/DeclaredSkillLevelRadioButtonSetFormField.stub'
 import { useDeclaredSkillsStore } from '@/features/student/declaredSkills/stores/declaredSkills.store'
+import { EAssociationTypeKey } from '@/features/student/traces/types/traces.types'
+import { AssociateElementsDrawerSectionStub } from '@/features/student/traces/views/StudentToolsTracesView/components/StudentToolsTracesAddTraceDrawer/components/AssociateElementsDrawerSection/AssociateElementsDrawerSection.stub'
 import { AvButtonStub, AvCancelConfirmButtonsStub, AvDrawerStub, AvIconStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { mountComponent } from 'tests/utils'
 import { beforeEach, expect, vi } from 'vitest'
@@ -48,7 +50,8 @@ const stubs = {
     template: '<div data-testid="add-declared-skill-autocomplete-field"></div>',
     props: ['form']
   },
-  DeclaredSkillLevelRadioButtonSetFormField: DeclaredSkillLevelRadioButtonSetFormFieldStub
+  DeclaredSkillLevelRadioButtonSetFormField: DeclaredSkillLevelRadioButtonSetFormFieldStub,
+  AssociateElementsDrawerSection: AssociateElementsDrawerSectionStub,
 }
 
 BddTest().given('an add declared skill drawer component', () => {
@@ -265,6 +268,58 @@ BddTest().given('an add declared skill drawer component', () => {
     BddTest().then('it should render the footer section in drawer footer slot', () => {
       const footer = wrapper.find('[data-testid="add-declared-skill-drawer__footer"]')
       expect(footer.exists()).toBe(true)
+    })
+  })
+
+  BddTest().when('the associate elements section is rendered', () => {
+    BddTest().then('it should render the associate elements drawer section in the last accordion', () => {
+      const section = wrapper.findComponent(AssociateElementsDrawerSectionStub)
+      expect(section.exists()).toBe(true)
+    })
+
+    BddTest().then('it should pass a single typeConfig for activities', () => {
+      const section = wrapper.findComponent(AssociateElementsDrawerSectionStub)
+      const typeConfigs = section.props('typeConfigs') as { key: string }[]
+
+      expect(typeConfigs).toHaveLength(1)
+      expect(typeConfigs[0].key).toBe(EAssociationTypeKey.ACTIVITIES)
+    })
+
+    BddTest().then('it should default the active type key to activities', () => {
+      const section = wrapper.findComponent(AssociateElementsDrawerSectionStub)
+      expect(section.props('activeTypeKey')).toBe(EAssociationTypeKey.ACTIVITIES)
+    })
+  })
+
+  BddTest().when('the associate elements section emits a search query update', () => {
+    BddTest().then('it should forward the search query back to the section', async () => {
+      const section = wrapper.findComponent(AssociateElementsDrawerSectionStub)
+
+      await section.vm.$emit('update:searchQuery', 'react')
+      await wrapper.vm.$nextTick()
+
+      expect(section.props('searchQuery')).toBe('react')
+    })
+  })
+
+  BddTest().when('the associate elements section emits a selections update', () => {
+    BddTest().then('it should update the associationSelections form field', async () => {
+      const section = wrapper.findComponent(AssociateElementsDrawerSectionStub)
+      const newSelections = { [EAssociationTypeKey.ACTIVITIES]: ['activity-1'] }
+
+      await section.vm.$emit('update:selectionsByType', newSelections)
+      await wrapper.vm.$nextTick()
+
+      expect(section.props('selectionsByType')).toStrictEqual(newSelections)
+    })
+  })
+
+  BddTest().when('component has accordion items', () => {
+    BddTest().then('it should render the associations accordion with correct title', () => {
+      const accordions = wrapper.findAllComponents({ name: 'AvAccordion' })
+      const associationsAccordion = accordions[2]
+
+      expect(associationsAccordion.props('title')).toBe('Associer ma compétence')
     })
   })
 })

--- a/src/features/student/declaredSkills/components/overlays/AddDeclaredSkillDrawer/AddDeclaredSkillDrawer.vue
+++ b/src/features/student/declaredSkills/components/overlays/AddDeclaredSkillDrawer/AddDeclaredSkillDrawer.vue
@@ -1,8 +1,11 @@
 <script setup lang="ts">
+import type { Association } from '@/features/student/global/types/associations.types'
+import { EAssociationContextType, useSearchDeclaredActivitiesForAssociation } from '@/api/avenir-esr'
 import { ConfirmationModal, FormCancelConfirmButtons } from '@/common/components'
 import { useModal } from '@/common/composables'
 import { useUnsavedChangesGuard } from '@/common/composables/use-unsaved-changes-guard/use-unsaved-changes-guard'
 import { ICONS } from '@/common/constants'
+import { useDeclaredActivityAssociation } from '@/features/student/buildProject'
 import DeclaredSkillLevelRadioButtonSetFormField from '@/features/student/declaredSkills/components/interactions/formFields/DeclaredSkillLevelRadioButtonSetFormField/DeclaredSkillLevelRadioButtonSetFormField.vue'
 import DeclaredSkillReflectionFormField
   from '@/features/student/declaredSkills/components/interactions/formFields/DeclaredSkillReflectionFormField/DeclaredSkillReflectionFormField.vue'
@@ -12,6 +15,8 @@ import {
   useDeclaredSkillForm
 } from '@/features/student/declaredSkills/components/overlays/AddDeclaredSkillDrawer/use-declared-skill-form/use-declared-skill-form'
 import { useDeclaredSkillsStore } from '@/features/student/declaredSkills/stores/declaredSkills.store'
+import { type AssociateElementTypeConfig, EAssociationTypeKey } from '@/features/student/traces/types/traces.types'
+import AssociateElementsDrawerSection from '@/features/student/traces/views/StudentToolsTracesView/components/StudentToolsTracesAddTraceDrawer/components/AssociateElementsDrawerSection/AssociateElementsDrawerSection.vue'
 import { useToasterStore } from '@/store'
 import { AvAccordion, AvAccordionsGroup, AvDrawer, AvIconText, MDI_ICONS, useAvBreakpoints } from '@avenirs-esr/avenirs-dsav'
 import { useI18n } from 'vue-i18n'
@@ -44,9 +49,42 @@ const { canLeave, confirm, cancel } = useUnsavedChangesGuard({
   closeModal: hideConfirmationModal
 })
 
+const associationSelectionsField = form.useField({ name: 'associationSelections' })
+
+const associationActiveType = ref<string>(EAssociationTypeKey.ACTIVITIES)
+const associationSearchQuery = ref<string>('')
+
+const associationTypesConfigs = computed<AssociateElementTypeConfig[]>(() => [
+  {
+    key: EAssociationTypeKey.ACTIVITIES,
+    label: t('student.declaredSkills.overlays.AddDeclaredSkillDrawer.accordions.addAssociations.types.activities.label'),
+    searchPlaceholder: t('student.declaredSkills.overlays.AddDeclaredSkillDrawer.accordions.addAssociations.types.activities.placeholder')
+  }
+])
+const associationSearchParams = computed(() => ({
+  contextType: EAssociationContextType.DECLARED_SKILL,
+  keyword: associationSearchQuery.value.trim(),
+  page: 0,
+  pageSize: 100,
+}))
+
+const { declaredActivityToAssociation } = useDeclaredActivityAssociation()
+const {
+  data: activitiesToAssociate,
+  isLoading: isActivitiesLoading
+} = useSearchDeclaredActivitiesForAssociation(associationSearchParams, {
+  query: {
+    select: response => response.data.map(declaredActivityToAssociation),
+  }
+})
+
+const associationOptions = computed<Association[]>(() => activitiesToAssociate.value ?? [])
+const isAssociationSearchLoading = computed(() => isActivitiesLoading.value)
+
 async function handleCancel () {
   if (await canLeave()) {
     form.reset()
+    associationSearchQuery.value = ''
     declaredSkillsStore.hideCreateDeclaredSkillDrawer()
   }
 }
@@ -91,14 +129,31 @@ async function handleCancel () {
             >
               <div class="av-col av-gap-md">
                 <AddDeclaredSkillAutocompleteField :form="form" />
+
                 <DeclaredSkillReflectionFormField :form="form" />
               </div>
             </AvAccordion>
+
             <AvAccordion
               :title="t('student.declaredSkills.overlays.AddDeclaredSkillDrawer.accordions.declarations.title')"
               :icon="MDI_ICONS.FILE_DOCUMENT_BOX_MULTIPLE_OUTLINE"
             >
               <DeclaredSkillLevelRadioButtonSetFormField :form="form" />
+            </AvAccordion>
+
+            <AvAccordion
+              :title="t('student.declaredSkills.overlays.AddDeclaredSkillDrawer.accordions.addAssociations.title')"
+              :icon="MDI_ICONS.PLUS_CIRCLE_OUTLINE"
+            >
+              <AssociateElementsDrawerSection
+                v-model:active-type-key="associationActiveType"
+                v-model:search-query="associationSearchQuery"
+                :selections-by-type="associationSelectionsField.state.value.value"
+                :type-configs="associationTypesConfigs"
+                :options="associationOptions"
+                :loading="isAssociationSearchLoading"
+                @update:selections-by-type="associationSelectionsField.api.handleChange"
+              />
             </AvAccordion>
           </AvAccordionsGroup>
         </form>

--- a/src/features/student/declaredSkills/components/overlays/AddDeclaredSkillDrawer/types.ts
+++ b/src/features/student/declaredSkills/components/overlays/AddDeclaredSkillDrawer/types.ts
@@ -1,4 +1,5 @@
 import type { EDeclaredSkillLevel, EExternalSkillType } from '@/api/avenir-esr'
+import type { Association } from '@/features/student/global/types/associations.types'
 import type { IdTitle } from '@/types'
 import type { AvAutocompleteOption } from '@avenirs-esr/avenirs-dsav'
 
@@ -11,4 +12,5 @@ export interface DeclaredSkillFormData {
   selectedSkills: DeclaredSkillOption[]
   level: EDeclaredSkillLevel
   reflection?: string
+  associationSelections?: Record<string, Association[]>
 }

--- a/src/features/student/declaredSkills/components/overlays/AddDeclaredSkillDrawer/use-declared-skill-form/use-declared-skill-form.test.ts
+++ b/src/features/student/declaredSkills/components/overlays/AddDeclaredSkillDrawer/use-declared-skill-form/use-declared-skill-form.test.ts
@@ -1,11 +1,12 @@
 import type { DeclaredSkillFormData } from '@/features/student/declaredSkills/components/overlays/AddDeclaredSkillDrawer/types'
 import { EDeclaredSkillLevel, EExternalSkillType } from '@/api/avenir-esr'
 import { useDeclaredSkillForm } from '@/features/student/declaredSkills/components/overlays/AddDeclaredSkillDrawer/use-declared-skill-form/use-declared-skill-form'
+import { EAssociationTypeKey } from '@/features/student/traces/types/traces.types'
 import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { mountComposable } from 'tests/utils'
 import { beforeEach, expect, vi } from 'vitest'
 
-const onSkillAdded = vi.fn()
+const mockOnSkillAdded = vi.fn()
 
 const mockAddErrorMessage = vi.fn()
 
@@ -59,7 +60,7 @@ BddTest().given('the useDeclaredSkillForm composable', () => {
   }
 
   beforeEach(() => {
-    const result = mountComposable(() => useDeclaredSkillForm(onSkillAdded), {
+    const result = mountComposable(() => useDeclaredSkillForm(mockOnSkillAdded), {
       useI18n: true,
       useTanstack: true,
       usePinia: true
@@ -178,7 +179,7 @@ BddTest().given('the useDeclaredSkillForm composable', () => {
       handler({ value: validData, formApi: composableResult.form, meta: {} })
 
       await vi.waitFor(() => {
-        expect(onSkillAdded).toHaveBeenCalled()
+        expect(mockOnSkillAdded).toHaveBeenCalled()
       })
     })
   })
@@ -232,8 +233,70 @@ BddTest().given('the useDeclaredSkillForm composable', () => {
       })
     })
 
-    BddTest().then('it should not call onSkillAddedls', async () => {
-      expect(onSkillAdded).not.toHaveBeenCalled()
+    BddTest().then('it should not call mockOnSkillAddedls', async () => {
+      expect(mockOnSkillAdded).not.toHaveBeenCalled()
+    })
+  })
+
+  BddTest().when('form is submitted with association selections', () => {
+    BddTest().then('it should call mockOnSkillAdded when an activity is selected', async () => {
+      const formData: DeclaredSkillFormData = {
+        ...createValidFormData(),
+        associationSelections: {
+          [EAssociationTypeKey.ACTIVITIES]: [{ id: 'activity-1', title: 'Activity 1' }]
+        }
+      }
+
+      const handler = getOnSubmitHandler()
+      handler({ value: formData, formApi: composableResult.form, meta: {} })
+
+      await vi.waitFor(() => {
+        expect(mockOnSkillAdded).toHaveBeenCalled()
+      })
+    })
+
+    BddTest().then('it should call mockOnSkillAdded when multiple activities are selected', async () => {
+      const formData: DeclaredSkillFormData = {
+        ...createValidFormData(),
+        associationSelections: {
+          [EAssociationTypeKey.ACTIVITIES]: [
+            { id: 'activity-1', title: 'Activity 1' },
+            { id: 'activity-2', title: 'Activity 2' }
+          ]
+        }
+      }
+
+      const handler = getOnSubmitHandler()
+      handler({ value: formData, formApi: composableResult.form, meta: {} })
+
+      await vi.waitFor(() => {
+        expect(mockOnSkillAdded).toHaveBeenCalled()
+      })
+    })
+
+    BddTest().then('it should call mockOnSkillAdded when selections are empty', async () => {
+      const formData: DeclaredSkillFormData = {
+        ...createValidFormData(),
+        associationSelections: {}
+      }
+
+      const handler = getOnSubmitHandler()
+      handler({ value: formData, formApi: composableResult.form, meta: {} })
+
+      await vi.waitFor(() => {
+        expect(mockOnSkillAdded).toHaveBeenCalled()
+      })
+    })
+
+    BddTest().then('it should call mockOnSkillAdded when no associationSelections are provided', async () => {
+      const formData = createValidFormData()
+
+      const handler = getOnSubmitHandler()
+      handler({ value: formData, formApi: composableResult.form, meta: {} })
+
+      await vi.waitFor(() => {
+        expect(mockOnSkillAdded).toHaveBeenCalled()
+      })
     })
   })
 })

--- a/src/features/student/declaredSkills/components/overlays/AddDeclaredSkillDrawer/use-declared-skill-form/use-declared-skill-form.ts
+++ b/src/features/student/declaredSkills/components/overlays/AddDeclaredSkillDrawer/use-declared-skill-form/use-declared-skill-form.ts
@@ -1,10 +1,12 @@
 import type { BaseApiException } from '@/common/exceptions'
 import type { DeclaredSkillFormData } from '@/features/student/declaredSkills/components/overlays/AddDeclaredSkillDrawer/types'
-import { EDeclaredSkillLevel, EErrorCode, invalidateGetDeclaredSkillsProgresses, useCreateDeclaredSkillProgress } from '@/api/avenir-esr'
+import type { Association } from '@/features/student/global/types/associations.types'
+import { EDeclaredSkillLevel, EErrorCode, invalidateGetDeclaredSkillsProgresses, useAssociateActivityWithDeclaredSkills, useCreateDeclaredSkillProgress } from '@/api/avenir-esr'
 import { useApiErrors } from '@/common/composables/use-api-errors/use-api-errors'
 import { useFormValidators } from '@/common/composables/use-form-validators/use-form-validators'
 import { useTaskLoading } from '@/common/composables/use-task-loading/use-task-loading'
 import { DECLARED_SKILL_REFLECTION_MAX_LENGTH } from '@/features/student/declaredSkills/config'
+import { EAssociationTypeKey } from '@/features/student/traces/types/traces.types'
 import { useToasterStore } from '@/store'
 import { useForm } from '@tanstack/vue-form'
 import { useQueryClient } from '@tanstack/vue-query'
@@ -29,6 +31,28 @@ export function useDeclaredSkillForm (onSkillAdded?: () => void) {
 
   const { mutate: mutateCreateDeclaredSkillProgress, isPending } = useCreateDeclaredSkillProgress()
 
+  const { mutateAsync: associateWithActivities, isPending: isPendingAssociateWithActivities } = useAssociateActivityWithDeclaredSkills({
+    mutation: {
+      onError: (error: BaseApiException) => {
+        addErrorMessage({
+          title: t('global.error.generic'),
+          description: getErrorMessage(error),
+        })
+      }
+    }
+  })
+
+  function createAssociateSkillPromises (skillId: string, associationsByType: Record<string, Association[]>): Promise<unknown>[] {
+    return Object.entries(associationsByType).flatMap(([type, associations]) => {
+      switch (type) {
+        case EAssociationTypeKey.ACTIVITIES:
+          return associations.map(association => associateWithActivities({ declaredActivityId: association.id, data: { idsToAssociate: [skillId] } }))
+        default:
+          return []
+      }
+    })
+  }
+
   function createDeclaredSkill (value: DeclaredSkillFormData) {
     const selectedSkill = value.selectedSkills[0]
     mutateCreateDeclaredSkillProgress({
@@ -40,8 +64,12 @@ export function useDeclaredSkillForm (onSkillAdded?: () => void) {
       }
     }, {
       onError: onCreateDeclaredSkillError,
-      onSuccess: async () => {
-        await withTaskLoading(() => invalidateGetDeclaredSkillsProgresses(queryClient))
+      onSuccess: async (skill) => {
+        const promises: Promise<unknown>[] = value.associationSelections ? createAssociateSkillPromises(skill.id, value.associationSelections) : []
+
+        promises.push(invalidateGetDeclaredSkillsProgresses(queryClient))
+
+        await withTaskLoading(() => Promise.allSettled(promises))
         onSkillAdded?.()
       }
     })
@@ -50,7 +78,8 @@ export function useDeclaredSkillForm (onSkillAdded?: () => void) {
   const form = useForm({
     defaultValues: {
       selectedSkills: [],
-      level: EDeclaredSkillLevel.BEGINNER
+      level: EDeclaredSkillLevel.BEGINNER,
+      associationSelections: {}
     } as unknown as DeclaredSkillFormData,
     validators: {
       onChange ({ value }: { value: DeclaredSkillFormData }) {
@@ -89,7 +118,7 @@ export function useDeclaredSkillForm (onSkillAdded?: () => void) {
   return {
     form,
     isFormValid,
-    isSubmitting: isPending || isLoading.value,
+    isSubmitting: isPending || isLoading.value || isPendingAssociateWithActivities.value,
     hasSkillDetailsErrors
   }
 }

--- a/src/features/student/declaredSkills/locales/en.json
+++ b/src/features/student/declaredSkills/locales/en.json
@@ -40,6 +40,15 @@
               "title": "Add my skill",
               "reflectionLabel": "Reflective review"
             },
+            "addAssociations": {
+              "title": "Associate my skill",
+              "types": {
+                "activities": {
+                  "label": "My activities",
+                  "placeholder": "Search for an activity..."
+                }
+              }
+            },
             "declarations": {
               "title": "Submit my declarations"
             }

--- a/src/features/student/declaredSkills/locales/fr.json
+++ b/src/features/student/declaredSkills/locales/fr.json
@@ -40,6 +40,15 @@
               "title": "Ajouter ma compétence",
               "reflectionLabel": "Bilan reflexif"
             },
+            "addAssociations": {
+              "title": "Associer ma compétence",
+              "types": {
+                "activities": {
+                  "label": "Mes activités",
+                  "placeholder": "Rechercher une activité..."
+                }
+              }
+            },
             "declarations": {
               "title": "Effectuer mes déclarations"
             }


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
- Added the `AssociateElementsDrawerSection` to `AddDeclaredSkillDrawer` (**Ready for future improvements/evols**)

---

### Reference to an Issue, Feature, Task, User Story or another PR
- Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/2047

---

**Modified areas:**
- `src/features/student/declaredSkills/components/overlays/AddDeclaredSkillDrawer/AddDeclaredSkillDrawer.test.ts`
- `src/features/student/declaredSkills/components/overlays/AddDeclaredSkillDrawer/AddDeclaredSkillDrawer.vue`
- `src/features/student/declaredSkills/components/overlays/AddDeclaredSkillDrawer/types.ts`
- `src/features/student/declaredSkills/components/overlays/AddDeclaredSkillDrawer/use-declared-skill-form/use-declared-skill-form.test.ts`
- `src/features/student/declaredSkills/components/overlays/AddDeclaredSkillDrawer/use-declared-skill-form/use-declared-skill-form.ts`
- `src/features/student/declaredSkills/locales/en.json`
- `src/features/student/declaredSkills/locales/fr.json`

---

### Target Branch
`develop`

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [x] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process