### PR TITLE
refactor(2125): rename feedback panel and add readonly state for subm…

### DIFF
--- a/src/features/staff/feedbacks/locales/en.json
+++ b/src/features/staff/feedbacks/locales/en.json
@@ -65,7 +65,7 @@
                 "title": "My feedback"
               }
             },
-            "title": "Write a feedback"
+            "title": "Feedback management"
           }
         },
         "ActivityFeedbacksView": {

--- a/src/features/staff/feedbacks/locales/fr.json
+++ b/src/features/staff/feedbacks/locales/fr.json
@@ -65,7 +65,7 @@
                 "title": "Mon feedback"
               }
             },
-            "title": "Rédiger un feedback"
+            "title": "Gestion du feedback"
           }
         },
         "ActivityFeedbacksView": {

--- a/src/features/staff/feedbacks/views/ActivityFeedbackDetailsView/ActivityFeedbackDetailsView.test.ts
+++ b/src/features/staff/feedbacks/views/ActivityFeedbackDetailsView/ActivityFeedbackDetailsView.test.ts
@@ -87,8 +87,8 @@ BddTest().given('an activity feedback details view', () => {
       await flushPromises()
     })
 
-    BddTest().then('it should not render the write feedback floating panel', () => {
-      expect(wrapper.findComponent(FeedbackManagementFloatingPanelStub).exists()).toBe(false)
+    BddTest().then('it should render the write feedback floating panel', () => {
+      expect(wrapper.findComponent(FeedbackManagementFloatingPanelStub).exists()).toBe(true)
     })
   })
 

--- a/src/features/staff/feedbacks/views/ActivityFeedbackDetailsView/ActivityFeedbackDetailsView.vue
+++ b/src/features/staff/feedbacks/views/ActivityFeedbackDetailsView/ActivityFeedbackDetailsView.vue
@@ -1,7 +1,6 @@
 <script lang="ts" setup>
 import type { AvSelectSelectedOption } from '@avenirs-esr/avenirs-dsav'
 import {
-  EFeedbackStatus,
   EUserCategory,
   useGetFeedbackDetails,
   useGetFeedbacksByActivity,
@@ -62,9 +61,6 @@ const studentPerspective = computed(() =>
   feedback.value?.reflexion ?? ''
 )
 
-const showWriteFeedbackPanel = computed(() => !!feedback.value
-  && (feedback.value.status === EFeedbackStatus.NEW || feedback.value.status === EFeedbackStatus.IN_PROCESS))
-
 const breadcrumbLinks = computed(() => [
   { text: t('staff.global.navigation.tabs.home'), to: ROUTES.STAFF.HOME },
   { text: t('staff.global.navigation.tabs.studentTracking') },
@@ -114,7 +110,7 @@ const pageTitle = computed(() =>
   </div>
 
   <FeedbackManagementFloatingPanel
-    v-if="showWriteFeedbackPanel && feedback"
+    v-if="feedback"
     :feedback="feedback"
     :activity-title="activityTitle"
   />

--- a/src/features/staff/feedbacks/views/ActivityFeedbackDetailsView/components/interaction/formFields/FeedbackFormField/FeedbackFormField.stub.ts
+++ b/src/features/staff/feedbacks/views/ActivityFeedbackDetailsView/components/interaction/formFields/FeedbackFormField/FeedbackFormField.stub.ts
@@ -2,6 +2,6 @@ import type { Component } from 'vue'
 
 export const FeedbackFormFieldStub: Component = {
   name: 'FeedbackFormField',
-  props: ['form'],
+  props: ['form', 'readonly'],
   template: '<div data-testid="feedback-form-field" />'
 }

--- a/src/features/staff/feedbacks/views/ActivityFeedbackDetailsView/components/interaction/formFields/FeedbackFormField/FeedbackFormField.test.ts
+++ b/src/features/staff/feedbacks/views/ActivityFeedbackDetailsView/components/interaction/formFields/FeedbackFormField/FeedbackFormField.test.ts
@@ -46,4 +46,19 @@ BddTest().given('a feedback form field', () => {
       expect(textarea.props('modelValue')).toBe('')
     })
   })
+
+  BddTest().when('the component is mounted with readonly true', () => {
+    beforeEach(() => {
+      vi.clearAllMocks()
+      wrapper = mountComponent(TestHost, {
+        props: { readonly: true },
+        global: { stubs }
+      })
+    })
+
+    BddTest().then('it should pass disabled true to the feedback textarea', () => {
+      const textarea = wrapper.findComponent(FeedbackTextareaStub)
+      expect(textarea.props('disabled')).toBe(true)
+    })
+  })
 })

--- a/src/features/staff/feedbacks/views/ActivityFeedbackDetailsView/components/interaction/formFields/FeedbackFormField/FeedbackFormField.vue
+++ b/src/features/staff/feedbacks/views/ActivityFeedbackDetailsView/components/interaction/formFields/FeedbackFormField/FeedbackFormField.vue
@@ -8,9 +8,10 @@ import { markRaw } from 'vue'
 
 interface FeedbackFormFieldProps {
   form: WriteFeedbackForm
+  readonly?: boolean
 }
 
-const { form } = defineProps<FeedbackFormFieldProps>()
+const { form, readonly } = defineProps<FeedbackFormFieldProps>()
 
 const emit = defineEmits<{
   autosave: [value: UpdateFeedbackRequest]
@@ -34,6 +35,7 @@ const debouncedAutosave = debounce((value: string, hasErrors: boolean) => {
         v-bind="$attrs"
         :model-value="field.state.value ?? ''"
         :error-message="field.state.meta.errors?.join(', ')"
+        :disabled="readonly"
         @blur="field.handleBlur"
         @update:model-value="(value) => {
           field.handleChange(value ?? '');

--- a/src/features/staff/feedbacks/views/ActivityFeedbackDetailsView/components/interaction/tabs/WriteFeedbackTab/WriteFeedbackTab.stub.ts
+++ b/src/features/staff/feedbacks/views/ActivityFeedbackDetailsView/components/interaction/tabs/WriteFeedbackTab/WriteFeedbackTab.stub.ts
@@ -5,6 +5,7 @@ export const WriteFeedbackTabStub = defineComponent({
   name: 'WriteFeedbackTab',
   props: {
     feedback: { type: Object as PropType<FeedbackDetailsDTO>, required: false },
+    readonly: { type: Boolean, required: false, default: false },
   },
   emits: ['cancel', 'feedbackSent'],
   template: '<div data-testid="write-feedback-tab-stub" />',

--- a/src/features/staff/feedbacks/views/ActivityFeedbackDetailsView/components/interaction/tabs/WriteFeedbackTab/WriteFeedbackTab.vue
+++ b/src/features/staff/feedbacks/views/ActivityFeedbackDetailsView/components/interaction/tabs/WriteFeedbackTab/WriteFeedbackTab.vue
@@ -11,9 +11,10 @@ import { useI18n } from 'vue-i18n'
 
 export interface WriteFeedbackTabProps {
   feedback: FeedbackDetailsDTO
+  readonly?: boolean
 }
 
-const { feedback } = defineProps<WriteFeedbackTabProps>()
+const { feedback, readonly } = defineProps<WriteFeedbackTabProps>()
 
 const emit = defineEmits<{
   (e: 'cancel'): void
@@ -46,6 +47,7 @@ function submitFeedback () {
       onSuccess: async () => {
         await withTaskLoading(() => invalidateGetFeedbackDetails(queryClient, EUserCategory.STAFF, feedback.id))
         addSuccessMessage(t('staff.feedbacks.views.ActivityFeedbackDetailsView.FeedbackManagementFloatingPanel.tabs.write.success.sendFeedback'))
+        form.reset()
         emit('feedbackSent')
       },
       onError: (error) => {
@@ -91,13 +93,14 @@ watch(isDirty, (newValue) => {
     >
       <FeedbackFormField
         :form="form"
+        :readonly="readonly"
         data-testid="feedback-form-field"
         @autosave="saveFeedback"
       />
     </form>
 
     <div
-      v-memo="[isFormValid, isSubmitting, isDirty, isPending]"
+      v-memo="[isFormValid, isSubmitting, isDirty, isPending, isLoading]"
       class="av-row av-justify-end av-p-md"
     >
       <AvCancelConfirmButtons
@@ -106,7 +109,7 @@ watch(isDirty, (newValue) => {
         :confirm-icon="MS_ICONS.SEND_OUTLINE_ROUNDED"
         :cancel-is-loading="isPending || isLoading"
         :confirm-is-loading="isDirty || isPending || isSubmitting || isLoading"
-        :confirm-disabled="isDirty && !isFormValid"
+        :confirm-disabled="readonly || !isFormValid"
         @cancel="handleCancel"
         @confirm="submitFeedback"
       />

--- a/src/features/staff/feedbacks/views/ActivityFeedbackDetailsView/components/overlays/FeedbackManagementFloatingPanel/FeedbackManagementFloatingPanel.test.ts
+++ b/src/features/staff/feedbacks/views/ActivityFeedbackDetailsView/components/overlays/FeedbackManagementFloatingPanel/FeedbackManagementFloatingPanel.test.ts
@@ -71,6 +71,10 @@ BddTest().given('a write feedback floating panel', () => {
     BddTest().then('it should display the history count in the tab title', () => {
       expect(getHistoryTabTitle()).toContain(`(${mockedFeedbackHistory.length})`)
     })
+
+    BddTest().then('it should render the floating panel with the updated title', () => {
+      expect(wrapper.findComponent(AvFloatingPanelStub).props('title')).toBe('Gestion du feedback')
+    })
   })
 
   BddTest().when('the feedback history is empty', () => {

--- a/src/features/staff/feedbacks/views/ActivityFeedbackDetailsView/composables/use-write-feedback-form/use-write-feedback-form.test.ts
+++ b/src/features/staff/feedbacks/views/ActivityFeedbackDetailsView/composables/use-write-feedback-form/use-write-feedback-form.test.ts
@@ -71,10 +71,6 @@ BddTest().given('a write feedback form', () => {
       expect(composableResult.form.state.values.feedback).toBe('')
     })
 
-    BddTest().then('it should not be valid initially', () => {
-      expect(composableResult.isFormValid.value).toBe(false)
-    })
-
     BddTest().and('callback is provided', () => {
       beforeEach(() => {
         mockOnFeedbackSaved = vi.fn()

--- a/src/features/staff/feedbacks/views/ActivityFeedbackDetailsView/composables/use-write-feedback-form/use-write-feedback-form.ts
+++ b/src/features/staff/feedbacks/views/ActivityFeedbackDetailsView/composables/use-write-feedback-form/use-write-feedback-form.ts
@@ -93,7 +93,7 @@ export function useWriteFeedbackForm ({ feedback, onFeedbackSaved, onCancel }: U
 
   const isFormValid = computed(() => {
     const state = form.useStore(state => state)
-    return state.value.isValid && !state.value.isValidating && state.value.isDirty
+    return state.value.isValid && !state.value.isValidating
   })
 
   const isDirty = computed(() => {


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
- Added E2E tests (Playwright + Cucumber) covering the feedback management floating panel behavior when a feedback is in process vs. submitted: form field enabled/disabled, send button enabled/disabled, cancel button always enabled.
- Added status filter navigation helpers on the feedbacks list page (filter by in-process / submitted status, access first matching row) to reliably target a feedback with the desired status.

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/2125

### Target Branch
develop


### Known Limitations or Side Effects
None identified.

## ✅ Checklist
- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (E2E scenarios added for in-process and submitted feedback states)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [ ] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process