### PR TITLE
feat(2085): add trace association limit badge in activity settings

### DIFF
--- a/src/features/staff/activities/locales/en.json
+++ b/src/features/staff/activities/locales/en.json
@@ -92,7 +92,9 @@
           "NationalActivitySettingDetails": {
             "badges": {
               "feedbackIterations": "0 iterations | {count} iteration | {count} iterations",
-              "unlimitedIterations": "Unlimited iterations"
+              "traceAssociations": "1 trace | {count} traces",
+              "unlimitedIterations": "Unlimited iterations",
+              "unlimitedTraces": "Unlimited traces"
             }
           },
           "tabs": {

--- a/src/features/staff/activities/locales/fr.json
+++ b/src/features/staff/activities/locales/fr.json
@@ -92,7 +92,9 @@
           "NationalActivitySettingDetails": {
             "badges": {
               "feedbackIterations": "{count} itération | {count} itérations",
-              "unlimitedIterations": "Itérations illimitées"
+              "traceAssociations": "1 trace | {count} traces",
+              "unlimitedIterations": "Itérations illimitées",
+              "unlimitedTraces": "Traces illimitées"
             }
           },
           "tabs": {

--- a/src/features/staff/activities/views/NationalActivityCatalogView/components/NationalActivitySettingDetails/NationalActivitySettingDetails.test.ts
+++ b/src/features/staff/activities/views/NationalActivityCatalogView/components/NationalActivitySettingDetails/NationalActivitySettingDetails.test.ts
@@ -6,7 +6,8 @@ import { ICONS } from '@/common/constants'
 import {
   ACTIVITY_FEEDBACK_ALLOWED_ITERATIONS_DISABLED,
   ACTIVITY_FEEDBACK_ALLOWED_ITERATIONS_INFINITY,
-  ACTIVITY_TRACE_SETTING_DISABLED_VALUE
+  ACTIVITY_TRACE_SETTING_DISABLED_VALUE,
+  ACTIVITY_TRACE_SETTING_INFINITY_VALUE
 } from '@/features/staff/activities/config'
 import NationalActivitySettingDetails from '@/features/staff/activities/views/NationalActivityCatalogView/components/NationalActivitySettingDetails/NationalActivitySettingDetails.vue'
 import { MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
@@ -111,6 +112,11 @@ BddTest().given('a national activity setting details component', () => {
       expect(badge.exists()).toBe(true)
       expect(badge.props('enabled')).toBe(false)
     })
+
+    BddTest().then('it should not display a trace association badge', () => {
+      const badge = findIterationsBadgeIn('national-activity-setting-details-trace')
+      expect(badge.exists()).toBe(false)
+    })
   })
 
   BddTest().when('the trace association is enabled', () => {
@@ -122,6 +128,35 @@ BddTest().given('a national activity setting details component', () => {
       const badge = findEnabledDisabledStatusBadgeIn('national-activity-setting-details-trace')
       expect(badge.exists()).toBe(true)
       expect(badge.props('enabled')).toBe(true)
+    })
+
+    BddTest().then('it should display the trace association count badge', () => {
+      const badge = findIterationsBadgeIn('national-activity-setting-details-trace')
+
+      expect(badge.exists()).toBe(true)
+      expect(badge.props('label')).toBe('5 traces')
+      expect(badge.props('color')).toBe('var(--light-foreground-neutral)')
+      expect(badge.props('backgroundColor')).toBe('var(--light-background-neutral)')
+      expect(badge.props('icon')).toBe(MDI_ICONS.ATTACH_FILE)
+    })
+  })
+
+  BddTest().when('the trace association is enabled with unlimited traces', () => {
+    beforeEach(() => {
+      mountWith({
+        ...mockedActivityContent,
+        traceAllowedAssociations: ACTIVITY_TRACE_SETTING_INFINITY_VALUE,
+      })
+    })
+
+    BddTest().then('it should display the unlimited traces badge', () => {
+      const badge = findIterationsBadgeIn('national-activity-setting-details-trace')
+
+      expect(badge.exists()).toBe(true)
+      expect(badge.props('label')).toBe('Traces illimitées')
+      expect(badge.props('color')).toBe('var(--light-foreground-neutral)')
+      expect(badge.props('backgroundColor')).toBe('var(--light-background-neutral)')
+      expect(badge.props('icon')).toBe(MDI_ICONS.ATTACH_FILE)
     })
   })
 

--- a/src/features/staff/activities/views/NationalActivityCatalogView/components/NationalActivitySettingDetails/NationalActivitySettingDetails.vue
+++ b/src/features/staff/activities/views/NationalActivityCatalogView/components/NationalActivitySettingDetails/NationalActivitySettingDetails.vue
@@ -6,7 +6,8 @@ import { ICONS } from '@/common/constants'
 import {
   ACTIVITY_FEEDBACK_ALLOWED_ITERATIONS_DISABLED,
   ACTIVITY_FEEDBACK_ALLOWED_ITERATIONS_INFINITY,
-  ACTIVITY_TRACE_SETTING_DISABLED_VALUE
+  ACTIVITY_TRACE_SETTING_DISABLED_VALUE,
+  ACTIVITY_TRACE_SETTING_INFINITY_VALUE
 } from '@/features/staff/activities/config'
 import { AvBadge, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
 import { useI18n } from 'vue-i18n'
@@ -28,6 +29,15 @@ const feedbackIterationsLabel = computed(() => activity.feedbackAllowedIteration
       'staff.activities.views.NationalActivityCatalogView.NationalActivitySettingDetails.badges.feedbackIterations',
       activity.feedbackAllowedIterations
     )
+)
+
+const traceAssociationsLabel = computed(() =>
+  activity.traceAllowedAssociations === ACTIVITY_TRACE_SETTING_INFINITY_VALUE
+    ? t('staff.activities.views.NationalActivityCatalogView.NationalActivitySettingDetails.badges.unlimitedTraces')
+    : t(
+        'staff.activities.views.NationalActivityCatalogView.NationalActivitySettingDetails.badges.traceAssociations',
+        activity.traceAllowedAssociations
+      )
 )
 </script>
 
@@ -51,7 +61,17 @@ const feedbackIterationsLabel = computed(() => activity.feedbackAllowedIteration
       background-color="var(--other-background-base)"
       data-testid="national-activity-setting-details-trace"
     >
-      <EnabledDisabledStatusBadge :enabled="isTraceEnabled" />
+      <div class="av-row av-gap-xs av-align-center av-wrap">
+        <EnabledDisabledStatusBadge :enabled="isTraceEnabled" />
+
+        <AvBadge
+          v-if="isTraceEnabled"
+          :label="traceAssociationsLabel"
+          :icon="MDI_ICONS.ATTACH_FILE"
+          color="var(--light-foreground-neutral)"
+          background-color="var(--light-background-neutral)"
+        />
+      </div>
     </IconTitleCardContainer>
     <IconTitleCardContainer
       :title="t('staff.activities.views.EditNationalActivityView.ActivityFeedbackFormField.title')"


### PR DESCRIPTION


## 📝 Pull Request Description

### Brief description of changes applied
<!-- Describe the changes introduced by this pull request. -->

add trace association limit badge in activity settings
---

### Reference to an Issue, Feature, Task, User Story or another PR
<!-- Mention related issue numbers or links (e.g. Closes #123, Implements #456). -->
<!-- Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/### -->
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/2085

<img width="1489" height="576" alt="image" src="https://github.com/user-attachments/assets/f9cc1b7a-7a32-430b-9719-47915b18a269" />
