### PR TITLE
feat(2146): update activity status badge colors and tests

### DIFF
--- a/src/common/activities/badges/ActivityStatusBadge/ActivityStatusBadge.test.ts
+++ b/src/common/activities/badges/ActivityStatusBadge/ActivityStatusBadge.test.ts
@@ -10,12 +10,13 @@ BddTest().given('an activity status badge', () => {
 
   const stubs = { AvBadge: AvBadgeStub }
 
-  const scenario: Array<{ props: ActivityStatusBadgeProps, label: string, icon: string }> = [
-    { props: { status: EActivityStatus.DRAFT }, label: 'brouillon', icon: MDI_ICONS.TEXT_BOX_EDIT_OUTLINE },
-    { props: { status: EActivityStatus.PUBLISHED }, label: 'publiée', icon: MDI_ICONS.TEXT_BOX_CHECK_OUTLINE },
+  const scenario: Array<{ props: ActivityStatusBadgeProps, label: string, icon: string, color: string, backgroundColor: string }> = [
+    { props: { status: EActivityStatus.DRAFT }, label: 'brouillon', icon: MDI_ICONS.TEXT_BOX_EDIT_OUTLINE, color: 'var(--text1)', backgroundColor: 'var(--surface-background)' },
+    { props: { status: EActivityStatus.PUBLISHED }, label: 'publiée', icon: MDI_ICONS.TEXT_BOX_CHECK_OUTLINE, color: 'var(--dark-background-success)', backgroundColor: 'var(--light-background-success)' },
+    { props: { status: EActivityStatus.UNPUBLISHED }, label: 'dépubliée', icon: MDI_ICONS.TEXT_BOX_CHECK_OUTLINE, color: 'var(--dark-background-warn)', backgroundColor: 'var(--light-background-warn)' },
   ]
 
-  scenario.forEach(({ props, label, icon }) => {
+  scenario.forEach(({ props, label, icon, color, backgroundColor }) => {
     BddTest().when(`the badge is rendered with status ${props.status}`, () => {
       beforeEach(() => {
         wrapper = mount(ActivityStatusBadge, { props, global: { stubs } })
@@ -34,6 +35,13 @@ BddTest().given('an activity status badge', () => {
       BddTest().then('it should render the badge icon', () => {
         const badge = wrapper.findComponent(AvBadgeStub)
         expect(badge.props('icon')).toBe(icon)
+      })
+
+      BddTest().then('it should render the badge colors', () => {
+        const badge = wrapper.findComponent(AvBadgeStub)
+
+        expect(badge.props('color')).toBe(color)
+        expect(badge.props('backgroundColor')).toBe(backgroundColor)
       })
     })
   })

--- a/src/common/activities/badges/ActivityStatusBadge/ActivityStatusBadge.vue
+++ b/src/common/activities/badges/ActivityStatusBadge/ActivityStatusBadge.vue
@@ -13,10 +13,34 @@ const { t } = useI18n()
 
 const label = computed(() => t(`global.activities.badges.statuses.${status}`))
 
+const badgeColors = computed(() => {
+  switch (status) {
+    case EActivityStatus.UNPUBLISHED:
+      return {
+        color: 'var(--dark-background-warn)',
+        backgroundColor: 'var(--light-background-warn)',
+      }
+
+    case EActivityStatus.PUBLISHED:
+      return {
+        color: 'var(--dark-background-success)',
+        backgroundColor: 'var(--light-background-success)',
+      }
+
+    case EActivityStatus.DRAFT:
+    default:
+      return {
+        color: 'var(--text1)',
+        backgroundColor: 'var(--surface-background)',
+      }
+  }
+})
+
 const icon = computed(() => {
   switch (status) {
     case EActivityStatus.DRAFT:
       return MDI_ICONS.TEXT_BOX_EDIT_OUTLINE
+    case EActivityStatus.UNPUBLISHED:
     case EActivityStatus.PUBLISHED:
     default:
       return MDI_ICONS.TEXT_BOX_CHECK_OUTLINE
@@ -28,8 +52,8 @@ const icon = computed(() => {
   <AvBadge
     :label="label"
     :icon="icon"
-    color="var(--text1)"
-    background-color="var(--surface-background)"
+    :color="badgeColors.color"
+    :background-color="badgeColors.backgroundColor"
     border-color="var(--stroke)"
   />
 </template>


### PR DESCRIPTION


## 📝 Pull Request Description

### Brief description of changes applied
<!-- Describe the changes introduced by this pull request. -->

update activity status badge colors and tests
---

### Reference to an Issue, Feature, Task, User Story or another PR
<!-- Mention related issue numbers or links (e.g. Closes #123, Implements #456). -->
<!-- Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/### -->
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/2146
---
<img width="1609" height="550" alt="image" src="https://github.com/user-attachments/assets/ed961cbe-10b9-40f1-a00c-90447601a783" />

