### PR TITLE
feat(2285): create staff activity long icon card

### DIFF
--- a/api-specs/avenir-esr.swagger.json
+++ b/api-specs/avenir-esr.swagger.json
@@ -3793,6 +3793,14 @@
               "type": "integer",
               "format": "int32"
             }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/EActivityStatus"
+            }
           }
         ],
         "responses": {

--- a/src/__mocks__/fixtures/staffs/activities.fixtures.ts
+++ b/src/__mocks__/fixtures/staffs/activities.fixtures.ts
@@ -136,7 +136,7 @@ export const mockedActivityDraftUpdateResponse: ActivityDraftUpdateResponse = {
   draftId: '5046ec1c-c8f3-4d06-abf3-71ba4a73643c',
 }
 
-const allStaffActivities: ActivityStaffOverviewDTO[] = [
+export const allStaffActivities: ActivityStaffOverviewDTO[] = [
   {
     activityId: ACTIVITY_WITH_FILE_AND_LINK_ID,
     title: 'Activité "Connaissance de soi" : Définir ses valeurs',
@@ -198,12 +198,15 @@ const allStaffActivities: ActivityStaffOverviewDTO[] = [
 export function createMockedPagedResponseActivityStaffOverviewDTO (
   pageSize: number,
   totalElements: number,
-  page: number
+  page: number,
+  status?: EActivityStatus | null
 ): PagedResponseActivityStaffOverviewDTO {
   const actualTotalElements = Math.min(totalElements, allStaffActivities.length)
   const start = page * pageSize
   const end = start + pageSize
-  const paginatedActivities = allStaffActivities.slice(start, end)
+  const paginatedActivities = allStaffActivities.slice(start, end).map((activity) => {
+    return status ? { ...activity, activityStatus: status } : activity
+  })
   const totalPages = Math.ceil(actualTotalElements / pageSize)
 
   return {

--- a/src/__mocks__/msw/handlers/staffs/activities.handlers.ts
+++ b/src/__mocks__/msw/handlers/staffs/activities.handlers.ts
@@ -59,6 +59,18 @@ export const getPublishedActivityContentErrorHandler = http.get(`*${getGetActivi
   )
 })
 
+export const getStaffActivityWorkingSpaceOverviewHandler = http.get(`*${getGetStaffActivityWorkingSpaceUrl()}`, ({ request }) => {
+  const url = new URL(request.url)
+  const status = url.searchParams.get('status') as EActivityStatus | null
+
+  const mockData = createMockedPagedResponseActivityStaffOverviewDTO(3, 3, 0, status)
+
+  return HttpResponse.json<PagedResponseActivityStaffOverviewDTO>(mockData, {
+    status: HttpStatusCode.OK,
+    headers: { 'Content-Type': 'application/json' },
+  })
+})
+
 export const getStaffActivityWorkingSpaceErrorHandler = http.get(`*${getGetStaffActivityWorkingSpaceUrl()}`, () => {
   return HttpResponse.json(
     { message: 'Erreur interne du serveur', code: ErrorCodes.SERVER },

--- a/src/features/staff/global/locales/en.json
+++ b/src/features/staff/global/locales/en.json
@@ -34,6 +34,24 @@
             "editProfile": "Edit profile"
           },
           "widgets": {
+            "ActivitiesWidget": {
+              "emptyState": {
+                "draft": "You have no modified activities at the moment.",
+                "published": "You have no published activities at the moment."
+              },
+              "errorState": {
+                "draft": "An error occurred while retrieving your modified activities.",
+                "published": "An error occurred while retrieving your published activities."
+              },
+              "seeAll": {
+                "draft": "See all my modified activities",
+                "published": "See all my published activities"
+              },
+              "title": {
+                "draft": "My latest modified activities",
+                "published": "My latest published activities"
+              }
+            },
             "FeedbacksWidget": {
               "emptyState": "You have no feedback requests to process at the moment.",
               "error": "An error occurred while retrieving your feedback requests.",

--- a/src/features/staff/global/locales/fr.json
+++ b/src/features/staff/global/locales/fr.json
@@ -34,6 +34,24 @@
             "editProfile": "Modifier mon profil"
           },
           "widgets": {
+            "ActivitiesWidget": {
+              "emptyState": {
+                "draft": "Vous n’avez aucune activité modifiée pour le moment.",
+                "published": "Vous n’avez aucune activité publiée pour le moment."
+              },
+              "errorState": {
+                "draft": "Une erreur est survenue lors de la récupération de vos activités modifiées.",
+                "published": "Une erreur est survenue lors de la récupération de vos activités publiées."
+              },
+              "seeAll": {
+                "draft": "Voir toutes mes activités modifiées",
+                "published": "Voir toutes mes activités publiées"
+              },
+              "title": {
+                "draft": "Mes dernières activités modifiées",
+                "published": "Mes dernières activités publiées"
+              }
+            },
             "FeedbacksWidget": {
               "emptyState": "Vous n’avez aucune demande de feedback à traiter pour le moment.",
               "error": "Une erreur est survenue lors de la récupération de vos demandes de feedback.",

--- a/src/features/staff/global/views/StaffHomeView/StaffHomeView.test.ts
+++ b/src/features/staff/global/views/StaffHomeView/StaffHomeView.test.ts
@@ -1,6 +1,7 @@
 import type { VueWrapper } from '@vue/test-utils'
 import { UpdateProfileDrawerStub } from '@/common/components/overlay/drawers/UpdateProfileDrawer/UpdateProfileDrawer.stub'
 import { ProfileCardStub } from '@/common/components/ProfileCard/ProfileCard.stub'
+import { ActivitiesWidgetStub } from '@/features/staff/global/views/StaffHomeView/components/ActivitiesWidget/ActivitiesWidget.stub'
 import { FeedbacksWidgetStub } from '@/features/staff/global/views/StaffHomeView/components/FeedbacksWidget/FeedbacksWidget.stub'
 import StaffHomeView from '@/features/staff/global/views/StaffHomeView/StaffHomeView.vue'
 import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
@@ -13,7 +14,8 @@ BddTest().given('a staff home view', () => {
   const stubs = {
     ProfileCard: ProfileCardStub,
     UpdateProfileDrawer: UpdateProfileDrawerStub,
-    FeedbacksWidget: FeedbacksWidgetStub
+    FeedbacksWidget: FeedbacksWidgetStub,
+    ActivitiesWidget: ActivitiesWidgetStub,
   }
 
   BddTest().when('the component is mounted', () => {
@@ -46,6 +48,13 @@ BddTest().given('a staff home view', () => {
       await vi.waitFor(() => {
         const feedbacksWidget = wrapper.findComponent(FeedbacksWidgetStub)
         expect(feedbacksWidget.exists()).toBe(true)
+      })
+    })
+
+    BddTest().then('it should render two ActivitiesWidget components', async () => {
+      await vi.waitFor(() => {
+        const activitiesWidgets = wrapper.findAllComponents(ActivitiesWidgetStub)
+        expect(activitiesWidgets).toHaveLength(2)
       })
     })
   })

--- a/src/features/staff/global/views/StaffHomeView/StaffHomeView.vue
+++ b/src/features/staff/global/views/StaffHomeView/StaffHomeView.vue
@@ -3,6 +3,7 @@ import { EUserCategory, useGetProfile } from '@/api/avenir-esr'
 import UpdateProfileDrawer from '@/common/components/overlay/drawers/UpdateProfileDrawer/UpdateProfileDrawer.vue'
 import ProfileCard from '@/common/components/ProfileCard/ProfileCard.vue'
 import { useDrawer } from '@/common/composables/use-drawer/use-drawer'
+import ActivitiesWidget from '@/features/staff/global/views/StaffHomeView/components/ActivitiesWidget/ActivitiesWidget.vue'
 import FeedbacksWidget from '@/features/staff/global/views/StaffHomeView/components/FeedbacksWidget/FeedbacksWidget.vue'
 import { AvRichButton, MDI_ICONS, useGlobalBackgroundColor } from '@avenirs-esr/avenirs-dsav'
 import { useI18n } from 'vue-i18n'
@@ -50,6 +51,8 @@ const { data: staffSummary } = useGetProfile(EUserCategory.STAFF)
     </div>
     <div class="layout-home__main av-col av-gap-xl">
       <FeedbacksWidget />
+      <ActivitiesWidget is-draft />
+      <ActivitiesWidget />
     </div>
   </div>
 

--- a/src/features/staff/global/views/StaffHomeView/components/ActivitiesWidget/ActivitiesWidget.stub.ts
+++ b/src/features/staff/global/views/StaffHomeView/components/ActivitiesWidget/ActivitiesWidget.stub.ts
@@ -1,0 +1,12 @@
+export const ActivitiesWidgetStub = defineComponent({
+  name: 'ActivitiesWidget',
+  props: {
+    isDraft: {
+      type: Boolean,
+      default: false
+    }
+  },
+  template: `
+    <div :data-testid="\`\${isDraft ? 'draft' : 'published'}-activities-widget\`" />
+  `
+})

--- a/src/features/staff/global/views/StaffHomeView/components/ActivitiesWidget/ActivitiesWidget.test.ts
+++ b/src/features/staff/global/views/StaffHomeView/components/ActivitiesWidget/ActivitiesWidget.test.ts
@@ -1,0 +1,116 @@
+import { getStaffActivityWorkingSpaceErrorHandler, getStaffActivityWorkingSpaceOverviewHandler } from '@/__mocks__/msw/handlers/staffs/activities.handlers'
+import { server } from '@/__mocks__/msw/server'
+import { HomeWidgetStub } from '@/common/components/cards/HomeWidget/HomeWidget.stub'
+import { QuerySuspenseStub } from '@/common/components/QuerySuspense/QuerySuspense.stub'
+import ActivitiesWidget from '@/features/staff/global/views/StaffHomeView/components/ActivitiesWidget/ActivitiesWidget.vue'
+import { ActivityLongIconCardStub } from '@/features/staff/global/views/StaffHomeView/components/ActivityLongIconCard/ActivityLongIconCard.stub'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { flushPromises, type VueWrapper } from '@vue/test-utils'
+import { mountComponent } from 'tests/utils'
+import { beforeEach, vi } from 'vitest'
+
+BddTest().given('an activities widget', async () => {
+  let wrapper: VueWrapper<InstanceType<typeof ActivitiesWidget>>
+
+  const stubs = {
+    HomeWidget: HomeWidgetStub,
+    ActivityLongIconCard: ActivityLongIconCardStub,
+    QuerySuspense: QuerySuspenseStub
+  }
+
+  BddTest().when('the component is mounted with isDraft prop', () => {
+    const props = { isDraft: true }
+
+    BddTest().and('the query succeeds', () => {
+      beforeEach(async () => {
+        vi.clearAllMocks()
+        server.use(getStaffActivityWorkingSpaceOverviewHandler)
+
+        wrapper = mountComponent(ActivitiesWidget, { props, global: { stubs } })
+
+        await flushPromises()
+      })
+
+      BddTest().then('it should render the draft activities widget', () => {
+        expect(wrapper.findComponent(HomeWidgetStub).exists()).toBe(true)
+        expect(wrapper.find('[data-testid="draft-activities-widget"]').exists()).toBe(true)
+      })
+
+      BddTest().then('it should render the activity long icon cards', async () => {
+        await vi.waitFor(() => {
+          const cards = wrapper.findAllComponents(ActivityLongIconCardStub)
+          expect(cards.length).toBeGreaterThan(0)
+        })
+      })
+    })
+
+    BddTest().and('the query fails', () => {
+      beforeEach(async () => {
+        vi.clearAllMocks()
+        server.use(getStaffActivityWorkingSpaceErrorHandler)
+
+        wrapper = mountComponent(ActivitiesWidget, { props, global: { stubs } })
+
+        await flushPromises()
+      })
+
+      BddTest().then('it should render the draft activities widget', () => {
+        expect(wrapper.findComponent(HomeWidgetStub).exists()).toBe(true)
+        expect(wrapper.find('[data-testid="draft-activities-widget"]').exists()).toBe(true)
+      })
+
+      BddTest().then('it should render the query suspense error state', () => {
+        expect(wrapper.find('[data-testid="query-suspense-error"]').exists()).toBe(true)
+        expect(wrapper.find('[data-testid="query-suspense-error"]').text()).toContain('Une erreur est survenue lors de la récupération de vos activités modifiées.')
+      })
+    })
+  })
+
+  BddTest().when('the component is mounted without isDraft prop', () => {
+    const props = { isDraft: false }
+
+    BddTest().and('the query succeeds', () => {
+      beforeEach(async () => {
+        vi.clearAllMocks()
+        server.use(getStaffActivityWorkingSpaceOverviewHandler)
+
+        wrapper = mountComponent(ActivitiesWidget, { props, global: { stubs } })
+
+        await flushPromises()
+      })
+
+      BddTest().then('it should render the published activities widget', () => {
+        expect(wrapper.findComponent(HomeWidgetStub).exists()).toBe(true)
+        expect(wrapper.find('[data-testid="published-activities-widget"]').exists()).toBe(true)
+      })
+
+      BddTest().then('it should render the activity long icon cards', async () => {
+        await vi.waitFor(() => {
+          const cards = wrapper.findAllComponents(ActivityLongIconCardStub)
+          expect(cards.length).toBeGreaterThan(0)
+        })
+      })
+    })
+
+    BddTest().and('the query fails', () => {
+      beforeEach(async () => {
+        vi.clearAllMocks()
+        server.use(getStaffActivityWorkingSpaceErrorHandler)
+
+        wrapper = mountComponent(ActivitiesWidget, { props, global: { stubs } })
+
+        await flushPromises()
+      })
+
+      BddTest().then('it should render the published activities widget', () => {
+        expect(wrapper.findComponent(HomeWidgetStub).exists()).toBe(true)
+        expect(wrapper.find('[data-testid="published-activities-widget"]').exists()).toBe(true)
+        expect(wrapper.find('[data-testid="published-activities-widget"]').text()).toContain('Une erreur est survenue lors de la récupération de vos activités publiées.')
+      })
+
+      BddTest().then('it should render the query suspense error state', () => {
+        expect(wrapper.find('[data-testid="query-suspense-error"]').exists()).toBe(true)
+      })
+    })
+  })
+})

--- a/src/features/staff/global/views/StaffHomeView/components/ActivitiesWidget/ActivitiesWidget.vue
+++ b/src/features/staff/global/views/StaffHomeView/components/ActivitiesWidget/ActivitiesWidget.vue
@@ -1,0 +1,62 @@
+<script setup lang="ts">
+import { EActivityStatus, useGetStaffActivityWorkingSpace } from '@/api/avenir-esr'
+import HomeWidget from '@/common/components/cards/HomeWidget/HomeWidget.vue'
+import QuerySuspense from '@/common/components/QuerySuspense/QuerySuspense.vue'
+import { useApiErrors } from '@/common/composables/use-api-errors/use-api-errors'
+import { ICONS, ROUTES } from '@/common/constants'
+import ActivityLongIconCard from '@/features/staff/global/views/StaffHomeView/components/ActivityLongIconCard/ActivityLongIconCard.vue'
+import { useI18n } from 'vue-i18n'
+
+const { isDraft = false } = defineProps<{ isDraft?: boolean }>()
+
+const { getErrorMessage } = useApiErrors()
+
+const params = computed(() => ({
+  page: 0,
+  pageSize: 3,
+  status: isDraft ? EActivityStatus.DRAFT : EActivityStatus.PUBLISHED
+}))
+
+const { data, error, isLoading, isFetching } = useGetStaffActivityWorkingSpace(params)
+const activities = computed(() => data.value?.data || [])
+
+const { t } = useI18n()
+
+const i18nExtension = computed(() => isDraft ? 'draft' : 'published')
+
+const homeWidgetPops = computed(() => ({
+  title: t(`staff.global.views.StaffHomeView.widgets.ActivitiesWidget.title.${i18nExtension.value}`),
+  titleIcon: ICONS.ACTIVITY,
+  seeAllLabel: t(`staff.global.views.StaffHomeView.widgets.ActivitiesWidget.seeAll.${i18nExtension.value}`),
+  to: ROUTES.STAFF.ACTIVITIES
+}))
+
+const emptyStateMessage = computed(() => t(`staff.global.views.StaffHomeView.widgets.ActivitiesWidget.emptyState.${i18nExtension.value}`))
+const errorStateTitle = computed(() => t(`staff.global.views.StaffHomeView.widgets.ActivitiesWidget.errorState.${i18nExtension.value}`))
+const errorStateDescription = computed(() => getErrorMessage(error.value))
+</script>
+
+<template>
+  <HomeWidget
+    v-bind="homeWidgetPops"
+    type="main"
+    :data-testid="`${i18nExtension}-activities-widget`"
+  >
+    <QuerySuspense
+      :is-loading="isLoading || isFetching"
+      :is-empty="activities.length === 0"
+      :error="error"
+      :error-title="errorStateTitle"
+      :error-description="errorStateDescription"
+      :empty-state-message="emptyStateMessage"
+    >
+      <div class="av-col av-gap-md">
+        <ActivityLongIconCard
+          v-for="activity in activities"
+          :key="activity.activityId"
+          :activity="activity"
+        />
+      </div>
+    </QuerySuspense>
+  </HomeWidget>
+</template>

--- a/src/features/staff/global/views/StaffHomeView/components/ActivityLongIconCard/ActivityLongIconCard.stub.ts
+++ b/src/features/staff/global/views/StaffHomeView/components/ActivityLongIconCard/ActivityLongIconCard.stub.ts
@@ -1,0 +1,13 @@
+import type { ActivityOverviewDTO, DeclaredActivityViewDTO } from '@/api/avenir-esr'
+import type { PropType } from 'vue'
+
+export const ActivityLongIconCardStub = defineComponent({
+  name: 'ActivityLongIconCard',
+  props: {
+    activity: {
+      type: Object as PropType<ActivityOverviewDTO | DeclaredActivityViewDTO>,
+      required: false
+    },
+  },
+  template: '<div data-testid="activity-long-icon-card-stub"></div>'
+})

--- a/src/features/staff/global/views/StaffHomeView/components/ActivityLongIconCard/ActivityLongIconCard.test.ts
+++ b/src/features/staff/global/views/StaffHomeView/components/ActivityLongIconCard/ActivityLongIconCard.test.ts
@@ -1,0 +1,85 @@
+import { allStaffActivities } from '@/__mocks__/fixtures/staffs/activities.fixtures'
+import { EActivityStatus } from '@/api/avenir-esr'
+import { ActivityThematicBadgeStub } from '@/common/activities/badges/ActivityThematicBadge/ActivityThematicBadge.stub'
+import { DeclaredActivityStatusBadgeStub } from '@/common/activities/badges/DeclaredActivityStatusBadge/DeclaredActivityStatusBadge.stub'
+import { LongIconCardStub } from '@/common/components/cards/LongIconCard/LongIconCard.stub'
+import ActivityLongIconCard from '@/features/staff/global/views/StaffHomeView/components/ActivityLongIconCard/ActivityLongIconCard.vue'
+import { MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { expect } from 'vitest'
+
+BddTest().given('an activity long icon card', () => {
+  let wrapper: VueWrapper<InstanceType<typeof ActivityLongIconCard>>
+
+  const stubs = {
+    LongIconCard: LongIconCardStub,
+    DeclaredActivityStatusBadge: DeclaredActivityStatusBadgeStub,
+    ActivityThematicBadge: ActivityThematicBadgeStub,
+  }
+
+  const draftActivity = { ...allStaffActivities[0], activityStatus: EActivityStatus.DRAFT }
+  const publishedActivity = { ...allStaffActivities[0], activityStatus: EActivityStatus.PUBLISHED }
+
+  BddTest().when('the component is mounted with a draft activity', () => {
+    beforeEach(() => {
+      wrapper = mount(ActivityLongIconCard, {
+        props: { activity: draftActivity },
+        global: {
+          stubs
+        }
+      })
+    })
+
+    BddTest().then('it should render the LongIconCard component', () => {
+      const longIconCard = wrapper.findComponent(LongIconCardStub)
+      expect(longIconCard.exists()).toBe(true)
+    })
+
+    BddTest().then('it should render the activity title as LongIconCard title', () => {
+      expect(wrapper.findComponent(LongIconCardStub).props('title')).toBe(draftActivity.title)
+    })
+
+    BddTest().then('it should render the activity thematic badge', () => {
+      expect(wrapper.findComponent(ActivityThematicBadgeStub).exists()).toBe(true)
+    })
+
+    BddTest().then('it should render the draft activity icon', () => {
+      expect(wrapper.findComponent(LongIconCardStub).props('icon')).toEqual({
+        name: MDI_ICONS.TEXT_BOX_EDIT_OUTLINE,
+        color: 'var(--light-foreground-neutral)'
+      })
+    })
+  })
+
+  BddTest().when('the component is mounted with a published activity', () => {
+    beforeEach(() => {
+      wrapper = mount(ActivityLongIconCard, {
+        props: { activity: publishedActivity },
+        global: {
+          stubs
+        }
+      })
+    })
+
+    BddTest().then('it should render the LongIconCard component', () => {
+      const longIconCard = wrapper.findComponent(LongIconCardStub)
+      expect(longIconCard.exists()).toBe(true)
+    })
+
+    BddTest().then('it should render the activity title as LongIconCard title', () => {
+      expect(wrapper.findComponent(LongIconCardStub).props('title')).toBe(publishedActivity.title)
+    })
+
+    BddTest().then('it should render the activity thematic badge', () => {
+      expect(wrapper.findComponent(ActivityThematicBadgeStub).exists()).toBe(true)
+    })
+
+    BddTest().then('it should render the published activity icon', () => {
+      expect(wrapper.findComponent(LongIconCardStub).props('icon')).toEqual({
+        name: MDI_ICONS.TEXT_BOX_CHECK_OUTLINE,
+        color: 'var(--dark-background-success)'
+      })
+    })
+  })
+})

--- a/src/features/staff/global/views/StaffHomeView/components/ActivityLongIconCard/ActivityLongIconCard.vue
+++ b/src/features/staff/global/views/StaffHomeView/components/ActivityLongIconCard/ActivityLongIconCard.vue
@@ -1,0 +1,38 @@
+<script lang="ts" setup>
+import { type ActivityStaffOverviewDTO, EActivityStatus } from '@/api/avenir-esr'
+import ActivityThematicBadge from '@/common/activities/badges/ActivityThematicBadge/ActivityThematicBadge.vue'
+import LongIconCard from '@/common/components/cards/LongIconCard/LongIconCard.vue'
+import { ROUTES } from '@/common/constants'
+import { MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
+
+export interface ActivityLongIconCardProps {
+  activity: ActivityStaffOverviewDTO
+}
+
+const { activity } = defineProps<ActivityLongIconCardProps>()
+
+const isDraft = computed(() => activity.activityStatus === EActivityStatus.DRAFT)
+
+const longIconCardProps = computed(() => ({
+  title: activity.title,
+  icon: {
+    name: isDraft.value ? MDI_ICONS.TEXT_BOX_EDIT_OUTLINE : MDI_ICONS.TEXT_BOX_CHECK_OUTLINE,
+    color: isDraft.value ? 'var(--light-foreground-neutral)' : 'var(--dark-background-success)'
+  },
+  iconBackgroundColor: isDraft.value ? 'var(--light-background-neutral)' : 'var(--light-background-success)',
+  to: { name: ROUTES.STAFF.ACTIVITY_CATALOG.name, params: { status: activity.activityStatus, id: activity.activityId } }
+}))
+</script>
+
+<template>
+  <LongIconCard
+    v-bind="longIconCardProps"
+    data-testid="activity-long-icon-card"
+    :data-activity-id="activity.activityId"
+    :data-status="activity.activityStatus"
+  >
+    <div class="av-row av-gap-sm">
+      <ActivityThematicBadge :thematic="activity.thematic" />
+    </div>
+  </LongIconCard>
+</template>


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
<!-- Describe the changes introduced by this pull request. -->

:sparkles: add ActivityLongIconCard for staff
:sparkles: add ActivitiesWidget for staff
:sparkles: implement two ActivitiesWidget in StaffHomeView for draft and published activities

---

### Reference to an Issue, Feature, Task, User Story or another PR
<!-- Mention related issue numbers or links (e.g. Closes #123, Implements #456). -->
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/2285
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/2292
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/2293

---

### Documentation
<!-- Detail any updates made to documentation, configuration steps, or technical specs. -->

---

### Target Branch
<!-- Which branch is this PR targeting (e.g. `main`, `develop`)? -->

develop

---

### Additional Notes
<!-- Include any relevant context, technical details, or reasons behind certain decisions. -->

<img width="1908" height="1081" alt="image" src="https://github.com/user-attachments/assets/350d12e1-d08e-45ac-853b-39c3d97b2cb2" />

https://github.com/user-attachments/assets/4a162c87-e7a7-403b-97a9-7eb20bdbbdfe

---

### Known Limitations or Side Effects
<!-- List any limitations, known bugs, or side effects this PR may introduce. -->

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [ ] No unnecessary code (e.g., debug logs, commented code)
- [ ] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and detaiils for the update process

---