### PR TITLE
feat(2317): create DeleteActivitiesSelector component

### DIFF
--- a/src/__mocks__/fixtures/student/activities.fixtures.ts
+++ b/src/__mocks__/fixtures/student/activities.fixtures.ts
@@ -3,6 +3,7 @@ import {
   type ActivityNavigationDTO,
   type ActivityOverviewDTO,
   type ActivityPresentationDTO,
+  type DeclaredActivityAssociationDTO,
   type DeclaredActivityAssociationsDTO,
   type DeclaredActivityDetailsDTO,
   type DeclaredActivityViewDTO,
@@ -559,6 +560,26 @@ export function createMockedPagedResponseAssociationSearchResultDeclaredActivity
       totalElements: filteredActivities.length,
       totalPages,
       page
+    }
+  }
+}
+
+export function buildAssociation (
+  overrides: Partial<DeclaredActivityAssociationDTO['declaredActivity']> & { associationId: string }
+): DeclaredActivityAssociationDTO {
+  const { associationId, ...declaredActivityOverrides } = overrides
+
+  return {
+    associationId,
+    declaredActivity: {
+      id: `activity-${associationId}`,
+      activityId: `activity-${associationId}`,
+      title: `Activity ${associationId}`,
+      thematic: EActivityThematic.SELF_KNOWLEDGE,
+      summary: 'summary',
+      description: 'description',
+      status: EDeclaredActivityStatus.SUBSCRIBED,
+      ...declaredActivityOverrides
     }
   }
 }

--- a/src/common/activities/rules/activities.rules.test.ts
+++ b/src/common/activities/rules/activities.rules.test.ts
@@ -1,7 +1,7 @@
-import type { DeclaredActivityDetailsDTO, FeedbackOverviewDTO, UserInfoDTO } from '@/api/avenir-esr'
+import type { DeclaredActivityAssociationDTO, DeclaredActivityDetailsDTO, FeedbackOverviewDTO, UserInfoDTO } from '@/api/avenir-esr'
 import { mockedDeclaredActivityDetails } from '@/__mocks__/fixtures/student/activities.fixtures'
-import { EFeedbackStatus } from '@/api/avenir-esr'
-import { canCreateFeedbackRequest, computeRemainingFeedbacks } from '@/common/activities/rules/activities.rules'
+import { EActivityThematic, EDeclaredActivityStatus, EFeedbackStatus } from '@/api/avenir-esr'
+import { canCreateFeedbackRequest, computeRemainingFeedbacks, isDeletableDeclaredActivityAssociation } from '@/common/activities/rules/activities.rules'
 import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { expect } from 'vitest'
 
@@ -34,6 +34,21 @@ function buildDeclaredActivityDetails (
       feedbackAllowedIterations
     },
     feedbacks
+  }
+}
+
+function buildDeclaredActivityAssociation (status: EDeclaredActivityStatus, associationId = 'association-1'): DeclaredActivityAssociationDTO {
+  return {
+    associationId,
+    declaredActivity: {
+      id: `activity-${associationId}`,
+      activityId: `activity-${associationId}`,
+      title: `Activity ${associationId}`,
+      thematic: EActivityThematic.SELF_KNOWLEDGE,
+      summary: 'summary',
+      description: 'description',
+      status
+    }
   }
 }
 
@@ -143,6 +158,36 @@ BddTest().given('canCreateFeedbackRequest', () => {
         ])
         expect(canCreateFeedbackRequest(declaredActivityDetails, 1)).toBe(false)
       })
+    })
+  })
+})
+
+BddTest().given('isDeletableDeclaredActivityAssociation', () => {
+  BddTest().when('the declared activity is subscribed', () => {
+    BddTest().then('it should return true', () => {
+      const association = buildDeclaredActivityAssociation(EDeclaredActivityStatus.SUBSCRIBED)
+      expect(isDeletableDeclaredActivityAssociation(association)).toBe(true)
+    })
+  })
+
+  BddTest().when('the declared activity is in progress', () => {
+    BddTest().then('it should return true', () => {
+      const association = buildDeclaredActivityAssociation(EDeclaredActivityStatus.IN_PROGRESS)
+      expect(isDeletableDeclaredActivityAssociation(association)).toBe(true)
+    })
+  })
+
+  BddTest().when('the declared activity is submitted', () => {
+    BddTest().then('it should return false', () => {
+      const association = buildDeclaredActivityAssociation(EDeclaredActivityStatus.SUBMITTED)
+      expect(isDeletableDeclaredActivityAssociation(association)).toBe(false)
+    })
+  })
+
+  BddTest().when('the declared activity is completed', () => {
+    BddTest().then('it should return false', () => {
+      const association = buildDeclaredActivityAssociation(EDeclaredActivityStatus.COMPLETED)
+      expect(isDeletableDeclaredActivityAssociation(association)).toBe(false)
     })
   })
 })

--- a/src/common/activities/rules/activities.rules.ts
+++ b/src/common/activities/rules/activities.rules.ts
@@ -1,4 +1,4 @@
-import { type DeclaredActivityDetailsDTO, EFeedbackStatus } from '@/api/avenir-esr'
+import { type DeclaredActivityAssociationDTO, type DeclaredActivityDetailsDTO, EDeclaredActivityStatus, EFeedbackStatus } from '@/api/avenir-esr'
 
 export function computeRemainingFeedbacks (declaredActivityDetails: DeclaredActivityDetailsDTO) {
   const { feedbackAllowedIterations } = declaredActivityDetails.activity
@@ -12,4 +12,13 @@ export function computeRemainingFeedbacks (declaredActivityDetails: DeclaredActi
 export function canCreateFeedbackRequest (declaredActivityDetails: DeclaredActivityDetailsDTO, remainingFeedbacks: number) {
   const lastFeedback = declaredActivityDetails.feedbacks?.at(0)
   return remainingFeedbacks !== 0 && lastFeedback?.status !== EFeedbackStatus.IN_PROCESS
+}
+
+const NOT_DELETABLE_DECLARED_ACTIVITY_STATUSES = new Set([
+  EDeclaredActivityStatus.SUBMITTED,
+  EDeclaredActivityStatus.COMPLETED
+])
+
+export function isDeletableDeclaredActivityAssociation (association: DeclaredActivityAssociationDTO) {
+  return !NOT_DELETABLE_DECLARED_ACTIVITY_STATUSES.has(association.declaredActivity.status)
 }

--- a/src/features/student/declaredSkills/components/overlays/modals/DeleteDeclaredSkillAssociatedActivitiesModal/DeleteDeclaredSkillAssociatedActivitiesModal.test.ts
+++ b/src/features/student/declaredSkills/components/overlays/modals/DeleteDeclaredSkillAssociatedActivitiesModal/DeleteDeclaredSkillAssociatedActivitiesModal.test.ts
@@ -5,7 +5,7 @@ import { EDeclaredActivityStatus } from '@/api/avenir-esr'
 import DeleteDeclaredSkillAssociatedActivitiesModal, {
   type DeleteDeclaredSkillAssociatedActivitiesModalProps
 } from '@/features/student/declaredSkills/components/overlays/modals/DeleteDeclaredSkillAssociatedActivitiesModal/DeleteDeclaredSkillAssociatedActivitiesModal.vue'
-import { CompactCardSelectorStub } from '@/features/student/global/components/cards/CompactCardSelector/CompactCardSelector.stub'
+import { DeleteActivitiesSelectorStub } from '@/features/student/global/components/cards/DeleteActivitiesSelector/DeleteActivitiesSelector.stub'
 import { DeleteAssociationsModalStub } from '@/features/student/global/components/overlays/modals/DeleteAssociationsModal/DeleteAssociationsModal.stub'
 import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { mountComponent } from 'tests/utils'
@@ -30,7 +30,7 @@ BddTest().given('a delete declared skill associated activities modal', () => {
 
   const stubs = {
     DeleteAssociationsModal: DeleteAssociationsModalStub,
-    CompactCardSelector: CompactCardSelectorStub,
+    DeleteActivitiesSelector: DeleteActivitiesSelectorStub,
   }
 
   const associations = createMockedDeclaredActivitiesAssociations(4)
@@ -58,32 +58,29 @@ BddTest().given('a delete declared skill associated activities modal', () => {
       expect(confirmModal.exists()).toBe(true)
     })
 
-    BddTest().then('it should render the compact card selector', () => {
-      const selector = wrapper.findComponent(CompactCardSelectorStub)
+    BddTest().then('it should render the delete activities selector', () => {
+      const selector = wrapper.findComponent(DeleteActivitiesSelectorStub)
       expect(selector.exists()).toBe(true)
     })
 
-    BddTest().then('it should only expose deletable associations excluding submitted and completed activities', () => {
-      const selector = wrapper.findComponent(CompactCardSelectorStub)
-      expect(selector.props('elements')).toEqual([
-        { id: 'declared-activity-association-1', title: 'Activité déclarée associée 1' },
-        { id: 'declared-activity-association-2', title: 'Activité déclarée associée 2' },
-      ])
+    BddTest().then('it should pass all associations through without filtering', () => {
+      const selector = wrapper.findComponent(DeleteActivitiesSelectorStub)
+      expect(selector.props('associations')).toEqual(associations)
     })
 
     BddTest().then('it should initialize selectedIds as empty', () => {
-      const selector = wrapper.findComponent(CompactCardSelectorStub)
+      const selector = wrapper.findComponent(DeleteActivitiesSelectorStub)
       expect(selector.props('modelValue')).toEqual([])
     })
 
-    BddTest().and('the user selects associations from the compact card selector', () => {
+    BddTest().and('the user selects deletable associations from the selector', () => {
       beforeEach(() => {
-        const selector = wrapper.findComponent(CompactCardSelectorStub)
+        const selector = wrapper.findComponent(DeleteActivitiesSelectorStub)
         selector.vm.$emit('update:modelValue', ['declared-activity-association-1', 'declared-activity-association-2'])
       })
 
       BddTest().then('the selectedIds should be updated accordingly', () => {
-        const selector = wrapper.findComponent(CompactCardSelectorStub)
+        const selector = wrapper.findComponent(DeleteActivitiesSelectorStub)
         expect(selector.props('modelValue')).toEqual(['declared-activity-association-1', 'declared-activity-association-2'])
       })
     })
@@ -99,7 +96,7 @@ BddTest().given('a delete declared skill associated activities modal', () => {
       })
 
       BddTest().then('the selectedIds should be reset', () => {
-        const selector = wrapper.findComponent(CompactCardSelectorStub)
+        const selector = wrapper.findComponent(DeleteActivitiesSelectorStub)
         expect(selector.props('modelValue')).toEqual([])
       })
     })
@@ -133,7 +130,7 @@ BddTest().given('a delete declared skill associated activities modal', () => {
 
       BddTest().then('the selectedIds should be reset', async () => {
         await vi.waitFor(() => {
-          const selector = wrapper.findComponent(CompactCardSelectorStub)
+          const selector = wrapper.findComponent(DeleteActivitiesSelectorStub)
           expect(selector.props('modelValue')).toEqual([])
         })
       })

--- a/src/features/student/declaredSkills/components/overlays/modals/DeleteDeclaredSkillAssociatedActivitiesModal/DeleteDeclaredSkillAssociatedActivitiesModal.vue
+++ b/src/features/student/declaredSkills/components/overlays/modals/DeleteDeclaredSkillAssociatedActivitiesModal/DeleteDeclaredSkillAssociatedActivitiesModal.vue
@@ -3,9 +3,7 @@ import type { BaseApiException } from '@/common/exceptions'
 import { type DeclaredActivityAssociationDTO, invalidateGetDeclaredSkillProgressDetails, invalidateGetDeclaredSkillWithDeclaredActivities, useDeleteDeclaredSkillAssociations } from '@/api/avenir-esr'
 import { useApiErrors } from '@/common/composables/use-api-errors/use-api-errors'
 import { useTaskLoading } from '@/common/composables/use-task-loading/use-task-loading'
-import { ICONS } from '@/common/constants'
-import { isDeletableDeclaredActivityAssociation } from '@/features/student/declaredSkills/rules/declared-activity-association.rules'
-import CompactCardSelector from '@/features/student/global/components/cards/CompactCardSelector/CompactCardSelector.vue'
+import DeleteActivitiesSelector from '@/features/student/global/components/cards/DeleteActivitiesSelector/DeleteActivitiesSelector.vue'
 import DeleteAssociationsModal from '@/features/student/global/components/overlays/modals/DeleteAssociationsModal/DeleteAssociationsModal.vue'
 import { useToasterStore } from '@/store'
 import { useQueryClient } from '@tanstack/vue-query'
@@ -31,11 +29,6 @@ const { isLoading, withTaskLoading } = useTaskLoading()
 const queryClient = useQueryClient()
 
 const selectedIds = ref<string[]>([])
-
-const selectableElements = computed(() => associations.filter(isDeletableDeclaredActivityAssociation).map(({ associationId, declaredActivity }) => ({
-  id: associationId,
-  title: declaredActivity.title,
-})))
 
 const { mutate: deleteDeclaredSkillAssociations } = useDeleteDeclaredSkillAssociations({
   mutation: {
@@ -76,16 +69,15 @@ function onCancel () {
 <template>
   <DeleteAssociationsModal
     :show="show"
-    :associations="selectableElements"
+    :associations="associations.map(({ associationId, declaredActivity }) => ({ id: associationId, title: declaredActivity.title }))"
     :selected-association-ids="selectedIds"
     :is-loading="isLoading"
     @cancel="onCancel"
     @confirm-delete="onConfirmDelete"
   >
-    <CompactCardSelector
+    <DeleteActivitiesSelector
       v-model="selectedIds"
-      :elements="selectableElements"
-      :icon="ICONS.ACTIVITY"
+      :associations="associations"
     />
   </DeleteAssociationsModal>
 </template>

--- a/src/features/student/global/components/cards/CompactCardSelector/CompactCardSelector.stub.ts
+++ b/src/features/student/global/components/cards/CompactCardSelector/CompactCardSelector.stub.ts
@@ -3,7 +3,10 @@ import type { PropType } from 'vue'
 export const CompactCardSelectorStub = defineComponent({
   name: 'CompactCardSelectorStub',
   props: {
-    elements: { type: Array as PropType<{ id: string, title: string, showSlot?: boolean }[]>, required: true },
+    elements: {
+      type: Array as PropType<{ id: string, title: string, showSlot?: boolean, disabled?: boolean, baseElement?: unknown }[]>,
+      required: true
+    },
     readonly: { type: Boolean, default: false },
     icon: { type: String, required: true },
     color: { type: String },
@@ -22,25 +25,28 @@ export const CompactCardSelectorStub = defineComponent({
           v-if="!readonly"
           role="button"
           data-testid="compact-card-selector"
-          @click="$emit('update:modelValue', toggleSelection(element.id))"
-          @keydown.enter="$emit('update:modelValue', toggleSelection(element.id))"
-          @keydown.space="$emit('update:modelValue', toggleSelection(element.id))"
+          @click="onToggle(element)"
+          @keydown.enter="onToggle(element)"
+          @keydown.space="onToggle(element)"
         >
           {{ element.title }}
         </a>
-        <slot v-if="element.showSlot" />
+        <slot v-if="element.showSlot" :element="element.baseElement" />
       </div>
     </div>
   `,
   methods: {
+    onToggle (element: { id: string, disabled?: boolean }) {
+      if (element.disabled) {
+        return
+      }
+      this.$emit('update:modelValue', this.toggleSelection(element.id))
+    },
     toggleSelection (value: string) {
       const isSelected = this.modelValue.includes(value)
-      if (isSelected) {
-        return this.modelValue.filter(v => v !== value)
-      }
-      else {
-        return [...this.modelValue, value]
-      }
-    },
-  },
+      return isSelected
+        ? this.modelValue.filter(v => v !== value)
+        : [...this.modelValue, value]
+    }
+  }
 })

--- a/src/features/student/global/components/cards/CompactCardSelector/CompactCardSelector.test.ts
+++ b/src/features/student/global/components/cards/CompactCardSelector/CompactCardSelector.test.ts
@@ -95,4 +95,24 @@ BddTest().given('a compact card selector', () => {
       expect(wrapper.find('[data-testid="selector-overlay"]').exists()).toBe(false)
     })
   })
+
+  BddTest().when('the component is mounted with a disabled element', () => {
+    const props: CompactCardSelectorProps = {
+      elements: [
+        { id: '1', title: 'Element 1', disabled: true },
+        { id: '2', title: 'Element 2' }
+      ],
+      icon: MDI_ICONS.ACCOUNT_CIRCLE_OUTLINE,
+    }
+
+    beforeEach(() => {
+      wrapper = mount(CompactCardSelector, { props, global: { stubs } })
+    })
+
+    BddTest().then('it should propagate disabled to the selector overlay stub', () => {
+      const overlay = wrapper.findComponent(SelectorOverlayStub)
+      expect(overlay.props('selectableElements')[0]).toMatchObject({ value: '1', disabled: true })
+      expect(overlay.props('selectableElements')[1]).toMatchObject({ value: '2', disabled: false })
+    })
+  })
 })

--- a/src/features/student/global/components/cards/CompactCardSelector/CompactCardSelector.vue
+++ b/src/features/student/global/components/cards/CompactCardSelector/CompactCardSelector.vue
@@ -32,7 +32,7 @@ import { getUnknownElementProp } from '@/features/student/global/components/card
  */
 
 export interface CompactCardSelectorProps {
-  elements: { id: string, title: string, showSlot?: boolean, baseElement?: unknown }[]
+  elements: { id: string, title: string, showSlot?: boolean, baseElement?: unknown, disabled?: boolean, isLoading?: boolean }[]
   readonly?: boolean
   icon: string
   color?: string
@@ -74,7 +74,9 @@ const selectableElements = computed(() => {
     value: element.id,
     label: element.title,
     showSlot: getUnknownElementProp<boolean>(element, 'showSlot') ?? false,
-    baseElement: element.baseElement
+    baseElement: element.baseElement,
+    disabled: getUnknownElementProp<boolean>(element, 'disabled') ?? false,
+    isLoading: getUnknownElementProp<boolean>(element, 'isLoading') ?? false
   }))
 })
 

--- a/src/features/student/global/components/cards/DeleteActivitiesSelector/DeleteActivitiesSelector.stub.ts
+++ b/src/features/student/global/components/cards/DeleteActivitiesSelector/DeleteActivitiesSelector.stub.ts
@@ -1,0 +1,28 @@
+import type { DeclaredActivityAssociationDTO } from '@/api/avenir-esr'
+import type { PropType } from 'vue'
+
+export const DeleteActivitiesSelectorStub = defineComponent({
+  name: 'DeleteActivitiesSelectorStub',
+  props: {
+    associations: { type: Array as PropType<DeclaredActivityAssociationDTO[]>, required: true },
+    readonly: { type: Boolean, default: false },
+    modelValue: { type: Array as PropType<string[]>, default: () => [] }
+  },
+  emits: ['update:modelValue'],
+  template: `
+    <div data-testid="delete-activities-selector-stub">
+      <div v-for="association in associations" :key="association.associationId">
+        <a
+          v-if="!readonly"
+          role="button"
+          data-testid="delete-activities-selector-item"
+          :data-association-id="association.associationId"
+          :data-status="association.declaredActivity.status"
+          @click="$emit('update:modelValue', [association.associationId])"
+        >
+          {{ association.declaredActivity.title }}
+        </a>
+      </div>
+    </div>
+  `
+})

--- a/src/features/student/global/components/cards/DeleteActivitiesSelector/DeleteActivitiesSelector.test.ts
+++ b/src/features/student/global/components/cards/DeleteActivitiesSelector/DeleteActivitiesSelector.test.ts
@@ -1,0 +1,84 @@
+import { buildAssociation } from '@/__mocks__/fixtures/student/activities.fixtures'
+import { EDeclaredActivityStatus } from '@/api/avenir-esr'
+import DeclaredActivityStatusBadge from '@/common/activities/badges/DeclaredActivityStatusBadge/DeclaredActivityStatusBadge.vue'
+import { CompactCardSelectorStub } from '@/features/student/global/components/cards/CompactCardSelector/CompactCardSelector.stub'
+import DeleteActivitiesSelector, { type DeleteActivitiesSelectorProps } from '@/features/student/global/components/cards/DeleteActivitiesSelector/DeleteActivitiesSelector.vue'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { beforeEach, expect } from 'vitest'
+
+BddTest().given('a delete activities selector', () => {
+  let wrapper: VueWrapper<InstanceType<typeof DeleteActivitiesSelector>>
+
+  const stubs = {
+    CompactCardSelector: CompactCardSelectorStub
+  }
+
+  BddTest().when('the component is mounted with a deletable and a non-deletable association', () => {
+    const props: DeleteActivitiesSelectorProps = {
+      associations: [
+        buildAssociation({ associationId: '1', status: EDeclaredActivityStatus.SUBSCRIBED }),
+        buildAssociation({ associationId: '2', status: EDeclaredActivityStatus.SUBMITTED })
+      ]
+    }
+
+    beforeEach(() => {
+      wrapper = mount(DeleteActivitiesSelector, { props, global: { stubs } })
+    })
+
+    BddTest().then('it should map each association disabled state from isDeletableDeclaredActivityAssociation', () => {
+      const compactCardSelector = wrapper.findComponent(CompactCardSelectorStub)
+      const elements = compactCardSelector.props('elements')
+
+      expect(elements).toEqual([
+        expect.objectContaining({ id: '1', disabled: false }),
+        expect.objectContaining({ id: '2', disabled: true })
+      ])
+    })
+
+    BddTest().then('it should render a status badge for every association', () => {
+      const badges = wrapper.findAllComponents(DeclaredActivityStatusBadge)
+      expect(badges).toHaveLength(props.associations.length)
+      expect(badges[0].props('status')).toBe(EDeclaredActivityStatus.SUBSCRIBED)
+      expect(badges[1].props('status')).toBe(EDeclaredActivityStatus.SUBMITTED)
+    })
+  })
+
+  BddTest().when('an association is selected', () => {
+    const props: DeleteActivitiesSelectorProps = {
+      associations: [
+        buildAssociation({ associationId: '1', status: EDeclaredActivityStatus.SUBSCRIBED })
+      ]
+    }
+
+    beforeEach(() => {
+      wrapper = mount(DeleteActivitiesSelector, { props, global: { stubs } })
+    })
+
+    BddTest().then('it should update the model with the association id', async () => {
+      const compactCardSelector = wrapper.findComponent(CompactCardSelectorStub)
+      await compactCardSelector.vm.$emit('update:modelValue', ['1'])
+
+      expect(wrapper.emitted('update:modelValue')).toBeTruthy()
+      expect(wrapper.emitted('update:modelValue')?.[0][0]).toEqual(['1'])
+    })
+  })
+
+  BddTest().when('the component is mounted in readonly mode', () => {
+    const props: DeleteActivitiesSelectorProps = {
+      associations: [
+        buildAssociation({ associationId: '1', status: EDeclaredActivityStatus.SUBSCRIBED })
+      ],
+      readonly: true
+    }
+
+    beforeEach(() => {
+      wrapper = mount(DeleteActivitiesSelector, { props, global: { stubs } })
+    })
+
+    BddTest().then('it should pass readonly down to the compact card selector', () => {
+      const compactCardSelector = wrapper.findComponent(CompactCardSelectorStub)
+      expect(compactCardSelector.props('readonly')).toBe(true)
+    })
+  })
+})

--- a/src/features/student/global/components/cards/DeleteActivitiesSelector/DeleteActivitiesSelector.vue
+++ b/src/features/student/global/components/cards/DeleteActivitiesSelector/DeleteActivitiesSelector.vue
@@ -1,0 +1,54 @@
+<script setup lang="ts">
+import type { DeclaredActivityAssociationDTO, DeclaredActivityViewDTO } from '@/api/avenir-esr'
+import DeclaredActivityStatusBadge from '@/common/activities/badges/DeclaredActivityStatusBadge/DeclaredActivityStatusBadge.vue'
+import { isDeletableDeclaredActivityAssociation } from '@/common/activities/rules/activities.rules'
+import { ICONS } from '@/common/constants'
+import CompactCardSelector from '@/features/student/global/components/cards/CompactCardSelector/CompactCardSelector.vue'
+
+export interface DeleteActivitiesSelectorProps {
+  associations: DeclaredActivityAssociationDTO[]
+  readonly?: boolean
+}
+
+defineOptions({
+  inheritAttrs: false
+})
+
+const { associations } = defineProps<DeleteActivitiesSelectorProps>()
+
+const selectedIds = defineModel<string[]>({ default: [] })
+
+const selectableElements = computed(() => associations.map((association) => {
+  const { associationId, declaredActivity } = association
+  return {
+    id: associationId,
+    title: declaredActivity.title,
+    baseElement: declaredActivity,
+    showSlot: true,
+    disabled: !isDeletableDeclaredActivityAssociation(association)
+  }
+}))
+</script>
+
+<template>
+  <div class="av-row av-justify-center av-gap-sm av-radius-md av-wrap">
+    <CompactCardSelector
+      v-model="selectedIds"
+      :elements="selectableElements"
+      :icon="ICONS.ACTIVITY"
+      color="var(--text1)"
+      icon-color="var(--icon)"
+      background-color="var(--surface-background)"
+      checkbox-color="var(--dark-background-primary1)"
+      overlay-color="var(--dark-background-primary1)"
+      :overlay-opacity="0.25"
+      :readonly="readonly"
+    >
+      <template #default="{ element }">
+        <DeclaredActivityStatusBadge
+          :status="(element as DeclaredActivityViewDTO).status"
+        />
+      </template>
+    </CompactCardSelector>
+  </div>
+</template>

--- a/src/features/student/traces/components/composites/TraceAssociations/TraceAssociations.test.ts
+++ b/src/features/student/traces/components/composites/TraceAssociations/TraceAssociations.test.ts
@@ -383,13 +383,10 @@ BddTest().given('a student trace associations component', () => {
       expect(dropdown.exists()).toBe(true)
     })
 
-    BddTest().then('it should pass only deletable declared activity associations to the delete activities modal', () => {
+    BddTest().then('it should pass all declared activity associations to the delete activities modal without filtering', () => {
       const activitiesModal = wrapper.findComponent(DeleteTraceAssociatedActivitiesModalStub)
-      const expectedAssociations = declaredActivityAssociations.filter(
-        association => association.declaredActivity.status !== EDeclaredActivityStatus.COMPLETED
-      )
 
-      expect(activitiesModal.props('associations')).toEqual(expectedAssociations)
+      expect(activitiesModal.props('associations')).toEqual(declaredActivityAssociations)
       expect(activitiesModal.props('traceId')).toBe(traceId)
     })
   })

--- a/src/features/student/traces/components/composites/TraceAssociations/TraceAssociations.vue
+++ b/src/features/student/traces/components/composites/TraceAssociations/TraceAssociations.vue
@@ -111,7 +111,7 @@ const deletableDeclaredActivityAssociations = computed(() =>
   <DeleteTraceAssociatedActivitiesModal
     :show="showActivitiesModal"
     :trace-id="traceId"
-    :associations="deletableDeclaredActivityAssociations"
+    :associations="declaredActivityAssociations"
     @cancel="hideActivitiesModal"
     @deleted="hideActivitiesModal"
   />

--- a/src/features/student/traces/views/StudentTraceView/components/overlays/modals/DeleteTraceAssociatedActivitiesModal/DeleteTraceAssociatedActivitiesModal.test.ts
+++ b/src/features/student/traces/views/StudentTraceView/components/overlays/modals/DeleteTraceAssociatedActivitiesModal/DeleteTraceAssociatedActivitiesModal.test.ts
@@ -2,7 +2,7 @@ import type { DeclaredActivityAssociationDTO } from '@/api/avenir-esr'
 import { deleteTraceAssociationsErrorHandler } from '@/__mocks__/msw/handlers/student/traces.handlers'
 import { server } from '@/__mocks__/msw/server'
 import { EActivityThematic, EDeclaredActivityStatus } from '@/api/avenir-esr'
-import { CompactCardSelectorStub } from '@/features/student/global/components/cards/CompactCardSelector/CompactCardSelector.stub'
+import { DeleteActivitiesSelectorStub } from '@/features/student/global/components/cards/DeleteActivitiesSelector/DeleteActivitiesSelector.stub'
 import { DeleteAssociationsModalStub } from '@/features/student/global/components/overlays/modals/DeleteAssociationsModal/DeleteAssociationsModal.stub'
 import DeleteTraceAssociatedActivitiesModal, {
   type DeleteTraceAssociatedActivitiesModalProps
@@ -30,7 +30,7 @@ BddTest().given('a delete trace associated activities modal', () => {
 
   const stubs = {
     DeleteAssociationsModal: DeleteAssociationsModalStub,
-    CompactCardSelector: CompactCardSelectorStub,
+    DeleteActivitiesSelector: DeleteActivitiesSelectorStub,
   }
 
   const associations: DeclaredActivityAssociationDTO[] = [
@@ -80,32 +80,29 @@ BddTest().given('a delete trace associated activities modal', () => {
       expect(confirmModal.exists()).toBe(true)
     })
 
-    BddTest().then('it should render the compact card selector', () => {
-      const selector = wrapper.findComponent(CompactCardSelectorStub)
+    BddTest().then('it should render the delete activities selector', () => {
+      const selector = wrapper.findComponent(DeleteActivitiesSelectorStub)
       expect(selector.exists()).toBe(true)
     })
 
-    BddTest().then('it should pass selectable elements derived from associations to the compact card selector', () => {
-      const selector = wrapper.findComponent(CompactCardSelectorStub)
-      expect(selector.props('elements')).toEqual([
-        { id: 'assoc-1', title: 'Activité 1' },
-        { id: 'assoc-2', title: 'Activité 2' },
-      ])
+    BddTest().then('it should pass all associations through without filtering', () => {
+      const selector = wrapper.findComponent(DeleteActivitiesSelectorStub)
+      expect(selector.props('associations')).toEqual(associations)
     })
 
     BddTest().then('it should initialize selectedIds as empty', () => {
-      const selector = wrapper.findComponent(CompactCardSelectorStub)
+      const selector = wrapper.findComponent(DeleteActivitiesSelectorStub)
       expect(selector.props('modelValue')).toEqual([])
     })
 
-    BddTest().and('the user selects associations from the compact card selector', () => {
+    BddTest().and('the user selects associations from the selector', () => {
       beforeEach(() => {
-        const selector = wrapper.findComponent(CompactCardSelectorStub)
+        const selector = wrapper.findComponent(DeleteActivitiesSelectorStub)
         selector.vm.$emit('update:modelValue', ['assoc-1', 'assoc-2'])
       })
 
       BddTest().then('the selectedIds should be updated accordingly', () => {
-        const selector = wrapper.findComponent(CompactCardSelectorStub)
+        const selector = wrapper.findComponent(DeleteActivitiesSelectorStub)
         expect(selector.props('modelValue')).toEqual(['assoc-1', 'assoc-2'])
       })
     })
@@ -121,7 +118,7 @@ BddTest().given('a delete trace associated activities modal', () => {
       })
 
       BddTest().then('the selectedIds should be reset', () => {
-        const selector = wrapper.findComponent(CompactCardSelectorStub)
+        const selector = wrapper.findComponent(DeleteActivitiesSelectorStub)
         expect(selector.props('modelValue')).toEqual([])
       })
     })
@@ -155,7 +152,7 @@ BddTest().given('a delete trace associated activities modal', () => {
 
       BddTest().then('the selectedIds should be reset', async () => {
         await vi.waitFor(() => {
-          const selector = wrapper.findComponent(CompactCardSelectorStub)
+          const selector = wrapper.findComponent(DeleteActivitiesSelectorStub)
           expect(selector.props('modelValue')).toEqual([])
         })
       })

--- a/src/features/student/traces/views/StudentTraceView/components/overlays/modals/DeleteTraceAssociatedActivitiesModal/DeleteTraceAssociatedActivitiesModal.vue
+++ b/src/features/student/traces/views/StudentTraceView/components/overlays/modals/DeleteTraceAssociatedActivitiesModal/DeleteTraceAssociatedActivitiesModal.vue
@@ -3,8 +3,7 @@ import type { BaseApiException } from '@/common/exceptions'
 import { type DeclaredActivityAssociationDTO, invalidateGetTraceAssociations, invalidateGetTraceDetail, useDeleteTraceAssociations } from '@/api/avenir-esr'
 import { useApiErrors } from '@/common/composables/use-api-errors/use-api-errors'
 import { useTaskLoading } from '@/common/composables/use-task-loading/use-task-loading'
-import { ICONS } from '@/common/constants'
-import CompactCardSelector from '@/features/student/global/components/cards/CompactCardSelector/CompactCardSelector.vue'
+import DeleteActivitiesSelector from '@/features/student/global/components/cards/DeleteActivitiesSelector/DeleteActivitiesSelector.vue'
 import DeleteAssociationsModal from '@/features/student/global/components/overlays/modals/DeleteAssociationsModal/DeleteAssociationsModal.vue'
 import { useToasterStore } from '@/store'
 import { useQueryClient } from '@tanstack/vue-query'
@@ -30,11 +29,6 @@ const { isLoading, withTaskLoading } = useTaskLoading()
 const queryClient = useQueryClient()
 
 const selectedIds = ref<string[]>([])
-
-const selectableElements = computed(() => associations.map(({ associationId, declaredActivity }) => ({
-  id: associationId,
-  title: declaredActivity.title,
-})))
 
 const { mutate: deleteTraceAssociations } = useDeleteTraceAssociations({
   mutation: {
@@ -75,16 +69,15 @@ function onCancel () {
 <template>
   <DeleteAssociationsModal
     :show="show"
-    :associations="selectableElements"
+    :associations="associations.map(({ associationId, declaredActivity }) => ({ id: associationId, title: declaredActivity.title }))"
     :selected-association-ids="selectedIds"
     :is-loading="isLoading"
     @cancel="onCancel"
     @confirm-delete="onConfirmDelete"
   >
-    <CompactCardSelector
+    <DeleteActivitiesSelector
       v-model="selectedIds"
-      :elements="selectableElements"
-      :icon="ICONS.ACTIVITY"
+      :associations="associations"
     />
   </DeleteAssociationsModal>
 </template>


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
Création du composant DeleteActivitiesSelector, destiné à remplacer CompactCardSelector dans les modales de suppression d'association d'activités.Contrairement à l'usage précédent (qui filtrait les activités soumises/terminées avant affichage), ce composant affiche toutes les activités associées, tout en :

* affichant un badge de statut (DeclaredActivityStatusBadge) sur chaque carte
* désactivant (non sélectionnables, grisées) les cartes dont l'activité est soumise ou terminée


---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/2317

---

### Target Branch
develop

---

### Additional Notes
<img width="1435" height="706" alt="image" src="https://github.com/user-attachments/assets/d7358f80-1e23-4113-944a-c692b4824cc4" />
<img width="1236" height="853" alt="image" src="https://github.com/user-attachments/assets/888f794e-cdfd-460a-a9f3-f41a8806caf4" />



---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and detaiils for the update process