### PR TITLE
feat(2177): implement activity kit valorization

### DIFF
--- a/src/__mocks__/msw/handlers/student/activities.handlers.ts
+++ b/src/__mocks__/msw/handlers/student/activities.handlers.ts
@@ -452,17 +452,10 @@ export const updateActivityHandler = http.patch(`*${getUpdateDeclaredActivityUrl
     )
   }
 
-  return HttpResponse.json<string>('Period updated successfully', {
+  return HttpResponse.json<string>('Activity updated successfully', {
     status: 200,
     headers: { 'Content-Type': 'application/json' }
   })
-})
-
-export const updateActivityPeriodHandler = http.patch(`*${getUpdateDeclaredActivityUrl(':declaredActivityId')}`, () => {
-  return HttpResponse.json(
-    { message: 'Internal Server Error', code: ErrorCodes.SERVER },
-    { status: 500, headers: { 'Content-Type': 'application/json' } }
-  )
 })
 
 export const updateActivityReflectionHandler = http.put(`*${getUpdateReflectionUrl(':activityId')}`, async ({ params, request }) => {

--- a/src/features/student/buildProject/components/interactions/formFields/ActivityPeriodFormField/ActivityPeriodFormField.vue
+++ b/src/features/student/buildProject/components/interactions/formFields/ActivityPeriodFormField/ActivityPeriodFormField.vue
@@ -12,8 +12,9 @@ interface ActivityPeriodFormFieldProps {
 const { form, label } = defineProps<ActivityPeriodFormFieldProps>()
 const { t } = useI18n()
 
-const startDateField = form.useField({ name: 'startDate' })
-const endDateField = form.useField({ name: 'endDate' })
+const periodForm = form as SubscribeActivityForm
+const startDateField = periodForm.useField({ name: 'startDate' })
+const endDateField = periodForm.useField({ name: 'endDate' })
 
 function setStartDate (value: string) {
   startDateField.api.handleChange(value)

--- a/src/features/student/buildProject/components/overlays/UpdateActivityDrawer/UpdateActivityDrawer.test.ts
+++ b/src/features/student/buildProject/components/overlays/UpdateActivityDrawer/UpdateActivityDrawer.test.ts
@@ -4,6 +4,7 @@ import { ConfirmationModalStub } from '@/common/components/ConfirmationModal/Con
 import { FormCancelConfirmButtonsStub } from '@/common/components/FormCancelConfirmButtons/FormCancelConfirmButtons.stub'
 import { ActivityPeriodFormFieldStub } from '@/features/student/buildProject/components/interactions/formFields/ActivityPeriodFormField/ActivityPeriodFormField.stub'
 import UpdateActivityDrawer from '@/features/student/buildProject/components/overlays/UpdateActivityDrawer/UpdateActivityDrawer.vue'
+import { KitValorizationToggleFormFieldStub } from '@/features/student/global/components/interaction/formFields/KitValorizationToggleFormField/KitValorizationToggleFormField.stub'
 import { AvAccordionStub, AvDrawerStub, AvIconTextStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { mountComponent } from 'tests/utils'
 import { beforeEach, expect, vi } from 'vitest'
@@ -34,6 +35,7 @@ BddTest().given('the UpdateActivityDrawer component', () => {
     AvIconText: AvIconTextStub,
     AvAccordion: AvAccordionStub,
     ActivityPeriodFormField: ActivityPeriodFormFieldStub,
+    KitValorizationToggleFormField: KitValorizationToggleFormFieldStub,
     ConfirmationModal: ConfirmationModalStub,
     FormCancelConfirmButtons: FormCancelConfirmButtonsStub,
   }
@@ -75,6 +77,16 @@ BddTest().given('the UpdateActivityDrawer component', () => {
     BddTest().then('it should render ActivityPeriodFormField', () => {
       const periodField = wrapper.findComponent({ name: 'ActivityPeriodFormField' })
       expect(periodField.exists()).toBe(true)
+    })
+
+    BddTest().then('it should render KitValorizationToggleFormField', () => {
+      const valorizationField = wrapper.findComponent({ name: 'KitValorizationToggleFormField' })
+      expect(valorizationField.exists()).toBe(true)
+    })
+
+    BddTest().then('it should render the valorization accordion first', () => {
+      const accordions = wrapper.findAllComponents({ name: 'AvAccordion' })
+      expect(accordions[0].props('title')).toBe('Valorisation dans mon kit')
     })
   })
 

--- a/src/features/student/buildProject/components/overlays/UpdateActivityDrawer/UpdateActivityDrawer.vue
+++ b/src/features/student/buildProject/components/overlays/UpdateActivityDrawer/UpdateActivityDrawer.vue
@@ -7,6 +7,8 @@ import { useUnsavedChangesGuard } from '@/common/composables/use-unsaved-changes
 import ActivityPeriodFormField
   from '@/features/student/buildProject/components/interactions/formFields/ActivityPeriodFormField/ActivityPeriodFormField.vue'
 import { useUpdateActivityForm } from '@/features/student/buildProject/components/overlays/UpdateActivityDrawer/use-update-activity-form/use-update-activity-form'
+import KitValorizationToggleFormField
+  from '@/features/student/global/components/interaction/formFields/KitValorizationToggleFormField/KitValorizationToggleFormField.vue'
 import { useToasterStore } from '@/store'
 import { AvAccordion, AvAccordionsGroup, AvDrawer, AvIconText, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
 import { startOfDay } from 'date-fns'
@@ -92,6 +94,15 @@ const isDemo = __DEMO_MODE__
         @submit.prevent.stop="form.handleSubmit"
       >
         <AvAccordionsGroup :active-accordion="0">
+          <AvAccordion
+            :title="t('student.buildProject.activities.overlays.UpdateActivityDrawer.sections.valorization')"
+            :icon="MDI_ICONS.STAR_OUTLINE"
+          >
+            <div class="av-flex-col-md">
+              <KitValorizationToggleFormField :form="form" />
+            </div>
+          </AvAccordion>
+
           <AvAccordion
             :title="t('student.buildProject.activities.overlays.UpdateActivityDrawer.sections.period')"
             :icon="MDI_ICONS.CALENDAR_OUTLINE"

--- a/src/features/student/buildProject/components/overlays/UpdateActivityDrawer/use-update-activity-form/use-update-activity-form.test.ts
+++ b/src/features/student/buildProject/components/overlays/UpdateActivityDrawer/use-update-activity-form/use-update-activity-form.test.ts
@@ -58,6 +58,43 @@ BddTest().given('the useUpdateActivityForm composable', () => {
     })
   })
 
+  BddTest().when('the form is initialized from a valorized activity', () => {
+    let result: ReturnType<typeof useUpdateActivityForm>
+
+    beforeEach(() => {
+      const { result: composableResult } = mountComposable(
+        () => useUpdateActivityForm({ ...mockedDeclaredActivityDetails, valorized: true }),
+        { useTanstack: true, useI18n: true, usePinia: true }
+      )
+      result = composableResult
+    })
+
+    BddTest().then('it should pre-fill valorized from the activity', () => {
+      expect(result.form.getFieldValue('valorized')).toBe(true)
+    })
+  })
+
+  BddTest().when('the valorization is toggled from the initial value', () => {
+    let result: ReturnType<typeof useUpdateActivityForm>
+
+    beforeEach(async () => {
+      const { result: composableResult } = mountComposable(
+        () => useUpdateActivityForm(mockedDeclaredActivityDetails),
+        { useTanstack: true, useI18n: true, usePinia: true }
+      )
+      result = composableResult
+      result.form.setFieldValue('valorized', true)
+      await flushPromises()
+    })
+
+    BddTest().then('it should be dirty', async () => {
+      await vi.waitFor(() => {
+        const state = result.form.useStore(s => s)
+        expect(state.value.isDirty).toBe(true)
+      })
+    })
+  })
+
   BddTest().when('a date is changed from the initial value', () => {
     let result: ReturnType<typeof useUpdateActivityForm>
 

--- a/src/features/student/buildProject/components/overlays/UpdateActivityDrawer/use-update-activity-form/use-update-activity-form.ts
+++ b/src/features/student/buildProject/components/overlays/UpdateActivityDrawer/use-update-activity-form/use-update-activity-form.ts
@@ -9,9 +9,10 @@ import { useQueryClient } from '@tanstack/vue-query'
 import { type MaybeRef, toValue } from 'vue'
 import { useI18n } from 'vue-i18n'
 
-export interface UpdateActivityPeriodFormData {
+export interface UpdateActivityFormData {
   startDate: string | null
   endDate: string | null
+  valorized: boolean
 }
 
 export function useUpdateActivityForm (
@@ -25,16 +26,20 @@ export function useUpdateActivityForm (
   const queryClient = useQueryClient()
   const { isLoading, withTaskLoading } = useTaskLoading()
 
-  const { mutate: mutateUpdatePeriod, isPending } = useUpdateDeclaredActivity()
+  const { mutate: mutateUpdateDeclaredActivity, isPending } = useUpdateDeclaredActivity()
 
-  function updateActivityPeriod (period: { startDate: string, endDate: string } | undefined) {
-    mutateUpdatePeriod({
+  function updateActivity (value: UpdateActivityFormData) {
+    const period = value.startDate && value.endDate
+      ? { startDate: value.startDate, endDate: value.endDate }
+      : undefined
+
+    mutateUpdateDeclaredActivity({
       declaredActivityId: toValue(declaredActivity).id,
-      data: { period }
+      data: { period, valorized: value.valorized }
     }, {
       onError: (error: BaseApiException) => {
         addErrorMessage({
-          title: t('student.buildProject.activities.overlays.UpdateActivityDrawer.errors.updatePeriod'),
+          title: t('student.buildProject.activities.overlays.UpdateActivityDrawer.errors.updateActivity'),
           description: getErrorMessage(error)
         })
       },
@@ -48,10 +53,11 @@ export function useUpdateActivityForm (
   const form = useForm({
     defaultValues: {
       startDate: toValue(declaredActivity).startDate ?? null,
-      endDate: toValue(declaredActivity).endDate ?? null
-    } as UpdateActivityPeriodFormData,
+      endDate: toValue(declaredActivity).endDate ?? null,
+      valorized: toValue(declaredActivity).valorized ?? false
+    } as UpdateActivityFormData,
     validators: {
-      onSubmit ({ value }: { value: UpdateActivityPeriodFormData }) {
+      onSubmit ({ value }: { value: UpdateActivityFormData }) {
         const { startDate, endDate } = value
         return {
           fields: {
@@ -61,10 +67,8 @@ export function useUpdateActivityForm (
         }
       }
     },
-    onSubmit: ({ value }: { value: UpdateActivityPeriodFormData }) => {
-      updateActivityPeriod(value.startDate && value.endDate
-        ? { startDate: value.startDate, endDate: value.endDate }
-        : undefined)
+    onSubmit: ({ value }: { value: UpdateActivityFormData }) => {
+      updateActivity(value)
     }
   })
 
@@ -73,8 +77,9 @@ export function useUpdateActivityForm (
     (activity) => {
       form.reset({
         startDate: activity.startDate ?? null,
-        endDate: activity.endDate ?? null
-      } as UpdateActivityPeriodFormData)
+        endDate: activity.endDate ?? null,
+        valorized: activity.valorized ?? false
+      } as UpdateActivityFormData)
     }
   )
 

--- a/src/features/student/buildProject/locales/en.json
+++ b/src/features/student/buildProject/locales/en.json
@@ -50,15 +50,16 @@
               "description": "Are you sure you want to cancel your changes? Unsaved changes will be lost."
             },
             "errors": {
-              "updatePeriod": "An error occurred while updating the activity. Please try again later."
+              "updateActivity": "An error occurred while updating the activity. Please try again later."
             },
             "sections": {
               "notificationHint": "You will receive a notification 1 day before the start of your activity.",
               "period": "Achievement period",
               "periodLabel": "Update my personal achievement period",
-              "reminder": "Reminders"
+              "reminder": "Reminders",
+              "valorization": "Kit valorization"
             },
-            "success": "The achievement period has been successfully updated.",
+            "success": "The activity has been successfully updated.",
             "title": "Edit activity"
           }
         },

--- a/src/features/student/buildProject/locales/fr.json
+++ b/src/features/student/buildProject/locales/fr.json
@@ -50,15 +50,16 @@
               "description": "Êtes-vous certain(e) de vouloir annuler les modifications ? Les changements non enregistrés seront perdus."
             },
             "errors": {
-              "updatePeriod": "Une erreur est survenue lors de la mise à jour de l'activité. Veuillez réessayer plus tard."
+              "updateActivity": "Une erreur est survenue lors de la mise à jour de l'activité. Veuillez réessayer plus tard."
             },
             "sections": {
               "notificationHint": "Vous recevrez une notification 1 jour avant le début de votre activité.",
               "period": "Période de réalisation",
               "periodLabel": "Modifier ma période de réalisation personnelle",
-              "reminder": "Rappels"
+              "reminder": "Rappels",
+              "valorization": "Valorisation dans mon kit"
             },
-            "success": "La période de réalisation a été mise à jour avec succès.",
+            "success": "L'activité a été mise à jour avec succès.",
             "title": "Modifier l'activité"
           }
         },

--- a/src/features/student/buildProject/views/ProjectActivitiesView/components/ActivityLibraryCard/ActivityLibraryCard.test.ts
+++ b/src/features/student/buildProject/views/ProjectActivitiesView/components/ActivityLibraryCard/ActivityLibraryCard.test.ts
@@ -3,6 +3,7 @@ import {
   ActivityThematicBadgeStub
 } from '@/common/activities/badges/ActivityThematicBadge/ActivityThematicBadge.stub'
 import { DeclaredActivityStatusBadgeStub } from '@/common/activities/badges/DeclaredActivityStatusBadge/DeclaredActivityStatusBadge.stub'
+import { ValorizedBadgeStub } from '@/common/components/badges/ValorizedBadge/ValorizedBadge.stub'
 import {
   ActivityPeriodBadgeStub
 } from '@/features/student/buildProject/components/badges/ActivityPeriodBadge/ActivityPeriodBadge.stub'
@@ -32,6 +33,7 @@ BddTest().given('an ActivityLibraryCard', () => {
     DeclaredActivityStatusBadge: DeclaredActivityStatusBadgeStub,
     ActivityThematicBadge: ActivityThematicBadgeStub,
     ActivityPeriodBadge: ActivityPeriodBadgeStub,
+    ValorizedBadge: ValorizedBadgeStub,
     RouterLink: RouterLinkStub
   }
 
@@ -101,6 +103,44 @@ BddTest().given('an ActivityLibraryCard', () => {
 
     BddTest().then('it should display the summary text', () => {
       expect(wrapper.text()).toContain(baseActivity.summary)
+    })
+
+    BddTest().then('it should not render ValorizedBadge when valorized is undefined', () => {
+      const valorizedBadge = wrapper.findComponent(ValorizedBadgeStub)
+      expect(valorizedBadge.exists()).toBe(false)
+    })
+  })
+
+  BddTest().when('the component is mounted with a valorized activity', () => {
+    beforeEach(() => {
+      wrapper = mount(ActivityLibraryCard, {
+        props: { activity: { ...baseActivity, valorized: true } },
+        global: { stubs }
+      })
+    })
+
+    BddTest().then('it should render ValorizedBadge', () => {
+      const valorizedBadge = wrapper.findComponent(ValorizedBadgeStub)
+      expect(valorizedBadge.exists()).toBe(true)
+    })
+
+    BddTest().then('it should pass valorized true to ValorizedBadge', () => {
+      const valorizedBadge = wrapper.findComponent(ValorizedBadgeStub)
+      expect(valorizedBadge.props('valorized')).toBe(true)
+    })
+  })
+
+  BddTest().when('the component is mounted with a non valorized activity', () => {
+    beforeEach(() => {
+      wrapper = mount(ActivityLibraryCard, {
+        props: { activity: { ...baseActivity, valorized: false } },
+        global: { stubs }
+      })
+    })
+
+    BddTest().then('it should not render ValorizedBadge', () => {
+      const valorizedBadge = wrapper.findComponent(ValorizedBadgeStub)
+      expect(valorizedBadge.exists()).toBe(false)
     })
   })
 

--- a/src/features/student/buildProject/views/ProjectActivitiesView/components/ActivityLibraryCard/ActivityLibraryCard.vue
+++ b/src/features/student/buildProject/views/ProjectActivitiesView/components/ActivityLibraryCard/ActivityLibraryCard.vue
@@ -2,6 +2,7 @@
 import { type DeclaredActivityViewDTO, EDeclaredActivityStatus } from '@/api/avenir-esr'
 import ActivityThematicBadge from '@/common/activities/badges/ActivityThematicBadge/ActivityThematicBadge.vue'
 import DeclaredActivityStatusBadge from '@/common/activities/badges/DeclaredActivityStatusBadge/DeclaredActivityStatusBadge.vue'
+import ValorizedBadge from '@/common/components/badges/ValorizedBadge/ValorizedBadge.vue'
 import { ICONS, ROUTES } from '@/common/constants'
 import ActivityPeriodBadge from '@/features/student/buildProject/components/badges/ActivityPeriodBadge/ActivityPeriodBadge.vue'
 import { FloatingIconCard } from '@/features/student/global'
@@ -53,6 +54,10 @@ const isNotSubscribed = computed(() => activity.status !== EDeclaredActivityStat
         <div class="av-col av-pr-4xl--md av-pl-none av-pl-md--md">
           <div class="av-col av-row--md av-gap-sm av-justify-start av-justify-between--md av-px-xs">
             <div class="av-row av-row-wrap av-align-center av-gap-sm av-hidden av-unhidden--md">
+              <ValorizedBadge
+                v-if="activity.valorized"
+                :valorized="activity.valorized"
+              />
               <ActivityPeriodBadge v-if="activity.startDate && activity.endDate" />
               <DeclaredActivityStatusBadge
                 v-if="isNotSubscribed"

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/ProjectActivityDetails/ProjectActivityDetails.test.ts
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/ProjectActivityDetails/ProjectActivityDetails.test.ts
@@ -1,5 +1,6 @@
 import type { VueWrapper } from '@vue/test-utils'
 import { mockedDeclaredActivityDetails } from '@/__mocks__/fixtures/student/activities.fixtures'
+import { ValorizedBadgeStub } from '@/common/components/badges/ValorizedBadge/ValorizedBadge.stub'
 import { CardStub } from '@/common/components/cards/Card/Card.stub'
 import { IconTitleCardContainerStub } from '@/common/components/cards/IconTitleCardContainer/IconTitleCardContainer.stub'
 import { ActivityResourcesListStub } from '@/common/components/lists/ActivityResourcesList/ActivityResourcesList.stub'
@@ -23,6 +24,7 @@ BddTest().given('a project activity details component', () => {
     AvPeriodInput: AvPeriodInputStub,
     IconTitleCardContainer: IconTitleCardContainerStub,
     ActivityResourcesList: ActivityResourcesListStub,
+    ValorizedBadge: ValorizedBadgeStub,
   }
 
   BddTest().when('the component is mounted with recommendedCompletionContexts containing "-" lines and startDate and endDate', () => {
@@ -98,6 +100,50 @@ BddTest().given('a project activity details component', () => {
 
       const items = list.findAll('li')
       expect(items.length).toBe(0)
+    })
+  })
+
+  BddTest().when('the activity is valorized', () => {
+    const props: ProjectActivityDetailsProps = {
+      declaredActivityDetails: {
+        ...mockedDeclaredActivityDetails,
+        valorized: true,
+      },
+    }
+
+    beforeEach(() => {
+      wrapper = mountComponent(ProjectActivityDetails, {
+        props,
+        global: { stubs },
+      })
+    })
+
+    BddTest().then('it should render ValorizedBadge with valorized true', () => {
+      const badge = wrapper.findComponent(ValorizedBadgeStub)
+      expect(badge.exists()).toBe(true)
+      expect(badge.props('valorized')).toBe(true)
+    })
+  })
+
+  BddTest().when('the activity is not valorized', () => {
+    const props: ProjectActivityDetailsProps = {
+      declaredActivityDetails: {
+        ...mockedDeclaredActivityDetails,
+        valorized: false,
+      },
+    }
+
+    beforeEach(() => {
+      wrapper = mountComponent(ProjectActivityDetails, {
+        props,
+        global: { stubs },
+      })
+    })
+
+    BddTest().then('it should render ValorizedBadge with valorized false', () => {
+      const badge = wrapper.findComponent(ValorizedBadgeStub)
+      expect(badge.exists()).toBe(true)
+      expect(badge.props('valorized')).toBe(false)
     })
   })
 

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/ProjectActivityDetails/ProjectActivityDetails.vue
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/ProjectActivityDetails/ProjectActivityDetails.vue
@@ -3,6 +3,7 @@ import type { DeclaredActivityDetailsDTO } from '@/api/avenir-esr'
 import ActivityDescriptionContent from '@/common/activities/components/ActivityDescriptionContent/ActivityDescriptionContent.vue'
 import ActivityPeriodDisplay from '@/common/activities/components/ActivityPeriodDisplay/ActivityPeriodDisplay.vue'
 import ActivityRecommendedCompletionContextsList from '@/common/activities/components/ActivityRecommendedCompletionContextsList/ActivityRecommendedCompletionContextsList.vue'
+import ValorizedBadge from '@/common/components/badges/ValorizedBadge/ValorizedBadge.vue'
 import Card from '@/common/components/cards/Card/Card.vue'
 import IconTitleCardContainer from '@/common/components/cards/IconTitleCardContainer/IconTitleCardContainer.vue'
 import ActivityResourcesList from '@/common/components/lists/ActivityResourcesList/ActivityResourcesList.vue'
@@ -25,6 +26,7 @@ const resourceCount = computed(() => (activity.value.files?.length ?? 0) + (acti
     class="av-col av-gap-md"
     data-testid="project-activity-details"
   >
+    <ValorizedBadge :valorized="declaredActivityDetails.valorized" />
     <ActivityPeriodDisplay
       v-if="hasPeriodInfo"
       :start-date="declaredActivityDetails.startDate"

--- a/src/features/student/global/components/interaction/formFields/KitValorizationToggleFormField/KitValorizationToggleFormField.vue
+++ b/src/features/student/global/components/interaction/formFields/KitValorizationToggleFormField/KitValorizationToggleFormField.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { UpdateActivityForm } from '@/features/student/buildProject/types/forms.types'
 import type { UpdateDeclaredSkillForm } from '@/features/student/declaredSkills/views/StudentUpdateDeclaredSkillView/components/use-update-declared-skill-form/use-update-declared-skill-form'
 import type {
   UpdateSelfKnowledgeCategoryElementForm
@@ -8,7 +9,7 @@ import ValorizeToggle from '@/features/student/global/components/interaction/tog
 import { markRaw, useAttrs } from 'vue'
 
 interface DeclaredSkillValorizationToggleFormFieldProps {
-  form: UpdateDeclaredSkillForm | UpdateSelfKnowledgeCategoryElementForm | UpdateTraceForm
+  form: UpdateActivityForm | UpdateDeclaredSkillForm | UpdateSelfKnowledgeCategoryElementForm | UpdateTraceForm
 }
 
 const { form } = defineProps<DeclaredSkillValorizationToggleFormFieldProps>()


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> Implements activity kit valorization toggle functionality. Adds support for updating the valorization status of activities within the activity kit, including form validation, tests, and i18n support.

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/2177
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/2179

---

### Documentation
> Updated locale files (en.json, fr.json) for the buildProject feature to support new valorization toggle labels and descriptions.

---

### Target Branch
> `develop`

---

### Additional Notes
> - Integrated `KitValorizationToggleFormField` into `UpdateActivityDrawer` for activity updates
> - Extended `use-update-activity-form` composable to handle kit valorization state
> - Added comprehensive test coverage for new form field and activity details
> - Follows existing form patterns and conventions from the traces feature

---

### Known Limitations or Side Effects
> None identified.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [x] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [x] i18n handled (texts are translated)
- [x] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [x] Semantic Versioning respected
- [x] Add to `CHANGELOG.md` file all properties and database change and detaiils for the update process
