### PR TITLE
feat(2306): create ActivityExecutionPeriodFormField and integrate in modality section

### DIFF
--- a/src/features/staff/activities/components/interactions/formFields/ActivityExecutionPeriodFormField/ActivityExecutionPeriodFormField.stub.ts
+++ b/src/features/staff/activities/components/interactions/formFields/ActivityExecutionPeriodFormField/ActivityExecutionPeriodFormField.stub.ts
@@ -1,0 +1,16 @@
+import type { EditActivityForm } from '@/features/staff/activities/types/forms.types'
+import type { PropType } from 'vue'
+
+export const ActivityExecutionPeriodFormFieldStub = defineComponent({
+  name: 'ActivityExecutionPeriodFormField',
+  props: {
+    form: {
+      type: Object as PropType<EditActivityForm>,
+    },
+    disabled: {
+      type: Boolean,
+      required: false
+    }
+  },
+  template: '<div data-testid="activity-execution-period-form-field-stub"></div>',
+})

--- a/src/features/staff/activities/components/interactions/formFields/ActivityExecutionPeriodFormField/ActivityExecutionPeriodFormField.test.ts
+++ b/src/features/staff/activities/components/interactions/formFields/ActivityExecutionPeriodFormField/ActivityExecutionPeriodFormField.test.ts
@@ -1,0 +1,179 @@
+import type { EditActivityFormData } from '@/features/staff/activities/types/forms.types'
+import { EActivityThematic } from '@/api/avenir-esr'
+import ActivityExecutionPeriodFormField from '@/features/staff/activities/components/interactions/formFields/ActivityExecutionPeriodFormField/ActivityExecutionPeriodFormField.vue'
+import { ACTIVITY_TRACE_SETTING_INFINITY_VALUE } from '@/features/staff/activities/config'
+import { EditActivityFormDataBannerAction } from '@/features/staff/activities/types/forms.types'
+import { ToggleParameterCardStub } from '@/features/staff/global/components/cards/ToggleParameterCard/ToggleParameterCard.stub'
+import { AvPeriodInputStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { useForm } from '@tanstack/vue-form'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { beforeEach, expect, vi } from 'vitest'
+
+function mountField (overrides: Partial<EditActivityFormData> = {}, disabled = false) {
+  const TestWrapper = defineComponent({
+    setup () {
+      const defaultValues: EditActivityFormData = {
+        title: 'Test activity',
+        thematic: EActivityThematic.TRANSVERSAL,
+        description: '',
+        enableReflection: true,
+        recommendedCompletionContexts: '',
+        startDate: undefined,
+        endDate: undefined,
+        feedbackAllowedIterations: undefined,
+        summary: '',
+        traceAllowedAssociations: ACTIVITY_TRACE_SETTING_INFINITY_VALUE,
+        bannerAction: EditActivityFormDataBannerAction.NONE,
+        files: [],
+        links: [],
+        ...overrides,
+      }
+      const form = useForm({ defaultValues })
+      return { form }
+    },
+    components: { ActivityExecutionPeriodFormField },
+    template: `<ActivityExecutionPeriodFormField :form="form" :disabled="${disabled}" />`,
+  })
+
+  return mount(TestWrapper, {
+    global: {
+      stubs: {
+        ToggleParameterCard: ToggleParameterCardStub,
+        AvPeriodInput: AvPeriodInputStub,
+      },
+    },
+  })
+}
+
+BddTest().given('an ActivityExecutionPeriodFormField component', () => {
+  let wrapper: VueWrapper
+
+  const getFormField = () =>
+    wrapper.findComponent(ActivityExecutionPeriodFormField) as VueWrapper<InstanceType<typeof ActivityExecutionPeriodFormField>>
+
+  const getToggleParameterCard = () =>
+    wrapper.findComponent(ToggleParameterCardStub) as VueWrapper<InstanceType<typeof ToggleParameterCardStub>>
+
+  const getPeriodInput = () =>
+    wrapper.findComponent(AvPeriodInputStub) as VueWrapper<InstanceType<typeof AvPeriodInputStub>>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  BddTest().when('the component is mounted without any date', () => {
+    beforeEach(() => {
+      wrapper = mountField()
+    })
+
+    BddTest().then('it should render the parameter card', () => {
+      expect(getToggleParameterCard().exists()).toBe(true)
+    })
+
+    BddTest().then('it should have the parameter card unchecked', () => {
+      expect(getToggleParameterCard().props('modelValue')).toBe(false)
+    })
+
+    BddTest().then('it should not render AvPeriodInput', () => {
+      expect(getPeriodInput().exists()).toBe(false)
+    })
+  })
+
+  BddTest().when('the component is mounted with startDate and endDate', () => {
+    beforeEach(() => {
+      wrapper = mountField({ startDate: '2025-02-01', endDate: '2025-10-29' })
+    })
+
+    BddTest().then('it should have the parameter card checked', () => {
+      expect(getToggleParameterCard().props('modelValue')).toBe(true)
+    })
+
+    BddTest().then('it should render AvPeriodInput', () => {
+      expect(getPeriodInput().exists()).toBe(true)
+    })
+
+    BddTest().then('it should pass correct props to AvPeriodInput', () => {
+      const periodInput = getPeriodInput()
+      expect(periodInput.props('startModelValue')).toBe('2025-02-01')
+      expect(periodInput.props('endModelValue')).toBe('2025-10-29')
+    })
+  })
+
+  BddTest().when('the component is mounted with disabled prop', () => {
+    beforeEach(() => {
+      wrapper = mountField({}, true)
+    })
+
+    BddTest().then('it should disable the parameter card', () => {
+      expect(getToggleParameterCard().props('disabled')).toBe(true)
+    })
+  })
+
+  BddTest().when('the toggle is enabled', () => {
+    beforeEach(async () => {
+      wrapper = mountField()
+      getToggleParameterCard().vm.$emit('update:modelValue', true)
+      await wrapper.vm.$nextTick()
+    })
+
+    BddTest().then('it should render AvPeriodInput', () => {
+      expect(getPeriodInput().exists()).toBe(true)
+    })
+
+    BddTest().then('it should not emit autosave', () => {
+      expect(getFormField().emitted('autosave')).toBeFalsy()
+    })
+  })
+
+  BddTest().when('the toggle is disabled after having dates set', () => {
+    beforeEach(async () => {
+      wrapper = mountField({ startDate: '2025-02-01', endDate: '2025-10-29' })
+      getToggleParameterCard().vm.$emit('update:modelValue', false)
+      await wrapper.vm.$nextTick()
+    })
+
+    BddTest().then('it should hide AvPeriodInput', () => {
+      expect(getPeriodInput().exists()).toBe(false)
+    })
+
+    BddTest().then('it should emit autosave with both dates undefined', () => {
+      const emitted = getFormField().emitted('autosave')
+      expect(emitted).toBeTruthy()
+      const lastCall = emitted![emitted!.length - 1][0]
+      expect(lastCall).toEqual({ startDate: undefined, endDate: undefined })
+    })
+  })
+
+  BddTest().when('only the start date is filled', () => {
+    beforeEach(async () => {
+      wrapper = mountField()
+      getToggleParameterCard().vm.$emit('update:modelValue', true)
+      await wrapper.vm.$nextTick()
+      getPeriodInput().vm.$emit('update:startModelValue', '2025-02-01')
+      await wrapper.vm.$nextTick()
+    })
+
+    BddTest().then('it should not emit autosave', () => {
+      expect(getFormField().emitted('autosave')).toBeFalsy()
+    })
+  })
+
+  BddTest().when('both dates are filled', () => {
+    beforeEach(async () => {
+      wrapper = mountField()
+      getToggleParameterCard().vm.$emit('update:modelValue', true)
+      await wrapper.vm.$nextTick()
+      getPeriodInput().vm.$emit('update:startModelValue', '2025-02-01')
+      await wrapper.vm.$nextTick()
+      getPeriodInput().vm.$emit('update:endModelValue', '2025-10-29')
+      await wrapper.vm.$nextTick()
+    })
+
+    BddTest().then('it should emit autosave with both dates', () => {
+      const emitted = getFormField().emitted('autosave')
+      expect(emitted).toBeTruthy()
+      const lastCall = emitted![emitted!.length - 1][0]
+      expect(lastCall).toEqual({ startDate: '2025-02-01', endDate: '2025-10-29' })
+    })
+  })
+})

--- a/src/features/staff/activities/components/interactions/formFields/ActivityExecutionPeriodFormField/ActivityExecutionPeriodFormField.vue
+++ b/src/features/staff/activities/components/interactions/formFields/ActivityExecutionPeriodFormField/ActivityExecutionPeriodFormField.vue
@@ -1,0 +1,81 @@
+<script setup lang="ts">
+import type { ActivityDraftUpdateRequest } from '@/api/avenir-esr'
+import type { EditActivityForm } from '@/features/staff/activities/types/forms.types'
+import ToggleParameterCard from '@/features/staff/global/components/cards/ToggleParameterCard/ToggleParameterCard.vue'
+import { AvPeriodInput, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
+import { useI18n } from 'vue-i18n'
+
+interface ActivityExecutionPeriodFormFieldProps {
+  form: EditActivityForm
+  disabled?: boolean
+}
+
+defineOptions({ inheritAttrs: false })
+
+const { form } = defineProps<ActivityExecutionPeriodFormFieldProps>()
+
+const emit = defineEmits<{
+  autosave: [value: Partial<ActivityDraftUpdateRequest>]
+}>()
+
+const { t } = useI18n()
+
+const startDateField = form.useField({ name: 'startDate' })
+const endDateField = form.useField({ name: 'endDate' })
+
+const startDate = computed(() => startDateField.state.value.value || undefined)
+const endDate = computed(() => endDateField.state.value.value || undefined)
+
+const toggleOverride = ref(false)
+
+const inputEnabled = computed({
+  get: () => !!startDate.value || !!endDate.value || toggleOverride.value,
+  set: (newValue: boolean) => {
+    toggleOverride.value = newValue
+    if (!newValue) {
+      startDateField.api.handleChange(undefined)
+      endDateField.api.handleChange(undefined)
+      emit('autosave', { startDate: undefined, endDate: undefined })
+    }
+  },
+})
+
+function autosaveIfConsistent (start: string | undefined, end: string | undefined) {
+  if ((start && end) || (!start && !end)) {
+    emit('autosave', { startDate: start, endDate: end })
+  }
+}
+
+function setStartDate (value: string) {
+  startDateField.api.handleChange(value)
+  autosaveIfConsistent(value || undefined, endDate.value)
+}
+
+function setEndDate (value: string) {
+  endDateField.api.handleChange(value)
+  autosaveIfConsistent(startDate.value, value || undefined)
+}
+</script>
+
+<template>
+  <ToggleParameterCard
+    v-model="inputEnabled"
+    data-testid="execution-period-parameter-toggle"
+    :title="t('staff.activities.views.EditNationalActivityView.ActivityExecutionPeriodFormField.title')"
+    :icon="MDI_ICONS.CALENDAR_MONTH_OUTLINE"
+    :disabled
+  >
+    <AvPeriodInput
+      v-if="inputEnabled"
+      data-testid="activity-execution-period-input"
+      :label="t('staff.activities.views.EditNationalActivityView.ActivityExecutionPeriodFormField.periodLabel')"
+      :label-visible="false"
+      :start-model-value="startDate ?? ''"
+      :end-model-value="endDate ?? ''"
+      :start-error-message="startDateField.state.value.meta.errors?.join(', ')"
+      :end-error-message="endDateField.state.value.meta.errors?.join(', ')"
+      @update:start-model-value="setStartDate"
+      @update:end-model-value="setEndDate"
+    />
+  </ToggleParameterCard>
+</template>

--- a/src/features/staff/activities/locales/en.json
+++ b/src/features/staff/activities/locales/en.json
@@ -134,6 +134,10 @@
             "nextStepLabel": "Next step",
             "title": "Fill in the content"
           },
+          "ActivityExecutionPeriodFormField": {
+            "periodLabel": "Execution period dates",
+            "title": "Set an execution period"
+          },
           "ActivityFeedbackFormField": {
             "description": "When this setting is disabled, students cannot request feedback on their activity through COFOLIO.",
             "infinityToggleLabel": "Allow unlimited feedback iterations",

--- a/src/features/staff/activities/locales/fr.json
+++ b/src/features/staff/activities/locales/fr.json
@@ -134,6 +134,10 @@
             "nextStepLabel": "Étape suivante",
             "title": "Renseigner le contenu"
           },
+          "ActivityExecutionPeriodFormField": {
+            "periodLabel": "Dates de la période de réalisation",
+            "title": "Définir une période de réalisation"
+          },
           "ActivityFeedbackFormField": {
             "description": "Lorsque le paramètre est désactivé, les apprenants ne peuvent pas demander de feedback sur leur activité en passant par COFOLIO.",
             "infinityToggleLabel": "Autoriser un nombre illimité d'itérations de feedback",

--- a/src/features/staff/activities/types/forms.types.ts
+++ b/src/features/staff/activities/types/forms.types.ts
@@ -17,6 +17,8 @@ export interface EditActivityFormData extends ActivityDraftCreationFormData {
   description: string
   enableReflection?: boolean
   recommendedCompletionContexts: string
+  startDate?: string
+  endDate?: string
   feedbackAllowedIterations?: number
   summary: string
   traceAllowedAssociations?: number

--- a/src/features/staff/activities/views/EditNationalActivityView/EditNationalActivityView.vue
+++ b/src/features/staff/activities/views/EditNationalActivityView/EditNationalActivityView.vue
@@ -91,6 +91,8 @@ const defaultValues: EditActivityFormData = reactive({
   thematic: computed(() => content.value?.thematic ?? EActivityThematic.TRANSVERSAL),
   description: computed(() => content.value?.description ?? ''),
   recommendedCompletionContexts: computed(() => content.value?.recommendedCompletionContexts ?? ''),
+  startDate: computed(() => content.value?.startDate),
+  endDate: computed(() => content.value?.endDate),
   summary: computed(() => content.value?.summary ?? ''),
   enableReflection: computed(() => content.value?.enableReflection ?? true),
   feedbackAllowedIterations: computed(() => content.value?.feedbackAllowedIterations ?? undefined),
@@ -130,11 +132,18 @@ const form = useForm({
   onSubmit: async ({ value }: { value: EditActivityFormData }) => {
     cancelAutoSave()
     pendingAutoSaveData.value = {}
+
+    const hasBothDates = !!value.startDate && !!value.endDate
+    const periodDates = hasBothDates
+      ? { startDate: value.startDate, endDate: value.endDate }
+      : { startDate: undefined, endDate: undefined }
+
     await save({
       title: value.title,
       thematic: value.thematic,
       description: value.description,
       recommendedCompletionContexts: value.recommendedCompletionContexts,
+      ...periodDates,
       summary: value.summary,
       enableReflection: value.enableReflection ?? true,
       feedbackAllowedIterations: value.feedbackAllowedIterations ?? 0,

--- a/src/features/staff/activities/views/EditNationalActivityView/components/ActivityContentTab/ActivityContentTab.test.ts
+++ b/src/features/staff/activities/views/EditNationalActivityView/components/ActivityContentTab/ActivityContentTab.test.ts
@@ -1,6 +1,7 @@
 import { mockedActivityContent } from '@/__mocks__/fixtures/staffs/activities.fixtures'
 import { IconTitleCardContainerStub } from '@/common/components/cards/IconTitleCardContainer/IconTitleCardContainer.stub'
 import { ActivityConsignFormFieldStub } from '@/features/staff/activities/components/interactions/formFields/ActivityConsignFormField/ActivityConsignFormField.stub'
+import { ActivityExecutionPeriodFormFieldStub } from '@/features/staff/activities/components/interactions/formFields/ActivityExecutionPeriodFormField/ActivityExecutionPeriodFormField.stub'
 import { ActivityFeedbackFormFieldStub } from '@/features/staff/activities/components/interactions/formFields/ActivityFeedbackFormField/ActivityFeedbackFormField.stub'
 import { ActivityReflectionFormFieldStub } from '@/features/staff/activities/components/interactions/formFields/ActivityReflectionFormField/ActivityReflectionFormField.stub'
 import { ActivityTitleFormFieldStub } from '@/features/staff/activities/components/interactions/formFields/ActivityTitleFormField/ActivityTitleFormField.stub'
@@ -22,6 +23,7 @@ BddTest().given('an ActivityContentTab component', () => {
 
   const stubs = {
     ActivityConsignFormField: ActivityConsignFormFieldStub,
+    ActivityExecutionPeriodFormField: ActivityExecutionPeriodFormFieldStub,
     ActivityFeedbackFormField: ActivityFeedbackFormFieldStub,
     ActivityReflectionFormField: ActivityReflectionFormFieldStub,
     ActivityTitleFormField: ActivityTitleFormFieldStub,
@@ -92,6 +94,7 @@ BddTest().given('an ActivityContentTab component', () => {
     BddTest().then('it should render form fields', () => {
       expect(tab.findComponent(ActivityTitleFormFieldStub).exists()).toBe(true)
       expect(tab.findComponent(ActivityConsignFormFieldStub).exists()).toBe(true)
+      expect(tab.findComponent(ActivityExecutionPeriodFormFieldStub).exists()).toBe(true)
       expect(tab.findComponent(ActivityFeedbackFormFieldStub).exists()).toBe(true)
       expect(tab.findComponent(ActivityReflectionFormFieldStub).exists()).toBe(true)
       expect(tab.findComponent(ActivityTraceFormFieldStub).exists()).toBe(true)

--- a/src/features/staff/activities/views/EditNationalActivityView/components/ActivityContentTab/ActivityContentTab.vue
+++ b/src/features/staff/activities/views/EditNationalActivityView/components/ActivityContentTab/ActivityContentTab.vue
@@ -5,6 +5,8 @@ import IconTitleCardContainer from '@/common/components/cards/IconTitleCardConta
 import { ICONS } from '@/common/constants'
 import { isDifferentFile } from '@/common/utils/file/file'
 import ActivityConsignFormField from '@/features/staff/activities/components/interactions/formFields/ActivityConsignFormField/ActivityConsignFormField.vue'
+import ActivityExecutionPeriodFormField
+  from '@/features/staff/activities/components/interactions/formFields/ActivityExecutionPeriodFormField/ActivityExecutionPeriodFormField.vue'
 import ActivityFeedbackFormField from '@/features/staff/activities/components/interactions/formFields/ActivityFeedbackFormField/ActivityFeedbackFormField.vue'
 import ActivityRecommendedCompletionContextsFormField
   from '@/features/staff/activities/components/interactions/formFields/ActivityRecommendedCompletionContextsFormField/ActivityRecommendedCompletionContextsFormField.vue'
@@ -150,6 +152,11 @@ function deleteSelectedResources (files: (FileDTO | File)[], links: string[]) {
         :title-icon="MDI_ICONS.SETTINGS"
         collapsible
       >
+        <ActivityExecutionPeriodFormField
+          :disabled="hasEnrolledStudent"
+          :form="form"
+          @autosave="queueAutoSave"
+        />
         <ActivityReflectionFormField
           :disabled="hasEnrolledStudent"
           :form="form"


### PR DESCRIPTION
## 📝 Pull Request Description
### Brief description of changes applied
Creates the `ActivityExecutionPeriodFormField` component (toggle + `AvPeriodInput` for start/end dates) and integrates it into the Modalities section of `ActivityContentTab`, before `ActivityReflectionFormField`. The toggle state is derived from the presence of `startDate`/`endDate` (no dedicated backend field). Both dates remain independently optional at the UI level, but autosave and the "Save for later" submit only send the dates when both are filled, since the backend currently requires start and end dates to be either both provided or both absent (see Additional Notes).

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/2306

### Documentation
Added i18n keys (FR/EN) for `ActivityExecutionPeriodFormField` title and period label under `staff.activities.views.EditNationalActivityView`.

### Target Branch
develop

### Additional Notes

<img width="920" height="266" alt="image" src="https://github.com/user-attachments/assets/38323a30-9836-4959-a5df-b55d49f7c9e1" />

<img width="1355" height="330" alt="image" src="https://github.com/user-attachments/assets/2c3cc0d4-916f-4bd8-b96a-4d9602d1c904" />


### Known Limitations or Side Effects
- No visible feedback is currently given to the user when only one of the two dates is filled and the form is saved — the value is simply not persisted.
- No "end date must be after start date" validation is enforced yet (the existing `validateDateInterval` composable could be reused for this in a follow-up).

## ✅ Checklist
- [x] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [x] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process