### PR TITLE
refactor(2344): handle execution period display and edit in activity detail

### DIFF
--- a/src/features/student/buildProject/components/overlays/UpdateActivityDrawer/UpdateActivityDrawer.test.ts
+++ b/src/features/student/buildProject/components/overlays/UpdateActivityDrawer/UpdateActivityDrawer.test.ts
@@ -90,6 +90,38 @@ BddTest().given('the UpdateActivityDrawer component', () => {
     })
   })
 
+  BddTest().when('the activity has a staff-defined period', () => {
+    beforeEach(() => {
+      vi.clearAllMocks()
+      mockCanLeave.mockResolvedValue(true)
+
+      wrapper = mountComponent(UpdateActivityDrawer, {
+        props: {
+          show: true,
+          declaredActivity: {
+            ...mockedDeclaredActivityDetails,
+            activity: {
+              ...mockedDeclaredActivityDetails.activity,
+              startDate: '2024-01-01',
+              endDate: '2024-12-31'
+            }
+          }
+        },
+        global: { stubs }
+      })
+    })
+
+    BddTest().then('it should not render ActivityPeriodFormField', () => {
+      const periodField = wrapper.findComponent({ name: 'ActivityPeriodFormField' })
+      expect(periodField.exists()).toBe(false)
+    })
+
+    BddTest().then('it should still render KitValorizationToggleFormField', () => {
+      const valorizationField = wrapper.findComponent({ name: 'KitValorizationToggleFormField' })
+      expect(valorizationField.exists()).toBe(true)
+    })
+  })
+
   BddTest().when('the drawer is mounted with show=false', () => {
     beforeEach(() => {
       vi.clearAllMocks()

--- a/src/features/student/buildProject/components/overlays/UpdateActivityDrawer/UpdateActivityDrawer.vue
+++ b/src/features/student/buildProject/components/overlays/UpdateActivityDrawer/UpdateActivityDrawer.vue
@@ -39,6 +39,8 @@ const { form, isFormValid, isSubmitting } = useUpdateActivityForm(
   }
 )
 
+const isActivityPeriodDefined = computed(() => !!declaredActivity.activity.startDate || !!declaredActivity.activity.endDate)
+
 const { showModal: showConfirmationModal, displayModal: displayConfirmationModal, hideModal: hideConfirmationModal } = useModal()
 
 const isDirty = computed(() => {
@@ -104,6 +106,7 @@ const isDemo = __DEMO_MODE__
           </AvAccordion>
 
           <AvAccordion
+            v-if="!isActivityPeriodDefined"
             :title="t('student.buildProject.activities.overlays.UpdateActivityDrawer.sections.period')"
             :icon="MDI_ICONS.CALENDAR_OUTLINE"
           >

--- a/src/features/student/buildProject/components/overlays/UpdateActivityDrawer/use-update-activity-form/use-update-activity-form.test.ts
+++ b/src/features/student/buildProject/components/overlays/UpdateActivityDrawer/use-update-activity-form/use-update-activity-form.test.ts
@@ -142,6 +142,39 @@ BddTest().given('the useUpdateActivityForm composable', () => {
     })
   })
 
+  BddTest().when('the activity has a staff-defined period', () => {
+    const mockOnUpdated = vi.fn()
+    let result: ReturnType<typeof useUpdateActivityForm>
+
+    beforeEach(async () => {
+      const { result: composableResult } = mountComposable(
+        () => useUpdateActivityForm(
+          {
+            ...mockedDeclaredActivityDetails,
+            activity: {
+              ...mockedDeclaredActivityDetails.activity,
+              startDate: '2024-01-01',
+              endDate: '2024-12-31'
+            }
+          },
+          mockOnUpdated
+        ),
+        { useTanstack: true, useI18n: true, usePinia: true }
+      )
+      result = composableResult
+      result.form.setFieldValue('startDate', '2024-03-01')
+      result.form.setFieldValue('endDate', '2024-06-30')
+      await result.form.handleSubmit()
+      await flushPromises()
+    })
+
+    BddTest().then('it should still call the onUpdated callback', async () => {
+      await vi.waitFor(() => {
+        expect(mockOnUpdated).toHaveBeenCalledTimes(1)
+      })
+    })
+  })
+
   BddTest().when('no callback is provided', () => {
     let result: ReturnType<typeof useUpdateActivityForm>
 

--- a/src/features/student/buildProject/components/overlays/UpdateActivityDrawer/use-update-activity-form/use-update-activity-form.ts
+++ b/src/features/student/buildProject/components/overlays/UpdateActivityDrawer/use-update-activity-form/use-update-activity-form.ts
@@ -28,8 +28,13 @@ export function useUpdateActivityForm (
 
   const { mutate: mutateUpdateDeclaredActivity, isPending } = useUpdateDeclaredActivity()
 
+  const isActivityPeriodDefined = computed(() => {
+    const activity = toValue(declaredActivity).activity
+    return !!activity.startDate || !!activity.endDate
+  })
+
   function updateActivity (value: UpdateActivityFormData) {
-    const period = value.startDate && value.endDate
+    const period = !isActivityPeriodDefined.value && value.startDate && value.endDate
       ? { startDate: value.startDate, endDate: value.endDate }
       : undefined
 

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/ProjectActivityDetails/ProjectActivityDetails.test.ts
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/ProjectActivityDetails/ProjectActivityDetails.test.ts
@@ -76,6 +76,34 @@ BddTest().given('a project activity details component', () => {
     })
   })
 
+  BddTest().when('the activity has a staff-defined period, taking priority over the student period', () => {
+    const props: ProjectActivityDetailsProps = {
+      declaredActivityDetails: {
+        ...mockedDeclaredActivityDetails,
+        startDate: '2024-05-01',
+        endDate: '2024-05-15',
+        activity: {
+          ...mockedDeclaredActivityDetails.activity,
+          startDate: '2024-01-01',
+          endDate: '2024-12-31',
+        },
+      },
+    }
+
+    beforeEach(() => {
+      wrapper = mountComponent(ProjectActivityDetails, {
+        props,
+        global: { stubs },
+      })
+    })
+
+    BddTest().then('it should render AvPeriodInput with the staff-defined dates', () => {
+      const periodInput = wrapper.findComponent(AvPeriodInputStub)
+      expect(periodInput.props('startModelValue')).toBe('2024-01-01')
+      expect(periodInput.props('endModelValue')).toBe('2024-12-31')
+    })
+  })
+
   BddTest().when('the component is mounted with empty recommendedCompletionContexts', () => {
     const props: ProjectActivityDetailsProps = {
       declaredActivityDetails: {
@@ -153,6 +181,11 @@ BddTest().given('a project activity details component', () => {
         ...mockedDeclaredActivityDetails,
         startDate: undefined,
         endDate: undefined,
+        activity: {
+          ...mockedDeclaredActivityDetails.activity,
+          startDate: undefined,
+          endDate: undefined,
+        },
       },
     }
 

--- a/src/features/student/buildProject/views/ProjectActivityDetailedView/components/ProjectActivityDetails/ProjectActivityDetails.vue
+++ b/src/features/student/buildProject/views/ProjectActivityDetailedView/components/ProjectActivityDetails/ProjectActivityDetails.vue
@@ -16,8 +16,13 @@ export interface ProjectActivityDetailsProps {
 }
 const { declaredActivityDetails } = defineProps<ProjectActivityDetailsProps>()
 const { t } = useI18n()
-const hasPeriodInfo = computed(() => !!declaredActivityDetails.startDate || !!declaredActivityDetails.endDate)
+
 const activity = computed(() => declaredActivityDetails.activity)
+const isActivityPeriodDefined = computed(() => !!activity.value.startDate || !!activity.value.endDate)
+const hasPeriodInfo = computed(() => isActivityPeriodDefined.value || !!declaredActivityDetails.startDate || !!declaredActivityDetails.endDate)
+const periodStartDate = computed(() => isActivityPeriodDefined.value ? activity.value.startDate : declaredActivityDetails.startDate)
+const periodEndDate = computed(() => isActivityPeriodDefined.value ? activity.value.endDate : declaredActivityDetails.endDate)
+
 const resourceCount = computed(() => (activity.value.files?.length ?? 0) + (activity.value.links?.length ?? 0))
 </script>
 
@@ -29,8 +34,8 @@ const resourceCount = computed(() => (activity.value.files?.length ?? 0) + (acti
     <ValorizedBadge :valorized="declaredActivityDetails.valorized" />
     <ActivityPeriodDisplay
       v-if="hasPeriodInfo"
-      :start-date="declaredActivityDetails.startDate"
-      :end-date="declaredActivityDetails.endDate"
+      :start-date="periodStartDate"
+      :end-date="periodEndDate"
     />
     <Card
       background-color="var(--card2)"


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
Handle the display and modification of the achievement period in the activity detail view. When the STAFF has defined a period on the activity, it is displayed with priority and the student can no longer personalize it (the "Achievement period" accordion is hidden in the update drawer). When no STAFF period is defined, the student can still view/enter/modify their own personal period.

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/2344

---

### Target Branch
develop

<img width="1434" height="714" alt="image" src="https://github.com/user-attachments/assets/73108958-0998-4aeb-9f5e-34e86a0b1bb7" />

<img width="1434" height="714" alt="image" src="https://github.com/user-attachments/assets/f3bfe26a-2b1c-4201-9f28-85abab7470ff" />

---

### Additional Notes
<!-- Include any relevant context, technical details, or reasons behind certain decisions. -->

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [x] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [x] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [x] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and detaiils for the update process