### PR TITLE
feat(2197): display associated experiences to a declared skill

### DIFF
--- a/api-specs/avenir-esr.swagger.json
+++ b/api-specs/avenir-esr.swagger.json
@@ -5672,7 +5672,11 @@
           "declaredExperience": {
             "$ref": "#/components/schemas/DeclaredExperienceViewDTO"
           }
-        }
+        },
+        "required": [
+          "associationId",
+          "declaredExperience"
+        ]
       },
       "DeclaredSkillAssociationDTO": {
         "type": "object",

--- a/src/__mocks__/fixtures/student/declaredExperiences.fixtures.ts
+++ b/src/__mocks__/fixtures/student/declaredExperiences.fixtures.ts
@@ -1,6 +1,7 @@
 import { mockedTraceOverview } from '@/__mocks__/fixtures/student/traces.fixtures'
 import {
   type AssociationSearchResultDeclaredExperienceDTO,
+  type DeclaredExperienceAssociationDTO,
   type DeclaredExperienceAssociationsDTO,
   type DeclaredExperienceViewDTO,
   EExperienceType,
@@ -98,6 +99,13 @@ export function searchDeclaredExperienceById (
   id: string
 ): DeclaredExperienceViewDTO | undefined {
   return mockedDeclaredExperiences.find(p => p.id === id)
+}
+
+export function createMockedDeclaredExperiencesAssociations (count: number): DeclaredExperienceAssociationDTO[] {
+  return createMockedDeclaredExperiences(count).map((declaredExperience, index) => ({
+    associationId: `declared-experience-association-${index + 1}`,
+    declaredExperience
+  }))
 }
 
 export function createMockedDeclaredExperienceAssociationsDTO (

--- a/src/__mocks__/fixtures/student/skills.fixtures.ts
+++ b/src/__mocks__/fixtures/student/skills.fixtures.ts
@@ -1,4 +1,5 @@
 import { createMockedTraceAssociations } from '@/__mocks__/fixtures/student/activities.fixtures'
+import { createMockedDeclaredExperiencesAssociations } from '@/__mocks__/fixtures/student/declaredExperiences.fixtures'
 import { mockedTraceOverview } from '@/__mocks__/fixtures/student/traces.fixtures'
 import {
   type AssociationSearchResultDeclaredSkillIDTO,
@@ -217,7 +218,7 @@ export function createMockedDeclaredActivitiesAssociations (count: number): Decl
 export const mockedDeclaredSkillAssociations: DeclaredSkillAssociationsDTO = {
   traceAssociations: createMockedTraceAssociations(2),
   declaredActivityAssociations: createMockedDeclaredActivitiesAssociations(1),
-  declaredExperienceAssociations: []
+  declaredExperienceAssociations: createMockedDeclaredExperiencesAssociations(2)
 }
 
 export function createMockedAllSkillListItemDTO (): SkillListItemDTO[] {

--- a/src/features/student/declaredSkills/views/StudentDeclaredSkillView/StudentDeclaredSkillView.test.ts
+++ b/src/features/student/declaredSkills/views/StudentDeclaredSkillView/StudentDeclaredSkillView.test.ts
@@ -115,14 +115,15 @@ BddTest().given('a student declared skill view', () => {
       await vi.waitFor(() => {
         const activeTab = wrapper.findComponent(AvTabStub)
         expect(activeTab.exists()).toBe(true)
-        expect(String(activeTab.props('title'))).toContain('3')
+        expect(String(activeTab.props('title'))).toContain('5')
 
         const associationsComponent = wrapper.findComponent(StudentDeclaredSkillAssociationsStub)
         expect(associationsComponent.exists()).toBe(true)
         expect(associationsComponent.props('declaredSkillId')).toBe('declared-skill-progress-1')
         expect(associationsComponent.props('associatedTraces')).toHaveLength(2)
         expect(associationsComponent.props('associatedDeclaredActivities')).toHaveLength(1)
-        expect(associationsComponent.props('countAssociations')).toBe(3)
+        expect(associationsComponent.props('associatedDeclaredExperiences')).toHaveLength(2)
+        expect(associationsComponent.props('countAssociations')).toBe(5)
         expect(associationsComponent.props('associationsError')).toBeFalsy()
       })
     })
@@ -134,7 +135,7 @@ BddTest().given('a student declared skill view', () => {
       await vi.waitFor(() => {
         const activeTab = wrapper.findComponent(AvTabStub)
         expect(activeTab.exists()).toBe(true)
-        expect(String(activeTab.props('title'))).toContain('3')
+        expect(String(activeTab.props('title'))).toContain('5')
       })
     })
 

--- a/src/features/student/declaredSkills/views/StudentDeclaredSkillView/StudentDeclaredSkillView.vue
+++ b/src/features/student/declaredSkills/views/StudentDeclaredSkillView/StudentDeclaredSkillView.vue
@@ -39,11 +39,13 @@ const { data, error: associationsError } = useGetDeclaredSkillWithDeclaredActivi
 )
 const traceAssociations = computed(() => data.value?.traceAssociations ?? [])
 const declaredActivityAssociations = computed(() => data.value?.declaredActivityAssociations ?? [])
+const declaredExperienceAssociations = computed(() => data.value?.declaredExperienceAssociations ?? [])
 
 const { originalErrorCode, isNotFound, getErrorMessage } = useApiErrors(error)
 const isDeclaredSkillNotFound = computed(() => originalErrorCode.value === ErrorCodes.DECLARED_SKILL_PROGRESS_NOT_FOUND || isNotFound.value)
 const skillTitle = computed(() => declaredSkillDetailed.value?.title ?? '')
-const countAssociations = computed(() => (traceAssociations.value?.length ?? 0) + (declaredActivityAssociations.value?.length ?? 0))
+const countAssociations = computed(() =>
+  traceAssociations.value.length + declaredActivityAssociations.value.length + declaredExperienceAssociations.value.length)
 
 const breadcrumbLinks = computed(() => [
   { text: t('student.global.navigation.tabs.home'), to: ROUTES.STUDENT.HOME },
@@ -98,6 +100,7 @@ function handleSkillDeleted () {
         :declared-skill-id="declaredSkillDetailed.id"
         :associated-traces="traceAssociations"
         :associated-declared-activities="declaredActivityAssociations"
+        :associated-declared-experiences="declaredExperienceAssociations"
         :associations-error="associationsError"
         :count-associations="countAssociations"
       />

--- a/src/features/student/declaredSkills/views/StudentDeclaredSkillView/components/StudentDeclaredSkillAssociations/StudentDeclaredSkillAssociations.stub.ts
+++ b/src/features/student/declaredSkills/views/StudentDeclaredSkillView/components/StudentDeclaredSkillAssociations/StudentDeclaredSkillAssociations.stub.ts
@@ -1,4 +1,4 @@
-import type { DeclaredActivityAssociationDTO, TraceAssociationDTO } from '@/api/avenir-esr'
+import type { DeclaredActivityAssociationDTO, DeclaredExperienceAssociationDTO, TraceAssociationDTO } from '@/api/avenir-esr'
 import type { BaseApiException } from '@/common/exceptions'
 
 export const StudentDeclaredSkillAssociationsStub = defineComponent({
@@ -14,6 +14,10 @@ export const StudentDeclaredSkillAssociationsStub = defineComponent({
     },
     associatedDeclaredActivities: {
       type: Array as () => DeclaredActivityAssociationDTO[],
+      required: true
+    },
+    associatedDeclaredExperiences: {
+      type: Array as () => DeclaredExperienceAssociationDTO[],
       required: true
     },
     associationsError: {

--- a/src/features/student/declaredSkills/views/StudentDeclaredSkillView/components/StudentDeclaredSkillAssociations/StudentDeclaredSkillAssociations.test.ts
+++ b/src/features/student/declaredSkills/views/StudentDeclaredSkillView/components/StudentDeclaredSkillAssociations/StudentDeclaredSkillAssociations.test.ts
@@ -1,6 +1,7 @@
 import type { TraceAssociationDTO } from '@/api/avenir-esr'
 import type { VueWrapper } from '@vue/test-utils'
 import { mockedTraceDeclaredActivityAssociations, mockedTraceOverview } from '@/__mocks__/fixtures/student'
+import { createMockedDeclaredExperiencesAssociations } from '@/__mocks__/fixtures/student/declaredExperiences.fixtures'
 import { createMockedDeclaredActivitiesAssociations } from '@/__mocks__/fixtures/student/skills.fixtures'
 import { EDeclaredActivityStatus } from '@/api/avenir-esr'
 import { QuerySuspenseStub } from '@/common/components/QuerySuspense/QuerySuspense.stub'
@@ -13,11 +14,15 @@ import { DeclaredSkillAssociateElementsDropdownStub } from '@/features/student/d
 import { DeleteDeclaredSkillAssociatedElementsDropdownStub } from '@/features/student/declaredSkills/views/StudentDeclaredSkillView/components/overlays/dropdowns/DeleteDeclaredSkillAssociatedElementsDropdown/DeleteDeclaredSkillAssociatedElementsDropdown.stub'
 import StudentDeclaredSkillAssociations
   from '@/features/student/declaredSkills/views/StudentDeclaredSkillView/components/StudentDeclaredSkillAssociations/StudentDeclaredSkillAssociations.vue'
+import { AssociatedDeclaredExperiencesCardStub }
+  from '@/features/student/personalCareer/components/cards/AssociatedDeclaredExperiencesCard/AssociatedDeclaredExperiencesCard.stub'
 import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { mountComponent } from 'tests/utils'
 import { beforeEach, expect, vi } from 'vitest'
 
 const declaredSkillId = 'declared-skill-progress-1'
+
+const mockedAssociatedDeclaredExperiences = createMockedDeclaredExperiencesAssociations(2)
 
 const mockedAssociatedTraces: TraceAssociationDTO[] = mockedTraceOverview.map((trace, i) => ({
   associationId: `skill-trace-assoc-${i + 1}`,
@@ -28,6 +33,7 @@ const stubs = {
   QuerySuspense: QuerySuspenseStub,
   AssociatedTracesCard: AssociatedTracesCardStub,
   AssociatedDeclaredActivitiesCard: AssociatedDeclaredActivitiesCardStub,
+  AssociatedDeclaredExperiencesCard: AssociatedDeclaredExperiencesCardStub,
   DeclaredSkillAssociateElementsDropdown: DeclaredSkillAssociateElementsDropdownStub,
   DeleteDeclaredSkillAssociatedElementsDropdown: DeleteDeclaredSkillAssociatedElementsDropdownStub,
   AssociateActivitiesToDeclaredSkillModal: AssociateActivitiesToDeclaredSkillModalStub,
@@ -48,7 +54,8 @@ BddTest().given('a student declared skill associations component', () => {
           declaredSkillId,
           associatedTraces: mockedAssociatedTraces,
           associatedDeclaredActivities: mockedTraceDeclaredActivityAssociations,
-          countAssociations: 3
+          associatedDeclaredExperiences: mockedAssociatedDeclaredExperiences,
+          countAssociations: 5
         },
         global: { stubs }
       })
@@ -94,6 +101,16 @@ BddTest().given('a student declared skill associations component', () => {
     BddTest().then('it should pass associatedDeclaredActivities prop to AssociatedDeclaredActivitiesCard', () => {
       const card = wrapper.findComponent(AssociatedDeclaredActivitiesCardStub)
       expect(card.props('associatedActivities')).toEqual(mockedTraceDeclaredActivityAssociations)
+    })
+
+    BddTest().then('it should render AssociatedDeclaredExperiencesCard', () => {
+      const card = wrapper.findComponent(AssociatedDeclaredExperiencesCardStub)
+      expect(card.exists()).toBe(true)
+    })
+
+    BddTest().then('it should pass associatedDeclaredExperiences prop to AssociatedDeclaredExperiencesCard', () => {
+      const card = wrapper.findComponent(AssociatedDeclaredExperiencesCardStub)
+      expect(card.props('associatedExperiences')).toEqual(mockedAssociatedDeclaredExperiences)
     })
 
     BddTest().then('it should render the declared skill associate elements dropdown', () => {
@@ -167,6 +184,7 @@ BddTest().given('a student declared skill associations component', () => {
           declaredSkillId,
           associatedTraces: mockedAssociatedTraces,
           associatedDeclaredActivities,
+          associatedDeclaredExperiences: [],
           countAssociations: 3
         },
         global: { stubs }
@@ -245,6 +263,7 @@ BddTest().given('a student declared skill associations component', () => {
           declaredSkillId,
           associatedTraces: [],
           associatedDeclaredActivities,
+          associatedDeclaredExperiences: [],
           countAssociations: 2
         },
         global: { stubs }
@@ -264,6 +283,7 @@ BddTest().given('a student declared skill associations component', () => {
           declaredSkillId,
           associatedTraces: [],
           associatedDeclaredActivities: [],
+          associatedDeclaredExperiences: [],
           countAssociations: 0
         },
         global: { stubs }
@@ -302,6 +322,11 @@ BddTest().given('a student declared skill associations component', () => {
       expect(card.exists()).toBe(false)
     })
 
+    BddTest().then('it should not render AssociatedDeclaredExperiencesCard', () => {
+      const card = wrapper.findComponent(AssociatedDeclaredExperiencesCardStub)
+      expect(card.exists()).toBe(false)
+    })
+
     BddTest().then('it should render the associate activities modal with the declared skill id', () => {
       const modal = wrapper.findComponent(AssociateActivitiesToDeclaredSkillModalStub)
       expect(modal.props('declaredSkillId')).toBe(declaredSkillId)
@@ -315,6 +340,7 @@ BddTest().given('a student declared skill associations component', () => {
           declaredSkillId,
           associatedTraces: [],
           associatedDeclaredActivities: [],
+          associatedDeclaredExperiences: [],
           associationsError: {
             status: 404,
             code: ErrorCodes.ASSOCIATION_NOT_FOUND,
@@ -355,6 +381,11 @@ BddTest().given('a student declared skill associations component', () => {
 
     BddTest().then('it should not render AssociatedDeclaredActivitiesCard', () => {
       const card = wrapper.findComponent(AssociatedDeclaredActivitiesCardStub)
+      expect(card.exists()).toBe(false)
+    })
+
+    BddTest().then('it should not render AssociatedDeclaredExperiencesCard', () => {
+      const card = wrapper.findComponent(AssociatedDeclaredExperiencesCardStub)
       expect(card.exists()).toBe(false)
     })
   })

--- a/src/features/student/declaredSkills/views/StudentDeclaredSkillView/components/StudentDeclaredSkillAssociations/StudentDeclaredSkillAssociations.vue
+++ b/src/features/student/declaredSkills/views/StudentDeclaredSkillView/components/StudentDeclaredSkillAssociations/StudentDeclaredSkillAssociations.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { DeclaredActivityAssociationDTO, TraceAssociationDTO } from '@/api/avenir-esr'
+import type { DeclaredActivityAssociationDTO, DeclaredExperienceAssociationDTO, TraceAssociationDTO } from '@/api/avenir-esr'
 import type { BaseApiException } from '@/common/exceptions'
 import { QuerySuspense } from '@/common/components'
 import { useModal } from '@/common/composables'
@@ -16,11 +16,13 @@ import DeclaredSkillAssociateElementsDropdown
   from '@/features/student/declaredSkills/views/StudentDeclaredSkillView/components/overlays/dropdowns/DeclaredSkillAssociateElementsDropdown/DeclaredSkillAssociateElementsDropdown.vue'
 import DeleteDeclaredSkillAssociatedElementsDropdown
   from '@/features/student/declaredSkills/views/StudentDeclaredSkillView/components/overlays/dropdowns/DeleteDeclaredSkillAssociatedElementsDropdown/DeleteDeclaredSkillAssociatedElementsDropdown.vue'
+import { AssociatedDeclaredExperiencesCard } from '@/features/student/personalCareer'
 import { useI18n } from 'vue-i18n'
 
 interface StudentDeclaredSkillAssociationsProps {
   declaredSkillId: string
   associatedDeclaredActivities: DeclaredActivityAssociationDTO[]
+  associatedDeclaredExperiences: DeclaredExperienceAssociationDTO[]
   associatedTraces: TraceAssociationDTO[]
   associationsError?: BaseApiException | null
   countAssociations?: number
@@ -30,6 +32,7 @@ const {
   declaredSkillId,
   associatedTraces,
   associatedDeclaredActivities,
+  associatedDeclaredExperiences,
   associationsError,
   countAssociations
 } = defineProps<StudentDeclaredSkillAssociationsProps>()
@@ -86,6 +89,7 @@ function onAssociated () {
         <div class="av-col av-gap-md">
           <AssociatedTracesCard :associated-traces="associatedTraces" />
           <AssociatedDeclaredActivitiesCard :associated-activities="associatedDeclaredActivities" />
+          <AssociatedDeclaredExperiencesCard :associated-experiences="associatedDeclaredExperiences" />
         </div>
       </QuerySuspense>
     </div>

--- a/src/features/student/global/components/cards/AssociationCard/AssociationCard.stub.ts
+++ b/src/features/student/global/components/cards/AssociationCard/AssociationCard.stub.ts
@@ -34,5 +34,5 @@ export const AssociationCardStub = defineComponent({
       required: false
     }
   },
-  template: '<div data-testid="association-card"></div>'
+  template: '<div data-testid="association-card"><slot name="body" /><slot name="footer" /></div>'
 })

--- a/src/features/student/personalCareer/components/badges/DeclaredExperienceTypeBadge/DeclaredExperienceTypeBadge.stub.ts
+++ b/src/features/student/personalCareer/components/badges/DeclaredExperienceTypeBadge/DeclaredExperienceTypeBadge.stub.ts
@@ -1,0 +1,13 @@
+import type { EExperienceType } from '@/api/avenir-esr'
+import type { PropType } from 'vue'
+
+export const DeclaredExperienceTypeBadgeStub = defineComponent({
+  name: 'DeclaredExperienceTypeBadge',
+  props: {
+    experienceType: {
+      type: String as PropType<EExperienceType>,
+      required: true
+    }
+  },
+  template: '<div data-testid="declared-experience-type-badge-stub">{{ experienceType }}</div>'
+})

--- a/src/features/student/personalCareer/components/badges/DeclaredExperienceTypeBadge/DeclaredExperienceTypeBadge.test.ts
+++ b/src/features/student/personalCareer/components/badges/DeclaredExperienceTypeBadge/DeclaredExperienceTypeBadge.test.ts
@@ -1,0 +1,66 @@
+import { EExperienceType } from '@/api/avenir-esr'
+import DeclaredExperienceTypeBadge
+  from '@/features/student/personalCareer/components/badges/DeclaredExperienceTypeBadge/DeclaredExperienceTypeBadge.vue'
+import { RI_ICONS } from '@avenirs-esr/avenirs-dsav'
+import { AvBadgeStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { beforeEach, expect, vi } from 'vitest'
+
+BddTest().given('a declared experience type badge', () => {
+  let wrapper: VueWrapper
+  let badge: VueWrapper<InstanceType<typeof AvBadgeStub>>
+
+  const stubs = { AvBadge: AvBadgeStub }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  BddTest().when('the component is mounted with a professional experience type', () => {
+    beforeEach(() => {
+      wrapper = mount(DeclaredExperienceTypeBadge, {
+        props: { experienceType: EExperienceType.PROFESSIONAL },
+        global: { stubs }
+      })
+      badge = wrapper.findComponent(AvBadgeStub) as VueWrapper<InstanceType<typeof AvBadgeStub>>
+    })
+
+    BddTest().then('it should display the professional label', () => {
+      expect(badge.props('label')).toBe('Expérience professionnelle')
+    })
+
+    BddTest().then('it should apply the dark primary3 background color', () => {
+      expect(badge.props('backgroundColor')).toBe('var(--dark-background-primary3)')
+    })
+
+    BddTest().then('it should use the honour line icon', () => {
+      expect(badge.props('icon')).toBe(RI_ICONS.HONOUR_LINE)
+    })
+
+    BddTest().then('it should use the card2 text color', () => {
+      expect(badge.props('color')).toBe('var(--card2)')
+    })
+
+    BddTest().then('it should enable ellipsis', () => {
+      expect(badge.props('ellipsis')).toBe(true)
+    })
+  })
+
+  BddTest().when('the component is mounted with a personal experience type', () => {
+    beforeEach(() => {
+      wrapper = mount(DeclaredExperienceTypeBadge, {
+        props: { experienceType: EExperienceType.PERSONAL },
+        global: { stubs }
+      })
+      badge = wrapper.findComponent(AvBadgeStub) as VueWrapper<InstanceType<typeof AvBadgeStub>>
+    })
+
+    BddTest().then('it should display the personal label', () => {
+      expect(badge.props('label')).toBe('Expérience personnelle')
+    })
+
+    BddTest().then('it should apply the dark success background color', () => {
+      expect(badge.props('backgroundColor')).toBe('var(--dark-background-success)')
+    })
+  })
+})

--- a/src/features/student/personalCareer/components/badges/DeclaredExperienceTypeBadge/DeclaredExperienceTypeBadge.vue
+++ b/src/features/student/personalCareer/components/badges/DeclaredExperienceTypeBadge/DeclaredExperienceTypeBadge.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+import type { EExperienceType } from '@/api/avenir-esr'
+import { AvBadge, RI_ICONS } from '@avenirs-esr/avenirs-dsav'
+import { useI18n } from 'vue-i18n'
+
+export interface DeclaredExperienceTypeBadgeProps {
+  experienceType: EExperienceType
+}
+
+const { experienceType } = defineProps<DeclaredExperienceTypeBadgeProps>()
+
+const { t } = useI18n()
+
+const experienceTypeColorMap: Record<EExperienceType, string> = {
+  PROFESSIONAL: 'var(--dark-background-primary3)',
+  PERSONAL: 'var(--dark-background-success)'
+}
+</script>
+
+<template>
+  <AvBadge
+    :label="t(`student.personalCareer.declaredExperienceType.${experienceType}`)"
+    :background-color="experienceTypeColorMap[experienceType]"
+    :icon="RI_ICONS.HONOUR_LINE"
+    color="var(--card2)"
+    data-testid="declared-experience-type-badge"
+    ellipsis
+  />
+</template>

--- a/src/features/student/personalCareer/components/cards/AssociatedDeclaredExperienceCard/AssociatedDeclaredExperienceCard.stub.ts
+++ b/src/features/student/personalCareer/components/cards/AssociatedDeclaredExperienceCard/AssociatedDeclaredExperienceCard.stub.ts
@@ -1,0 +1,17 @@
+import type { DeclaredExperienceViewDTO } from '@/api/avenir-esr'
+import type { PropType } from 'vue'
+
+export const AssociatedDeclaredExperienceCardStub = defineComponent({
+  name: 'AssociatedDeclaredExperienceCard',
+  props: {
+    declaredExperience: {
+      type: Object as PropType<DeclaredExperienceViewDTO>,
+      required: true
+    },
+    disabled: {
+      type: Boolean,
+      required: false
+    }
+  },
+  template: '<div data-testid="associated-declared-experience-card"></div>'
+})

--- a/src/features/student/personalCareer/components/cards/AssociatedDeclaredExperienceCard/AssociatedDeclaredExperienceCard.test.ts
+++ b/src/features/student/personalCareer/components/cards/AssociatedDeclaredExperienceCard/AssociatedDeclaredExperienceCard.test.ts
@@ -1,0 +1,103 @@
+import { type DeclaredExperienceViewDTO, EExperienceType } from '@/api/avenir-esr'
+import { ICONS, ROUTES } from '@/common/constants'
+import { AssociationCardStub } from '@/features/student/global/components/cards/AssociationCard/AssociationCard.stub'
+import { DeclaredExperienceTypeBadgeStub }
+  from '@/features/student/personalCareer/components/badges/DeclaredExperienceTypeBadge/DeclaredExperienceTypeBadge.stub'
+import AssociatedDeclaredExperienceCard, {
+  type AssociatedDeclaredExperienceCardProps
+} from '@/features/student/personalCareer/components/cards/AssociatedDeclaredExperienceCard/AssociatedDeclaredExperienceCard.vue'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { beforeEach, expect, vi } from 'vitest'
+
+BddTest().given('an associated declared experience card', () => {
+  let wrapper: VueWrapper<InstanceType<typeof AssociatedDeclaredExperienceCard>>
+
+  const stubs = {
+    AssociationCard: AssociationCardStub,
+    DeclaredExperienceTypeBadge: DeclaredExperienceTypeBadgeStub
+  }
+
+  const mockedDeclaredExperience: DeclaredExperienceViewDTO = {
+    id: 'declared-experience-1',
+    title: 'Développeur Web',
+    experienceType: EExperienceType.PROFESSIONAL,
+    organization: 'AVENIR(S)',
+    startDate: '2026-01-01',
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z'
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  BddTest().when('the component is mounted', () => {
+    const props: AssociatedDeclaredExperienceCardProps = {
+      declaredExperience: mockedDeclaredExperience
+    }
+
+    beforeEach(() => {
+      wrapper = mount(AssociatedDeclaredExperienceCard, { props, global: { stubs } })
+    })
+
+    BddTest().then('it should render the AssociationCard with the correct props', () => {
+      const associationCard = wrapper.findComponent(AssociationCardStub)
+
+      expect(associationCard.exists()).toBe(true)
+      expect(associationCard.props()).toMatchObject({
+        title: mockedDeclaredExperience.title,
+        icon: ICONS.EXPERIENCES,
+        color: 'var(--icon)',
+        hoverBorderColor: 'var(--dark-background-neutral)',
+        iconBorderColor: 'var(--other-border-skill-card)',
+        backgroundColor: 'var(--surface-background)',
+        to: {
+          name: ROUTES.STUDENT.DECLARED_EXPERIENCE.name,
+          params: { id: mockedDeclaredExperience.id }
+        }
+      })
+    })
+
+    BddTest().then('it should pass disabled as false to the AssociationCard by default', () => {
+      const associationCard = wrapper.findComponent(AssociationCardStub)
+      expect(associationCard.props('disabled')).toBe(false)
+    })
+
+    BddTest().then('it should render the experience type badge with the experience type', () => {
+      const badge = wrapper.findComponent(DeclaredExperienceTypeBadgeStub)
+      expect(badge.exists()).toBe(true)
+      expect(badge.props('experienceType')).toBe(EExperienceType.PROFESSIONAL)
+    })
+  })
+
+  BddTest().when('the component is mounted without an experience type', () => {
+    const props: AssociatedDeclaredExperienceCardProps = {
+      declaredExperience: { ...mockedDeclaredExperience, experienceType: undefined }
+    }
+
+    beforeEach(() => {
+      wrapper = mount(AssociatedDeclaredExperienceCard, { props, global: { stubs } })
+    })
+
+    BddTest().then('it should not render the experience type badge', () => {
+      expect(wrapper.findComponent(DeclaredExperienceTypeBadgeStub).exists()).toBe(false)
+    })
+  })
+
+  BddTest().when('the component is mounted with disabled=true', () => {
+    const props: AssociatedDeclaredExperienceCardProps = {
+      declaredExperience: mockedDeclaredExperience,
+      disabled: true
+    }
+
+    beforeEach(() => {
+      wrapper = mount(AssociatedDeclaredExperienceCard, { props, global: { stubs } })
+    })
+
+    BddTest().then('it should pass disabled=true to the AssociationCard', () => {
+      const associationCard = wrapper.findComponent(AssociationCardStub)
+      expect(associationCard.props('disabled')).toBe(true)
+    })
+  })
+})

--- a/src/features/student/personalCareer/components/cards/AssociatedDeclaredExperienceCard/AssociatedDeclaredExperienceCard.vue
+++ b/src/features/student/personalCareer/components/cards/AssociatedDeclaredExperienceCard/AssociatedDeclaredExperienceCard.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import type { DeclaredExperienceViewDTO } from '@/api/avenir-esr'
+import { ICONS, ROUTES } from '@/common/constants'
+import AssociationCard from '@/features/student/global/components/cards/AssociationCard/AssociationCard.vue'
+import DeclaredExperienceTypeBadge
+  from '@/features/student/personalCareer/components/badges/DeclaredExperienceTypeBadge/DeclaredExperienceTypeBadge.vue'
+
+export interface AssociatedDeclaredExperienceCardProps {
+  declaredExperience: DeclaredExperienceViewDTO
+  disabled?: boolean
+}
+
+const { declaredExperience, disabled } = defineProps<AssociatedDeclaredExperienceCardProps>()
+</script>
+
+<template>
+  <AssociationCard
+    :title="declaredExperience.title"
+    :icon="ICONS.EXPERIENCES"
+    color="var(--icon)"
+    hover-border-color="var(--dark-background-neutral)"
+    icon-border-color="var(--other-border-skill-card)"
+    background-color="var(--surface-background)"
+    :to="{ name: ROUTES.STUDENT.DECLARED_EXPERIENCE.name, params: { id: declaredExperience.id } }"
+    :disabled="disabled"
+    data-testid="associated-declared-experience-card"
+    :data-experience-id="declaredExperience.id"
+  >
+    <template #body>
+      <DeclaredExperienceTypeBadge
+        v-if="declaredExperience.experienceType"
+        :experience-type="declaredExperience.experienceType"
+      />
+    </template>
+  </AssociationCard>
+</template>

--- a/src/features/student/personalCareer/components/cards/AssociatedDeclaredExperiencesCard/AssociatedDeclaredExperiencesCard.stub.ts
+++ b/src/features/student/personalCareer/components/cards/AssociatedDeclaredExperiencesCard/AssociatedDeclaredExperiencesCard.stub.ts
@@ -1,0 +1,20 @@
+import type { DeclaredExperienceAssociationDTO } from '@/api/avenir-esr'
+
+export const AssociatedDeclaredExperiencesCardStub = defineComponent({
+  name: 'AssociatedDeclaredExperiencesCard',
+  props: {
+    associatedExperiences: {
+      type: Array as () => DeclaredExperienceAssociationDTO[],
+      required: true
+    },
+    disabled: {
+      type: Boolean,
+      required: false
+    }
+  },
+  template: `
+    <div v-if="associatedExperiences.length > 0" data-testid="associated-declared-experiences-card-stub">
+      <span v-for="experience in associatedExperiences" :key="experience.associationId" data-testid="associated-declared-experience">{{ experience.declaredExperience.title }}</span>
+    </div>
+  `
+})

--- a/src/features/student/personalCareer/components/cards/AssociatedDeclaredExperiencesCard/AssociatedDeclaredExperiencesCard.test.ts
+++ b/src/features/student/personalCareer/components/cards/AssociatedDeclaredExperiencesCard/AssociatedDeclaredExperiencesCard.test.ts
@@ -1,0 +1,96 @@
+import { createMockedDeclaredExperiencesAssociations } from '@/__mocks__/fixtures/student/declaredExperiences.fixtures'
+import { AssociationsCardStub } from '@/features/student/global/components/cards/AssociationsCard/AssociationsCard.stub'
+import { AssociatedDeclaredExperienceCardStub }
+  from '@/features/student/personalCareer/components/cards/AssociatedDeclaredExperienceCard/AssociatedDeclaredExperienceCard.stub'
+import AssociatedDeclaredExperiencesCard, {
+  type AssociatedDeclaredExperiencesCardProps
+} from '@/features/student/personalCareer/components/cards/AssociatedDeclaredExperiencesCard/AssociatedDeclaredExperiencesCard.vue'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { beforeEach, expect, vi } from 'vitest'
+
+BddTest().given('an associated declared experiences card', () => {
+  let wrapper: VueWrapper<InstanceType<typeof AssociatedDeclaredExperiencesCard>>
+
+  const stubs = {
+    AssociationsCard: AssociationsCardStub,
+    AssociatedDeclaredExperienceCard: AssociatedDeclaredExperienceCardStub
+  }
+
+  const mockedAssociations = createMockedDeclaredExperiencesAssociations(3)
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  BddTest().when('the component is mounted with associated experiences', () => {
+    const props: AssociatedDeclaredExperiencesCardProps = {
+      associatedExperiences: mockedAssociations
+    }
+
+    beforeEach(() => {
+      wrapper = mount(AssociatedDeclaredExperiencesCard, { props, global: { stubs } })
+    })
+
+    BddTest().then('it should render a card for each associated experience', () => {
+      const experienceCards = wrapper.findAllComponents(AssociatedDeclaredExperienceCardStub)
+      expect(experienceCards).toHaveLength(mockedAssociations.length)
+    })
+
+    BddTest().then('it should pass each declared experience to its card', () => {
+      const experienceCards = wrapper.findAllComponents(AssociatedDeclaredExperienceCardStub)
+      experienceCards.forEach((card, index) => {
+        expect(card.props('declaredExperience')).toEqual(mockedAssociations[index].declaredExperience)
+      })
+    })
+
+    BddTest().then('it should pass the plural title with count', () => {
+      expect(wrapper.findComponent(AssociationsCardStub).props('title')).toBe(`Mes expériences déclarées associées (${mockedAssociations.length})`)
+    })
+  })
+
+  BddTest().when('the component is mounted with a single associated experience', () => {
+    const props: AssociatedDeclaredExperiencesCardProps = {
+      associatedExperiences: [mockedAssociations[0]]
+    }
+
+    beforeEach(() => {
+      wrapper = mount(AssociatedDeclaredExperiencesCard, { props, global: { stubs } })
+    })
+
+    BddTest().then('it should pass the singular title with count', () => {
+      expect(wrapper.findComponent(AssociationsCardStub).props('title')).toBe('Mon expérience déclarée associée (1)')
+    })
+  })
+
+  BddTest().when('the component is mounted with no associated experiences', () => {
+    const props: AssociatedDeclaredExperiencesCardProps = {
+      associatedExperiences: []
+    }
+
+    beforeEach(() => {
+      wrapper = mount(AssociatedDeclaredExperiencesCard, { props, global: { stubs } })
+    })
+
+    BddTest().then('it should render nothing', () => {
+      expect(wrapper.findComponent(AssociationsCardStub).exists()).toBe(false)
+    })
+  })
+
+  BddTest().when('the component is mounted with disabled=true', () => {
+    const props: AssociatedDeclaredExperiencesCardProps = {
+      associatedExperiences: mockedAssociations,
+      disabled: true
+    }
+
+    beforeEach(() => {
+      wrapper = mount(AssociatedDeclaredExperiencesCard, { props, global: { stubs } })
+    })
+
+    BddTest().then('it should pass disabled=true to each AssociatedDeclaredExperienceCard', () => {
+      const experienceCards = wrapper.findAllComponents(AssociatedDeclaredExperienceCardStub)
+      expect(experienceCards.length).toBeGreaterThan(0)
+      experienceCards.forEach(card => expect(card.props('disabled')).toBe(true))
+    })
+  })
+})

--- a/src/features/student/personalCareer/components/cards/AssociatedDeclaredExperiencesCard/AssociatedDeclaredExperiencesCard.vue
+++ b/src/features/student/personalCareer/components/cards/AssociatedDeclaredExperiencesCard/AssociatedDeclaredExperiencesCard.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+import type { DeclaredExperienceAssociationDTO } from '@/api/avenir-esr'
+import { ICONS } from '@/common/constants'
+import AssociationsCard from '@/features/student/global/components/cards/AssociationsCard/AssociationsCard.vue'
+import AssociatedDeclaredExperienceCard
+  from '@/features/student/personalCareer/components/cards/AssociatedDeclaredExperienceCard/AssociatedDeclaredExperienceCard.vue'
+import { useI18n } from 'vue-i18n'
+
+export interface AssociatedDeclaredExperiencesCardProps {
+  associatedExperiences: DeclaredExperienceAssociationDTO[]
+  disabled?: boolean
+}
+
+const { associatedExperiences, disabled } = defineProps<AssociatedDeclaredExperiencesCardProps>()
+
+const { t } = useI18n()
+
+const title = computed(() => t('student.personalCareer.cards.AssociatedDeclaredExperiencesCard.title', { count: associatedExperiences.length }))
+</script>
+
+<template>
+  <AssociationsCard
+    v-if="associatedExperiences.length > 0"
+    :title
+    :icon="ICONS.EXPERIENCES"
+    data-testid="associated-declared-experiences-card"
+  >
+    <AssociatedDeclaredExperienceCard
+      v-for="associatedExperience in associatedExperiences"
+      :key="associatedExperience.associationId"
+      :declared-experience="associatedExperience.declaredExperience"
+      :disabled="disabled"
+    />
+  </AssociationsCard>
+</template>

--- a/src/features/student/personalCareer/components/cards/DeclaredExperienceCard/DeclaredExperienceCard.test.ts
+++ b/src/features/student/personalCareer/components/cards/DeclaredExperienceCard/DeclaredExperienceCard.test.ts
@@ -1,8 +1,10 @@
 import { type DeclaredExperienceViewDTO, EExperienceType } from '@/api/avenir-esr'
 import { PeriodBadgeStub } from '@/common/activities/badges/PeriodBadge/PeriodBadge.stub'
 import { FloatingIconCardStub } from '@/features/student/global/components/cards/FloatingIconCard/FloatingIconCard.stub'
+import { DeclaredExperienceTypeBadgeStub }
+  from '@/features/student/personalCareer/components/badges/DeclaredExperienceTypeBadge/DeclaredExperienceTypeBadge.stub'
 import DeclaredExperienceCard from '@/features/student/personalCareer/components/cards/DeclaredExperienceCard/DeclaredExperienceCard.vue'
-import { MDI_ICONS, RI_ICONS } from '@avenirs-esr/avenirs-dsav'
+import { MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
 import { AvBadgeStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { mount, RouterLinkStub, type VueWrapper } from '@vue/test-utils'
 import { beforeEach, expect, vi } from 'vitest'
@@ -14,7 +16,8 @@ BddTest().given('a declared experience card', () => {
     FloatingIconCard: FloatingIconCardStub,
     AvBadge: AvBadgeStub,
     RouterLink: RouterLinkStub,
-    PeriodBadge: PeriodBadgeStub
+    PeriodBadge: PeriodBadgeStub,
+    DeclaredExperienceTypeBadge: DeclaredExperienceTypeBadgeStub
   }
 
   const baseDeclaredExperience: DeclaredExperienceViewDTO = {
@@ -84,27 +87,18 @@ BddTest().given('a declared experience card', () => {
     })
 
     BddTest().and('the experience type badge is rendered', () => {
-      let experienceTypeBadge: VueWrapper<InstanceType<typeof AvBadgeStub>> | undefined
+      let experienceTypeBadge: VueWrapper<InstanceType<typeof DeclaredExperienceTypeBadgeStub>>
 
       beforeEach(() => {
-        const badges = wrapper.findAllComponents({ name: 'AvBadge' })
-        experienceTypeBadge = badges.find(badge => badge.props('label') === 'Expérience professionnelle') as VueWrapper<InstanceType<typeof AvBadgeStub>>
+        experienceTypeBadge = wrapper.findComponent(DeclaredExperienceTypeBadgeStub) as VueWrapper<InstanceType<typeof DeclaredExperienceTypeBadgeStub>>
       })
 
       BddTest().then('it should exist', () => {
-        expect(experienceTypeBadge).toBeDefined()
+        expect(experienceTypeBadge.exists()).toBe(true)
       })
 
-      BddTest().then('it should have honour line icon', () => {
-        expect(experienceTypeBadge?.props('icon')).toBe(RI_ICONS.HONOUR_LINE)
-      })
-
-      BddTest().then('it should have dark primary3 background color for professional', () => {
-        expect(experienceTypeBadge?.props('backgroundColor')).toBe('var(--dark-background-primary3)')
-      })
-
-      BddTest().then('it should have card2 text color', () => {
-        expect(experienceTypeBadge?.props('color')).toBe('var(--card2)')
+      BddTest().then('it should receive the professional experience type', () => {
+        expect(experienceTypeBadge.props('experienceType')).toBe(EExperienceType.PROFESSIONAL)
       })
     })
 
@@ -139,8 +133,6 @@ BddTest().given('a declared experience card', () => {
   })
 
   BddTest().when('the component is mounted with PERSONAL experience type', () => {
-    let experienceTypeBadge: VueWrapper<InstanceType<typeof AvBadgeStub>> | undefined
-
     beforeEach(() => {
       wrapper = mount(DeclaredExperienceCard, {
         props: {
@@ -151,42 +143,11 @@ BddTest().given('a declared experience card', () => {
         },
         global: { stubs }
       })
-      const badges = wrapper.findAllComponents({ name: 'AvBadge' })
-      experienceTypeBadge = badges.find(badge => badge.props('label') === 'Expérience personnelle') as VueWrapper<InstanceType<typeof AvBadgeStub>>
     })
 
-    BddTest().then('it should display personal experience label', () => {
-      expect(experienceTypeBadge).toBeDefined()
-    })
-
-    BddTest().then('it should apply dark success background color', () => {
-      expect(experienceTypeBadge?.props('backgroundColor')).toBe('var(--dark-background-success)')
-    })
-  })
-
-  BddTest().when('the component is mounted with PROFESSIONAL experience type', () => {
-    let experienceTypeBadge: VueWrapper<InstanceType<typeof AvBadgeStub>> | undefined
-
-    beforeEach(() => {
-      wrapper = mount(DeclaredExperienceCard, {
-        props: {
-          declaredExperience: {
-            ...baseDeclaredExperience,
-            experienceType: EExperienceType.PROFESSIONAL
-          }
-        },
-        global: { stubs }
-      })
-      const badges = wrapper.findAllComponents({ name: 'AvBadge' })
-      experienceTypeBadge = badges.find(badge => badge.props('label') === 'Expérience professionnelle') as VueWrapper<InstanceType<typeof AvBadgeStub>>
-    })
-
-    BddTest().then('it should display professional experience label', () => {
-      expect(experienceTypeBadge).toBeDefined()
-    })
-
-    BddTest().then('it should apply dark primary3 background color', () => {
-      expect(experienceTypeBadge?.props('backgroundColor')).toBe('var(--dark-background-primary3)')
+    BddTest().then('it should pass the personal experience type to the badge', () => {
+      const experienceTypeBadge = wrapper.findComponent(DeclaredExperienceTypeBadgeStub)
+      expect(experienceTypeBadge.props('experienceType')).toBe(EExperienceType.PERSONAL)
     })
   })
 
@@ -204,10 +165,7 @@ BddTest().given('a declared experience card', () => {
     })
 
     BddTest().then('it should not render experience type badge', () => {
-      const badges = wrapper.findAllComponents({ name: 'AvBadge' })
-      const experienceTypeLabels = ['Expérience personnelle', 'Expérience professionnelle']
-      const hasExperienceTypeBadge = badges.some(badge => experienceTypeLabels.includes(badge.props('label') as string))
-      expect(hasExperienceTypeBadge).toBe(false)
+      expect(wrapper.findComponent(DeclaredExperienceTypeBadgeStub).exists()).toBe(false)
     })
   })
 

--- a/src/features/student/personalCareer/components/cards/DeclaredExperienceCard/DeclaredExperienceCard.vue
+++ b/src/features/student/personalCareer/components/cards/DeclaredExperienceCard/DeclaredExperienceCard.vue
@@ -1,14 +1,13 @@
 <script setup lang="ts">
-import type { DeclaredExperienceViewDTO, EExperienceType } from '@/api/avenir-esr'
+import type { DeclaredExperienceViewDTO } from '@/api/avenir-esr'
 import PeriodBadge from '@/common/activities/badges/PeriodBadge/PeriodBadge.vue'
 import { ROUTES } from '@/common/constants'
 import FloatingIconCard from '@/features/student/global/components/cards/FloatingIconCard/FloatingIconCard.vue'
-import { AvBadge, MDI_ICONS, RI_ICONS } from '@avenirs-esr/avenirs-dsav'
-import { useI18n } from 'vue-i18n'
+import DeclaredExperienceTypeBadge
+  from '@/features/student/personalCareer/components/badges/DeclaredExperienceTypeBadge/DeclaredExperienceTypeBadge.vue'
+import { AvBadge, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
 
 defineProps<{ declaredExperience: DeclaredExperienceViewDTO }>()
-
-const { t } = useI18n()
 
 const iconOptions = {
   name: MDI_ICONS.HUB_OUTLINE,
@@ -16,11 +15,6 @@ const iconOptions = {
   right: '0.4rem',
   bottom: 'calc(-1 * 3.3rem)',
   borderColor: 'var(--other-border-skill-card)'
-}
-
-const experienceTypeColorMap: Record<EExperienceType, string> = {
-  PROFESSIONAL: 'var(--dark-background-primary3)',
-  PERSONAL: 'var(--dark-background-success)'
 }
 </script>
 
@@ -50,13 +44,9 @@ const experienceTypeColorMap: Record<EExperienceType, string> = {
               :end-date="declaredExperience.endDate"
             />
 
-            <AvBadge
+            <DeclaredExperienceTypeBadge
               v-if="declaredExperience.experienceType"
-              :label="t(`student.personalCareer.declaredExperienceType.${declaredExperience.experienceType}`)"
-              :background-color="experienceTypeColorMap[declaredExperience.experienceType]"
-              :icon="RI_ICONS.HONOUR_LINE"
-              color="var(--card2)"
-              ellipsis
+              :experience-type="declaredExperience.experienceType"
             />
             <AvBadge
               :label="declaredExperience.organization"

--- a/src/features/student/personalCareer/index.ts
+++ b/src/features/student/personalCareer/index.ts
@@ -1,3 +1,6 @@
+export { default as AssociatedDeclaredExperiencesCard }
+  from '@/features/student/personalCareer/components/cards/AssociatedDeclaredExperiencesCard/AssociatedDeclaredExperiencesCard.vue'
+
 export { default as AddDeclaredProgramDrawer }
   from '@/features/student/personalCareer/components/overlays/AddDeclaredProgramDrawer/AddDeclaredProgramDrawer.vue'
 

--- a/src/features/student/personalCareer/locales/en.json
+++ b/src/features/student/personalCareer/locales/en.json
@@ -1,6 +1,11 @@
 {
   "student": {
     "personalCareer": {
+      "cards": {
+        "AssociatedDeclaredExperiencesCard": {
+          "title": "My associated declared experience ({count}) | My associated declared experiences ({count})"
+        }
+      },
       "declaredExperienceType": {
         "PERSONAL": "Personal experience",
         "PROFESSIONAL": "Professional experience"

--- a/src/features/student/personalCareer/locales/fr.json
+++ b/src/features/student/personalCareer/locales/fr.json
@@ -1,6 +1,11 @@
 {
   "student": {
     "personalCareer": {
+      "cards": {
+        "AssociatedDeclaredExperiencesCard": {
+          "title": "Mon expérience déclarée associée ({count}) | Mes expériences déclarées associées ({count})"
+        }
+      },
       "declaredExperienceType": {
         "PERSONAL": "Expérience personnelle",
         "PROFESSIONAL": "Expérience professionnelle"


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied

Added support for displaying associated declared experiences (Mes expériences associées) to a declared skill. This includes:
- New `AssociatedDeclaredExperiencesCard` component that displays a list of associated declared experiences
- New `AssociatedDeclaredExperienceCard` component for individual experience display
- New `DeclaredExperienceTypeBadge` component to show the experience type
- Updated `StudentDeclaredSkillAssociations` to integrate the new component
- Updated `StudentDeclaredSkillView` to fetch and pass associated experiences data
- Comprehensive test coverage for all new components
- i18n support (French and English)

---

### Reference to an Issue, Feature, Task, User Story or another PR

Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/2197

---

### Documentation

- Added i18n keys for experience-related strings in both French and English locales
- Components follow the established pattern from similar association cards (AssociatedTracesCard, AssociatedDeclaredActivitiesCard)
- Swagger spec updated to reflect the new API endpoint

---

### Target Branch

`develop`

---

### Additional Notes

- The implementation follows the existing feature-based architecture pattern
- Reused design system components (AvCard, AvButton, etc.) from @avenirs-esr/avenirs-dsav
- Tests use the BddTest utility pattern established in the project
- All components include proper TypeScript typing and slot definitions

---

### Known Limitations or Side Effects

None identified.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [x] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [x] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and detaiils for the update process