### PR TITLE
refactor(2361): replace self-knowledge category entities with fixed enum

### DIFF
--- a/api-specs/avenir-esr.swagger.json
+++ b/api-specs/avenir-esr.swagger.json
@@ -985,62 +985,7 @@
         }
       }
     },
-    "/me/self-knowledge/{selfKnowledgeCategoryId}/elements": {
-      "get": {
-        "tags": [
-          "self-knowledge-controller"
-        ],
-        "operationId": "getSelfKnowledgeElements",
-        "parameters": [
-          {
-            "name": "selfKnowledgeCategoryId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          },
-          {
-            "name": "page",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "format": "int32"
-            }
-          },
-          {
-            "name": "pageSize",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "format": "int32"
-            }
-          },
-          {
-            "name": "isValorized",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/PagedResponseSelfKnowledgeElementViewDTO"
-                }
-              }
-            }
-          }
-        }
-      },
+    "/me/self-knowledge/{selfKnowledgeCategory}/elements": {
       "post": {
         "tags": [
           "self-knowledge-controller"
@@ -1048,12 +993,22 @@
         "operationId": "createSelfKnowledgeElement",
         "parameters": [
           {
-            "name": "selfKnowledgeCategoryId",
+            "name": "selfKnowledgeCategory",
             "in": "path",
             "required": true,
             "schema": {
               "type": "string",
-              "format": "uuid"
+              "enum": [
+                "STRENGTHS",
+                "VALUES",
+                "ASPIRATIONS",
+                "MOTIVATION",
+                "IMPROVEMENT",
+                "INTERESTS",
+                "INSPIRATIONS",
+                "OBLIGATIONS",
+                "TESTIMONIALS"
+              ]
             }
           }
         ],
@@ -1114,7 +1069,7 @@
               "schema": {
                 "type": "array",
                 "items": {
-                  "type": "string"
+                  "$ref": "#/components/schemas/ESelfKnowledgeCategory"
                 }
               }
             }
@@ -2953,6 +2908,97 @@
         }
       }
     },
+    "/me/self-knowledge/elements": {
+      "get": {
+        "tags": [
+          "self-knowledge-controller"
+        ],
+        "operationId": "getSelfKnowledgeElements",
+        "parameters": [
+          {
+            "name": "selfKnowledgeCategories",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/ESelfKnowledgeCategory"
+              }
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "isValorized",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedResponseSelfKnowledgeElementViewDTO"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "self-knowledge-controller"
+        ],
+        "operationId": "deleteSelfKnowledgeElements",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/me/self-knowledge/categories/available": {
       "get": {
         "tags": [
@@ -3201,6 +3247,38 @@
             }
           }
         }
+      },
+      "delete": {
+        "tags": [
+          "declared-experience-controller"
+        ],
+        "operationId": "deleteDeclaredExperienceAssociations",
+        "parameters": [
+          {
+            "name": "experienceId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AssociationsDeleteRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
       }
     },
     "/me/declared/experiences/view": {
@@ -3234,6 +3312,14 @@
             "required": false,
             "schema": {
               "type": "boolean"
+            }
+          },
+          {
+            "name": "experienceType",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/EExperienceType"
             }
           }
         ],
@@ -4081,41 +4167,7 @@
         }
       }
     },
-    "/me/self-knowledge/elements": {
-      "delete": {
-        "tags": [
-          "self-knowledge-controller"
-        ],
-        "operationId": "deleteSelfKnowledgeElements",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "format": "uuid"
-                }
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/me/self-knowledge/categories/{categoryId}": {
+    "/me/self-knowledge/categories/{selfKnowledgeCategory}": {
       "delete": {
         "tags": [
           "self-knowledge-controller"
@@ -4123,12 +4175,11 @@
         "operationId": "removeSelfKnowledgeCategory",
         "parameters": [
           {
-            "name": "categoryId",
+            "name": "selfKnowledgeCategory",
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "$ref": "#/components/schemas/ESelfKnowledgeCategory"
             }
           }
         ],
@@ -4240,124 +4291,6 @@
         "responses": {
           "200": {
             "description": "OK"
-          }
-        }
-      }
-    },
-    "/back-office/admin/institutions": {
-      "get": {
-        "tags": [
-          "institution-controller"
-        ],
-        "operationId": "findAll",
-        "parameters": [
-          {
-            "name": "X-ADMIN-TOKEN",
-            "in": "header",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/InstitutionResponse"
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "put": {
-        "tags": [
-          "institution-controller"
-        ],
-        "operationId": "updateAll",
-        "parameters": [
-          {
-            "name": "X-ADMIN-TOKEN",
-            "in": "header",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/InstitutionData"
-                }
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/InstitutionResponse"
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "institution-controller"
-        ],
-        "operationId": "createAll",
-        "parameters": [
-          {
-            "name": "X-ADMIN-TOKEN",
-            "in": "header",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/InstitutionData"
-                }
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/InstitutionImportSummaryResponse"
-                }
-              }
-            }
           }
         }
       }
@@ -4561,189 +4494,6 @@
               "*/*": {
                 "schema": {
                   "$ref": "#/components/schemas/AdditionalSkillConfigurationDTO"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/back-office/admin/institutions/{id}": {
-      "get": {
-        "tags": [
-          "institution-controller"
-        ],
-        "operationId": "findById",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          },
-          {
-            "name": "X-ADMIN-TOKEN",
-            "in": "header",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/InstitutionResponse"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "institution-controller"
-        ],
-        "operationId": "delete",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          },
-          {
-            "name": "X-ADMIN-TOKEN",
-            "in": "header",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          }
-        }
-      }
-    },
-    "/interoperability/external-users/eppn/{eppn}/activate": {
-      "patch": {
-        "tags": [
-          "external-user-controller"
-        ],
-        "operationId": "activateExternalUserByEppn",
-        "parameters": [
-          {
-            "name": "eppn",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/ExternalUserDTO"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/interoperability/external-users": {
-      "get": {
-        "tags": [
-          "external-user-controller"
-        ],
-        "operationId": "getExternalUsers",
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ExternalUserDTO"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/interoperability/external-users/{id}": {
-      "get": {
-        "tags": [
-          "external-user-controller"
-        ],
-        "operationId": "getExternalUserById",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/ExternalUserDTO"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/interoperability/external-users/eppn/{eppn}": {
-      "get": {
-        "tags": [
-          "external-user-controller"
-        ],
-        "operationId": "getExternalUserByEppn",
-        "parameters": [
-          {
-            "name": "eppn",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/ExternalUserDTO"
                 }
               }
             }
@@ -5104,6 +4854,33 @@
           "valorized"
         ]
       },
+      "SelfKnowledgeCategoryDTO": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "$ref": "#/components/schemas/ESelfKnowledgeCategory",
+            "enum": [
+              "STRENGTHS",
+              "VALUES",
+              "ASPIRATIONS",
+              "MOTIVATION",
+              "IMPROVEMENT",
+              "INTERESTS",
+              "INSPIRATIONS",
+              "OBLIGATIONS",
+              "TESTIMONIALS"
+            ]
+          },
+          "mandatory": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "mandatory",
+          "type"
+        ]
+      },
       "SelfKnowledgeElementViewDTO": {
         "type": "object",
         "properties": {
@@ -5123,9 +4900,13 @@
           },
           "valorized": {
             "type": "boolean"
+          },
+          "category": {
+            "$ref": "#/components/schemas/SelfKnowledgeCategoryDTO"
           }
         },
         "required": [
+          "category",
           "description",
           "id",
           "title"
@@ -5406,6 +5187,23 @@
           "title"
         ]
       },
+      "DeclaredExperienceAssociationCountDTO": {
+        "type": "object",
+        "properties": {
+          "traceAssociationsCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "declaredSkillAssociationsCount": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "required": [
+          "declaredSkillAssociationsCount",
+          "traceAssociationsCount"
+        ]
+      },
       "DeclaredExperienceViewDTO": {
         "type": "object",
         "properties": {
@@ -5463,10 +5261,14 @@
           "updatedAt": {
             "type": "string",
             "format": "date-time"
+          },
+          "declaredExperienceAssociationCountDTO": {
+            "$ref": "#/components/schemas/DeclaredExperienceAssociationCountDTO"
           }
         },
         "required": [
           "createdAt",
+          "declaredExperienceAssociationCountDTO",
           "id",
           "organization",
           "startDate",
@@ -7072,42 +6874,6 @@
           "updatedAt"
         ]
       },
-      "SelfKnowledgeCategoryDTO": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "title": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string",
-            "$ref": "#/components/schemas/ESelfKnowledgeCategoryType",
-            "enum": [
-              "STRENGTHS",
-              "VALUES",
-              "ASPIRATIONS",
-              "MOTIVATION",
-              "IMPROVEMENT",
-              "INTERESTS",
-              "INSPIRATIONS",
-              "OBLIGATIONS",
-              "TESTIMONIALS"
-            ]
-          }
-        },
-        "required": [
-          "description",
-          "id",
-          "title",
-          "type"
-        ]
-      },
       "ActivityModifiedParameters": {
         "allOf": [
           {
@@ -8078,7 +7844,7 @@
           "NOT_STARTED"
         ]
       },
-      "ESelfKnowledgeCategoryType": {
+      "ESelfKnowledgeCategory": {
         "type": "string",
         "description": "Enum for self knowledge category types",
         "enum": [
@@ -8119,6 +7885,7 @@
           "DECLARED_PROGRAM_NOT_FOUND",
           "INSTITUTION_CONFIG_NOT_FOUND",
           "INSTITUTION_NOT_FOUND",
+          "GROUP_NOT_FOUND",
           "ACTIVITY_NOT_FOUND",
           "ACTIVITY_DRAFT_NOT_FOUND",
           "ACTIVITY_UNPUBLISHED",
@@ -8141,6 +7908,7 @@
           "DECLARED_ACTIVITY_LOCKED",
           "ASSOCIATION_ALREADY_EXIST",
           "INSTITUTION_HAI_ALREADY_EXISTS",
+          "GROUP_ID_SI_SCO_ALREADY_EXISTS",
           "MAX_FILE_SIZE_EXCEEDED",
           "FILE_STORAGE_ERROR",
           "CONFIGURATION_ERROR",
@@ -8170,6 +7938,11 @@
           "INSTITUTION_PRIMARY_CANNOT_HAVE_PARENT",
           "INSTITUTION_SECONDARY_REQUIRES_PARENT",
           "INSTITUTION_PARENT_MUST_BE_PRIMARY",
+          "GROUP_PROGRAM_CANNOT_HAVE_PARENT",
+          "GROUP_PROGRAM_OPTION_REQUIRES_PARENT",
+          "GROUP_PROGRAM_OPTION_PARENT_MUST_BE_PROGRAM",
+          "GROUP_STUDENT_GROUP_REQUIRES_PARENT",
+          "GROUP_STUDENT_GROUP_PARENT_MUST_BE_PROGRAM_OR_OPTION",
           "FIRSTNAME_IS_NULL",
           "LASTNAME_IS_NULL",
           "INVALID_DATE_FORMAT",
@@ -8292,72 +8065,6 @@
           "STUDENT"
         ]
       },
-      "InstitutionData": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "hai": {
-            "type": "string"
-          },
-          "siret": {
-            "type": "string"
-          },
-          "siren": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "PRIMARY",
-              "SECONDARY"
-            ]
-          },
-          "parentHai": {
-            "type": "string"
-          }
-        }
-      },
-      "InstitutionResponse": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "name": {
-            "type": "string"
-          },
-          "hai": {
-            "type": "string"
-          },
-          "siret": {
-            "type": "string"
-          },
-          "siren": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "PRIMARY",
-              "SECONDARY"
-            ]
-          },
-          "parentHai": {
-            "type": "string"
-          },
-          "createdAt": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "updatedAt": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      },
       "BuildLifeProjectConfigDTO": {
         "type": "object",
         "properties": {
@@ -8433,52 +8140,6 @@
           "label"
         ]
       },
-      "InstitutionImportFailureResponse": {
-        "type": "object",
-        "properties": {
-          "hai": {
-            "type": "string"
-          },
-          "message": {
-            "type": "string"
-          }
-        }
-      },
-      "InstitutionImportSummaryResponse": {
-        "type": "object",
-        "properties": {
-          "createdCount": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "updatedCount": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "failedCount": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "created": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/InstitutionResponse"
-            }
-          },
-          "updated": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/InstitutionResponse"
-            }
-          },
-          "failed": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/InstitutionImportFailureResponse"
-            }
-          }
-        }
-      },
       "InstitutionConfigurationElements": {
         "type": "object",
         "properties": {
@@ -8490,47 +8151,31 @@
           }
         }
       },
-      "ExternalUserDTO": {
-        "type": "object",
-        "properties": {
-          "eppn": {
-            "type": "string"
-          },
-          "firstName": {
-            "type": "string"
-          },
-          "lastName": {
-            "type": "string"
-          },
-          "email": {
-            "type": "string"
-          },
-          "category": {
-            "type": "string",
-            "enum": [
-              "STAFF",
-              "STUDENT"
-            ]
-          },
-          "externalId": {
-            "type": "string"
-          },
-          "source": {
-            "type": "string"
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "ACTIVE",
-              "INACTIVE",
-              "REMOVED",
-              "BLOCKED"
-            ]
-          },
-          "active": {
-            "type": "boolean"
-          }
-        }
+      "EExternalSource": {
+        "type": "string",
+        "description": "Enum for external source",
+        "enum": [
+          "PEGASE",
+          "BACK_OFFICE"
+        ]
+      },
+      "EUserCategory1": {
+        "type": "string",
+        "description": "Enum for external user category",
+        "enum": [
+          "STAFF",
+          "STUDENT"
+        ]
+      },
+      "EUserStatus": {
+        "type": "string",
+        "description": "Enum for external user status",
+        "enum": [
+          "ACTIVE",
+          "INACTIVE",
+          "REMOVED",
+          "BLOCKED"
+        ]
       },
       "ExternalSkillCategoryDTO": {
         "type": "object",
@@ -8638,31 +8283,6 @@
         "required": [
           "data",
           "page"
-        ]
-      },
-      "EExternalSource": {
-        "type": "string",
-        "description": "Enum for external source",
-        "enum": [
-          "PEGASE"
-        ]
-      },
-      "EUserCategory1": {
-        "type": "string",
-        "description": "Enum for external user category",
-        "enum": [
-          "STAFF",
-          "STUDENT"
-        ]
-      },
-      "EUserStatus": {
-        "type": "string",
-        "description": "Enum for external user status",
-        "enum": [
-          "ACTIVE",
-          "INACTIVE",
-          "REMOVED",
-          "BLOCKED"
         ]
       }
     }

--- a/src/__mocks__/fixtures/student/declaredExperiences.fixtures.ts
+++ b/src/__mocks__/fixtures/student/declaredExperiences.fixtures.ts
@@ -24,7 +24,11 @@ export const declaredExperienceViewDTOFixture: DeclaredExperienceViewDTO = {
   startDate: '2023-01',
   endDate: '2024-06',
   createdAt: '2024-01-15T10:30:00Z',
-  updatedAt: '2024-01-15T10:30:00Z'
+  updatedAt: '2024-01-15T10:30:00Z',
+  declaredExperienceAssociationCountDTO: {
+    traceAssociationsCount: 0,
+    declaredSkillAssociationsCount: 0
+  }
 }
 
 function createMockedDeclaredExperiences (count: number): DeclaredExperienceViewDTO[] {
@@ -48,7 +52,11 @@ function createMockedDeclaredExperiences (count: number): DeclaredExperienceView
       description: experience.description,
       startDate: '2023-01',
       createdAt: '2024-01-15T10:30:00Z',
-      updatedAt: '2024-01-15T10:30:00Z'
+      updatedAt: '2024-01-15T10:30:00Z',
+      declaredExperienceAssociationCountDTO: {
+        traceAssociationsCount: 0,
+        declaredSkillAssociationsCount: 0
+      }
     })
   }
 
@@ -92,7 +100,11 @@ export function createMockedDeclaredExperienceViewDTO (experienceId: string): De
     startDate: '2023-01',
     endDate: '2024-06',
     createdAt: '2024-01-15T10:30:00Z',
-    updatedAt: '2024-01-15T10:30:00Z'
+    updatedAt: '2024-01-15T10:30:00Z',
+    declaredExperienceAssociationCountDTO: {
+      traceAssociationsCount: 0,
+      declaredSkillAssociationsCount: 0
+    }
   }
 }
 

--- a/src/__mocks__/fixtures/student/self-knowledge.fixtures.ts
+++ b/src/__mocks__/fixtures/student/self-knowledge.fixtures.ts
@@ -1,23 +1,17 @@
-import { ESelfKnowledgeCategoryType, type PagedResponseSelfKnowledgeElementViewDTO, type SelfKnowledgeCategoryDTO, type SelfKnowledgeElementDetailsDTO, type SelfKnowledgeElementViewDTO } from '@/api/avenir-esr'
+import { ESelfKnowledgeCategory, type PagedResponseSelfKnowledgeElementViewDTO, type SelfKnowledgeCategoryDTO, type SelfKnowledgeElementDetailsDTO, type SelfKnowledgeElementViewDTO } from '@/api/avenir-esr'
 
 export const mockedSelfKnowledgeCategories: SelfKnowledgeCategoryDTO[] = [
   {
-    id: '4aec2faa-d986-4553-a14b-2ecabba415c8',
-    title: 'Mes points forts',
-    description: 'Identifier et valoriser mes qualités, talents et réussites marquantes.',
-    type: ESelfKnowledgeCategoryType.STRENGTHS
+    type: ESelfKnowledgeCategory.STRENGTHS,
+    mandatory: true
   },
   {
-    id: 'a0c79a9a-b5c0-411b-ba54-68d73de72225',
-    title: 'Mes valeurs',
-    description: 'Préciser ce qui est important pour moi et ce qui guide mes décisions au quotidien.',
-    type: ESelfKnowledgeCategoryType.VALUES
+    type: ESelfKnowledgeCategory.VALUES,
+    mandatory: true
   },
   {
-    id: '609965be-ebb1-44b3-bf8b-458a7ece6fb7',
-    title: 'Mes envies',
-    description: 'Clarifier ce que j\'ai envie d\'explorer, d\'apprendre ou de vivre à court et moyen terme.',
-    type: ESelfKnowledgeCategoryType.ASPIRATIONS
+    type: ESelfKnowledgeCategory.ASPIRATIONS,
+    mandatory: true
   }
 ]
 
@@ -69,19 +63,13 @@ const aspirationsElements = [
   { title: 'Partager mes connaissances', description: 'Transmettre mon savoir et former d\'autres personnes' }
 ]
 
-export function getCategoryElements (selfKnowledgeCategoryId: string): Array<{ title: string, description: string }> {
-  const category = mockedSelfKnowledgeCategories.find(cat => cat.id === selfKnowledgeCategoryId)
-
-  if (!category) {
-    return []
-  }
-
-  switch (category.type) {
-    case ESelfKnowledgeCategoryType.STRENGTHS:
+export function getCategoryElements (categoryType: ESelfKnowledgeCategory): Array<{ title: string, description: string }> {
+  switch (categoryType) {
+    case ESelfKnowledgeCategory.STRENGTHS:
       return strengthsElements
-    case ESelfKnowledgeCategoryType.VALUES:
+    case ESelfKnowledgeCategory.VALUES:
       return valuesElements
-    case ESelfKnowledgeCategoryType.ASPIRATIONS:
+    case ESelfKnowledgeCategory.ASPIRATIONS:
       return aspirationsElements
     default:
       return []
@@ -89,12 +77,12 @@ export function getCategoryElements (selfKnowledgeCategoryId: string): Array<{ t
 }
 
 export function createMockedPagedResponseSelfKnowledgeElementViewDTO (
-  selfKnowledgeCategoryId: string,
+  categoryType: ESelfKnowledgeCategory,
   pageSize: number,
   totalElements: number,
   page: number
 ): PagedResponseSelfKnowledgeElementViewDTO {
-  const categoryElements = getCategoryElements(selfKnowledgeCategoryId)
+  const categoryElements = getCategoryElements(categoryType)
   const mockedElements: SelfKnowledgeElementViewDTO[] = []
 
   const actualTotalElements = Math.min(totalElements, categoryElements.length)
@@ -104,7 +92,8 @@ export function createMockedPagedResponseSelfKnowledgeElementViewDTO (
       id: crypto.randomUUID(),
       title: categoryElements[i].title,
       description: categoryElements[i].description,
-      rating: Math.random() > 0.5 ? Math.floor(Math.random() * 5) + 1 : undefined
+      rating: Math.random() > 0.5 ? Math.floor(Math.random() * 5) + 1 : undefined,
+      category: { type: categoryType, mandatory: true }
     }
     mockedElements.push(element)
   }
@@ -120,4 +109,11 @@ export function createMockedPagedResponseSelfKnowledgeElementViewDTO (
   }
 }
 
-export const mockedSelfKnowledgeCategoriesAvailable: SelfKnowledgeCategoryDTO[] = mockedSelfKnowledgeCategories.slice(1)
+export const mockedSelfKnowledgeCategoriesAvailable: SelfKnowledgeCategoryDTO[] = [
+  ESelfKnowledgeCategory.MOTIVATION,
+  ESelfKnowledgeCategory.IMPROVEMENT,
+  ESelfKnowledgeCategory.INTERESTS,
+  ESelfKnowledgeCategory.INSPIRATIONS,
+  ESelfKnowledgeCategory.OBLIGATIONS,
+  ESelfKnowledgeCategory.TESTIMONIALS
+].map(type => ({ type, mandatory: false }))

--- a/src/__mocks__/msw/handlers/student/self-knowledge.handlers.ts
+++ b/src/__mocks__/msw/handlers/student/self-knowledge.handlers.ts
@@ -5,6 +5,7 @@ import {
   mockedSelfKnowledgeElementDetails
 } from '@/__mocks__/fixtures/student/self-knowledge.fixtures'
 import {
+  ESelfKnowledgeCategory,
   getAddSelfKnowledgeCategoriesUrl,
   getCreateSelfKnowledgeElementUrl,
   getDeleteSelfKnowledgeElementsUrl,
@@ -22,6 +23,8 @@ import {
 } from '@/api/avenir-esr'
 import { ErrorCodes } from '@/common/constants'
 import { http, HttpResponse } from 'msw'
+
+const CATEGORY_URL_PARAM = ':selfKnowledgeCategory' as ESelfKnowledgeCategory
 
 export const selfKnowledgeCategoriesErrorHandler = http.get(`*${getGetSelfKnowledgeCategoriesUrl()}`, () => {
   return HttpResponse.json(
@@ -54,7 +57,7 @@ export const selfKnowledgeElementDetailsNotFoundHandler = http.get(`*${getGetSel
   )
 })
 
-export const selfKnowledgeCategoryElementsErrorHandler = http.get(`*${getGetSelfKnowledgeElementsUrl(':selfKnowledgeCategoryId')}`, () => {
+export const selfKnowledgeCategoryElementsErrorHandler = http.get(`*${getGetSelfKnowledgeElementsUrl()}`, () => {
   return HttpResponse.json(
     { message: 'Internal Server Error', code: ErrorCodes.SERVER },
     {
@@ -78,7 +81,7 @@ export const selfKnowledgeCategoriesAvailableErrorHandler = http.get(`*${getGetS
   )
 })
 
-export const createSelfKnowledgeElementErrorHandler = http.post(`*${getCreateSelfKnowledgeElementUrl(':selfKnowledgeCategoryId')}`, () => {
+export const createSelfKnowledgeElementErrorHandler = http.post(`*${getCreateSelfKnowledgeElementUrl(CATEGORY_URL_PARAM)}`, () => {
   return HttpResponse.json(
     { message: 'Internal Server Error', code: ErrorCodes.SERVER },
     {
@@ -104,7 +107,7 @@ export const putUpdateSelfKnowledgeElementErrorNotFoundHandler = http.put(`*${ge
   )
 })
 
-export const postCreateSelfKnowledgeElementErrorHandler = http.post(`*${getCreateSelfKnowledgeElementUrl(':selfKnowledgeCategoryId')}`, () => {
+export const postCreateSelfKnowledgeElementErrorHandler = http.post(`*${getCreateSelfKnowledgeElementUrl(CATEGORY_URL_PARAM)}`, () => {
   return HttpResponse.json(
     { message: 'Internal Server Error', code: ErrorCodes.SERVER },
     { status: 500 }
@@ -163,14 +166,14 @@ export const selfKnowledgeHandlers = [
     })
   }),
 
-  http.get(`*${getGetSelfKnowledgeElementsUrl(':selfKnowledgeCategoryId')}`, ({ request, params }) => {
+  http.get(`*${getGetSelfKnowledgeElementsUrl()}`, ({ request }) => {
     const url = new URL(request.url)
-    const selfKnowledgeCategoryId = params.selfKnowledgeCategoryId as string
+    const categoryType = (url.searchParams.get('selfKnowledgeCategories')?.split(',')[0] ?? ESelfKnowledgeCategory.STRENGTHS) as ESelfKnowledgeCategory
     const page = Number.parseInt(url.searchParams.get('page') ?? '0')
     const pageSize = Number.parseInt(url.searchParams.get('pageSize') ?? '3')
     const totalElements = 10
 
-    const mockData = createMockedPagedResponseSelfKnowledgeElementViewDTO(selfKnowledgeCategoryId, pageSize, totalElements, page)
+    const mockData = createMockedPagedResponseSelfKnowledgeElementViewDTO(categoryType, pageSize, totalElements, page)
 
     return HttpResponse.json<PagedResponseSelfKnowledgeElementViewDTO>(mockData, {
       status: 200,
@@ -190,13 +193,13 @@ export const selfKnowledgeHandlers = [
   }),
 
   http.post(`*${getAddSelfKnowledgeCategoriesUrl()}`, async ({ request }) => {
-    const selfKnowledgeCategoryDTOs = await request.json() as SelfKnowledgeCategoryDTO[]
+    const selfKnowledgeCategories = await request.json() as ESelfKnowledgeCategory[]
 
-    if (selfKnowledgeCategoryDTOs.length === 0) {
+    if (selfKnowledgeCategories.length === 0) {
       return HttpResponse.json({ error: 'No categories provided', code: ErrorCodes.SELF_KNOWLEDGE_CATEGORY_IS_MANDATORY }, { status: 400 })
     }
 
-    if (selfKnowledgeCategoryDTOs[0].title === 'ERROR_CATEGORY') {
+    if ((selfKnowledgeCategories[0] as string) === 'ERROR_CATEGORY') {
       return HttpResponse.json(
         { error: 'Internal server error', code: ErrorCodes.SERVER },
         { status: 500 }
@@ -235,10 +238,10 @@ export const selfKnowledgeHandlers = [
     })
   }),
 
-  http.delete(`*${getRemoveSelfKnowledgeCategoryUrl(':categoryId')}`, async ({ params }) => {
-    const categoryId = params.categoryId as string
+  http.delete(`*${getRemoveSelfKnowledgeCategoryUrl(CATEGORY_URL_PARAM)}`, async ({ params }) => {
+    const selfKnowledgeCategory = params.selfKnowledgeCategory as string
 
-    if (categoryId === 'INVALID_CATEGORY_ID') {
+    if (selfKnowledgeCategory === 'INVALID_CATEGORY_ID') {
       return HttpResponse.json({ error: 'Invalid category ID', code: ErrorCodes.SELF_KNOWLEDGE_CATEGORY_NOT_FOUND }, { status: 404 })
     }
 
@@ -271,8 +274,9 @@ export const selfKnowledgeHandlers = [
     })
   }),
 
-  http.post(`*${getCreateSelfKnowledgeElementUrl(':selfKnowledgeCategoryId')}`, async ({ request }) => {
+  http.post(`*${getCreateSelfKnowledgeElementUrl(CATEGORY_URL_PARAM)}`, async ({ request, params }) => {
     const element = await request.json() as SelfKnowledgeElementRequest
+    const selfKnowledgeCategory = params.selfKnowledgeCategory as ESelfKnowledgeCategory
 
     if (element.title === 'ERROR_ELEMENT') {
       return HttpResponse.json(
@@ -292,7 +296,8 @@ export const selfKnowledgeHandlers = [
       id: crypto.randomUUID(),
       title: element.title,
       description: element.description,
-      rating: element.rating
+      rating: element.rating,
+      category: { type: selfKnowledgeCategory, mandatory: true }
     }
 
     return HttpResponse.json<SelfKnowledgeElementViewDTO>(response, {

--- a/src/features/student/buildProject/views/BuildProjectView/sections/BuildProjectSection/components/AddSelfKnowledgeCategoryButtonNode/AddSelfKnowledgeCategoryButtonNode.test.ts
+++ b/src/features/student/buildProject/views/BuildProjectView/sections/BuildProjectSection/components/AddSelfKnowledgeCategoryButtonNode/AddSelfKnowledgeCategoryButtonNode.test.ts
@@ -114,7 +114,7 @@ BddTest().given('an AddSelfKnowledgeCategoryButtonNode component', () => {
     })
 
     BddTest().and('the user selects categories and confirms', () => {
-      const selectedCategories = mockedSelfKnowledgeCategoriesAvailable.slice(0, 2).map(cat => cat.id)
+      const selectedCategories = mockedSelfKnowledgeCategoriesAvailable.slice(0, 2).map(cat => cat.type)
 
       beforeEach(async () => {
         const checkboxes = wrapper.findAllComponents(AvCheckboxStub)
@@ -156,7 +156,7 @@ BddTest().given('an AddSelfKnowledgeCategoryButtonNode component', () => {
     beforeEach(async () => {
       vi.clearAllMocks()
       mockNodes.value = ([...mockedSelfKnowledgeCategoriesAvailable, ...mockedSelfKnowledgeCategories]).map(cat => ({
-        id: cat.id,
+        id: cat.type,
         type: SELF_KNOWLEDGE_NODE_TYPES.SELF_KNOWLEDGE_CATEGORY,
         position: { x: 0, y: 0 },
         data: {}

--- a/src/features/student/buildProject/views/BuildProjectView/sections/BuildProjectSection/components/AddSelfKnowledgeCategoryButtonNode/AddSelfKnowledgeCategoryButtonNode.vue
+++ b/src/features/student/buildProject/views/BuildProjectView/sections/BuildProjectSection/components/AddSelfKnowledgeCategoryButtonNode/AddSelfKnowledgeCategoryButtonNode.vue
@@ -26,8 +26,11 @@ const categoriesAvailable = computed(() => fetchedCategoriesAvailable.value ?? [
 
 const categories = computed(() => fetchedCategories.value ?? [])
 
-const allCategories = computed(() => categories.value.concat(categoriesAvailable.value))
-const availableCategories = computed(() => allCategories.value.filter(category => categoryExists(category.id) === false))
+const allCategories = computed(() => categories.value.concat(categoriesAvailable.value).map(category => ({
+  type: category.type,
+  title: t(`student.selfKnowledge.categories.${category.type}.title`)
+})))
+const availableCategories = computed(() => allCategories.value.filter(category => categoryExists(category.type) === false))
 const usedCategoriesCount = computed(() => allCategories.value.length - availableCategories.value.length)
 
 const selectedCategoriesIds = ref<string[]>([])
@@ -45,7 +48,7 @@ function categoryExists (categoryId: string) {
 
 function onConfirmAddCategories () {
   selectedCategoriesIds.value.forEach((selectedId, index) => {
-    const category = allCategories.value.find(category => category.id === selectedId)
+    const category = allCategories.value.find(category => category.type === selectedId)
 
     if (!category) {
       addErrorMessage(t('student.buildProject.mindMap.selfKnowledge.addCategoryButton.errors.categoryNotFound', { id: selectedId }))
@@ -118,11 +121,11 @@ function onConfirmAddCategories () {
           <AvCheckboxesGroup id="add-self-knowledge-categories-modal-checkboxes-group">
             <AvCheckbox
               v-for="category in availableCategories"
-              :id="category.id"
-              :key="category.id"
+              :id="category.type"
+              :key="category.type"
               v-model="selectedCategoriesIds"
-              :value="category.id"
-              :name="category.id"
+              :value="category.type"
+              :name="category.type"
               :label="category.title"
             />
           </AvCheckboxesGroup>

--- a/src/features/student/buildProject/views/BuildProjectView/sections/BuildProjectSection/components/AddSelfKnowledgeElementButtonNode/AddSelfKnowledgeElementButtonNode.test.ts
+++ b/src/features/student/buildProject/views/BuildProjectView/sections/BuildProjectSection/components/AddSelfKnowledgeElementButtonNode/AddSelfKnowledgeElementButtonNode.test.ts
@@ -72,7 +72,7 @@ BddTest().given('an AddSelfKnowledgeElementButtonNode component', () => {
   BddTest().when('the component is mounted', () => {
     const props: ButtonNodeTemplateProps = {
       ...mandatoryNodeButtonTemplateProps,
-      data: { categoryId: mockedSelfKnowledgeCategories[0].id }
+      data: { categoryId: mockedSelfKnowledgeCategories[0].type }
     }
 
     beforeEach(async () => {
@@ -159,14 +159,14 @@ BddTest().given('an AddSelfKnowledgeElementButtonNode component', () => {
 
     BddTest().and('the user selects an existing element that is already added and confirms', () => {
       beforeEach(async () => {
-        mockNodes.value = ([...getCategoryElements(mockedSelfKnowledgeCategories[0].id)]).map(cat => ({
+        mockNodes.value = ([...getCategoryElements(mockedSelfKnowledgeCategories[0].type)]).map(cat => ({
           id: crypto.randomUUID(),
           type: SELF_KNOWLEDGE_NODE_TYPES.SELF_KNOWLEDGE_ELEMENT,
           position: { x: 0, y: 0 },
           data: {
             title: cat.title,
             description: cat.description,
-            categoryId: mockedSelfKnowledgeCategories[0].id
+            categoryId: mockedSelfKnowledgeCategories[0].type
           }
         }))
 
@@ -284,14 +284,14 @@ BddTest().given('an AddSelfKnowledgeElementButtonNode component', () => {
   BddTest().and('there are already some categories added in the nodes', () => {
     beforeEach(async () => {
       vi.clearAllMocks()
-      mockNodes.value = ([...getCategoryElements(mockedSelfKnowledgeCategories[0].id)]).map(cat => ({
+      mockNodes.value = ([...getCategoryElements(mockedSelfKnowledgeCategories[0].type)]).map(cat => ({
         id: crypto.randomUUID(),
         type: SELF_KNOWLEDGE_NODE_TYPES.SELF_KNOWLEDGE_CATEGORY,
         position: { x: 0, y: 0 },
         data: {
           title: cat.title,
           description: cat.description,
-          categoryId: mockedSelfKnowledgeCategories[0].id
+          categoryId: mockedSelfKnowledgeCategories[0].type
         }
       }))
     })

--- a/src/features/student/buildProject/views/BuildProjectView/sections/BuildProjectSection/components/AddSelfKnowledgeElementButtonNode/AddSelfKnowledgeElementButtonNode.vue
+++ b/src/features/student/buildProject/views/BuildProjectView/sections/BuildProjectSection/components/AddSelfKnowledgeElementButtonNode/AddSelfKnowledgeElementButtonNode.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { GetSelfKnowledgeElementsParams } from '@/api/avenir-esr'
+import type { ESelfKnowledgeCategory, GetSelfKnowledgeElementsParams } from '@/api/avenir-esr'
 import type { MindMapNodeTemplateProps } from '@/features/student/buildProject/views/BuildProjectView/sections/BuildProjectSection/types/mind-map-nodes.types'
 import { useGetSelfKnowledgeElements } from '@/api/avenir-esr'
 import ButtonNodeTemplate from '@/common/components/VueFlow/ButtonNodeTemplate/ButtonNodeTemplate.vue'
@@ -11,6 +11,7 @@ import { MIND_MAP_FLOW_ID } from '@/features/student/buildProject/views/BuildPro
 import { type AddElementFormData, useAddElementForm } from '@/features/student/buildProject/views/BuildProjectView/sections/BuildProjectSection/composables/use-add-element-form/use-add-element-form'
 import { SELF_KNOWLEDGE_NODE_TYPES } from '@/features/student/buildProject/views/BuildProjectView/sections/BuildProjectSection/types/self-knowledge-nodes.types'
 import CategoryElementRatingRadioButtonSet from '@/features/student/selfKnowledge/components/interactions/inputs/CategoryElementRatingRadioButtonSet/CategoryElementRatingRadioButtonSet.vue'
+import { toSelfKnowledgeCategoriesParam } from '@/features/student/selfKnowledge/utils/category.utils'
 import { useToasterStore } from '@/store'
 import { AvCheckbox, AvCheckboxesGroup, AvInput, AvModal, AvTab, AvTabs, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
 import { keepPreviousData } from '@tanstack/vue-query'
@@ -25,11 +26,12 @@ const { addErrorMessage } = useToasterStore()
 const { t } = useI18n()
 
 const params = computed<GetSelfKnowledgeElementsParams>(() => ({
+  selfKnowledgeCategories: toSelfKnowledgeCategoriesParam(data.categoryId as ESelfKnowledgeCategory),
   page: 0, // TODO: temporary value for POC purpose - need a real pagination later
   pageSize: 12 // TODO: temporary value for POC purpose - need a real pagination later
 }))
 
-const { data: fetchedElements } = useGetSelfKnowledgeElements(computed(() => data.categoryId as string), params, {
+const { data: fetchedElements } = useGetSelfKnowledgeElements(params, {
   query: { enabled: computed(() => !!data.categoryId), placeholderData: keepPreviousData }
 })
 const elements = computed(() => fetchedElements.value ? fetchedElements.value.data : [])

--- a/src/features/student/buildProject/views/BuildProjectView/sections/BuildProjectSection/components/SelfKnowledgeCategoryNode/SelfKnowledgeCategoryNode.test.ts
+++ b/src/features/student/buildProject/views/BuildProjectView/sections/BuildProjectSection/components/SelfKnowledgeCategoryNode/SelfKnowledgeCategoryNode.test.ts
@@ -17,7 +17,7 @@ BddTest().given('a SelfKnowledgeCategoryNode component', () => {
   }
 
   BddTest().when('the component is mounted', () => {
-    const props: NodeTemplateProps = { ...mandatoryNodeTemplateProps, id: mockedSelfKnowledgeCategories[0].id, data: {} }
+    const props: NodeTemplateProps = { ...mandatoryNodeTemplateProps, id: mockedSelfKnowledgeCategories[0].type, data: {} }
 
     beforeEach(() => {
       wrapper = mountComponent(SelfKnowledgeCategoryNode, { props, global: { stubs } })
@@ -32,7 +32,7 @@ BddTest().given('a SelfKnowledgeCategoryNode component', () => {
       await vi.waitFor(() => {
         const badge = wrapper.findComponent(AvBadgeStub)
         expect(badge.exists()).toBe(true)
-        expect(badge.props('label')).toBe(mockedSelfKnowledgeCategories[0].title)
+        expect(badge.props('label')).toBe('Mes points forts')
       })
     })
   })

--- a/src/features/student/buildProject/views/BuildProjectView/sections/BuildProjectSection/components/SelfKnowledgeCategoryNode/SelfKnowledgeCategoryNode.vue
+++ b/src/features/student/buildProject/views/BuildProjectView/sections/BuildProjectSection/components/SelfKnowledgeCategoryNode/SelfKnowledgeCategoryNode.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { ESelfKnowledgeCategory } from '@/api/avenir-esr'
 import type { MindMapNodeTemplateProps } from '@/features/student/buildProject/views/BuildProjectView/sections/BuildProjectSection/types/mind-map-nodes.types'
 import NodeTemplate from '@/common/components/VueFlow/NodeTemplate/NodeTemplate.vue'
 import { MIND_MAP_FLOW_ID } from '@/features/student/buildProject/views/BuildProjectView/sections/BuildProjectSection/components/MindMap/config'
@@ -7,7 +8,7 @@ import { AvBadge } from '@avenirs-esr/avenirs-dsav'
 
 const { id } = defineProps<MindMapNodeTemplateProps>()
 
-const { category, categoryIcon } = useSelfKnowledgeCategory(id)
+const { categoryTitle, categoryIcon } = useSelfKnowledgeCategory(computed(() => id as ESelfKnowledgeCategory))
 </script>
 
 <template>
@@ -19,7 +20,7 @@ const { category, categoryIcon } = useSelfKnowledgeCategory(id)
   >
     <template #title>
       <AvBadge
-        :label="category?.title ?? data.label"
+        :label="categoryTitle ?? data.label"
         small
         color="var(--text1)"
         background-color="var(--surface-background)"

--- a/src/features/student/buildProject/views/BuildProjectView/sections/BuildProjectSection/components/SelfKnowledgeElementNode/SelfKnowledgeElementNode.test.ts
+++ b/src/features/student/buildProject/views/BuildProjectView/sections/BuildProjectSection/components/SelfKnowledgeElementNode/SelfKnowledgeElementNode.test.ts
@@ -44,9 +44,9 @@ BddTest().given('a SelfKnowledgeElementNode component', () => {
     const props: NodeTemplateProps = {
       ...mandatoryNodeProps,
       flowId: 'test-flow',
-      id: mockedSelfKnowledgeCategories[0].id,
+      id: mockedSelfKnowledgeCategories[0].type,
       data: {
-        categoryId: mockedSelfKnowledgeCategories[0].id,
+        categoryId: mockedSelfKnowledgeCategories[0].type,
         title: 'Maîtriser de nouvelles langues',
         description: 'Apprendre et pratiquer de nouvelles langues étrangères'
       }
@@ -74,7 +74,8 @@ BddTest().given('a SelfKnowledgeElementNode component', () => {
             title: props.data.title,
             description: props.data.description,
             rating: props.data.rating,
-            id: 'temp-id'
+            id: 'temp-id',
+            category: mockedSelfKnowledgeCategories[0]
           })
           server.use(handler)
           wrapper.findComponent(TitleDescriptionNodeTemplateStub).vm.$emit(('updateInProfile'))
@@ -137,9 +138,9 @@ BddTest().given('a SelfKnowledgeElementNode component', () => {
     const props: NodeTemplateProps = {
       ...mandatoryNodeProps,
       flowId: 'test-flow',
-      id: mockedSelfKnowledgeCategories[0].id,
+      id: mockedSelfKnowledgeCategories[0].type,
       data: {
-        categoryId: mockedSelfKnowledgeCategories[0].id,
+        categoryId: mockedSelfKnowledgeCategories[0].type,
         title: 'Maîtriser de nouvelles langues',
         description: 'Apprendre et pratiquer de nouvelles langues étrangères',
         rating: 4

--- a/src/features/student/buildProject/views/BuildProjectView/sections/BuildProjectSection/components/SelfKnowledgeElementNode/SelfKnowledgeElementNode.vue
+++ b/src/features/student/buildProject/views/BuildProjectView/sections/BuildProjectSection/components/SelfKnowledgeElementNode/SelfKnowledgeElementNode.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { ESelfKnowledgeCategory } from '@/api/avenir-esr'
 import type { MindMapNodeTemplateProps } from '@/features/student/buildProject/views/BuildProjectView/sections/BuildProjectSection/types/mind-map-nodes.types'
 import { EErrorCode, invalidateGetSelfKnowledgeElementDetails, invalidateGetSelfKnowledgeElements, useCreateSelfKnowledgeElement, useUpdateSelfKnowledgeElement } from '@/api/avenir-esr'
 import { Rating } from '@/common/components'
@@ -23,7 +24,7 @@ const { mutate: mutateCreateSelfKnowledgeElement } = useCreateSelfKnowledgeEleme
 
 function addSelfKnowledgeCategoryElement () {
   mutateCreateSelfKnowledgeElement({
-    selfKnowledgeCategoryId: data.categoryId as string,
+    selfKnowledgeCategory: data.categoryId as ESelfKnowledgeCategory,
     data: {
       title: data.title,
       description: data.description,
@@ -32,7 +33,7 @@ function addSelfKnowledgeCategoryElement () {
     },
   }, {
     onSuccess: async (newElement) => {
-      await invalidateGetSelfKnowledgeElements(queryClient, data.categoryId as string)
+      await invalidateGetSelfKnowledgeElements(queryClient)
       addSuccessMessage(t('student.buildProject.mindMap.selfKnowledge.element.success'))
       updateNodeId(id, newElement.id)
     },

--- a/src/features/student/kit/views/StudentToolsKitView/components/ValorizedDeclaredExperienceItem/ValorizedDeclaredExperienceItem.test.ts
+++ b/src/features/student/kit/views/StudentToolsKitView/components/ValorizedDeclaredExperienceItem/ValorizedDeclaredExperienceItem.test.ts
@@ -16,7 +16,11 @@ const BASE_DECLARED_EXPERIENCE: DeclaredExperienceViewDTO = {
   startDate: '2023-01',
   endDate: '2023-06',
   createdAt: '2024-01-15T10:30:00Z',
-  updatedAt: '2024-01-15T10:30:00Z'
+  updatedAt: '2024-01-15T10:30:00Z',
+  declaredExperienceAssociationCountDTO: {
+    traceAssociationsCount: 0,
+    declaredSkillAssociationsCount: 0
+  }
 }
 
 const stubs = {

--- a/src/features/student/personalCareer/components/cards/AssociatedDeclaredExperienceCard/AssociatedDeclaredExperienceCard.test.ts
+++ b/src/features/student/personalCareer/components/cards/AssociatedDeclaredExperienceCard/AssociatedDeclaredExperienceCard.test.ts
@@ -25,7 +25,11 @@ BddTest().given('an associated declared experience card', () => {
     organization: 'AVENIR(S)',
     startDate: '2026-01-01',
     createdAt: '2026-01-01T00:00:00Z',
-    updatedAt: '2026-01-01T00:00:00Z'
+    updatedAt: '2026-01-01T00:00:00Z',
+    declaredExperienceAssociationCountDTO: {
+      traceAssociationsCount: 0,
+      declaredSkillAssociationsCount: 0
+    }
   }
 
   beforeEach(() => {

--- a/src/features/student/personalCareer/components/cards/DeclaredExperienceCard/DeclaredExperienceCard.test.ts
+++ b/src/features/student/personalCareer/components/cards/DeclaredExperienceCard/DeclaredExperienceCard.test.ts
@@ -28,7 +28,11 @@ BddTest().given('a declared experience card', () => {
     organization: 'Tech Company',
     startDate: '2023-01',
     createdAt: '2023-01-01T00:00:00Z',
-    updatedAt: '2023-01-01T00:00:00Z'
+    updatedAt: '2023-01-01T00:00:00Z',
+    declaredExperienceAssociationCountDTO: {
+      traceAssociationsCount: 0,
+      declaredSkillAssociationsCount: 0
+    }
   }
 
   beforeEach(() => {

--- a/src/features/student/personalCareer/components/navigation/DeclaredExperienceSideMenu/DeclaredExperienceSideMenu.test.ts
+++ b/src/features/student/personalCareer/components/navigation/DeclaredExperienceSideMenu/DeclaredExperienceSideMenu.test.ts
@@ -24,6 +24,10 @@ BddTest().given('a DeclaredExperienceSideMenu component', () => {
       startDate: '2022-01-01',
       createdAt: '2022-01-01T10:00:00Z',
       updatedAt: '2022-01-01T10:00:00Z',
+      declaredExperienceAssociationCountDTO: {
+        traceAssociationsCount: 0,
+        declaredSkillAssociationsCount: 0
+      },
     },
     {
       id: 'declared-experience-2',
@@ -32,6 +36,10 @@ BddTest().given('a DeclaredExperienceSideMenu component', () => {
       startDate: '2023-01-01',
       createdAt: '2023-01-01T10:00:00Z',
       updatedAt: '2023-01-01T10:00:00Z',
+      declaredExperienceAssociationCountDTO: {
+        traceAssociationsCount: 0,
+        declaredSkillAssociationsCount: 0
+      },
     },
     {
       id: 'declared-experience-3',
@@ -40,6 +48,10 @@ BddTest().given('a DeclaredExperienceSideMenu component', () => {
       startDate: '2024-01-01',
       createdAt: '2024-01-01T10:00:00Z',
       updatedAt: '2024-01-01T10:00:00Z',
+      declaredExperienceAssociationCountDTO: {
+        traceAssociationsCount: 0,
+        declaredSkillAssociationsCount: 0
+      },
     },
   ]
 

--- a/src/features/student/personalCareer/views/DeclaredExperienceView/components/DeclaredExperienceDetails/DeclaredExperienceDetails.test.ts
+++ b/src/features/student/personalCareer/views/DeclaredExperienceView/components/DeclaredExperienceDetails/DeclaredExperienceDetails.test.ts
@@ -44,6 +44,10 @@ const mockedDeclaredExperienceDetails: DeclaredExperienceViewDTO = {
   endDate: '2026-01-20',
   createdAt: '2026-01-01T10:00:00Z',
   updatedAt: '2026-01-02T10:00:00Z',
+  declaredExperienceAssociationCountDTO: {
+    traceAssociationsCount: 0,
+    declaredSkillAssociationsCount: 0
+  },
 }
 
 const mockedDeclaredExperienceDetailsWithUndefinedOptionalFields: DeclaredExperienceViewDTO = {

--- a/src/features/student/selfKnowledge/components/SelfKnowledgeMainSection/SelfKnowledgeMainSection.vue
+++ b/src/features/student/selfKnowledge/components/SelfKnowledgeMainSection/SelfKnowledgeMainSection.vue
@@ -73,7 +73,7 @@ const categories = computed(() => fetchedCategories.value ?? [])
     <div class="av-col av-gap-xl">
       <SelfKnowledgeCategoryElementsPaginatorCard
         v-for="category in categories"
-        :key="category.id"
+        :key="category.type"
         :category="category"
       />
     </div>

--- a/src/features/student/selfKnowledge/components/cards/SelfKnowledgeCategoryElementsPaginatorCard/SelfKnowledgeCategoryElementsPaginatorCard.test.ts
+++ b/src/features/student/selfKnowledge/components/cards/SelfKnowledgeCategoryElementsPaginatorCard/SelfKnowledgeCategoryElementsPaginatorCard.test.ts
@@ -1,7 +1,7 @@
 import { mockedSelfKnowledgeCategories } from '@/__mocks__/fixtures/student/self-knowledge.fixtures'
 import { selfKnowledgeCategoryElementsErrorHandler } from '@/__mocks__/msw/handlers/student/self-knowledge.handlers'
 import { server } from '@/__mocks__/msw/server'
-import { ESelfKnowledgeCategoryType, type SelfKnowledgeCategoryDTO } from '@/api/avenir-esr'
+import { ESelfKnowledgeCategory, type SelfKnowledgeCategoryDTO } from '@/api/avenir-esr'
 import { CardStub } from '@/common/components/cards/Card/Card.stub'
 import { QuerySuspenseStub } from '@/common/components/QuerySuspense/QuerySuspense.stub'
 import SelfKnowledgeCategoryElementsPaginatorCard from '@/features/student/selfKnowledge/components/cards/SelfKnowledgeCategoryElementsPaginatorCard/SelfKnowledgeCategoryElementsPaginatorCard.vue'
@@ -62,21 +62,21 @@ BddTest().given('a self knowledge category elements paginator card', () => {
       category: mockedSelfKnowledgeCategories[0],
       expectedTitle: 'Mes points forts',
       expectedDescription: 'Identifier et valoriser mes qualités, talents et réussites marquantes.',
-      expectedType: ESelfKnowledgeCategoryType.STRENGTHS
+      expectedType: ESelfKnowledgeCategory.STRENGTHS
     },
     {
       name: 'values',
       category: mockedSelfKnowledgeCategories[1],
       expectedTitle: 'Mes valeurs',
       expectedDescription: 'Préciser ce qui est important pour moi et ce qui guide mes décisions au quotidien.',
-      expectedType: ESelfKnowledgeCategoryType.VALUES
+      expectedType: ESelfKnowledgeCategory.VALUES
     },
     {
       name: 'aspirations',
       category: mockedSelfKnowledgeCategories[2],
       expectedTitle: 'Mes envies',
       expectedDescription: 'Clarifier ce que j\'ai envie d\'explorer, d\'apprendre ou de vivre à court et moyen terme.',
-      expectedType: ESelfKnowledgeCategoryType.ASPIRATIONS
+      expectedType: ESelfKnowledgeCategory.ASPIRATIONS
     }
   ]
 
@@ -132,7 +132,7 @@ BddTest().given('a self knowledge category elements paginator card', () => {
             expect(firstCard.props('element')).toHaveProperty('id')
             expect(firstCard.props('element')).toHaveProperty('title')
             expect(firstCard.props('element')).toHaveProperty('description')
-            expect(firstCard.props('categoryId')).toBe(category.id)
+            expect(firstCard.props('categoryType')).toBe(category.type)
           })
         })
 
@@ -151,8 +151,8 @@ BddTest().given('a self knowledge category elements paginator card', () => {
             const deleteModal = wrapper.findComponent(DeleteSelfKnowledgeElementsModalStub)
             expect(deleteModal.exists()).toBe(true)
             expect(deleteModal.props('show')).toBe(true)
-            expect(deleteModal.props('categoryId')).toBeDefined()
-            expect(deleteModal.props('categoryId')).toBe(category.id)
+            expect(deleteModal.props('categoryType')).toBeDefined()
+            expect(deleteModal.props('categoryType')).toBe(category.type)
           })
         })
       })
@@ -180,12 +180,9 @@ BddTest().given('a self knowledge category elements paginator card', () => {
   })
 
   BddTest().and('the category has no elements', () => {
-    const emptyCategoryId = 'non-existent-id'
     const emptyCategory: SelfKnowledgeCategoryDTO = {
-      id: emptyCategoryId,
-      title: 'Empty Category',
-      description: 'A category with no elements',
-      type: ESelfKnowledgeCategoryType.STRENGTHS
+      type: ESelfKnowledgeCategory.OBLIGATIONS,
+      mandatory: false
     }
 
     BddTest().when('the component is mounted', () => {
@@ -299,11 +296,9 @@ BddTest().given('a self knowledge category elements paginator card', () => {
   })
 
   BddTest().and('a deletable category', () => {
-    const obligationsCategory = {
-      id: 'deletable-category-id',
-      title: 'My obligations',
-      description: 'Some description.',
-      type: ESelfKnowledgeCategoryType.OBLIGATIONS
+    const obligationsCategory: SelfKnowledgeCategoryDTO = {
+      type: ESelfKnowledgeCategory.OBLIGATIONS,
+      mandatory: false
     }
 
     BddTest().when('the component is mounted', () => {
@@ -331,8 +326,8 @@ BddTest().given('a self knowledge category elements paginator card', () => {
             const deleteModal = wrapper.findComponent(DeleteSelfKnowledgeCategoryModalStub)
             expect(deleteModal.exists()).toBe(true)
             expect(deleteModal.props('show')).toBe(true)
-            expect(deleteModal.props('categoryId')).toBe(obligationsCategory.id)
-            expect(deleteModal.props('categoryTitle')).toBe(obligationsCategory.title)
+            expect(deleteModal.props('categoryType')).toBe(obligationsCategory.type)
+            expect(deleteModal.props('categoryTitle')).toBe('Mes obligations')
             expect(deleteModal.props('elementsCount')).toBe(0)
           })
         })

--- a/src/features/student/selfKnowledge/components/cards/SelfKnowledgeCategoryElementsPaginatorCard/SelfKnowledgeCategoryElementsPaginatorCard.vue
+++ b/src/features/student/selfKnowledge/components/cards/SelfKnowledgeCategoryElementsPaginatorCard/SelfKnowledgeCategoryElementsPaginatorCard.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { type GetSelfKnowledgeElementsParams, type SelfKnowledgeCategoryDTO, useGetSelfKnowledgeElements } from '@/api/avenir-esr'
+import type { GetSelfKnowledgeElementsParams, SelfKnowledgeCategoryDTO } from '@/api/avenir-esr'
+import { useGetSelfKnowledgeElements } from '@/api/avenir-esr'
 import Card from '@/common/components/cards/Card/Card.vue'
 import QuerySuspense from '@/common/components/QuerySuspense/QuerySuspense.vue'
 import { useModal } from '@/common/composables'
@@ -9,6 +10,7 @@ import DeleteSelfKnowledgeCategoryModal from '@/features/student/selfKnowledge/c
 import DeleteSelfKnowledgeElementsModal from '@/features/student/selfKnowledge/components/modals/DeleteSelfKnowledgeElementsModal/DeleteSelfKnowledgeElementsModal.vue'
 import { useSelfKnowledgeCategory } from '@/features/student/selfKnowledge/composables/use-self-knowledge-category/use-self-knowledge-category'
 import { useSelfKnowledgeStore } from '@/features/student/selfKnowledge/stores/self-knowledge.store'
+import { toSelfKnowledgeCategoriesParam } from '@/features/student/selfKnowledge/utils/category.utils'
 import { AvIconText, AvPagination, getPaginationPages } from '@avenirs-esr/avenirs-dsav'
 import { keepPreviousData } from '@tanstack/vue-query'
 import { useI18n } from 'vue-i18n'
@@ -24,10 +26,13 @@ const { openAddElementDrawer } = useSelfKnowledgeStore()
 
 const currentPage = ref(0)
 
-const params = computed<GetSelfKnowledgeElementsParams>(() => ({ page: currentPage.value }))
+const params = computed<GetSelfKnowledgeElementsParams>(() => ({
+  selfKnowledgeCategories: toSelfKnowledgeCategoriesParam(category.type),
+  page: currentPage.value
+}))
 
-const { data, isLoading, error } = useGetSelfKnowledgeElements(computed(() => category.id), params, {
-  query: { enabled: computed(() => !!category.id), placeholderData: keepPreviousData }
+const { data, isLoading, error } = useGetSelfKnowledgeElements(params, {
+  query: { placeholderData: keepPreviousData }
 })
 
 const elements = computed(() => data.value?.data ?? [])
@@ -35,8 +40,10 @@ const pageInfo = computed(() => data.value?.page)
 
 const {
   categoryType,
+  categoryTitle: categoryDisplayTitle,
+  categoryDescription,
   categoryIcon
-} = useSelfKnowledgeCategory(computed(() => category.id))
+} = useSelfKnowledgeCategory(computed(() => category.type))
 
 const {
   displayModal: displayDeleteCategoryModal,
@@ -51,7 +58,7 @@ const {
 } = useModal()
 
 const totalElements = computed(() => pageInfo.value?.totalElements ?? 0)
-const categoryTitle = computed(() => `${category.title} (${totalElements.value})`)
+const categoryTitle = computed(() => `${categoryDisplayTitle.value} (${totalElements.value})`)
 const totalPages = computed(() => pageInfo.value?.totalPages ?? 0)
 const pages = computed(() => getPaginationPages(totalPages))
 
@@ -97,7 +104,7 @@ function onElementDeleted () {
     </template>
 
     <div class="av-col av-gap-sm">
-      <span class="s2-regular av-text-text2">{{ category.description }}</span>
+      <span class="s2-regular av-text-text2">{{ categoryDescription }}</span>
 
       <QuerySuspense
         :error="error"
@@ -126,7 +133,7 @@ function onElementDeleted () {
               v-for="element in elements"
               :key="element.id"
               :element="element"
-              :category-id="category.id"
+              :category-type="category.type"
             />
           </div>
         </div>
@@ -136,8 +143,8 @@ function onElementDeleted () {
 
   <DeleteSelfKnowledgeCategoryModal
     :show="showDeleteCategoryModal"
-    :category-id="category.id"
-    :category-title="category.title"
+    :category-type="category.type"
+    :category-title="categoryDisplayTitle"
     :elements-count="elements.length"
     @cancel="hideDeleteCategoryModal"
     @confirm="hideDeleteCategoryModal"
@@ -146,7 +153,7 @@ function onElementDeleted () {
   <DeleteSelfKnowledgeElementsModal
     v-if="pageInfo"
     :show="showDeleteElementModal"
-    :category-id="category.id"
+    :category-type="category.type"
     :total-count="pageInfo.totalElements"
     @cancel="hideDeleteElementModal"
     @confirm="onElementDeleted"

--- a/src/features/student/selfKnowledge/components/cards/SelfKnowledgeElementCard/SelfKnowledgeElementCard.stub.ts
+++ b/src/features/student/selfKnowledge/components/cards/SelfKnowledgeElementCard/SelfKnowledgeElementCard.stub.ts
@@ -8,7 +8,7 @@ export const SelfKnowledgeElementCardStub = defineComponent({
       type: Object as PropType<SelfKnowledgeElementViewDTO>,
       required: true
     },
-    categoryId: {
+    categoryType: {
       type: String,
       required: true
     },

--- a/src/features/student/selfKnowledge/components/cards/SelfKnowledgeElementCard/SelfKnowledgeElementCard.test.ts
+++ b/src/features/student/selfKnowledge/components/cards/SelfKnowledgeElementCard/SelfKnowledgeElementCard.test.ts
@@ -1,4 +1,4 @@
-import { ESelfKnowledgeCategoryType, type SelfKnowledgeElementViewDTO } from '@/api/avenir-esr/generated/types'
+import { ESelfKnowledgeCategory, type SelfKnowledgeElementViewDTO } from '@/api/avenir-esr/generated/types'
 import { RatingStub } from '@/common/components/Rating/Rating.stub'
 import { FloatingIconCardStub } from '@/features/student/global/components/cards/FloatingIconCard/FloatingIconCard.stub'
 import SelfKnowledgeElementCard from '@/features/student/selfKnowledge/components/cards/SelfKnowledgeElementCard/SelfKnowledgeElementCard.vue'
@@ -19,7 +19,8 @@ BddTest().given('a self knowledge element card', () => {
   const baseElement: SelfKnowledgeElementViewDTO = {
     id: '1',
     title: 'Test Element',
-    description: 'This is a test description for the element'
+    description: 'This is a test description for the element',
+    category: { type: ESelfKnowledgeCategory.VALUES, mandatory: true }
   }
 
   BddTest().when('the component is mounted with VALUES category type', () => {
@@ -27,8 +28,7 @@ BddTest().given('a self knowledge element card', () => {
       wrapper = mountComponent(SelfKnowledgeElementCard, {
         props: {
           element: baseElement,
-          categoryType: ESelfKnowledgeCategoryType.VALUES,
-          categoryId: 'a0c79a9a-b5c0-411b-ba54-68d73de72225'
+          categoryType: ESelfKnowledgeCategory.VALUES
         },
         global: { stubs }
       })
@@ -67,8 +67,7 @@ BddTest().given('a self knowledge element card', () => {
       wrapper = mountComponent(SelfKnowledgeElementCard, {
         props: {
           element: baseElement,
-          categoryType: ESelfKnowledgeCategoryType.STRENGTHS,
-          categoryId: '4aec2faa-d986-4553-a14b-2ecabba415c8'
+          categoryType: ESelfKnowledgeCategory.STRENGTHS
         },
         global: { stubs }
       })
@@ -85,8 +84,7 @@ BddTest().given('a self knowledge element card', () => {
       wrapper = mountComponent(SelfKnowledgeElementCard, {
         props: {
           element: baseElement,
-          categoryType: ESelfKnowledgeCategoryType.ASPIRATIONS,
-          categoryId: '609965be-ebb1-44b3-bf8b-458a7ece6fb7'
+          categoryType: ESelfKnowledgeCategory.ASPIRATIONS
         },
         global: { stubs }
       })
@@ -104,8 +102,7 @@ BddTest().given('a self knowledge element card', () => {
       wrapper = mountComponent(SelfKnowledgeElementCard, {
         props: {
           element: baseElement,
-          categoryType: ESelfKnowledgeCategoryType.VALUES,
-          categoryId: 'a0c79a9a-b5c0-411b-ba54-68d73de72225',
+          categoryType: ESelfKnowledgeCategory.VALUES,
           categoryColor: 'var(--custom-color)'
         },
         global: { stubs }
@@ -128,8 +125,7 @@ BddTest().given('a self knowledge element card', () => {
       wrapper = mountComponent(SelfKnowledgeElementCard, {
         props: {
           element: elementWithRating,
-          categoryType: ESelfKnowledgeCategoryType.VALUES,
-          categoryId: 'a0c79a9a-b5c0-411b-ba54-68d73de72225'
+          categoryType: ESelfKnowledgeCategory.VALUES
         },
         global: { stubs }
       })
@@ -158,8 +154,7 @@ BddTest().given('a self knowledge element card', () => {
       wrapper = mountComponent(SelfKnowledgeElementCard, {
         props: {
           element: baseElement,
-          categoryType: ESelfKnowledgeCategoryType.VALUES,
-          categoryId: 'a0c79a9a-b5c0-411b-ba54-68d73de72225'
+          categoryType: ESelfKnowledgeCategory.VALUES
         },
         global: { stubs }
       })
@@ -181,8 +176,7 @@ BddTest().given('a self knowledge element card', () => {
       wrapper = mountComponent(SelfKnowledgeElementCard, {
         props: {
           element: elementWithLongDescription,
-          categoryType: ESelfKnowledgeCategoryType.VALUES,
-          categoryId: 'a0c79a9a-b5c0-411b-ba54-68d73de72225'
+          categoryType: ESelfKnowledgeCategory.VALUES
         },
         global: { stubs }
       })
@@ -201,14 +195,14 @@ BddTest().given('a self knowledge element card', () => {
         id: '123',
         title: 'Complete Element',
         description: 'A complete element with all properties',
-        rating: 5
+        rating: 5,
+        category: { type: ESelfKnowledgeCategory.STRENGTHS, mandatory: true }
       }
 
       wrapper = mountComponent(SelfKnowledgeElementCard, {
         props: {
           element: completeElement,
-          categoryType: ESelfKnowledgeCategoryType.STRENGTHS,
-          categoryId: '4aec2faa-d986-4553-a14b-2ecabba415c8',
+          categoryType: ESelfKnowledgeCategory.STRENGTHS,
           categoryColor: 'var(--strength-color)'
         },
         global: { stubs }

--- a/src/features/student/selfKnowledge/components/cards/SelfKnowledgeElementCard/SelfKnowledgeElementCard.vue
+++ b/src/features/student/selfKnowledge/components/cards/SelfKnowledgeElementCard/SelfKnowledgeElementCard.vue
@@ -1,35 +1,29 @@
 <script lang="ts" setup>
-import type { SelfKnowledgeElementViewDTO } from '@/api/avenir-esr'
+import type { ESelfKnowledgeCategory, SelfKnowledgeElementViewDTO } from '@/api/avenir-esr'
 import { Rating } from '@/common/components'
 import { ROUTES } from '@/common/constants'
 import { FloatingIconCard } from '@/features/student/global'
-import {
-  useSelfKnowledgeCategory
-} from '@/features/student/selfKnowledge/composables/use-self-knowledge-category/use-self-knowledge-category'
 import { getSelfKnowledgeCategoryIcon } from '@/features/student/selfKnowledge/utils/category.utils'
-import { toValue } from 'vue'
 
 export interface SelfKnowledgeElementCardProps {
   element: SelfKnowledgeElementViewDTO
-  categoryId: string
+  categoryType: ESelfKnowledgeCategory
   categoryColor?: string
 }
 
 const {
   categoryColor = 'var(--light-foreground-primary1)',
-  categoryId,
+  categoryType,
   element,
 } = defineProps<SelfKnowledgeElementCardProps>()
 
-const { categoryType } = useSelfKnowledgeCategory(computed(() => categoryId))
-
 const iconOptions = computed(() => ({
-  name: getSelfKnowledgeCategoryIcon(toValue(categoryType)),
+  name: getSelfKnowledgeCategoryIcon(categoryType),
 }))
 </script>
 
 <template>
-  <RouterLink :to="{ name: ROUTES.STUDENT.SELFKNOWLEDGE_CATEGORY.name, params: { id: categoryId }, query: { elementId: element.id } }">
+  <RouterLink :to="{ name: ROUTES.STUDENT.SELFKNOWLEDGE_CATEGORY.name, params: { id: categoryType }, query: { elementId: element.id } }">
     <FloatingIconCard
       :title="element.title"
       :header-rows="2"

--- a/src/features/student/selfKnowledge/components/dropdowns/SelfKnowledgeElementsDropdown/SelfKnowledgeElementsDropdown.stub.ts
+++ b/src/features/student/selfKnowledge/components/dropdowns/SelfKnowledgeElementsDropdown/SelfKnowledgeElementsDropdown.stub.ts
@@ -1,11 +1,11 @@
-import type { ESelfKnowledgeCategoryType } from '@/api/avenir-esr'
+import type { ESelfKnowledgeCategory } from '@/api/avenir-esr'
 import type { PropType } from 'vue'
 
 export const SelfKnowledgeElementsDropdownStub = defineComponent({
   name: 'SelfKnowledgeElementsDropdown',
   props: {
     categoryType: {
-      type: String as PropType<ESelfKnowledgeCategoryType>,
+      type: String as PropType<ESelfKnowledgeCategory>,
       required: true
     }
   },

--- a/src/features/student/selfKnowledge/components/dropdowns/SelfKnowledgeElementsDropdown/SelfKnowledgeElementsDropdown.test.ts
+++ b/src/features/student/selfKnowledge/components/dropdowns/SelfKnowledgeElementsDropdown/SelfKnowledgeElementsDropdown.test.ts
@@ -1,4 +1,4 @@
-import { ESelfKnowledgeCategoryType } from '@/api/avenir-esr'
+import { ESelfKnowledgeCategory } from '@/api/avenir-esr'
 import SelfKnowledgeElementsDropdown, { type SelfKnowledgeElementsDropdownProps } from '@/features/student/selfKnowledge/components/dropdowns/SelfKnowledgeElementsDropdown/SelfKnowledgeElementsDropdown.vue'
 import { AvDropdownStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { mount, type VueWrapper } from '@vue/test-utils'
@@ -15,15 +15,15 @@ BddTest().given('a self knowledge elements dropdown', () => {
     return mount(SelfKnowledgeElementsDropdown, { props, global: { stubs } })
   }
 
-  function isCategoryDeletable (categoryType: ESelfKnowledgeCategoryType) {
+  function isCategoryDeletable (categoryType: ESelfKnowledgeCategory) {
     return (![
-      ESelfKnowledgeCategoryType.VALUES,
-      ESelfKnowledgeCategoryType.STRENGTHS,
-      ESelfKnowledgeCategoryType.ASPIRATIONS
+      ESelfKnowledgeCategory.VALUES,
+      ESelfKnowledgeCategory.STRENGTHS,
+      ESelfKnowledgeCategory.ASPIRATIONS
     ].includes(categoryType))
   }
 
-  for (const category of Object.values(ESelfKnowledgeCategoryType)) {
+  for (const category of Object.values(ESelfKnowledgeCategory)) {
     BddTest().and(`the category type is ${category}`, () => {
       BddTest().when('the component is mounted', () => {
         beforeEach(() => {

--- a/src/features/student/selfKnowledge/components/dropdowns/SelfKnowledgeElementsDropdown/SelfKnowledgeElementsDropdown.vue
+++ b/src/features/student/selfKnowledge/components/dropdowns/SelfKnowledgeElementsDropdown/SelfKnowledgeElementsDropdown.vue
@@ -1,10 +1,10 @@
 <script lang="ts" setup>
-import { ESelfKnowledgeCategoryType } from '@/api/avenir-esr'
+import { ESelfKnowledgeCategory } from '@/api/avenir-esr'
 import { AvDropdown, type AvDropdownItem, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
 import { useI18n } from 'vue-i18n'
 
 export interface SelfKnowledgeElementsDropdownProps {
-  categoryType: ESelfKnowledgeCategoryType
+  categoryType: ESelfKnowledgeCategory
 }
 
 const { categoryType } = defineProps<SelfKnowledgeElementsDropdownProps>()
@@ -21,9 +21,9 @@ const { t } = useI18n()
 const isDemo = __DEMO_MODE__
 
 const isCategoryDeletable = computed(() => ![
-  ESelfKnowledgeCategoryType.VALUES,
-  ESelfKnowledgeCategoryType.STRENGTHS,
-  ESelfKnowledgeCategoryType.ASPIRATIONS
+  ESelfKnowledgeCategory.VALUES,
+  ESelfKnowledgeCategory.STRENGTHS,
+  ESelfKnowledgeCategory.ASPIRATIONS
 ].includes(categoryType))
 
 enum SelfKnowledgeElementsDropdownEvents {

--- a/src/features/student/selfKnowledge/components/modals/AddSelfKnowledgeCategoriesModal/AddSelfKnowledgeCategoriesModal.test.ts
+++ b/src/features/student/selfKnowledge/components/modals/AddSelfKnowledgeCategoriesModal/AddSelfKnowledgeCategoriesModal.test.ts
@@ -155,7 +155,7 @@ BddTest().given('an add self knowledge categories modal', () => {
 
       BddTest().then('it should call the mutation and show a success message', async () => {
         await vi.waitFor(() => {
-          expect(mockAddSuccessMessage).toHaveBeenCalledWith('2 catégories ajoutées avec succès')
+          expect(mockAddSuccessMessage).toHaveBeenCalledWith(`${mockedSelfKnowledgeCategoriesAvailable.length} catégories ajoutées avec succès`)
           expect(mockAddErrorMessage).not.toHaveBeenCalled()
         })
       })

--- a/src/features/student/selfKnowledge/components/modals/AddSelfKnowledgeCategoriesModal/AddSelfKnowledgeCategoriesModal.vue
+++ b/src/features/student/selfKnowledge/components/modals/AddSelfKnowledgeCategoriesModal/AddSelfKnowledgeCategoriesModal.vue
@@ -1,4 +1,5 @@
 <script lang="ts" setup>
+import type { ESelfKnowledgeCategory } from '@/api/avenir-esr'
 import { invalidateGetSelfKnowledgeCategories, useAddSelfKnowledgeCategories, useGetSelfKnowledgeCategoriesAvailable } from '@/api/avenir-esr'
 import { useApiErrors } from '@/common/composables/use-api-errors/use-api-errors'
 import { useTaskLoading } from '@/common/composables/use-task-loading/use-task-loading'
@@ -25,14 +26,18 @@ const { data: fetchedCategoriesAvailable } = useGetSelfKnowledgeCategoriesAvaila
 const queryClient = useQueryClient()
 const { isLoading, withTaskLoading } = useTaskLoading()
 
-const categoriesAvailable = computed(() => fetchedCategoriesAvailable.value ?? [])
+const categoriesAvailable = computed(() => (fetchedCategoriesAvailable.value ?? []).map(category => ({
+  type: category.type,
+  title: t(`student.selfKnowledge.categories.${category.type}.title`),
+  description: t(`student.selfKnowledge.categories.${category.type}.description`)
+})))
 
 const { mutate: mutateAddSelfKnowledgeCategories, isPending } = useAddSelfKnowledgeCategories()
 
 const selected = ref<string[]>([])
 
 function addSelfKnowledgeCategories () {
-  mutateAddSelfKnowledgeCategories({ data: selected.value }, {
+  mutateAddSelfKnowledgeCategories({ data: selected.value as ESelfKnowledgeCategory[] }, {
     onSuccess: async () => {
       await withTaskLoading(() => invalidateGetSelfKnowledgeCategories(queryClient))
       addSuccessMessage(t('student.selfKnowledge.SelfKnowledgeMainSection.modals.addSelfKnowledgeCategories.success', { count: selected.value.length }))
@@ -81,11 +86,11 @@ function resetSelected () {
       <AvCheckboxesGroup id="add-self-knowledge-categories-modal-checkboxes-group">
         <AvCheckbox
           v-for="category in categoriesAvailable"
-          :id="category.id"
-          :key="category.id"
+          :id="category.type"
+          :key="category.type"
           v-model="selected"
-          :value="category.id"
-          :name="category.id"
+          :value="category.type"
+          :name="category.type"
         >
           <template #label>
             <span class="b2-regular av-text-text1">

--- a/src/features/student/selfKnowledge/components/modals/ConfirmDeleteSelfKnowledgeElementsModal/ConfirmDeleteSelfKnowledgeElementsModal.test.ts
+++ b/src/features/student/selfKnowledge/components/modals/ConfirmDeleteSelfKnowledgeElementsModal/ConfirmDeleteSelfKnowledgeElementsModal.test.ts
@@ -1,3 +1,4 @@
+import { ESelfKnowledgeCategory } from '@/api/avenir-esr'
 import { ConfirmationModalStub } from '@/common/components/ConfirmationModal/ConfirmationModal.stub'
 import ConfirmDeleteSelfKnowledgeElementsModal, { type ConfirmDeleteSelfKnowledgeElementsModalProps } from '@/features/student/selfKnowledge/components/modals/ConfirmDeleteSelfKnowledgeElementsModal/ConfirmDeleteSelfKnowledgeElementsModal.vue'
 import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
@@ -13,7 +14,7 @@ BddTest().given('a confirm delete self knowledge element modal', () => {
     const props: ConfirmDeleteSelfKnowledgeElementsModalProps = {
       show: true,
       elements: [
-        { id: '1', title: 'Element 1', description: 'Description 1' }
+        { id: '1', title: 'Element 1', description: 'Description 1', category: { type: ESelfKnowledgeCategory.STRENGTHS, mandatory: true } }
       ],
     }
 
@@ -59,8 +60,8 @@ BddTest().given('a confirm delete self knowledge element modal', () => {
     const props: ConfirmDeleteSelfKnowledgeElementsModalProps = {
       show: true,
       elements: [
-        { id: '1', title: 'Element 1', description: 'Description 1' },
-        { id: '2', title: 'Element 2', description: 'Description 2' },
+        { id: '1', title: 'Element 1', description: 'Description 1', category: { type: ESelfKnowledgeCategory.STRENGTHS, mandatory: true } },
+        { id: '2', title: 'Element 2', description: 'Description 2', category: { type: ESelfKnowledgeCategory.STRENGTHS, mandatory: true } },
       ],
     }
 

--- a/src/features/student/selfKnowledge/components/modals/DeleteSelfKnowledgeCategoryModal/DeleteSelfKnowledgeCategoryModal.stub.ts
+++ b/src/features/student/selfKnowledge/components/modals/DeleteSelfKnowledgeCategoryModal/DeleteSelfKnowledgeCategoryModal.stub.ts
@@ -2,7 +2,7 @@ export const DeleteSelfKnowledgeCategoryModalStub = defineComponent({
   name: 'DeleteSelfKnowledgeCategoryModal',
   props: {
     show: Boolean,
-    categoryId: String,
+    categoryType: String,
     categoryTitle: String,
     elementsCount: Number
   },

--- a/src/features/student/selfKnowledge/components/modals/DeleteSelfKnowledgeCategoryModal/DeleteSelfKnowledgeCategoryModal.test.ts
+++ b/src/features/student/selfKnowledge/components/modals/DeleteSelfKnowledgeCategoryModal/DeleteSelfKnowledgeCategoryModal.test.ts
@@ -1,4 +1,5 @@
 import type { VueWrapper } from '@vue/test-utils'
+import { ESelfKnowledgeCategory } from '@/api/avenir-esr'
 import DeleteSelfKnowledgeCategoryModal, { type DeleteSelfKnowledgeCategoryModalProps } from '@/features/student/selfKnowledge/components/modals/DeleteSelfKnowledgeCategoryModal/DeleteSelfKnowledgeCategoryModal.vue'
 import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { mockAddErrorMessage, mockAddSuccessMessage } from 'tests/mocks'
@@ -37,7 +38,7 @@ BddTest().given('the DeleteSelfKnowledgeCategoryModal component', () => {
     const props: DeleteSelfKnowledgeCategoryModalProps = {
       show: true,
       categoryTitle: 'Category with 3 elements',
-      categoryId: 'category-1',
+      categoryType: ESelfKnowledgeCategory.STRENGTHS,
       elementsCount: 3,
     }
 
@@ -114,7 +115,7 @@ BddTest().given('the DeleteSelfKnowledgeCategoryModal component', () => {
     const props: DeleteSelfKnowledgeCategoryModalProps = {
       show: true,
       categoryTitle: 'Category with 1 element',
-      categoryId: 'category-2',
+      categoryType: ESelfKnowledgeCategory.VALUES,
       elementsCount: 1,
     }
 
@@ -144,7 +145,7 @@ BddTest().given('the DeleteSelfKnowledgeCategoryModal component', () => {
     const props: DeleteSelfKnowledgeCategoryModalProps = {
       show: true,
       categoryTitle: 'Category with 1 invalid element',
-      categoryId: 'INVALID_CATEGORY_ID',
+      categoryType: 'INVALID_CATEGORY_ID' as ESelfKnowledgeCategory,
       elementsCount: 1,
     }
 
@@ -183,7 +184,7 @@ BddTest().given('the DeleteSelfKnowledgeCategoryModal component', () => {
     const props: DeleteSelfKnowledgeCategoryModalProps = {
       show: true,
       categoryTitle: 'Empty Category',
-      categoryId: 'category-3',
+      categoryType: ESelfKnowledgeCategory.ASPIRATIONS,
       elementsCount: 0,
     }
 

--- a/src/features/student/selfKnowledge/components/modals/DeleteSelfKnowledgeCategoryModal/DeleteSelfKnowledgeCategoryModal.vue
+++ b/src/features/student/selfKnowledge/components/modals/DeleteSelfKnowledgeCategoryModal/DeleteSelfKnowledgeCategoryModal.vue
@@ -1,4 +1,5 @@
 <script lang="ts" setup>
+import type { ESelfKnowledgeCategory } from '@/api/avenir-esr'
 import { invalidateGetSelfKnowledgeCategories, useRemoveSelfKnowledgeCategory } from '@/api/avenir-esr'
 import { useApiErrors } from '@/common/composables/use-api-errors/use-api-errors'
 import { useTaskLoading } from '@/common/composables/use-task-loading/use-task-loading'
@@ -10,11 +11,11 @@ import { useI18n } from 'vue-i18n'
 export interface DeleteSelfKnowledgeCategoryModalProps {
   show: boolean
   categoryTitle: string
-  categoryId: string
+  categoryType: ESelfKnowledgeCategory
   elementsCount: number
 }
 
-const { categoryTitle, categoryId } = defineProps<DeleteSelfKnowledgeCategoryModalProps>()
+const { categoryTitle, categoryType } = defineProps<DeleteSelfKnowledgeCategoryModalProps>()
 
 const emit = defineEmits<{
   (e: 'cancel'): void
@@ -30,7 +31,7 @@ const { isLoading, withTaskLoading } = useTaskLoading()
 const { mutate: mutateRemoveSelfKnowledgeCategory, isPending } = useRemoveSelfKnowledgeCategory()
 
 function removeSelfKnowledgeCategory () {
-  mutateRemoveSelfKnowledgeCategory({ categoryId }, {
+  mutateRemoveSelfKnowledgeCategory({ selfKnowledgeCategory: categoryType }, {
     onSuccess: async () => {
       await withTaskLoading(() => invalidateGetSelfKnowledgeCategories(queryClient))
       addSuccessMessage(t('student.selfKnowledge.SelfKnowledgeMainSection.modals.deleteSelfKnowledgeCategory.success', { category: categoryTitle }))

--- a/src/features/student/selfKnowledge/components/modals/DeleteSelfKnowledgeElementsModal/DeleteSelfKnowledgeElementsModal.stub.ts
+++ b/src/features/student/selfKnowledge/components/modals/DeleteSelfKnowledgeElementsModal/DeleteSelfKnowledgeElementsModal.stub.ts
@@ -2,7 +2,7 @@ export const DeleteSelfKnowledgeElementsModalStub = defineComponent({
   name: 'DeleteSelfKnowledgeElementsModal',
   props: {
     show: Boolean,
-    categoryId: String,
+    categoryType: String,
     totalCount: Number
   },
   emits: ['cancel', 'confirm'],

--- a/src/features/student/selfKnowledge/components/modals/DeleteSelfKnowledgeElementsModal/DeleteSelfKnowledgeElementsModal.test.ts
+++ b/src/features/student/selfKnowledge/components/modals/DeleteSelfKnowledgeElementsModal/DeleteSelfKnowledgeElementsModal.test.ts
@@ -1,5 +1,6 @@
 import type { VueWrapper } from '@vue/test-utils'
 import { mockedSelfKnowledgeCategories } from '@/__mocks__/fixtures/student/self-knowledge.fixtures'
+import { ESelfKnowledgeCategory } from '@/api/avenir-esr'
 import DeleteSelfKnowledgeElementsModal, { type DeleteSelfKnowledgeElementsModalProps } from '@/features/student/selfKnowledge/components/modals/DeleteSelfKnowledgeElementsModal/DeleteSelfKnowledgeElementsModal.vue'
 import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { mockAddErrorMessage, mockAddSuccessMessage } from 'tests/mocks'
@@ -53,10 +54,9 @@ BddTest().given('a delete self knowledge element modal', () => {
   }
 
   BddTest().and('no elements to delete are provided', () => {
-    const nonExistentCategoryId = 'non-existent-category-id'
     const props: DeleteSelfKnowledgeElementsModalProps = {
       show: true,
-      categoryId: nonExistentCategoryId,
+      categoryType: ESelfKnowledgeCategory.OBLIGATIONS,
       totalCount: 0
     }
 
@@ -78,10 +78,10 @@ BddTest().given('a delete self knowledge element modal', () => {
   })
 
   BddTest().and('a single element to delete is provided', () => {
-    const strengthsCategoryId = mockedSelfKnowledgeCategories[0].id
+    const strengthsCategoryType = mockedSelfKnowledgeCategories[0].type
     const props: DeleteSelfKnowledgeElementsModalProps = {
       show: true,
-      categoryId: strengthsCategoryId,
+      categoryType: strengthsCategoryType,
       totalCount: 1
     }
 
@@ -191,10 +191,10 @@ BddTest().given('a delete self knowledge element modal', () => {
   })
 
   BddTest().and('many elements to delete are provided', () => {
-    const strengthsCategoryId = mockedSelfKnowledgeCategories[0].id
+    const strengthsCategoryType = mockedSelfKnowledgeCategories[0].type
     const props: DeleteSelfKnowledgeElementsModalProps = {
       show: true,
-      categoryId: strengthsCategoryId,
+      categoryType: strengthsCategoryType,
       totalCount: 10
     }
 

--- a/src/features/student/selfKnowledge/components/modals/DeleteSelfKnowledgeElementsModal/DeleteSelfKnowledgeElementsModal.vue
+++ b/src/features/student/selfKnowledge/components/modals/DeleteSelfKnowledgeElementsModal/DeleteSelfKnowledgeElementsModal.vue
@@ -1,4 +1,5 @@
 <script lang="ts" setup>
+import type { ESelfKnowledgeCategory } from '@/api/avenir-esr'
 import { invalidateGetSelfKnowledgeElements, useDeleteSelfKnowledgeElements } from '@/api/avenir-esr'
 import { useModal } from '@/common/composables'
 import { useApiErrors } from '@/common/composables/use-api-errors/use-api-errors'
@@ -6,9 +7,6 @@ import { useTaskLoading } from '@/common/composables/use-task-loading/use-task-l
 import { INFINITE_SCROLL_BOTTOM_DISTANCE } from '@/common/constants'
 import ConfirmDeleteSelfKnowledgeElementsModal from '@/features/student/selfKnowledge/components/modals/ConfirmDeleteSelfKnowledgeElementsModal/ConfirmDeleteSelfKnowledgeElementsModal.vue'
 import SelfKnowledgeElementsSelector from '@/features/student/selfKnowledge/components/pickers/SelfKnowledgeElementsSelector/SelfKnowledgeElementsSelector.vue'
-import {
-  useSelfKnowledgeCategory
-} from '@/features/student/selfKnowledge/composables/use-self-knowledge-category/use-self-knowledge-category'
 import {
   useSelfKnowledgePaginatedElements
 } from '@/features/student/selfKnowledge/composables/use-self-knowledge-paginated-elements/use-self-knowledge-paginated-elements'
@@ -20,7 +18,7 @@ import { useI18n } from 'vue-i18n'
 
 export interface DeleteSelfKnowledgeElementsModalProps {
   show: boolean
-  categoryId: string
+  categoryType: ESelfKnowledgeCategory
   totalCount: number
 }
 
@@ -31,7 +29,7 @@ const emit = defineEmits<{
   (e: 'confirm'): void
 }>()
 
-const { totalCount, categoryId } = toRefs(props)
+const { totalCount, categoryType } = toRefs(props)
 
 const { t } = useI18n()
 const {
@@ -44,15 +42,13 @@ const { isLoading, withTaskLoading } = useTaskLoading()
 const { getErrorMessage } = useApiErrors()
 const { addErrorMessage, addSuccessMessage } = useToasterStore()
 
-const { categoryType } = useSelfKnowledgeCategory(categoryId)
-
 const {
   elements,
   isFetching,
   hasMoreElements,
   loadMoreElements,
 } = useSelfKnowledgePaginatedElements({
-  selfKnowledgeCategoryId: computed(() => categoryId.value),
+  selfKnowledgeCategory: computed(() => categoryType.value),
   pageSize: totalCount
 })
 
@@ -72,7 +68,7 @@ const { mutate: mutateDeleteSelfKnowledgeElements, isPending } = useDeleteSelfKn
 function deleteSelfKnowledgeElements () {
   mutateDeleteSelfKnowledgeElements({ data: selectedElementIds.value }, {
     onSuccess: async (_data, variables) => {
-      await withTaskLoading(() => invalidateGetSelfKnowledgeElements(queryClient, categoryId))
+      await withTaskLoading(() => invalidateGetSelfKnowledgeElements(queryClient))
       onDeleteSuccess(variables.data.length)
     },
     onError: error => addErrorMessage({

--- a/src/features/student/selfKnowledge/components/navigation/SelfKnowledgeElementsSideMenu/SelfKnowledgeElementsSideMenu.test.ts
+++ b/src/features/student/selfKnowledge/components/navigation/SelfKnowledgeElementsSideMenu/SelfKnowledgeElementsSideMenu.test.ts
@@ -1,4 +1,4 @@
-import { ESelfKnowledgeCategoryType, type SelfKnowledgeElementViewDTO } from '@/api/avenir-esr'
+import { ESelfKnowledgeCategory, type SelfKnowledgeElementViewDTO } from '@/api/avenir-esr'
 import { SideMenuStub } from '@/common/components/navigation/SideMenu/SideMenu.stub'
 import { FloatingIconCardStub } from '@/features/student/global/components/cards/FloatingIconCard/FloatingIconCard.stub'
 import { SelfKnowledgeElementCompactCardStub } from '@/features/student/selfKnowledge/components/cards/SelfKnowledgeElementCompactCard/SelfKnowledgeElementCompactCard.stub'
@@ -15,24 +15,27 @@ BddTest().given(' a SelfKnowledgeElementsSideMenu component', () => {
       id: '1',
       title: 'Intitulé de l\'élément n°1 sur deux lignes maximum',
       description: 'Petit texte qui explique comment l\'étudiant a développé cet élément, dans quelles formation, exp...',
-      rating: 3
+      rating: 3,
+      category: { type: ESelfKnowledgeCategory.STRENGTHS, mandatory: true }
     },
     {
       id: '2',
       title: 'Force de communication',
       description: 'J\'ai développé cette compétence lors de mes projets de groupe et mes présentations en classe.',
-      rating: 4
+      rating: 4,
+      category: { type: ESelfKnowledgeCategory.STRENGTHS, mandatory: true }
     },
     {
       id: '3',
       title: 'Créativité',
       description: 'Ma créativité s\'exprime dans mes projets artistiques et mes solutions innovantes.',
-      rating: 5
+      rating: 5,
+      category: { type: ESelfKnowledgeCategory.STRENGTHS, mandatory: true }
     },
   ]
 
   const props: SelfKnowledgeElementsSideMenuProps = {
-    categoryType: ESelfKnowledgeCategoryType.STRENGTHS,
+    categoryType: ESelfKnowledgeCategory.STRENGTHS,
     elements: dummyElements,
     selectedElementId: '2'
   }

--- a/src/features/student/selfKnowledge/components/navigation/SelfKnowledgeElementsSideMenu/SelfKnowledgeElementsSideMenu.vue
+++ b/src/features/student/selfKnowledge/components/navigation/SelfKnowledgeElementsSideMenu/SelfKnowledgeElementsSideMenu.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import type { ESelfKnowledgeCategoryType, SelfKnowledgeElementViewDTO } from '@/api/avenir-esr'
+import type { ESelfKnowledgeCategory, SelfKnowledgeElementViewDTO } from '@/api/avenir-esr'
 import SideMenu from '@/common/components/navigation/SideMenu/SideMenu.vue'
 import { INFINITE_SCROLL_BOTTOM_DISTANCE } from '@/common/constants'
 import SelfKnowledgeElementCompactCard from '@/features/student/selfKnowledge/components/cards/SelfKnowledgeElementCompactCard/SelfKnowledgeElementCompactCard.vue'
@@ -9,7 +9,7 @@ import capitalize from 'lodash-es/capitalize'
 import { useI18n } from 'vue-i18n'
 
 export interface SelfKnowledgeElementsSideMenuProps {
-  categoryType: ESelfKnowledgeCategoryType
+  categoryType: ESelfKnowledgeCategory
   selectedElementId: string
   elements: SelfKnowledgeElementViewDTO[]
   countElements?: number

--- a/src/features/student/selfKnowledge/components/overlays/AddSelfKnowledgeCategoryElementDrawer/AddSelfKnowledgeCategoryElementDrawer.test.ts
+++ b/src/features/student/selfKnowledge/components/overlays/AddSelfKnowledgeCategoryElementDrawer/AddSelfKnowledgeCategoryElementDrawer.test.ts
@@ -1,4 +1,4 @@
-import { ESelfKnowledgeCategoryType, type SelfKnowledgeCategoryDTO } from '@/api/avenir-esr'
+import { ESelfKnowledgeCategory, type SelfKnowledgeCategoryDTO } from '@/api/avenir-esr'
 import { ConfirmationModalStub } from '@/common/components/ConfirmationModal/ConfirmationModal.stub'
 import { CategoryElementDescriptionTextareaFormFieldStub } from '@/features/student/selfKnowledge/components/interactions/formFields/CategoryElementDescriptionTextareaFormField/CategoryElementDescriptionTextareaFormField.stub'
 import { CategoryElementRatingRadioButtonSetFormFieldStub } from '@/features/student/selfKnowledge/components/interactions/formFields/CategoryElementRatingRadioButtonSetFormField/CategoryElementRatingRadioButtonSetFormField.stub'
@@ -46,10 +46,8 @@ BddTest().given('an add self knowledge category element drawer component', () =>
   let wrapper: ReturnType<typeof mountComponent<typeof AddSelfKnowledgeCategoryElementDrawer>>
 
   const mockCategory: SelfKnowledgeCategoryDTO = {
-    id: 'category-123',
-    title: 'Mes compétences',
-    description: 'Category description',
-    type: ESelfKnowledgeCategoryType.STRENGTHS
+    type: ESelfKnowledgeCategory.STRENGTHS,
+    mandatory: true
   }
 
   const stubs = {
@@ -263,10 +261,8 @@ BddTest().given('an add self knowledge category element drawer component', () =>
     BddTest().then('it should display correct category type in title', async () => {
       const store = useSelfKnowledgeStore()
       const interestCategory: SelfKnowledgeCategoryDTO = {
-        id: 'category-456',
-        title: 'Mes centres d\'intérêt',
-        description: 'Interest category',
-        type: ESelfKnowledgeCategoryType.INTERESTS
+        type: ESelfKnowledgeCategory.INTERESTS,
+        mandatory: false
       }
 
       store.openAddElementDrawer(interestCategory)

--- a/src/features/student/selfKnowledge/components/overlays/AddSelfKnowledgeCategoryElementDrawer/AddSelfKnowledgeCategoryElementDrawer.vue
+++ b/src/features/student/selfKnowledge/components/overlays/AddSelfKnowledgeCategoryElementDrawer/AddSelfKnowledgeCategoryElementDrawer.vue
@@ -22,7 +22,6 @@ const showDrawer = toRef(selfKnowledgeStore, 'showAddElementDrawer')
 const selectedCategoryType = computed(() => selfKnowledgeStore.selectedCategory!.type)
 const selectedCategoryTypeTranslation = computed(() => t(`student.selfKnowledge.categoryType.${selectedCategoryType.value}`))
 
-const selectedCategoryId = computed(() => selfKnowledgeStore.selectedCategory!.id)
 const selectedCategoryIcon = computed(() => getSelfKnowledgeCategoryIcon(selectedCategoryType.value))
 
 function onElementCreated () {
@@ -33,7 +32,7 @@ function onElementCreated () {
   confirmCancel()
 }
 
-const { form, isFormValid, isSubmitting, hasElementDetailsErrors } = useAddSelfKnowledgeCategoryElementForm(selectedCategoryId, onElementCreated)
+const { form, isFormValid, isSubmitting, hasElementDetailsErrors } = useAddSelfKnowledgeCategoryElementForm(selectedCategoryType, onElementCreated)
 
 const isFormDirty = form.useStore(state => state.isDirty)
 

--- a/src/features/student/selfKnowledge/components/overlays/AddSelfKnowledgeCategoryElementDrawer/use-add-self-knowledge-category-element-form/use-add-self-knowledge-category-element-form.test.ts
+++ b/src/features/student/selfKnowledge/components/overlays/AddSelfKnowledgeCategoryElementDrawer/use-add-self-knowledge-category-element-form/use-add-self-knowledge-category-element-form.test.ts
@@ -1,6 +1,7 @@
 import type { SelfKnowledgeCategoryElementFormData } from '@/features/student/selfKnowledge/types/forms.types'
 import { createSelfKnowledgeElementErrorHandler } from '@/__mocks__/msw/handlers/student/self-knowledge.handlers'
 import { server } from '@/__mocks__/msw/server'
+import { ESelfKnowledgeCategory } from '@/api/avenir-esr'
 import { useAddSelfKnowledgeCategoryElementForm } from '@/features/student/selfKnowledge/components/overlays/AddSelfKnowledgeCategoryElementDrawer/use-add-self-knowledge-category-element-form/use-add-self-knowledge-category-element-form'
 import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { mountComposable } from 'tests/utils'
@@ -9,7 +10,7 @@ import { beforeEach, expect, vi } from 'vitest'
 BddTest().given('the useAddSelfKnowledgeCategoryElementForm composable', () => {
   let composableResult: ReturnType<typeof useAddSelfKnowledgeCategoryElementForm>
   let mockOnElementCreated: ReturnType<typeof vi.fn>
-  const mockCategoryId = 'category-123'
+  const mockCategoryId = ESelfKnowledgeCategory.STRENGTHS
 
   const createValidFormData = (rating: number | null = 3): SelfKnowledgeCategoryElementFormData => ({
     title: 'My Strength',
@@ -153,7 +154,7 @@ BddTest().given('the useAddSelfKnowledgeCategoryElementForm composable', () => {
 
   BddTest().when('form is submitted with reactive category ID', () => {
     BddTest().then('it should use the current value of categoryId', async () => {
-      const reactiveCategoryId = ref('reactive-category-456')
+      const reactiveCategoryId = ref(ESelfKnowledgeCategory.VALUES)
 
       const result = mountComposable(() => useAddSelfKnowledgeCategoryElementForm(reactiveCategoryId, mockOnElementCreated), {
         useI18n: true,

--- a/src/features/student/selfKnowledge/components/overlays/AddSelfKnowledgeCategoryElementDrawer/use-add-self-knowledge-category-element-form/use-add-self-knowledge-category-element-form.ts
+++ b/src/features/student/selfKnowledge/components/overlays/AddSelfKnowledgeCategoryElementDrawer/use-add-self-knowledge-category-element-form/use-add-self-knowledge-category-element-form.ts
@@ -1,3 +1,4 @@
+import type { ESelfKnowledgeCategory } from '@/api/avenir-esr'
 import type { BaseApiException } from '@/common/exceptions'
 import type { SelfKnowledgeCategoryElementFormData } from '@/features/student/selfKnowledge/types/forms.types'
 import type { MaybeRef } from '@vueuse/core'
@@ -13,7 +14,7 @@ import { toValue } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 export function useAddSelfKnowledgeCategoryElementForm (
-  selfKnowledgeCategoryId: MaybeRef<string>,
+  selfKnowledgeCategory: MaybeRef<ESelfKnowledgeCategory>,
   onElementCreated?: () => void
 ) {
   const { t } = useI18n()
@@ -34,7 +35,7 @@ export function useAddSelfKnowledgeCategoryElementForm (
 
   function createSelfKnowledgeElement (formData: SelfKnowledgeCategoryElementFormData) {
     mutateCreateSelfKnowledgeElement({
-      selfKnowledgeCategoryId: toValue(selfKnowledgeCategoryId),
+      selfKnowledgeCategory: toValue(selfKnowledgeCategory),
       data: {
         title: formData.title,
         description: formData.description,
@@ -43,7 +44,7 @@ export function useAddSelfKnowledgeCategoryElementForm (
       }
     }, {
       onSuccess: async () => {
-        await withTaskLoading(() => invalidateGetSelfKnowledgeElements(queryClient, toValue(selfKnowledgeCategoryId)))
+        await withTaskLoading(() => invalidateGetSelfKnowledgeElements(queryClient))
         onElementCreated?.()
       },
       onError: onCreateElementError

--- a/src/features/student/selfKnowledge/components/pickers/SelfKnowledgeElementsSelector/SelfKnowledgeElementsSelector.test.ts
+++ b/src/features/student/selfKnowledge/components/pickers/SelfKnowledgeElementsSelector/SelfKnowledgeElementsSelector.test.ts
@@ -1,4 +1,4 @@
-import { ESelfKnowledgeCategoryType } from '@/api/avenir-esr'
+import { ESelfKnowledgeCategory } from '@/api/avenir-esr'
 import { CompactCardSelectorStub } from '@/features/student/global/components/cards/CompactCardSelector/CompactCardSelector.stub'
 import SelfKnowledgeElementsSelector, { type SelfKnowledgeElementsSelectorProps } from '@/features/student/selfKnowledge/components/pickers/SelfKnowledgeElementsSelector/SelfKnowledgeElementsSelector.vue'
 import { AvIconStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
@@ -16,7 +16,7 @@ BddTest().given('a self knowledge element selector', () => {
   BddTest().and('no elements are given', () => {
     const props: SelfKnowledgeElementsSelectorProps = {
       elements: [],
-      categoryType: ESelfKnowledgeCategoryType.STRENGTHS
+      categoryType: ESelfKnowledgeCategory.STRENGTHS
     }
 
     BddTest().when('the component is mounted', () => {
@@ -37,10 +37,11 @@ BddTest().given('a self knowledge element selector', () => {
         {
           id: '1',
           title: 'Element 1',
-          description: 'Description 1'
+          description: 'Description 1',
+          category: { type: ESelfKnowledgeCategory.STRENGTHS, mandatory: true }
         }
       ],
-      categoryType: ESelfKnowledgeCategoryType.STRENGTHS
+      categoryType: ESelfKnowledgeCategory.STRENGTHS
     }
 
     BddTest().when('the component is mounted', () => {
@@ -83,15 +84,17 @@ BddTest().given('a self knowledge element selector', () => {
         {
           id: '1',
           title: 'Element 1',
-          description: 'Description 1'
+          description: 'Description 1',
+          category: { type: ESelfKnowledgeCategory.STRENGTHS, mandatory: true }
         },
         {
           id: '2',
           title: 'Element 2',
-          description: 'Description 2'
+          description: 'Description 2',
+          category: { type: ESelfKnowledgeCategory.STRENGTHS, mandatory: true }
         }
       ],
-      categoryType: ESelfKnowledgeCategoryType.STRENGTHS
+      categoryType: ESelfKnowledgeCategory.STRENGTHS
     }
 
     BddTest().when('the component is mounted', () => {
@@ -114,10 +117,11 @@ BddTest().given('a self knowledge element selector', () => {
         {
           id: '1',
           title: 'Element 1',
-          description: 'Description 1'
+          description: 'Description 1',
+          category: { type: ESelfKnowledgeCategory.STRENGTHS, mandatory: true }
         }
       ],
-      categoryType: ESelfKnowledgeCategoryType.STRENGTHS,
+      categoryType: ESelfKnowledgeCategory.STRENGTHS,
       readonly: true
     }
 

--- a/src/features/student/selfKnowledge/components/pickers/SelfKnowledgeElementsSelector/SelfKnowledgeElementsSelector.vue
+++ b/src/features/student/selfKnowledge/components/pickers/SelfKnowledgeElementsSelector/SelfKnowledgeElementsSelector.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
-import type { ESelfKnowledgeCategoryType, SelfKnowledgeElementViewDTO } from '@/api/avenir-esr'
+import type { ESelfKnowledgeCategory, SelfKnowledgeElementViewDTO } from '@/api/avenir-esr'
 import CompactCardSelector from '@/features/student/global/components/cards/CompactCardSelector/CompactCardSelector.vue'
 import { getSelfKnowledgeCategoryIcon } from '@/features/student/selfKnowledge/utils/category.utils'
 
 export interface SelfKnowledgeElementsSelectorProps {
   elements: SelfKnowledgeElementViewDTO[]
-  categoryType: ESelfKnowledgeCategoryType
+  categoryType: ESelfKnowledgeCategory
   readonly?: boolean
 }
 

--- a/src/features/student/selfKnowledge/components/tabs/SelfKnowledgeElementTabs/SelfKnowledgeElementTabs.test.ts
+++ b/src/features/student/selfKnowledge/components/tabs/SelfKnowledgeElementTabs/SelfKnowledgeElementTabs.test.ts
@@ -1,4 +1,4 @@
-import type { ESelfKnowledgeCategoryType } from '@/api/avenir-esr'
+import type { ESelfKnowledgeCategory } from '@/api/avenir-esr'
 import type { VueWrapper } from '@vue/test-utils'
 import { ICONS } from '@/common/constants'
 import SelfKnowledgeElementTabs
@@ -34,7 +34,7 @@ BddTest().given('a self knowledge tabs component', () => {
     beforeEach(() => {
       wrapper = mountComponent(SelfKnowledgeElementTabs, {
         props: {
-          categoryType: 'STRENGTHS' as ESelfKnowledgeCategoryType
+          categoryType: 'STRENGTHS' as ESelfKnowledgeCategory
         },
         slots: {
           element: '<div class="element-slot-content">Element content</div>',

--- a/src/features/student/selfKnowledge/components/tabs/SelfKnowledgeElementTabs/SelfKnowledgeElementTabs.vue
+++ b/src/features/student/selfKnowledge/components/tabs/SelfKnowledgeElementTabs/SelfKnowledgeElementTabs.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
-import type { ESelfKnowledgeCategoryType } from '@/api/avenir-esr'
+import type { ESelfKnowledgeCategory } from '@/api/avenir-esr'
 import type { Slot } from 'vue'
 import { ICONS } from '@/common/constants'
 import { AvTab, AvTabs, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
 import { useI18n } from 'vue-i18n'
 
 interface SelfKnowledgeProps {
-  categoryType: ESelfKnowledgeCategoryType
+  categoryType: ESelfKnowledgeCategory
 }
 
 const { categoryType } = defineProps<SelfKnowledgeProps>()

--- a/src/features/student/selfKnowledge/composables/use-self-knowledge-category/use-self-knowledge-category.test.ts
+++ b/src/features/student/selfKnowledge/composables/use-self-knowledge-category/use-self-knowledge-category.test.ts
@@ -1,6 +1,6 @@
+import type { ESelfKnowledgeCategory } from '@/api/avenir-esr'
 import type { Ref } from 'vue'
 import { mockedSelfKnowledgeCategories } from '@/__mocks__/fixtures/student/self-knowledge.fixtures'
-import { ESelfKnowledgeCategoryType } from '@/api/avenir-esr'
 import { useSelfKnowledgeCategory } from '@/features/student/selfKnowledge/composables/use-self-knowledge-category/use-self-knowledge-category'
 import { getSelfKnowledgeCategoryIcon } from '@/features/student/selfKnowledge/utils/category.utils'
 import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
@@ -8,15 +8,15 @@ import { mountComposable } from 'tests/utils'
 import { beforeEach, expect, vi } from 'vitest'
 
 BddTest().given('the useSelfKnowledgeCategory composable', () => {
-  let categoryId: Ref<string>
+  let categoryType: Ref<ESelfKnowledgeCategory>
   let composableResult: ReturnType<typeof useSelfKnowledgeCategory>
 
   const firstCategory = mockedSelfKnowledgeCategories[0]
   const secondCategory = mockedSelfKnowledgeCategories[1]
 
-  const mountWithCurrentCategoryId = () => {
+  const mountWithCurrentCategoryType = () => {
     const { result } = mountComposable(
-      () => useSelfKnowledgeCategory(categoryId),
+      () => useSelfKnowledgeCategory(categoryType),
       {
         useTanstack: true,
         useI18n: true
@@ -27,25 +27,15 @@ BddTest().given('the useSelfKnowledgeCategory composable', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
-    categoryId = ref('')
+    categoryType = ref(firstCategory.type)
   })
 
-  BddTest().when('a matching category exists for the given id', () => {
-    beforeEach(async () => {
-      categoryId.value = firstCategory.id
-      mountWithCurrentCategoryId()
-
-      await vi.waitFor(() => {
-        expect(composableResult.category.value).toBeDefined()
-      })
+  BddTest().when('the composable is mounted with a category type', () => {
+    beforeEach(() => {
+      mountWithCurrentCategoryType()
     })
 
-    BddTest().then('it should expose the matching category', () => {
-      expect(composableResult.category.value?.id).toBe(firstCategory.id)
-      expect(composableResult.category.value?.title).toBe(firstCategory.title)
-    })
-
-    BddTest().then('it should derive categoryType from the category', () => {
+    BddTest().then('it should expose the given categoryType', () => {
       expect(composableResult.categoryType.value).toBe(firstCategory.type)
     })
 
@@ -56,82 +46,45 @@ BddTest().given('the useSelfKnowledgeCategory composable', () => {
       expect(label.length).toBeGreaterThan(0)
     })
 
+    BddTest().then('it should compute a non empty translated categoryTitle', () => {
+      const title = composableResult.categoryTitle.value
+
+      expect(typeof title).toBe('string')
+      expect(title.length).toBeGreaterThan(0)
+    })
+
+    BddTest().then('it should compute a non empty translated categoryDescription', () => {
+      const description = composableResult.categoryDescription.value
+
+      expect(typeof description).toBe('string')
+      expect(description.length).toBeGreaterThan(0)
+    })
+
     BddTest().then('it should compute the categoryIcon from the category type', () => {
-      const expectedIcon = getSelfKnowledgeCategoryIcon(
-        firstCategory.type as ESelfKnowledgeCategoryType
-      )
-      expect(composableResult.categoryIcon.value).toBe(expectedIcon)
-    })
-  })
-
-  BddTest().when('no matching category exists for the given id', () => {
-    beforeEach(async () => {
-      categoryId.value = 'unknown-category-id'
-      mountWithCurrentCategoryId()
-
-      await vi.waitFor(() => {
-        expect(composableResult.categoryType.value).toBeDefined()
-      })
-    })
-
-    BddTest().then('it should expose undefined category', () => {
-      expect(composableResult.category.value).toBeUndefined()
-    })
-
-    BddTest().then('it should fallback categoryType to STRENGTHS', () => {
-      expect(composableResult.categoryType.value).toBe(
-        ESelfKnowledgeCategoryType.STRENGTHS
-      )
-    })
-
-    BddTest().then('it should compute a label for the fallback type', () => {
-      const label = composableResult.categoryTypeLabel.value
-
-      expect(typeof label).toBe('string')
-      expect(label.length).toBeGreaterThan(0)
-    })
-
-    BddTest().then('it should compute the icon based on the fallback type', () => {
-      const expectedIcon = getSelfKnowledgeCategoryIcon(
-        ESelfKnowledgeCategoryType.STRENGTHS
-      )
+      const expectedIcon = getSelfKnowledgeCategoryIcon(firstCategory.type)
       expect(composableResult.categoryIcon.value).toBe(expectedIcon)
     })
   })
 
   if (secondCategory) {
-    BddTest().when('the category id changes to another existing category', () => {
-      beforeEach(async () => {
-        categoryId.value = firstCategory.id
-        mountWithCurrentCategoryId()
-
-        await vi.waitFor(() => {
-          expect(composableResult.category.value?.id).toBe(firstCategory.id)
-        })
-
-        categoryId.value = secondCategory.id
-
-        await vi.waitFor(() => {
-          expect(composableResult.category.value?.id).toBe(secondCategory.id)
-        })
+    BddTest().when('the category type changes to another category', () => {
+      beforeEach(() => {
+        mountWithCurrentCategoryType()
+        categoryType.value = secondCategory.type
       })
 
-      BddTest().then('it should update the category reference', () => {
-        expect(composableResult.category.value).toBeDefined()
-        expect(composableResult.category.value?.id).toBe(secondCategory.id)
-        expect(composableResult.category.value?.title).toBe(secondCategory.title)
-      })
-
-      BddTest().then('it should update categoryType, label and icon accordingly', () => {
+      BddTest().then('it should update categoryType, label, title, description and icon accordingly', () => {
         expect(composableResult.categoryType.value).toBe(secondCategory.type)
 
         const label = composableResult.categoryTypeLabel.value
         expect(typeof label).toBe('string')
         expect(label.length).toBeGreaterThan(0)
 
-        const expectedIcon = getSelfKnowledgeCategoryIcon(
-          secondCategory.type as ESelfKnowledgeCategoryType
-        )
+        const title = composableResult.categoryTitle.value
+        expect(typeof title).toBe('string')
+        expect(title.length).toBeGreaterThan(0)
+
+        const expectedIcon = getSelfKnowledgeCategoryIcon(secondCategory.type)
         expect(composableResult.categoryIcon.value).toBe(expectedIcon)
       })
     })

--- a/src/features/student/selfKnowledge/composables/use-self-knowledge-category/use-self-knowledge-category.ts
+++ b/src/features/student/selfKnowledge/composables/use-self-knowledge-category/use-self-knowledge-category.ts
@@ -1,34 +1,34 @@
-import { ESelfKnowledgeCategoryType, useGetSelfKnowledgeCategories } from '@/api/avenir-esr'
+import type { ESelfKnowledgeCategory } from '@/api/avenir-esr'
 import { getSelfKnowledgeCategoryIcon } from '@/features/student/selfKnowledge/utils/category.utils'
 import { type MaybeRef, toValue } from 'vue'
 import { useI18n } from 'vue-i18n'
 
-export function useSelfKnowledgeCategory (categoryId: MaybeRef<string>) {
-  const { data: fetchedCategories } = useGetSelfKnowledgeCategories()
+export function useSelfKnowledgeCategory (categoryType: MaybeRef<ESelfKnowledgeCategory>) {
   const { t } = useI18n()
 
-  const categories = computed(() => fetchedCategories.value ?? [])
-
-  const category = computed(() =>
-    categories.value.find(cat => cat.id === toValue(categoryId))
-  )
-
-  const categoryType = computed(
-    () => category.value?.type ?? ESelfKnowledgeCategoryType.STRENGTHS
-  )
+  const type = computed(() => toValue(categoryType))
 
   const categoryTypeLabel = computed(() =>
-    t(`student.selfKnowledge.categoryType.${categoryType.value}`, { count: 2 })
+    t(`student.selfKnowledge.categoryType.${type.value}`, { count: 2 })
+  )
+
+  const categoryTitle = computed(() =>
+    t(`student.selfKnowledge.categories.${type.value}.title`)
+  )
+
+  const categoryDescription = computed(() =>
+    t(`student.selfKnowledge.categories.${type.value}.description`)
   )
 
   const categoryIcon = computed(() =>
-    getSelfKnowledgeCategoryIcon(categoryType.value)
+    getSelfKnowledgeCategoryIcon(type.value)
   )
 
   return {
-    category,
-    categoryType,
+    categoryType: type,
     categoryTypeLabel,
+    categoryTitle,
+    categoryDescription,
     categoryIcon
   }
 }

--- a/src/features/student/selfKnowledge/composables/use-self-knowledge-paginated-elements/use-self-knowledge-paginated-elements.test.ts
+++ b/src/features/student/selfKnowledge/composables/use-self-knowledge-paginated-elements/use-self-knowledge-paginated-elements.test.ts
@@ -1,5 +1,6 @@
 import type { SelfKnowledgeElementViewDTO } from '@/api/avenir-esr'
 import type { Ref } from 'vue'
+import { ESelfKnowledgeCategory } from '@/api/avenir-esr'
 import {
   useSelfKnowledgePaginatedElements
 } from '@/features/student/selfKnowledge/composables/use-self-knowledge-paginated-elements/use-self-knowledge-paginated-elements'
@@ -8,14 +9,14 @@ import { mountComposable } from 'tests/utils'
 import { beforeEach, expect, vi } from 'vitest'
 
 BddTest().given('the useSelfKnowledgePaginatedElements composable', () => {
-  let categoryId: Ref<string>
+  let categoryType: Ref<ESelfKnowledgeCategory>
   let composableResult: ReturnType<typeof useSelfKnowledgePaginatedElements>
 
   const mountWithCurrentCategory = () => {
     const { result } = mountComposable(
       () =>
         useSelfKnowledgePaginatedElements({
-          selfKnowledgeCategoryId: categoryId,
+          selfKnowledgeCategory: categoryType,
           pageSize: 3
         }),
       {
@@ -28,10 +29,10 @@ BddTest().given('the useSelfKnowledgePaginatedElements composable', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
-    categoryId = ref('')
+    categoryType = ref('' as ESelfKnowledgeCategory)
   })
 
-  BddTest().when('the category id is initially empty', () => {
+  BddTest().when('the category type is initially empty', () => {
     beforeEach(() => {
       mountWithCurrentCategory()
     })
@@ -42,9 +43,9 @@ BddTest().given('the useSelfKnowledgePaginatedElements composable', () => {
     })
   })
 
-  BddTest().when('the category id has a value and the first page is loaded', () => {
+  BddTest().when('the category type has a value and the first page is loaded', () => {
     beforeEach(async () => {
-      categoryId.value = '4aec2faa-d986-4553-a14b-2ecabba415c8'
+      categoryType.value = ESelfKnowledgeCategory.STRENGTHS
       mountWithCurrentCategory()
 
       await vi.waitFor(() => {
@@ -75,7 +76,7 @@ BddTest().given('the useSelfKnowledgePaginatedElements composable', () => {
     let firstPageElements: SelfKnowledgeElementViewDTO[]
 
     beforeEach(async () => {
-      categoryId.value = '4aec2faa-d986-4553-a14b-2ecabba415c8'
+      categoryType.value = ESelfKnowledgeCategory.STRENGTHS
       mountWithCurrentCategory()
 
       await vi.waitFor(() => {
@@ -109,7 +110,7 @@ BddTest().given('the useSelfKnowledgePaginatedElements composable', () => {
 
   BddTest().when('loadMoreElements is called multiple times', () => {
     beforeEach(async () => {
-      categoryId.value = '4aec2faa-d986-4553-a14b-2ecabba415c8'
+      categoryType.value = ESelfKnowledgeCategory.STRENGTHS
       mountWithCurrentCategory()
 
       await vi.waitFor(() => {
@@ -139,16 +140,16 @@ BddTest().given('the useSelfKnowledgePaginatedElements composable', () => {
     })
   })
 
-  BddTest().when('the category id becomes empty after having a value', () => {
+  BddTest().when('the category type becomes empty after having a value', () => {
     beforeEach(async () => {
-      categoryId.value = '4aec2faa-d986-4553-a14b-2ecabba415c8'
+      categoryType.value = ESelfKnowledgeCategory.STRENGTHS
       mountWithCurrentCategory()
 
       await vi.waitFor(() => {
         expect(composableResult.elements.value.length).toBe(3)
       })
 
-      categoryId.value = ''
+      categoryType.value = '' as ESelfKnowledgeCategory
 
       await vi.waitFor(() => {
         expect(composableResult.elements.value).toEqual([])
@@ -164,7 +165,7 @@ BddTest().given('the useSelfKnowledgePaginatedElements composable', () => {
 
   BddTest().when('resetPagination is called', () => {
     beforeEach(async () => {
-      categoryId.value = '4aec2faa-d986-4553-a14b-2ecabba415c8'
+      categoryType.value = ESelfKnowledgeCategory.STRENGTHS
       mountWithCurrentCategory()
 
       await vi.waitFor(() => {

--- a/src/features/student/selfKnowledge/composables/use-self-knowledge-paginated-elements/use-self-knowledge-paginated-elements.ts
+++ b/src/features/student/selfKnowledge/composables/use-self-knowledge-paginated-elements/use-self-knowledge-paginated-elements.ts
@@ -1,11 +1,11 @@
-import { type GetSelfKnowledgeElementsParams, type PageInfoDTO, type SelfKnowledgeElementViewDTO, useGetSelfKnowledgeElements } from '@/api/avenir-esr'
+import { type ESelfKnowledgeCategory, type GetSelfKnowledgeElementsParams, type PageInfoDTO, type SelfKnowledgeElementViewDTO, useGetSelfKnowledgeElements } from '@/api/avenir-esr'
 import { useInfiniteScrollPagination } from '@/common/composables'
-import { CATEGORY_ELEMENTS_PAGE_SIZE } from '@/features/student/selfKnowledge/utils/category.utils'
+import { CATEGORY_ELEMENTS_PAGE_SIZE, toSelfKnowledgeCategoriesParam } from '@/features/student/selfKnowledge/utils/category.utils'
 import { keepPreviousData } from '@tanstack/vue-query'
 import { type ComputedRef, type MaybeRef, type Ref, toValue } from 'vue'
 
 export interface UseSelfKnowledgePaginatedElementsParams {
-  selfKnowledgeCategoryId: MaybeRef<string>
+  selfKnowledgeCategory: MaybeRef<ESelfKnowledgeCategory>
   pageSize?: MaybeRef<number>
 }
 
@@ -20,17 +20,21 @@ export interface UseSelfKnowledgePaginatedElementsResult {
 }
 
 export function useSelfKnowledgePaginatedElements ({
-  selfKnowledgeCategoryId,
+  selfKnowledgeCategory,
   pageSize
 }: UseSelfKnowledgePaginatedElementsParams): UseSelfKnowledgePaginatedElementsResult {
-  const categoryId = computed(() => toValue(selfKnowledgeCategoryId))
+  const categoryType = computed(() => toValue(selfKnowledgeCategory))
   const size = computed(() => toValue(pageSize) ?? CATEGORY_ELEMENTS_PAGE_SIZE)
   const page = ref(0)
 
-  const params = computed<GetSelfKnowledgeElementsParams>(() => ({ page: page.value, pageSize: size.value }))
+  const params = computed<GetSelfKnowledgeElementsParams>(() => ({
+    selfKnowledgeCategories: toSelfKnowledgeCategoriesParam(categoryType.value),
+    page: page.value,
+    pageSize: size.value
+  }))
 
-  const { data, isFetching } = useGetSelfKnowledgeElements(categoryId, params, {
-    query: { enabled: computed(() => !!categoryId.value), placeholderData: keepPreviousData }
+  const { data, isFetching } = useGetSelfKnowledgeElements(params, {
+    query: { enabled: computed(() => !!categoryType.value), placeholderData: keepPreviousData }
   })
 
   const fetchedElements = computed(() => data.value?.data ?? [])
@@ -48,7 +52,7 @@ export function useSelfKnowledgePaginatedElements ({
     page,
   })
 
-  watch(categoryId, () => {
+  watch(categoryType, () => {
     resetPagination()
   })
 

--- a/src/features/student/selfKnowledge/locales/en.json
+++ b/src/features/student/selfKnowledge/locales/en.json
@@ -1,6 +1,44 @@
 {
   "student": {
     "selfKnowledge": {
+      "categories": {
+        "ASPIRATIONS": {
+          "description": "Clarify what I want to explore, learn or experience in the short and medium term.",
+          "title": "My aspirations"
+        },
+        "IMPROVEMENT": {
+          "description": "Identify the areas where I want to make progress.",
+          "title": "My areas for improvement"
+        },
+        "INSPIRATIONS": {
+          "description": "Identify the people, ideas or experiences that inspire me.",
+          "title": "My inspirations"
+        },
+        "INTERESTS": {
+          "description": "List the topics and activities that spark my curiosity.",
+          "title": "My interests"
+        },
+        "MOTIVATION": {
+          "description": "Clarify what drives me and motivates me in my professional life.",
+          "title": "My professional motivations"
+        },
+        "OBLIGATIONS": {
+          "description": "List the constraints and commitments I need to take into account.",
+          "title": "My obligations"
+        },
+        "STRENGTHS": {
+          "description": "Identify and highlight my qualities, talents and notable achievements.",
+          "title": "My strengths"
+        },
+        "TESTIMONIALS": {
+          "description": "Collect the feedback and testimonials I have received.",
+          "title": "My testimonials"
+        },
+        "VALUES": {
+          "description": "Clarify what matters to me and guides my daily decisions.",
+          "title": "My values"
+        }
+      },
       "categoryType": {
         "ASPIRATIONS": "aspiration | aspirations",
         "IMPROVEMENT": "area for improvement | areas for improvement",

--- a/src/features/student/selfKnowledge/locales/fr.json
+++ b/src/features/student/selfKnowledge/locales/fr.json
@@ -1,6 +1,44 @@
 {
   "student": {
     "selfKnowledge": {
+      "categories": {
+        "ASPIRATIONS": {
+          "description": "Clarifier ce que j'ai envie d'explorer, d'apprendre ou de vivre à court et moyen terme.",
+          "title": "Mes envies"
+        },
+        "IMPROVEMENT": {
+          "description": "Identifier les axes sur lesquels je souhaite progresser.",
+          "title": "Mes axes d'amélioration"
+        },
+        "INSPIRATIONS": {
+          "description": "Identifier les personnes, idées ou expériences qui m'inspirent.",
+          "title": "Mes inspirations"
+        },
+        "INTERESTS": {
+          "description": "Recenser les sujets et activités qui suscitent ma curiosité.",
+          "title": "Mes centres d'intérêt"
+        },
+        "MOTIVATION": {
+          "description": "Préciser ce qui m'anime et me pousse à agir dans ma vie professionnelle.",
+          "title": "Mes motivations professionnelles"
+        },
+        "OBLIGATIONS": {
+          "description": "Recenser les contraintes et engagements que je dois prendre en compte.",
+          "title": "Mes obligations"
+        },
+        "STRENGTHS": {
+          "description": "Identifier et valoriser mes qualités, talents et réussites marquantes.",
+          "title": "Mes points forts"
+        },
+        "TESTIMONIALS": {
+          "description": "Recueillir les retours et témoignages que l'on m'a donnés.",
+          "title": "Mes témoignages"
+        },
+        "VALUES": {
+          "description": "Préciser ce qui est important pour moi et ce qui guide mes décisions au quotidien.",
+          "title": "Mes valeurs"
+        }
+      },
       "categoryType": {
         "ASPIRATIONS": "envie | envies",
         "IMPROVEMENT": "axe d'amélioration | axes d'amélioration",

--- a/src/features/student/selfKnowledge/stores/self-knowledge.store.test.ts
+++ b/src/features/student/selfKnowledge/stores/self-knowledge.store.test.ts
@@ -1,4 +1,4 @@
-import { ESelfKnowledgeCategoryType, type SelfKnowledgeCategoryDTO } from '@/api/avenir-esr'
+import { ESelfKnowledgeCategory, type SelfKnowledgeCategoryDTO } from '@/api/avenir-esr'
 import { useSelfKnowledgeStore } from '@/features/student/selfKnowledge/stores/self-knowledge.store'
 import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { mountComposable } from 'tests/utils'
@@ -8,17 +8,13 @@ BddTest().given('a self knowledge store', () => {
   let store: ReturnType<typeof useSelfKnowledgeStore>
 
   const mockCategory: SelfKnowledgeCategoryDTO = {
-    id: 'category-123',
-    title: 'Mes points forts',
-    description: 'Category description',
-    type: ESelfKnowledgeCategoryType.STRENGTHS
+    type: ESelfKnowledgeCategory.STRENGTHS,
+    mandatory: true
   }
 
   const anotherMockCategory: SelfKnowledgeCategoryDTO = {
-    id: 'category-456',
-    title: 'Mes centres d\'intérêt',
-    description: 'Interest category',
-    type: ESelfKnowledgeCategoryType.INTERESTS
+    type: ESelfKnowledgeCategory.INTERESTS,
+    mandatory: false
   }
 
   beforeEach(() => {

--- a/src/features/student/selfKnowledge/utils/category.utils.test.ts
+++ b/src/features/student/selfKnowledge/utils/category.utils.test.ts
@@ -1,20 +1,20 @@
-import { ESelfKnowledgeCategoryType } from '@/api/avenir-esr'
+import { ESelfKnowledgeCategory } from '@/api/avenir-esr'
 import { getSelfKnowledgeCategoryIcon } from '@/features/student/selfKnowledge/utils/category.utils'
 import { MDI_ICONS, RI_ICONS } from '@avenirs-esr/avenirs-dsav'
 import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { beforeEach, expect } from 'vitest'
 
 BddTest().given('the getCategoryIcon utility function', () => {
-  const testCases: { categoryType: ESelfKnowledgeCategoryType, expectedIcon: string }[] = [
-    { categoryType: ESelfKnowledgeCategoryType.VALUES, expectedIcon: MDI_ICONS.DIAMOND_STONE },
-    { categoryType: ESelfKnowledgeCategoryType.STRENGTHS, expectedIcon: MDI_ICONS.WEIGHTS },
-    { categoryType: ESelfKnowledgeCategoryType.ASPIRATIONS, expectedIcon: RI_ICONS.HAND_HEART_LINE },
-    { categoryType: ESelfKnowledgeCategoryType.IMPROVEMENT, expectedIcon: MDI_ICONS.STAR_SHOOTING_OUTLINE },
-    { categoryType: ESelfKnowledgeCategoryType.INSPIRATIONS, expectedIcon: MDI_ICONS.STAR_SHOOTING_OUTLINE },
-    { categoryType: ESelfKnowledgeCategoryType.INTERESTS, expectedIcon: MDI_ICONS.STAR_SHOOTING_OUTLINE },
-    { categoryType: ESelfKnowledgeCategoryType.MOTIVATION, expectedIcon: MDI_ICONS.STAR_SHOOTING_OUTLINE },
-    { categoryType: ESelfKnowledgeCategoryType.OBLIGATIONS, expectedIcon: MDI_ICONS.STAR_SHOOTING_OUTLINE },
-    { categoryType: ESelfKnowledgeCategoryType.TESTIMONIALS, expectedIcon: MDI_ICONS.STAR_SHOOTING_OUTLINE },
+  const testCases: { categoryType: ESelfKnowledgeCategory, expectedIcon: string }[] = [
+    { categoryType: ESelfKnowledgeCategory.VALUES, expectedIcon: MDI_ICONS.DIAMOND_STONE },
+    { categoryType: ESelfKnowledgeCategory.STRENGTHS, expectedIcon: MDI_ICONS.WEIGHTS },
+    { categoryType: ESelfKnowledgeCategory.ASPIRATIONS, expectedIcon: RI_ICONS.HAND_HEART_LINE },
+    { categoryType: ESelfKnowledgeCategory.IMPROVEMENT, expectedIcon: MDI_ICONS.STAR_SHOOTING_OUTLINE },
+    { categoryType: ESelfKnowledgeCategory.INSPIRATIONS, expectedIcon: MDI_ICONS.STAR_SHOOTING_OUTLINE },
+    { categoryType: ESelfKnowledgeCategory.INTERESTS, expectedIcon: MDI_ICONS.STAR_SHOOTING_OUTLINE },
+    { categoryType: ESelfKnowledgeCategory.MOTIVATION, expectedIcon: MDI_ICONS.STAR_SHOOTING_OUTLINE },
+    { categoryType: ESelfKnowledgeCategory.OBLIGATIONS, expectedIcon: MDI_ICONS.STAR_SHOOTING_OUTLINE },
+    { categoryType: ESelfKnowledgeCategory.TESTIMONIALS, expectedIcon: MDI_ICONS.STAR_SHOOTING_OUTLINE },
   ]
 
   testCases.forEach(({ categoryType, expectedIcon }) => {

--- a/src/features/student/selfKnowledge/utils/category.utils.ts
+++ b/src/features/student/selfKnowledge/utils/category.utils.ts
@@ -1,17 +1,21 @@
-import { ESelfKnowledgeCategoryType } from '@/api/avenir-esr'
+import { ESelfKnowledgeCategory } from '@/api/avenir-esr'
 import { MDI_ICONS, RI_ICONS } from '@avenirs-esr/avenirs-dsav'
 
 export const CATEGORY_ELEMENTS_PAGE_SIZE = 3
 
-export function getSelfKnowledgeCategoryIcon (categoryType: ESelfKnowledgeCategoryType): string {
+export function getSelfKnowledgeCategoryIcon (categoryType: ESelfKnowledgeCategory): string {
   switch (categoryType) {
-    case ESelfKnowledgeCategoryType.VALUES:
+    case ESelfKnowledgeCategory.VALUES:
       return MDI_ICONS.DIAMOND_STONE
-    case ESelfKnowledgeCategoryType.STRENGTHS:
+    case ESelfKnowledgeCategory.STRENGTHS:
       return MDI_ICONS.WEIGHTS
-    case ESelfKnowledgeCategoryType.ASPIRATIONS:
+    case ESelfKnowledgeCategory.ASPIRATIONS:
       return RI_ICONS.HAND_HEART_LINE
     default:
       return MDI_ICONS.STAR_SHOOTING_OUTLINE
   }
+}
+
+export function toSelfKnowledgeCategoriesParam (categoryType: ESelfKnowledgeCategory): ESelfKnowledgeCategory[] {
+  return [categoryType]
 }

--- a/src/features/student/selfKnowledge/views/SelfKnowledgeCategoryView/SelfKnowledgeCategoryView.test.ts
+++ b/src/features/student/selfKnowledge/views/SelfKnowledgeCategoryView/SelfKnowledgeCategoryView.test.ts
@@ -86,7 +86,7 @@ const stubs = {
 
 BddTest().given('a self knowledge category view component', () => {
   let wrapper: VueWrapper<InstanceType<typeof SelfKnowledgeCategoryView>>
-  const categoryId = '4aec2faa-d986-4553-a14b-2ecabba415c8'
+  const categoryId = 'STRENGTHS'
 
   const mountComponentWithDefaults = async () => {
     wrapper = mountComponent(SelfKnowledgeCategoryView, {

--- a/src/features/student/selfKnowledge/views/SelfKnowledgeCategoryView/SelfKnowledgeCategoryView.vue
+++ b/src/features/student/selfKnowledge/views/SelfKnowledgeCategoryView/SelfKnowledgeCategoryView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { Ref } from 'vue'
-import { invalidateGetSelfKnowledgeElements, useDeleteSelfKnowledgeElements, useGetSelfKnowledgeElementDetails } from '@/api/avenir-esr'
+import { type ESelfKnowledgeCategory, invalidateGetSelfKnowledgeElements, useDeleteSelfKnowledgeElements, useGetSelfKnowledgeElementDetails } from '@/api/avenir-esr'
 import ConfirmationModal from '@/common/components/ConfirmationModal/ConfirmationModal.vue'
 import DetailedPageTitle from '@/common/components/DetailedPageTitle/DetailedPageTitle.vue'
 import ErrorMessage from '@/common/components/feedback/ErrorMessage/ErrorMessage.vue'
@@ -32,7 +32,9 @@ const { navigateToStudentSelfKnowledgeElementUpdate, navigateToStudentTrajectori
 const { showModal: showConfirmModal, displayModal: displayConfirmModal, hideModal: hideConfirmModal } = useModal()
 const { addErrorMessage, addSuccessMessage } = useToasterStore()
 
-const { categoryType } = useSelfKnowledgeCategory(computed(() => props.categoryId))
+const categoryId = computed(() => props.categoryId as ESelfKnowledgeCategory)
+
+const { categoryType } = useSelfKnowledgeCategory(categoryId)
 
 const breadcrumbLinks = computed(() => [
   { text: t('student.global.navigation.tabs.home'), to: ROUTES.STUDENT.HOME },
@@ -49,7 +51,7 @@ const {
   pageInfo,
   loadMoreElements
 } = useSelfKnowledgePaginatedElements({
-  selfKnowledgeCategoryId: props.categoryId
+  selfKnowledgeCategory: categoryId
 })
 
 const { data: selectedElementDetails, error } = useGetSelfKnowledgeElementDetails(selectedElementId)
@@ -67,7 +69,7 @@ function deleteSelfKnowledgeElement () {
       description: getErrorMessage(error)
     }),
     onSuccess: async () => {
-      await withTaskLoading(() => invalidateGetSelfKnowledgeElements(queryClient, props.categoryId))
+      await withTaskLoading(() => invalidateGetSelfKnowledgeElements(queryClient))
       addSuccessMessage(
         t('student.selfKnowledge.SelfKnowledgeMainSection.categoryElementsPaginator.modals.deleteElements.success', { count: 1 })
       )

--- a/src/features/student/selfKnowledge/views/SelfKnowledgeElementUpdateView/SelfKnowledgeElementUpdateView.test.ts
+++ b/src/features/student/selfKnowledge/views/SelfKnowledgeElementUpdateView/SelfKnowledgeElementUpdateView.test.ts
@@ -72,7 +72,7 @@ BddTest().given('a self knowledge element update view', () => {
     UpdateInProgressBadge: UpdateInProgressBadgeStub
   }
 
-  const categoryId = '4aec2faa-d986-4553-a14b-2ecabba415c8'
+  const categoryId = 'STRENGTHS'
   const elementId = '1'
 
   BddTest().when('the view is rendered', () => {

--- a/src/features/student/selfKnowledge/views/SelfKnowledgeElementUpdateView/SelfKnowledgeElementUpdateView.vue
+++ b/src/features/student/selfKnowledge/views/SelfKnowledgeElementUpdateView/SelfKnowledgeElementUpdateView.vue
@@ -1,4 +1,5 @@
 <script lang="ts" setup>
+import type { ESelfKnowledgeCategory } from '@/api/avenir-esr'
 import { useGetSelfKnowledgeElementDetails } from '@/api/avenir-esr'
 import UpdatePageTitle from '@/common/components/UpdatePageTitle/UpdatePageTitle.vue'
 import { useNavigation } from '@/common/composables'
@@ -28,17 +29,19 @@ const {
   navigateToStudentSelfKnowledgeCategory
 } = useNavigation()
 
+const categoryId = computed(() => props.categoryId as ESelfKnowledgeCategory)
+
 const {
   categoryType,
   categoryTypeLabel
-} = useSelfKnowledgeCategory(computed(() => props.categoryId))
+} = useSelfKnowledgeCategory(categoryId)
 
 const {
   elements,
   pageInfo,
   loadMoreElements
 } = useSelfKnowledgePaginatedElements({
-  selfKnowledgeCategoryId: computed(() => props.categoryId),
+  selfKnowledgeCategory: categoryId,
 })
 
 const breadcrumbLinks = computed(() => [


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> Self-knowledge categories (VALUES, STRENGTHS, ASPIRATIONS) are now represented by a fixed `ESelfKnowledgeCategory` enum instead of entities fetched from the API with their own IDs. Category titles, descriptions, and labels are now sourced from i18n rather than API responses. Fixtures, MSW handlers, and the swagger spec were updated to match the new API shape, and all self-knowledge components/composables (category view, element cards, drawers, modals, dropdowns, side menu, tabs, build project nodes) were adapted accordingly.

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/2361

---

### Documentation
> Updated `api-specs/avenir-esr.swagger.json` to reflect the new self-knowledge category enum shape.

---

### Target Branch
> `develop`

---

### Additional Notes
> Since orval generates a distinct enum per inline query-param schema, a helper (`toSelfKnowledgeCategoriesParam`) was added to bridge `ESelfKnowledgeCategory` to the endpoint-specific enum type even though both share the same string values.

---

### Known Limitations or Side Effects
> None identified.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [ ] No unnecessary code (e.g., debug logs, commented code)
- [ ] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process