### PR TITLE
feat(2163): display declared experiences in kit view

### DIFF
--- a/src/__mocks__/fixtures/student/declaredExperiences.fixtures.ts
+++ b/src/__mocks__/fixtures/student/declaredExperiences.fixtures.ts
@@ -29,11 +29,11 @@ export const declaredExperienceViewDTOFixture: DeclaredExperienceViewDTO = {
 
 function createMockedDeclaredExperiences (count: number): DeclaredExperienceViewDTO[] {
   const experiencesExample = [
-    { title: 'Développeur Junior', experienceType: EExperienceType.PROFESSIONAL, location: 'La Poste' },
-    { title: 'Assistant Marketing', experienceType: EExperienceType.PROFESSIONAL, location: 'Les Subsistances, Lyon' },
-    { title: 'Bénévole Associatif', experienceType: EExperienceType.PERSONAL, location: 'La Poste' },
-    { title: 'Contributeur Github', experienceType: EExperienceType.PERSONAL, location: 'Les Subsistances, Lyon' },
-    { title: 'Conseiller Vendeur', experienceType: EExperienceType.PROFESSIONAL, location: 'Marseille, France' }
+    { title: 'Développeur Junior', experienceType: EExperienceType.PROFESSIONAL, location: 'La Poste', description: 'Développement et maintenance d\'applications internes en équipe agile.' },
+    { title: 'Assistant Marketing', experienceType: EExperienceType.PROFESSIONAL, location: 'Les Subsistances, Lyon', description: 'Gestion des réseaux sociaux et création de supports de communication.' },
+    { title: 'Bénévole Associatif', experienceType: EExperienceType.PERSONAL, location: 'La Poste', description: 'Distribution alimentaire hebdomadaire auprès des personnes en difficulté.' },
+    { title: 'Contributeur Github', experienceType: EExperienceType.PERSONAL, location: 'Les Subsistances, Lyon', description: 'Contributions open source sur des projets Vue.js et TypeScript.' },
+    { title: 'Conseiller Vendeur', experienceType: EExperienceType.PROFESSIONAL, location: 'Marseille, France', description: 'Accueil et conseil client en magasin, gestion des stocks.' }
   ]
   const experiences: DeclaredExperienceViewDTO[] = []
 
@@ -45,6 +45,7 @@ function createMockedDeclaredExperiences (count: number): DeclaredExperienceView
       experienceType: experience.experienceType,
       organization: `Organization ${i}`,
       location: experience.location,
+      description: experience.description,
       startDate: '2023-01',
       createdAt: '2024-01-15T10:30:00Z',
       updatedAt: '2024-01-15T10:30:00Z'

--- a/src/__mocks__/msw/handlers/student/declaredExperiences.handlers.ts
+++ b/src/__mocks__/msw/handlers/student/declaredExperiences.handlers.ts
@@ -8,6 +8,7 @@ import {
   type DeclaredExperienceAssociationsDTO,
   type DeclaredExperienceViewDTO,
   getCreateDeclaredExperienceUrl,
+  type GetDeclaredExperienceViewParams,
   getDeleteDeclaredExperiencesUrl,
   getGetDeclaredExperienceAssociationsUrl,
   getGetDeclaredExperienceUrl,
@@ -32,6 +33,27 @@ export const declaredExperiencesQueryHandler = http.get(`*${getGetDeclaredExperi
     headers: { 'Content-Type': 'application/json' }
   })
 })
+
+export function createDeclaredExperienceViewHandler (
+  payload: PagedResponseDeclaredExperienceViewDTO,
+  onRequest?: (params: GetDeclaredExperienceViewParams) => void
+) {
+  return http.get(`*${getGetDeclaredExperienceViewUrl()}`, ({ request }) => {
+    if (onRequest) {
+      const searchParams = new URL(request.url).searchParams
+      onRequest({
+        page: searchParams.has('page') ? Number(searchParams.get('page')) : undefined,
+        pageSize: searchParams.has('pageSize') ? Number(searchParams.get('pageSize')) : undefined,
+        isValorized: searchParams.has('isValorized') ? searchParams.get('isValorized') === 'true' : undefined
+      })
+    }
+
+    return HttpResponse.json<PagedResponseDeclaredExperienceViewDTO>(payload, {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' }
+    })
+  })
+}
 
 export const declaredExperiencesQueryErrorHandler = http.get(`*${getGetDeclaredExperienceViewUrl()}`, () => {
   return HttpResponse.json(

--- a/src/features/student/kit/components/cards/ValorizedElementsCardContainer/ValorizedElementsCardContainer.stub.ts
+++ b/src/features/student/kit/components/cards/ValorizedElementsCardContainer/ValorizedElementsCardContainer.stub.ts
@@ -4,11 +4,17 @@ export const ValorizedElementsCardContainerStub = defineComponent({
     title: { type: String, required: true },
     error: { type: Object, default: null },
     isLoading: { type: Boolean, default: false },
+    isEmpty: { type: Boolean, default: false },
+    emptyStateMessage: { type: String, default: undefined },
+    seeAllLabel: { type: String, default: undefined },
+    seeAllTo: { type: [String, Object], default: undefined }
   },
   template: `
     <div data-testid="valorized-elements-card-container-stub">
       <div data-testid="valorized-elements-card-container-title">{{ title }}</div>
-      <slot />
+      <slot v-if="!isEmpty" />
+      <div v-else data-testid="valorized-elements-card-container-empty">{{ emptyStateMessage }}</div>
+      <div v-if="seeAllLabel" data-testid="valorized-elements-card-container-see-all">{{ seeAllLabel }}</div>
     </div>
   `,
 })

--- a/src/features/student/kit/components/cards/ValorizedElementsCardContainer/ValorizedElementsCardContainer.test.ts
+++ b/src/features/student/kit/components/cards/ValorizedElementsCardContainer/ValorizedElementsCardContainer.test.ts
@@ -4,7 +4,7 @@ import { BaseApiException } from '@/common/exceptions'
 import ValorizedElementsCardContainer, {
   type ValorizedElementsCardContainerProps
 } from '@/features/student/kit/components/cards/ValorizedElementsCardContainer/ValorizedElementsCardContainer.vue'
-import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { AvButtonStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { mount, type VueWrapper } from '@vue/test-utils'
 import { beforeEach, expect } from 'vitest'
 
@@ -13,7 +13,8 @@ BddTest().given('a valorized elements card container', () => {
 
   const stubs = {
     Card: CardStub,
-    QuerySuspense: QuerySuspenseStub
+    QuerySuspense: QuerySuspenseStub,
+    AvButton: AvButtonStub
   }
 
   const props: ValorizedElementsCardContainerProps = {
@@ -76,6 +77,48 @@ BddTest().given('a valorized elements card container', () => {
 
     BddTest().then('it should forward the error to QuerySuspense', () => {
       expect(wrapper.findComponent(QuerySuspenseStub).props('error')).toEqual(error)
+    })
+  })
+
+  BddTest().when('it is empty with a custom empty state message', () => {
+    beforeEach(() => {
+      wrapper = mount(ValorizedElementsCardContainer, {
+        props: { ...props, isEmpty: true, emptyStateMessage: 'Aucun élément valorisé' },
+        global: { stubs },
+      })
+    })
+
+    BddTest().then('it should forward isEmpty and emptyStateMessage to QuerySuspense', () => {
+      const querySuspense = wrapper.findComponent(QuerySuspenseStub)
+      expect(querySuspense.props('isEmpty')).toBe(true)
+      expect(querySuspense.props('emptyStateMessage')).toBe('Aucun élément valorisé')
+    })
+  })
+
+  BddTest().when('seeAllLabel and seeAllTo are provided', () => {
+    beforeEach(() => {
+      wrapper = mount(ValorizedElementsCardContainer, {
+        props: { ...props, seeAllLabel: 'Voir tout', seeAllTo: { name: 'some-route' } },
+        global: { stubs },
+      })
+    })
+
+    BddTest().then('it should render the see all button in the card title, right-aligned next to the title', () => {
+      const button = wrapper.findComponent(AvButtonStub)
+      expect(button.exists()).toBe(true)
+      expect(button.props('label')).toBe('Voir tout')
+      expect(button.props('to')).toEqual({ name: 'some-route' })
+      expect(wrapper.find('[data-testid="card-stub-title"]').findComponent(AvButtonStub).exists()).toBe(true)
+    })
+  })
+
+  BddTest().when('seeAllLabel and seeAllTo are not provided', () => {
+    beforeEach(() => {
+      wrapper = mount(ValorizedElementsCardContainer, { props, global: { stubs } })
+    })
+
+    BddTest().then('it should not render a see all button', () => {
+      expect(wrapper.find('[data-testid="see-all-button"]').exists()).toBe(false)
     })
   })
 })

--- a/src/features/student/kit/components/cards/ValorizedElementsCardContainer/ValorizedElementsCardContainer.vue
+++ b/src/features/student/kit/components/cards/ValorizedElementsCardContainer/ValorizedElementsCardContainer.vue
@@ -1,15 +1,33 @@
 <script setup lang="ts">
 import type { BaseApiException } from '@/common/exceptions'
+import type { Slot } from 'vue'
 import Card from '@/common/components/cards/Card/Card.vue'
 import QuerySuspense from '@/common/components/QuerySuspense/QuerySuspense.vue'
+import { AvButton, type AvButtonProps, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
 
 export interface ValorizedElementsCardContainerProps {
   title: string
   error?: BaseApiException | null
   isLoading?: boolean
+  isEmpty?: boolean
+  emptyStateMessage?: string
+  seeAllLabel?: string
+  seeAllTo?: AvButtonProps['to']
 }
 
-const { title, error = null, isLoading = false } = defineProps<ValorizedElementsCardContainerProps>()
+const {
+  title,
+  error = null,
+  isLoading = false,
+  isEmpty = false,
+  emptyStateMessage,
+  seeAllLabel,
+  seeAllTo
+} = defineProps<ValorizedElementsCardContainerProps>()
+
+defineSlots<{
+  default?: Slot
+}>()
 </script>
 
 <template>
@@ -21,13 +39,25 @@ const { title, error = null, isLoading = false } = defineProps<ValorizedElements
     title-background="var(--card)"
   >
     <template #title>
-      <span class="s1-regular">
-        {{ title }}
-      </span>
+      <div class="av-row av-align-center av-justify-between av-gap-sm av-w-full">
+        <span class="s1-regular">
+          {{ title }}
+        </span>
+        <AvButton
+          v-if="seeAllLabel && seeAllTo"
+          :label="seeAllLabel"
+          :icon="MDI_ICONS.ARROW_RIGHT_THIN"
+          small
+          :to="seeAllTo"
+          data-testid="see-all-button"
+        />
+      </div>
     </template>
     <QuerySuspense
       :error="error"
       :is-loading="isLoading"
+      :is-empty="isEmpty"
+      :empty-state-message="emptyStateMessage"
     >
       <slot />
     </QuerySuspense>

--- a/src/features/student/kit/locales/en.json
+++ b/src/features/student/kit/locales/en.json
@@ -1,6 +1,11 @@
 {
   "student": {
     "kit": {
+      "cards": {
+        "ValorizedElementsCardContainer": {
+          "emptyState": "You have not valorized this type of content yet, add and valorize {item} to build your kit"
+        }
+      },
       "views": {
         "StudentToolsKitView": {
           "consign": "Find all the content you have valorized here. Pick, sort, add, delete, and export it to create your CV, portfolio, LinkedIn profile, or cover letter!",
@@ -24,7 +29,14 @@
           "valorizedAssociatedTracesContainer": {
             "title": "My associated trace (1) | My associated traces ({count})"
           },
+          "valorizedDeclaredExperiencesContainer": {
+            "emptyStateItemLabel": "an experience",
+            "seeAll": "See all my other experiences",
+            "title": "Other experience (1) | Other experiences ({count})"
+          },
           "valorizedDeclaredSkillsContainer": {
+            "emptyStateItemLabel": "a skill",
+            "seeAll": "See all my declared skills",
             "title": "My valorized declared skill (1) | My valorized declared skills ({count})"
           },
           "valorizedNonAssociatedTracesContainer": {

--- a/src/features/student/kit/locales/fr.json
+++ b/src/features/student/kit/locales/fr.json
@@ -1,6 +1,11 @@
 {
   "student": {
     "kit": {
+      "cards": {
+        "ValorizedElementsCardContainer": {
+          "emptyState": "Vous n'avez pas encore valorisé ce type de contenu, ajoutez et valorisez {item} afin de constituer votre kit"
+        }
+      },
       "views": {
         "StudentToolsKitView": {
           "consign": "Retrouvez ici tout le contenu que vous avez valorisé. Piochez, triez, ajoutez, supprimez et exportez-le pour créer votre CV, votre portfolio, votre profil linkedIn ou votre lettre de motivation !",
@@ -24,7 +29,14 @@
           "valorizedAssociatedTracesContainer": {
             "title": "Ma trace associée (1) | Mes traces associées ({count})"
           },
+          "valorizedDeclaredExperiencesContainer": {
+            "emptyStateItemLabel": "une expérience",
+            "seeAll": "Voir toutes mes autres expériences",
+            "title": "Autre expérience (1) | Autres expériences ({count})"
+          },
           "valorizedDeclaredSkillsContainer": {
+            "emptyStateItemLabel": "une compétence",
+            "seeAll": "Voir toutes mes compétences déclarées",
             "title": "Ma compétence déclarée valorisée (1) | Mes compétences déclarées valorisées ({count})"
           },
           "valorizedNonAssociatedTracesContainer": {

--- a/src/features/student/kit/views/StudentToolsKitView/components/KitTextContentTab/KitTextContentTab.test.ts
+++ b/src/features/student/kit/views/StudentToolsKitView/components/KitTextContentTab/KitTextContentTab.test.ts
@@ -1,11 +1,13 @@
 import type { VueWrapper } from '@vue/test-utils'
 import KitTextContentTab from '@/features/student/kit/views/StudentToolsKitView/components/KitTextContentTab/KitTextContentTab.vue'
+import { ValorizedDeclaredExperiencesContainerStub } from '@/features/student/kit/views/StudentToolsKitView/components/ValorizedDeclaredExperiencesContainer/ValorizedDeclaredExperiencesContainer.stub'
 import { ValorizedDeclaredSkillsContainerStub } from '@/features/student/kit/views/StudentToolsKitView/components/ValorizedDeclaredSkillsContainer/ValorizedDeclaredSkillsContainer.stub'
 import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { mountComponent } from 'tests/utils'
 
 const stubs = {
-  ValorizedDeclaredSkillsContainer: ValorizedDeclaredSkillsContainerStub
+  ValorizedDeclaredSkillsContainer: ValorizedDeclaredSkillsContainerStub,
+  ValorizedDeclaredExperiencesContainer: ValorizedDeclaredExperiencesContainerStub
 }
 
 BddTest().given('a kit text content tab', () => {
@@ -16,12 +18,12 @@ BddTest().given('a kit text content tab', () => {
       wrapper = mountComponent(KitTextContentTab, { global: { stubs } })
     })
 
-    BddTest().then('it should display the placeholder text', () => {
-      expect(wrapper.text()).toContain('Placeholder - TODO in one of them #1307 #1308 #1314 #1310 #1995 #1926')
-    })
-
     BddTest().then('it should render the valorized declared skills container', () => {
       expect(wrapper.findComponent(ValorizedDeclaredSkillsContainerStub).exists()).toBe(true)
+    })
+
+    BddTest().then('it should render the valorized declared experiences container', () => {
+      expect(wrapper.findComponent(ValorizedDeclaredExperiencesContainerStub).exists()).toBe(true)
     })
   })
 })

--- a/src/features/student/kit/views/StudentToolsKitView/components/KitTextContentTab/KitTextContentTab.vue
+++ b/src/features/student/kit/views/StudentToolsKitView/components/KitTextContentTab/KitTextContentTab.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
+import ValorizedDeclaredExperiencesContainer from '@/features/student/kit/views/StudentToolsKitView/components/ValorizedDeclaredExperiencesContainer/ValorizedDeclaredExperiencesContainer.vue'
 import ValorizedDeclaredSkillsContainer from '@/features/student/kit/views/StudentToolsKitView/components/ValorizedDeclaredSkillsContainer/ValorizedDeclaredSkillsContainer.vue'
 </script>
 
 <template>
   <div class="av-col av-gap-md">
-    <p>Placeholder - TODO in one of them #1307 #1308 #1314 #1310 #1995 #1926</p>
     <ValorizedDeclaredSkillsContainer />
+    <ValorizedDeclaredExperiencesContainer />
   </div>
 </template>

--- a/src/features/student/kit/views/StudentToolsKitView/components/ValorizedDeclaredExperienceItem/ValorizedDeclaredExperienceItem.stub.ts
+++ b/src/features/student/kit/views/StudentToolsKitView/components/ValorizedDeclaredExperienceItem/ValorizedDeclaredExperienceItem.stub.ts
@@ -1,0 +1,10 @@
+import type { DeclaredExperienceViewDTO } from '@/api/avenir-esr'
+import type { PropType } from 'vue'
+
+export const ValorizedDeclaredExperienceItemStub = defineComponent({
+  name: 'ValorizedDeclaredExperienceItem',
+  template: '<div data-testid="valorized-declared-experience-item-stub" />',
+  props: {
+    declaredExperience: { type: Object as PropType<DeclaredExperienceViewDTO>, required: true }
+  }
+})

--- a/src/features/student/kit/views/StudentToolsKitView/components/ValorizedDeclaredExperienceItem/ValorizedDeclaredExperienceItem.test.ts
+++ b/src/features/student/kit/views/StudentToolsKitView/components/ValorizedDeclaredExperienceItem/ValorizedDeclaredExperienceItem.test.ts
@@ -1,0 +1,120 @@
+import type { DeclaredExperienceViewDTO } from '@/api/avenir-esr'
+import type { VueWrapper } from '@vue/test-utils'
+import { EExperienceType } from '@/api/avenir-esr'
+import { ROUTES } from '@/common/constants'
+import ValorizedDeclaredExperienceItem from '@/features/student/kit/views/StudentToolsKitView/components/ValorizedDeclaredExperienceItem/ValorizedDeclaredExperienceItem.vue'
+import { AvBadgeStub, AvButtonStub, AvTooltipStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { flushPromises } from '@vue/test-utils'
+import { mountComponent } from 'tests/utils'
+
+const BASE_DECLARED_EXPERIENCE: DeclaredExperienceViewDTO = {
+  id: 'c1e6a6f0-1c2d-4f3e-9a1b-3f2b1c0d4e5f',
+  title: 'Bénévole Associatif',
+  experienceType: EExperienceType.PERSONAL,
+  organization: 'Croix-Rouge',
+  description: 'Distribution alimentaire hebdomadaire auprès des personnes en difficulté',
+  startDate: '2023-01',
+  endDate: '2023-06',
+  createdAt: '2024-01-15T10:30:00Z',
+  updatedAt: '2024-01-15T10:30:00Z'
+}
+
+const stubs = {
+  AvButton: AvButtonStub,
+  AvTooltip: AvTooltipStub,
+  AvBadge: AvBadgeStub
+}
+
+function mountValorizedDeclaredExperienceItem (declaredExperience: DeclaredExperienceViewDTO) {
+  return mountComponent(ValorizedDeclaredExperienceItem, {
+    props: { declaredExperience },
+    global: { stubs }
+  })
+}
+
+BddTest().given('a valorized declared experience item', () => {
+  let wrapper: VueWrapper<InstanceType<typeof ValorizedDeclaredExperienceItem>>
+
+  BddTest().when('the component is mounted', () => {
+    beforeEach(async () => {
+      wrapper = mountValorizedDeclaredExperienceItem(BASE_DECLARED_EXPERIENCE)
+      await flushPromises()
+    })
+
+    BddTest().then('it should render the wrapped ValorizedItem with the experience title', () => {
+      expect(wrapper.find('[data-testid="valorized-item"]').exists()).toBe(true)
+      expect(wrapper.find('.title').text()).toBe(BASE_DECLARED_EXPERIENCE.title)
+    })
+
+    BddTest().then('it should render the access button pointing to the declared experience route', () => {
+      const button = wrapper.findComponent(AvButtonStub)
+      expect(button.props('to')).toEqual({
+        name: ROUTES.STUDENT.DECLARED_EXPERIENCE.name,
+        params: { id: BASE_DECLARED_EXPERIENCE.id }
+      })
+    })
+
+    BddTest().then('it should render the period badge', () => {
+      const labels = wrapper.findAllComponents(AvBadgeStub).map(badge => badge.props('label'))
+      expect(labels).toContain('01/2023 - 06/2023')
+    })
+
+    BddTest().then('it should render the organization badge', () => {
+      const labels = wrapper.findAllComponents(AvBadgeStub).map(badge => badge.props('label'))
+      expect(labels).toContain(BASE_DECLARED_EXPERIENCE.organization)
+    })
+
+    BddTest().then('it should render the experience type badge', () => {
+      const labels = wrapper.findAllComponents(AvBadgeStub).map(badge => badge.props('label'))
+      expect(labels).toContain('Expérience personnelle')
+    })
+
+    BddTest().then('it should render the description', () => {
+      expect(wrapper.text()).toContain(BASE_DECLARED_EXPERIENCE.description)
+    })
+  })
+
+  BddTest().when('the experience has no description', () => {
+    beforeEach(async () => {
+      wrapper = mountValorizedDeclaredExperienceItem({
+        ...BASE_DECLARED_EXPERIENCE,
+        description: undefined
+      })
+      await flushPromises()
+    })
+
+    BddTest().then('it should not render a description', () => {
+      expect(wrapper.text()).not.toContain(BASE_DECLARED_EXPERIENCE.description)
+    })
+  })
+
+  BddTest().when('the experience has no experience type', () => {
+    beforeEach(async () => {
+      wrapper = mountValorizedDeclaredExperienceItem({
+        ...BASE_DECLARED_EXPERIENCE,
+        experienceType: undefined
+      })
+      await flushPromises()
+    })
+
+    BddTest().then('it should not render the experience type badge', () => {
+      const labels = wrapper.findAllComponents(AvBadgeStub).map(badge => badge.props('label'))
+      expect(labels).not.toContain('Expérience personnelle')
+    })
+  })
+
+  BddTest().when('the experience has no end date', () => {
+    beforeEach(async () => {
+      wrapper = mountValorizedDeclaredExperienceItem({
+        ...BASE_DECLARED_EXPERIENCE,
+        endDate: undefined
+      })
+      await flushPromises()
+    })
+
+    BddTest().then('it should render the period badge as ongoing', () => {
+      const labels = wrapper.findAllComponents(AvBadgeStub).map(badge => badge.props('label'))
+      expect(labels).toContain('01/2023 - En cours')
+    })
+  })
+})

--- a/src/features/student/kit/views/StudentToolsKitView/components/ValorizedDeclaredExperienceItem/ValorizedDeclaredExperienceItem.vue
+++ b/src/features/student/kit/views/StudentToolsKitView/components/ValorizedDeclaredExperienceItem/ValorizedDeclaredExperienceItem.vue
@@ -1,0 +1,39 @@
+<script lang="ts" setup>
+import type { DeclaredExperienceViewDTO } from '@/api/avenir-esr'
+import PeriodBadge from '@/common/activities/badges/PeriodBadge/PeriodBadge.vue'
+import { ValorizedItemType } from '@/features/student/kit/types/valorized.types'
+import ValorizedItem from '@/features/student/kit/views/StudentToolsKitView/components/ValorizedItem/ValorizedItem.vue'
+import { DeclaredExperienceOrganizationBadge, DeclaredExperienceTypeBadge } from '@/features/student/personalCareer'
+
+export interface ValorizedDeclaredExperienceItemProps {
+  declaredExperience: DeclaredExperienceViewDTO
+}
+
+const { declaredExperience } = defineProps<ValorizedDeclaredExperienceItemProps>()
+</script>
+
+<template>
+  <ValorizedItem
+    :title="declaredExperience.title"
+    :item-id="declaredExperience.id"
+    :type="ValorizedItemType.DECLARED_EXPERIENCE"
+  >
+    <DeclaredExperienceOrganizationBadge :organization="declaredExperience.organization" />
+    <span
+      v-if="declaredExperience.description"
+      class="b2-regular av-max-lines"
+    >
+      {{ declaredExperience.description }}
+    </span>
+    <div class="av-row av-align-center av-wrap av-gap-xs">
+      <DeclaredExperienceTypeBadge
+        v-if="declaredExperience.experienceType"
+        :experience-type="declaredExperience.experienceType"
+      />
+      <PeriodBadge
+        :start-date="declaredExperience.startDate"
+        :end-date="declaredExperience.endDate"
+      />
+    </div>
+  </ValorizedItem>
+</template>

--- a/src/features/student/kit/views/StudentToolsKitView/components/ValorizedDeclaredExperiencesContainer/ValorizedDeclaredExperiencesContainer.stub.ts
+++ b/src/features/student/kit/views/StudentToolsKitView/components/ValorizedDeclaredExperiencesContainer/ValorizedDeclaredExperiencesContainer.stub.ts
@@ -1,0 +1,4 @@
+export const ValorizedDeclaredExperiencesContainerStub = defineComponent({
+  name: 'ValorizedDeclaredExperiencesContainer',
+  template: '<div data-testid="valorized-declared-experiences-container-stub" />',
+})

--- a/src/features/student/kit/views/StudentToolsKitView/components/ValorizedDeclaredExperiencesContainer/ValorizedDeclaredExperiencesContainer.test.ts
+++ b/src/features/student/kit/views/StudentToolsKitView/components/ValorizedDeclaredExperiencesContainer/ValorizedDeclaredExperiencesContainer.test.ts
@@ -1,0 +1,141 @@
+import type { GetDeclaredExperienceViewParams } from '@/api/avenir-esr'
+import { createMockedDeclaredExperiencesPagedResponse } from '@/__mocks__/fixtures/student/declaredExperiences.fixtures'
+import { createDeclaredExperienceViewHandler, declaredExperiencesQueryErrorHandler } from '@/__mocks__/msw/handlers/student/declaredExperiences.handlers'
+import { server } from '@/__mocks__/msw/server'
+import { EExperienceType } from '@/api/avenir-esr'
+import { ValorizedElementsCardContainerStub } from '@/features/student/kit/components/cards/ValorizedElementsCardContainer/ValorizedElementsCardContainer.stub'
+import { ValorizedDeclaredExperienceItemStub } from '@/features/student/kit/views/StudentToolsKitView/components/ValorizedDeclaredExperienceItem/ValorizedDeclaredExperienceItem.stub'
+import ValorizedDeclaredExperiencesContainer from '@/features/student/kit/views/StudentToolsKitView/components/ValorizedDeclaredExperiencesContainer/ValorizedDeclaredExperiencesContainer.vue'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { flushPromises, type VueWrapper } from '@vue/test-utils'
+import { mountComponent } from 'tests/utils'
+
+function personalCount (mockedResponse: ReturnType<typeof createMockedDeclaredExperiencesPagedResponse>) {
+  return mockedResponse.data.filter(experience => experience.experienceType === EExperienceType.PERSONAL).length
+}
+
+BddTest().given('a valorized declared experiences container', () => {
+  let wrapper: VueWrapper<InstanceType<typeof ValorizedDeclaredExperiencesContainer>>
+  let requestedParams: GetDeclaredExperienceViewParams
+
+  const stubs = {
+    ValorizedElementsCardContainer: ValorizedElementsCardContainerStub,
+    ValorizedDeclaredExperienceItem: ValorizedDeclaredExperienceItemStub
+  }
+
+  const mountDeclaredExperiencesContainer = async () => {
+    wrapper = mountComponent(ValorizedDeclaredExperiencesContainer, { global: { stubs } })
+    await flushPromises()
+  }
+
+  BddTest().when('the request succeeds with a mix of personal and professional experiences', () => {
+    const mockedResponse = createMockedDeclaredExperiencesPagedResponse(100, 10, 0)
+    const expectedPersonalCount = personalCount(mockedResponse)
+
+    beforeEach(async () => {
+      server.use(createDeclaredExperienceViewHandler(mockedResponse, (params) => {
+        requestedParams = params
+      }))
+
+      await mountDeclaredExperiencesContainer()
+    })
+
+    BddTest().then('it should fetch declared experiences with isValorized true and pageSize 100', () => {
+      expect(requestedParams.isValorized).toBe(true)
+      expect(requestedParams.pageSize).toBe(100)
+    })
+
+    BddTest().then('it should render the title with the count of personal experiences only', () => {
+      const container = wrapper.findComponent(ValorizedElementsCardContainerStub)
+      expect(container.exists()).toBe(true)
+      expect(container.props('title')).toBe(`Autres expériences (${expectedPersonalCount})`)
+    })
+
+    BddTest().then('it should not be loading, have no error and not be empty once fetched', () => {
+      const container = wrapper.findComponent(ValorizedElementsCardContainerStub)
+      expect(container.props('isLoading')).toBe(false)
+      expect(container.props('error')).toBe(null)
+      expect(container.props('isEmpty')).toBe(false)
+    })
+
+    BddTest().then('it should render one ValorizedDeclaredExperienceItem per personal experience only', () => {
+      const items = wrapper.findAllComponents(ValorizedDeclaredExperienceItemStub)
+      expect(items).toHaveLength(expectedPersonalCount)
+      items.forEach((item) => {
+        expect(item.props('declaredExperience').experienceType).toBe(EExperienceType.PERSONAL)
+      })
+    })
+
+    BddTest().then('it should pass the empty state message and see all link to the exhaustive experiences list', () => {
+      const container = wrapper.findComponent(ValorizedElementsCardContainerStub)
+      expect(container.props('emptyStateMessage')).toBe('Vous n\'avez pas encore valorisé ce type de contenu, ajoutez et valorisez une expérience afin de constituer votre kit')
+      expect(container.props('seeAllLabel')).toBe('Voir toutes mes autres expériences')
+      expect(container.props('seeAllTo')).toEqual({ name: 'personal-career-experiences' })
+    })
+  })
+
+  BddTest().when('the request succeeds with a single personal experience', () => {
+    const mockedResponse = createMockedDeclaredExperiencesPagedResponse(100, 2, 0)
+    const expectedPersonalCount = personalCount(mockedResponse)
+
+    beforeEach(async () => {
+      server.use(createDeclaredExperienceViewHandler(mockedResponse))
+
+      await mountDeclaredExperiencesContainer()
+    })
+
+    BddTest().then('it should render the title in the singular form', () => {
+      expect(expectedPersonalCount).toBe(1)
+      expect(wrapper.findComponent(ValorizedElementsCardContainerStub).props('title')).toBe('Autre expérience (1)')
+    })
+
+    BddTest().then('it should render a single ValorizedDeclaredExperienceItem', () => {
+      expect(wrapper.findAllComponents(ValorizedDeclaredExperienceItemStub)).toHaveLength(1)
+    })
+  })
+
+  BddTest().when('the request succeeds with only professional experiences', () => {
+    const mockedResponse = createMockedDeclaredExperiencesPagedResponse(100, 1, 0)
+
+    beforeEach(async () => {
+      expect(personalCount(mockedResponse)).toBe(0)
+      server.use(createDeclaredExperienceViewHandler(mockedResponse))
+
+      await mountDeclaredExperiencesContainer()
+    })
+
+    BddTest().then('it should render no ValorizedDeclaredExperienceItem', () => {
+      expect(wrapper.findAllComponents(ValorizedDeclaredExperienceItemStub)).toHaveLength(0)
+    })
+
+    BddTest().then('it should mark the container as empty', () => {
+      expect(wrapper.findComponent(ValorizedElementsCardContainerStub).props('isEmpty')).toBe(true)
+    })
+  })
+
+  BddTest().when('the request succeeds with 0 experiences', () => {
+    const mockedResponse = createMockedDeclaredExperiencesPagedResponse(100, 0, 0)
+
+    beforeEach(async () => {
+      server.use(createDeclaredExperienceViewHandler(mockedResponse))
+
+      await mountDeclaredExperiencesContainer()
+    })
+
+    BddTest().then('it should mark the container as empty', () => {
+      expect(wrapper.findComponent(ValorizedElementsCardContainerStub).props('isEmpty')).toBe(true)
+    })
+  })
+
+  BddTest().when('the request fails', () => {
+    beforeEach(async () => {
+      server.use(declaredExperiencesQueryErrorHandler)
+
+      await mountDeclaredExperiencesContainer()
+    })
+
+    BddTest().then('it should forward the error to the card container', () => {
+      expect(wrapper.findComponent(ValorizedElementsCardContainerStub).props('error')).toBeTruthy()
+    })
+  })
+})

--- a/src/features/student/kit/views/StudentToolsKitView/components/ValorizedDeclaredExperiencesContainer/ValorizedDeclaredExperiencesContainer.vue
+++ b/src/features/student/kit/views/StudentToolsKitView/components/ValorizedDeclaredExperiencesContainer/ValorizedDeclaredExperiencesContainer.vue
@@ -1,0 +1,44 @@
+<script setup lang="ts">
+import { EExperienceType, useGetDeclaredExperienceView } from '@/api/avenir-esr'
+import { ROUTES } from '@/common/constants'
+import ValorizedElementsCardContainer from '@/features/student/kit/components/cards/ValorizedElementsCardContainer/ValorizedElementsCardContainer.vue'
+import ValorizedDeclaredExperienceItem from '@/features/student/kit/views/StudentToolsKitView/components/ValorizedDeclaredExperienceItem/ValorizedDeclaredExperienceItem.vue'
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
+
+const { data, error, isFetching } = useGetDeclaredExperienceView(
+  { isValorized: true, pageSize: 100 }
+)
+
+const declaredExperiences = computed(() => (data.value?.data ?? []).filter(
+  declaredExperience => declaredExperience.experienceType === EExperienceType.PERSONAL
+))
+const totalElements = computed(() => declaredExperiences.value.length)
+const isEmpty = computed(() => totalElements.value === 0)
+const declaredExperiencesRoute = { name: ROUTES.STUDENT.PERSONAL_CAREER_EXPERIENCES.name }
+const emptyStateMessage = computed(() => t(
+  'student.kit.cards.ValorizedElementsCardContainer.emptyState',
+  { item: t('student.kit.views.StudentToolsKitView.valorizedDeclaredExperiencesContainer.emptyStateItemLabel') }
+))
+</script>
+
+<template>
+  <ValorizedElementsCardContainer
+    :title="t('student.kit.views.StudentToolsKitView.valorizedDeclaredExperiencesContainer.title', { count: totalElements })"
+    :error="error"
+    :is-loading="isFetching"
+    :is-empty="isEmpty"
+    :empty-state-message="emptyStateMessage"
+    :see-all-label="t('student.kit.views.StudentToolsKitView.valorizedDeclaredExperiencesContainer.seeAll')"
+    :see-all-to="declaredExperiencesRoute"
+    data-testid="valorized-declared-experiences-container"
+    collapsed
+  >
+    <ValorizedDeclaredExperienceItem
+      v-for="declaredExperience in declaredExperiences"
+      :key="declaredExperience.id"
+      :declared-experience="declaredExperience"
+    />
+  </ValorizedElementsCardContainer>
+</template>

--- a/src/features/student/kit/views/StudentToolsKitView/components/ValorizedDeclaredSkillsContainer/ValorizedDeclaredSkillsContainer.test.ts
+++ b/src/features/student/kit/views/StudentToolsKitView/components/ValorizedDeclaredSkillsContainer/ValorizedDeclaredSkillsContainer.test.ts
@@ -58,6 +58,14 @@ BddTest().given('a valorized declared skills container', () => {
         expect(items[index].props('declaredSkill')).toEqual(declaredSkill)
       })
     })
+
+    BddTest().then('it should not be empty and pass the empty state message and see all link to the exhaustive declared skills list', () => {
+      const container = wrapper.findComponent(ValorizedElementsCardContainerStub)
+      expect(container.props('isEmpty')).toBe(false)
+      expect(container.props('emptyStateMessage')).toBe('Vous n\'avez pas encore valorisé ce type de contenu, ajoutez et valorisez une compétence afin de constituer votre kit')
+      expect(container.props('seeAllLabel')).toBe('Voir toutes mes compétences déclarées')
+      expect(container.props('seeAllTo')).toEqual({ name: 'student-project-skills' })
+    })
   })
 
   BddTest().when('the declared skills progresses request succeeds with a single declared skill', () => {
@@ -89,6 +97,10 @@ BddTest().given('a valorized declared skills container', () => {
 
     BddTest().then('it should render no ValorizedDeclaredSkillItem', () => {
       expect(wrapper.findAllComponents(ValorizedDeclaredSkillItemStub)).toHaveLength(0)
+    })
+
+    BddTest().then('it should mark the container as empty', () => {
+      expect(wrapper.findComponent(ValorizedElementsCardContainerStub).props('isEmpty')).toBe(true)
     })
   })
 

--- a/src/features/student/kit/views/StudentToolsKitView/components/ValorizedDeclaredSkillsContainer/ValorizedDeclaredSkillsContainer.vue
+++ b/src/features/student/kit/views/StudentToolsKitView/components/ValorizedDeclaredSkillsContainer/ValorizedDeclaredSkillsContainer.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { useGetDeclaredSkillsProgresses } from '@/api/avenir-esr'
+import { ROUTES } from '@/common/constants'
 import ValorizedElementsCardContainer from '@/features/student/kit/components/cards/ValorizedElementsCardContainer/ValorizedElementsCardContainer.vue'
 import ValorizedDeclaredSkillItem from '@/features/student/kit/views/StudentToolsKitView/components/ValorizedDeclaredSkillItem/ValorizedDeclaredSkillItem.vue'
 import { useI18n } from 'vue-i18n'
@@ -12,6 +13,12 @@ const { data, error, isFetching } = useGetDeclaredSkillsProgresses(
 
 const declaredSkills = computed(() => data.value?.data ?? [])
 const totalElements = computed(() => data.value?.page?.totalElements ?? 0)
+const isEmpty = computed(() => totalElements.value === 0)
+const declaredSkillsRoute = { name: ROUTES.STUDENT.PROJECT_SKILLS.name }
+const emptyStateMessage = computed(() => t(
+  'student.kit.cards.ValorizedElementsCardContainer.emptyState',
+  { item: t('student.kit.views.StudentToolsKitView.valorizedDeclaredSkillsContainer.emptyStateItemLabel') }
+))
 </script>
 
 <template>
@@ -19,6 +26,10 @@ const totalElements = computed(() => data.value?.page?.totalElements ?? 0)
     :title="t('student.kit.views.StudentToolsKitView.valorizedDeclaredSkillsContainer.title', { count: totalElements })"
     :error="error"
     :is-loading="isFetching"
+    :is-empty="isEmpty"
+    :empty-state-message="emptyStateMessage"
+    :see-all-label="t('student.kit.views.StudentToolsKitView.valorizedDeclaredSkillsContainer.seeAll')"
+    :see-all-to="declaredSkillsRoute"
     data-testid="valorized-declared-skills-container"
     collapsed
   >

--- a/src/features/student/personalCareer/components/badges/DeclaredExperienceOrganizationBadge/DeclaredExperienceOrganizationBadge.stub.ts
+++ b/src/features/student/personalCareer/components/badges/DeclaredExperienceOrganizationBadge/DeclaredExperienceOrganizationBadge.stub.ts
@@ -1,0 +1,7 @@
+export const DeclaredExperienceOrganizationBadgeStub = defineComponent({
+  name: 'DeclaredExperienceOrganizationBadge',
+  props: {
+    organization: { type: String, required: true }
+  },
+  template: '<div data-testid="declared-experience-organization-badge-stub">{{ organization }}</div>'
+})

--- a/src/features/student/personalCareer/components/badges/DeclaredExperienceOrganizationBadge/DeclaredExperienceOrganizationBadge.test.ts
+++ b/src/features/student/personalCareer/components/badges/DeclaredExperienceOrganizationBadge/DeclaredExperienceOrganizationBadge.test.ts
@@ -1,0 +1,36 @@
+import DeclaredExperienceOrganizationBadge
+  from '@/features/student/personalCareer/components/badges/DeclaredExperienceOrganizationBadge/DeclaredExperienceOrganizationBadge.vue'
+import { MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
+import { AvBadgeStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { mount, type VueWrapper } from '@vue/test-utils'
+
+const stubs = {
+  AvBadge: AvBadgeStub
+}
+
+BddTest().given('a declared experience organization badge', () => {
+  let wrapper: VueWrapper<InstanceType<typeof DeclaredExperienceOrganizationBadge>>
+
+  BddTest().when('mounted with an organization', () => {
+    beforeEach(() => {
+      wrapper = mount(DeclaredExperienceOrganizationBadge, {
+        props: { organization: 'AVENIR(S)' },
+        global: { stubs }
+      })
+    })
+
+    BddTest().then('it should render the badge with the organization as label', () => {
+      const badge = wrapper.findComponent(AvBadgeStub)
+      expect(badge.exists()).toBe(true)
+      expect(badge.props('label')).toBe('AVENIR(S)')
+    })
+
+    BddTest().then('it should render the badge with correct props', () => {
+      const badge = wrapper.findComponent(AvBadgeStub)
+      expect(badge.props('icon')).toBe(MDI_ICONS.MAP_MARKER_OUTLINE)
+      expect(badge.props('color')).toBe('var(--text2)')
+      expect(badge.props('backgroundColor')).toBe('transparent')
+      expect(badge.props('ellipsis')).toBe(true)
+    })
+  })
+})

--- a/src/features/student/personalCareer/components/badges/DeclaredExperienceOrganizationBadge/DeclaredExperienceOrganizationBadge.vue
+++ b/src/features/student/personalCareer/components/badges/DeclaredExperienceOrganizationBadge/DeclaredExperienceOrganizationBadge.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+import { AvBadge, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
+
+export interface DeclaredExperienceOrganizationBadgeProps {
+  organization: string
+}
+
+const { organization } = defineProps<DeclaredExperienceOrganizationBadgeProps>()
+</script>
+
+<template>
+  <AvBadge
+    :label="organization"
+    :icon="MDI_ICONS.MAP_MARKER_OUTLINE"
+    color="var(--text2)"
+    background-color="transparent"
+    ellipsis
+  />
+</template>

--- a/src/features/student/personalCareer/components/cards/DeclaredExperienceCard/DeclaredExperienceCard.test.ts
+++ b/src/features/student/personalCareer/components/cards/DeclaredExperienceCard/DeclaredExperienceCard.test.ts
@@ -1,11 +1,13 @@
 import { type DeclaredExperienceViewDTO, EExperienceType } from '@/api/avenir-esr'
 import { PeriodBadgeStub } from '@/common/activities/badges/PeriodBadge/PeriodBadge.stub'
 import { FloatingIconCardStub } from '@/features/student/global/components/cards/FloatingIconCard/FloatingIconCard.stub'
+import { DeclaredExperienceOrganizationBadgeStub }
+  from '@/features/student/personalCareer/components/badges/DeclaredExperienceOrganizationBadge/DeclaredExperienceOrganizationBadge.stub'
 import { DeclaredExperienceTypeBadgeStub }
   from '@/features/student/personalCareer/components/badges/DeclaredExperienceTypeBadge/DeclaredExperienceTypeBadge.stub'
 import DeclaredExperienceCard from '@/features/student/personalCareer/components/cards/DeclaredExperienceCard/DeclaredExperienceCard.vue'
 import { MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
-import { AvBadgeStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { mount, RouterLinkStub, type VueWrapper } from '@vue/test-utils'
 import { beforeEach, expect, vi } from 'vitest'
 
@@ -14,10 +16,10 @@ BddTest().given('a declared experience card', () => {
 
   const stubs = {
     FloatingIconCard: FloatingIconCardStub,
-    AvBadge: AvBadgeStub,
     RouterLink: RouterLinkStub,
     PeriodBadge: PeriodBadgeStub,
-    DeclaredExperienceTypeBadge: DeclaredExperienceTypeBadgeStub
+    DeclaredExperienceTypeBadge: DeclaredExperienceTypeBadgeStub,
+    DeclaredExperienceOrganizationBadge: DeclaredExperienceOrganizationBadgeStub
   }
 
   const baseDeclaredExperience: DeclaredExperienceViewDTO = {
@@ -103,31 +105,18 @@ BddTest().given('a declared experience card', () => {
     })
 
     BddTest().and('the organization badge is rendered', () => {
-      let organizationBadge: VueWrapper<InstanceType<typeof AvBadgeStub>> | undefined
+      let organizationBadge: VueWrapper<InstanceType<typeof DeclaredExperienceOrganizationBadgeStub>>
 
       beforeEach(() => {
-        const badges = wrapper.findAllComponents({ name: 'AvBadge' })
-        organizationBadge = badges.find(badge => badge.props('label') === 'AVENIR(S)') as VueWrapper<InstanceType<typeof AvBadgeStub>>
+        organizationBadge = wrapper.findComponent(DeclaredExperienceOrganizationBadgeStub) as VueWrapper<InstanceType<typeof DeclaredExperienceOrganizationBadgeStub>>
       })
 
       BddTest().then('it should exist', () => {
-        expect(organizationBadge).toBeDefined()
+        expect(organizationBadge.exists()).toBe(true)
       })
 
-      BddTest().then('it should have map marker outline icon', () => {
-        expect(organizationBadge?.props('icon')).toBe(MDI_ICONS.MAP_MARKER_OUTLINE)
-      })
-
-      BddTest().then('it should have text2 color', () => {
-        expect(organizationBadge?.props('color')).toBe('var(--text2)')
-      })
-
-      BddTest().then('it should have transparent background', () => {
-        expect(organizationBadge?.props('backgroundColor')).toBe('transparent')
-      })
-
-      BddTest().then('it should have ellipsis enabled', () => {
-        expect(organizationBadge?.props('ellipsis')).toBe(true)
+      BddTest().then('it should receive the organization', () => {
+        expect(organizationBadge.props('organization')).toBe('AVENIR(S)')
       })
     })
   })
@@ -185,8 +174,8 @@ BddTest().given('a declared experience card', () => {
     })
 
     BddTest().then('it should only render the period and the organization badges', () => {
-      const badges = wrapper.findAllComponents({ name: 'AvBadge' })
-      expect(badges.length).toBe(1)
+      expect(wrapper.findComponent(DeclaredExperienceOrganizationBadgeStub).exists()).toBe(true)
+      expect(wrapper.findComponent(DeclaredExperienceTypeBadgeStub).exists()).toBe(false)
       expect(wrapper.findComponent({ name: 'PeriodBadge' }).exists()).toBe(true)
     })
   })

--- a/src/features/student/personalCareer/components/cards/DeclaredExperienceCard/DeclaredExperienceCard.vue
+++ b/src/features/student/personalCareer/components/cards/DeclaredExperienceCard/DeclaredExperienceCard.vue
@@ -3,9 +3,11 @@ import type { DeclaredExperienceViewDTO } from '@/api/avenir-esr'
 import PeriodBadge from '@/common/activities/badges/PeriodBadge/PeriodBadge.vue'
 import { ROUTES } from '@/common/constants'
 import FloatingIconCard from '@/features/student/global/components/cards/FloatingIconCard/FloatingIconCard.vue'
+import DeclaredExperienceOrganizationBadge
+  from '@/features/student/personalCareer/components/badges/DeclaredExperienceOrganizationBadge/DeclaredExperienceOrganizationBadge.vue'
 import DeclaredExperienceTypeBadge
   from '@/features/student/personalCareer/components/badges/DeclaredExperienceTypeBadge/DeclaredExperienceTypeBadge.vue'
-import { AvBadge, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
+import { MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
 
 defineProps<{ declaredExperience: DeclaredExperienceViewDTO }>()
 
@@ -48,12 +50,8 @@ const iconOptions = {
               v-if="declaredExperience.experienceType"
               :experience-type="declaredExperience.experienceType"
             />
-            <AvBadge
-              :label="declaredExperience.organization"
-              :icon="MDI_ICONS.MAP_MARKER_OUTLINE"
-              color="var(--text2)"
-              background-color="transparent"
-              ellipsis
+            <DeclaredExperienceOrganizationBadge
+              :organization="declaredExperience.organization"
             />
           </div>
         </div>

--- a/src/features/student/personalCareer/index.ts
+++ b/src/features/student/personalCareer/index.ts
@@ -1,3 +1,9 @@
+export { default as DeclaredExperienceOrganizationBadge }
+  from '@/features/student/personalCareer/components/badges/DeclaredExperienceOrganizationBadge/DeclaredExperienceOrganizationBadge.vue'
+
+export { default as DeclaredExperienceTypeBadge }
+  from '@/features/student/personalCareer/components/badges/DeclaredExperienceTypeBadge/DeclaredExperienceTypeBadge.vue'
+
 export { default as AssociatedDeclaredExperiencesCard }
   from '@/features/student/personalCareer/components/cards/AssociatedDeclaredExperiencesCard/AssociatedDeclaredExperiencesCard.vue'
 


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied

Implemented `ValorizedDeclaredExperiencesContainer` and `ValorizedDeclaredExperienceItem` components for displaying declared personal experiences with their associated badges (organisation/type) in the Kit view. This includes:
- New `ValorizedDeclaredExperiencesContainer` component that manages the display of multiple declared experiences
- New `ValorizedDeclaredExperienceItem` component that displays individual declared experience with both collapsed and expanded states
- New `DeclaredExperienceOrganizationBadge` component for showing organization badges
- Updated `ValorizedElementsCardContainer` to support the new experience component
- Integration in `KitTextContentTab`
- Comprehensive test coverage for all new components
- i18n support (French and English)
- MSW handler updates for test data

---

### Reference to an Issue, Feature, Task, User Story or another PR

Closes [#2163](https://github.com/avenirs-esr/AVENIRS-Project/issues/2163)

---

### Documentation

- Added i18n keys for declared experiences display in both French and English locales
- Components follow the established pattern from `ValorizedAssociatedTracesContainer` and `ValorizedItem`
- All components use design system components (@avenirs-esr/avenirs-dsav)
- Proper TypeScript typing and slot definitions on all components
- Implements both collapsed and expanded card states per Figma specifications

---

### Target Branch

`develop`

---

### Additional Notes

- Implementation follows the existing feature-based architecture pattern
- Reused established patterns from `ValorizedAssociatedTracesContainer` for consistency
- All components are properly tested with comprehensive test coverage
- Uses Figma design specifications from issue #2163 (collapsed and expanded card views)
- MSW handlers updated to provide realistic test data

---

### Known Limitations or Side Effects

None identified.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [x] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [x] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and detaiils for the update process