### PR TITLE
feat(2151): display declared programs in kit view

### DIFF
--- a/api-specs/avenir-esr.swagger.json
+++ b/api-specs/avenir-esr.swagger.json
@@ -6093,11 +6093,22 @@
           "title": {
             "type": "string"
           },
+          "description": {
+            "type": "string"
+          },
           "organization": {
             "type": "string"
           },
           "result": {
             "type": "string"
+          },
+          "startDate": {
+            "type": "string",
+            "format": "date"
+          },
+          "endDate": {
+            "type": "string",
+            "format": "date"
           },
           "valorized": {
             "type": "boolean"

--- a/src/__mocks__/fixtures/student/declaredPrograms.fixtures.ts
+++ b/src/__mocks__/fixtures/student/declaredPrograms.fixtures.ts
@@ -28,6 +28,9 @@ function createMockedDeclaredPrograms (count: number): DeclaredProgramViewDTO[] 
       id: `declared-program-${i}`,
       title: `Formation déclarée ${i}`,
       organization: `Établissement ${i}`,
+      description: i % 2 === 0 ? `Description de la formation ${i}` : undefined,
+      startDate: '2023-01-01',
+      endDate: i % 3 === 0 ? undefined : '2025-06-01',
       status: i % 3 === 0 ? EProgramStatus.COMPLETED : i % 3 === 1 ? EProgramStatus.IN_PROGRESS : EProgramStatus.NOT_STARTED,
       valorized: false,
       result: i % 2 === 0 ? `Résultat ${i}` : undefined

--- a/src/__mocks__/msw/handlers/student/declaredPrograms.handlers.ts
+++ b/src/__mocks__/msw/handlers/student/declaredPrograms.handlers.ts
@@ -6,6 +6,7 @@ import {
 import {
   type DeclaredProgramDetailedDTO,
   getCreateDeclaredProgramUrl,
+  type GetDeclaredProgramsParams,
   getDeleteDeclaredProgramUrl,
   getGetDeclaredProgramsUrl,
   getGetDeclaredProgramUrl,
@@ -53,19 +54,34 @@ export const declaredProgramsQueryEmptyHandler = http.get(`*${getGetDeclaredProg
   })
 })
 
-export const declaredProgramsQueryHandler = http.get(`*${getGetDeclaredProgramsUrl()}`, async ({ request }) => {
-  const url = new URL(request.url)
-  const page = Number.parseInt(url.searchParams.get('page') ?? '0')
-  const pageSize = Number.parseInt(url.searchParams.get('pageSize') ?? '10')
+export function createDeclaredProgramsViewHandler (
+  customPayload?: PagedResponseDeclaredProgramViewDTO,
+  onRequest?: (params: GetDeclaredProgramsParams) => void
+) {
+  return http.get(`*${getGetDeclaredProgramsUrl()}`, async ({ request }) => {
+    const url = new URL(request.url)
+    const page = Number.parseInt(url.searchParams.get('page') ?? '0')
+    const pageSize = Number.parseInt(url.searchParams.get('pageSize') ?? '10')
 
-  await delay('real')
-  const mockData = createMockedDeclaredProgramsPagedResponse(pageSize, 60, page)
+    if (onRequest) {
+      const searchParams = url.searchParams
+      onRequest({
+        page: searchParams.has('page') ? Number(searchParams.get('page')) : undefined,
+        pageSize: searchParams.has('pageSize') ? Number(searchParams.get('pageSize')) : undefined,
+        isValorized: searchParams.has('isValorized') ? searchParams.get('isValorized') === 'true' : undefined
+      })
+    }
 
-  return HttpResponse.json<PagedResponseDeclaredProgramViewDTO>(mockData, {
-    status: 200,
-    headers: { 'Content-Type': 'application/json' }
+    await delay('real')
+
+    const payload = customPayload ?? createMockedDeclaredProgramsPagedResponse(pageSize, 60, page)
+
+    return HttpResponse.json<PagedResponseDeclaredProgramViewDTO>(payload, {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' }
+    })
   })
-})
+}
 
 export const declaredProgramDetailedHandler = http.get(`*${getGetDeclaredProgramUrl(':id')}`, ({ params }) => {
   const { id } = params as { id: string }
@@ -105,7 +121,7 @@ export const declaredProgramDetailedNotFoundHandler = http.get(`*${getGetDeclare
 })
 
 export const declaredProgramsHandlers = [
-  declaredProgramsQueryHandler,
+  createDeclaredProgramsViewHandler(),
   http.post(
     `*${getCreateDeclaredProgramUrl()}`,
     () => {

--- a/src/common/utils/date/date.test.ts
+++ b/src/common/utils/date/date.test.ts
@@ -1,5 +1,6 @@
 import {
   formatDateLocalized,
+  formatDateToYearLocalized,
   formatDateToYearMonth,
   formatDateToYearMonthLocalized,
   formatTimeLocalized,
@@ -451,6 +452,32 @@ BddTest().given('a date to year-month localized formatter', () => {
       const fullDate = formatYearMonthToDate(yearMonth)
       expect(formatDateToYearMonthLocalized(fullDate, 'fr')).toBe('02/2025')
       expect(formatDateToYearMonthLocalized(fullDate, 'en')).toBe('2025/02')
+    })
+  })
+})
+
+BddTest().given('a date to year localized formatter', () => {
+  BddTest().when('providing a full ISO date with time', () => {
+    BddTest().then('it should extract the year', () => {
+      const date = '2025-05-23T14:31:50.007'
+      expect(formatDateToYearLocalized(date, 'fr')).toBe('2025')
+      expect(formatDateToYearLocalized(date, 'en')).toBe('2025')
+    })
+  })
+
+  BddTest().when('providing a date-only ISO string', () => {
+    BddTest().then('it should extract the year', () => {
+      const date = '2027-02-01'
+      expect(formatDateToYearLocalized(date, 'fr')).toBe('2027')
+      expect(formatDateToYearLocalized(date, 'en')).toBe('2027')
+    })
+  })
+
+  BddTest().when('providing an invalid date string', () => {
+    BddTest().then('it should throw an error', () => {
+      const date = 'not-a-date'
+      expect(() => formatDateToYearLocalized(date, 'fr')).toThrow(`Invalid ISO date: ${date}`)
+      expect(() => formatDateToYearLocalized(date, 'en')).toThrow(`Invalid ISO date: ${date}`)
     })
   })
 })

--- a/src/common/utils/date/date.ts
+++ b/src/common/utils/date/date.ts
@@ -161,3 +161,14 @@ export function formatDateToYearMonth (date: DateArg<Date>): string {
 export function formatDateToYearMonthLocalized (date: DateArg<Date>, localeCode: AvLocale): string {
   return formatLocalized(date, localeCode, { fr: 'MM/yyyy', en: 'yyyy/MM' })
 }
+
+/**
+ * Formats a date string (any supported ISO-like format) to a localized year string.
+ *
+ * @param date Date object, timestamp (number), or ISO string
+ * @param localeCode The locale to use
+ * @returns Formatted year string (e.g., "2025")
+ */
+export function formatDateToYearLocalized (date: DateArg<Date>, localeCode: AvLocale): string {
+  return formatLocalized(date, localeCode, 'yyyy')
+}

--- a/src/features/student/kit/locales/en.json
+++ b/src/features/student/kit/locales/en.json
@@ -34,6 +34,11 @@
             "seeAll": "See all my other experiences",
             "title": "Other experience (1) | Other experiences ({count})"
           },
+          "valorizedDeclaredProgramsContainer": {
+            "emptyStateItemLabel": "a program",
+            "seeAll": "See all my programs",
+            "title": "Program (1) | Programs ({count})"
+          },
           "valorizedDeclaredSkillsContainer": {
             "emptyStateItemLabel": "a skill",
             "seeAll": "See all my declared skills",

--- a/src/features/student/kit/locales/fr.json
+++ b/src/features/student/kit/locales/fr.json
@@ -34,6 +34,11 @@
             "seeAll": "Voir toutes mes autres expériences",
             "title": "Autre expérience (1) | Autres expériences ({count})"
           },
+          "valorizedDeclaredProgramsContainer": {
+            "emptyStateItemLabel": "une formation",
+            "seeAll": "Voir toutes mes formations",
+            "title": "Formation (1) | Formations ({count})"
+          },
           "valorizedDeclaredSkillsContainer": {
             "emptyStateItemLabel": "une compétence",
             "seeAll": "Voir toutes mes compétences déclarées",

--- a/src/features/student/kit/views/StudentToolsKitView/components/KitTextContentTab/KitTextContentTab.test.ts
+++ b/src/features/student/kit/views/StudentToolsKitView/components/KitTextContentTab/KitTextContentTab.test.ts
@@ -1,13 +1,15 @@
 import type { VueWrapper } from '@vue/test-utils'
 import KitTextContentTab from '@/features/student/kit/views/StudentToolsKitView/components/KitTextContentTab/KitTextContentTab.vue'
 import { ValorizedDeclaredExperiencesContainerStub } from '@/features/student/kit/views/StudentToolsKitView/components/ValorizedDeclaredExperiencesContainer/ValorizedDeclaredExperiencesContainer.stub'
+import { ValorizedDeclaredProgramsContainerStub } from '@/features/student/kit/views/StudentToolsKitView/components/ValorizedDeclaredProgramsContainer/ValorizedDeclaredProgramsContainer.stub'
 import { ValorizedDeclaredSkillsContainerStub } from '@/features/student/kit/views/StudentToolsKitView/components/ValorizedDeclaredSkillsContainer/ValorizedDeclaredSkillsContainer.stub'
 import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { mountComponent } from 'tests/utils'
 
 const stubs = {
   ValorizedDeclaredSkillsContainer: ValorizedDeclaredSkillsContainerStub,
-  ValorizedDeclaredExperiencesContainer: ValorizedDeclaredExperiencesContainerStub
+  ValorizedDeclaredExperiencesContainer: ValorizedDeclaredExperiencesContainerStub,
+  ValorizedDeclaredProgramsContainer: ValorizedDeclaredProgramsContainerStub
 }
 
 BddTest().given('a kit text content tab', () => {
@@ -24,6 +26,10 @@ BddTest().given('a kit text content tab', () => {
 
     BddTest().then('it should render the valorized declared experiences container', () => {
       expect(wrapper.findComponent(ValorizedDeclaredExperiencesContainerStub).exists()).toBe(true)
+    })
+
+    BddTest().then('it should render the valorized declared programs container', () => {
+      expect(wrapper.findComponent(ValorizedDeclaredProgramsContainerStub).exists()).toBe(true)
     })
   })
 })

--- a/src/features/student/kit/views/StudentToolsKitView/components/KitTextContentTab/KitTextContentTab.vue
+++ b/src/features/student/kit/views/StudentToolsKitView/components/KitTextContentTab/KitTextContentTab.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import ValorizedDeclaredExperiencesContainer from '@/features/student/kit/views/StudentToolsKitView/components/ValorizedDeclaredExperiencesContainer/ValorizedDeclaredExperiencesContainer.vue'
+import ValorizedDeclaredProgramsContainer from '@/features/student/kit/views/StudentToolsKitView/components/ValorizedDeclaredProgramsContainer/ValorizedDeclaredProgramsContainer.vue'
 import ValorizedDeclaredSkillsContainer from '@/features/student/kit/views/StudentToolsKitView/components/ValorizedDeclaredSkillsContainer/ValorizedDeclaredSkillsContainer.vue'
 </script>
 
@@ -7,5 +8,6 @@ import ValorizedDeclaredSkillsContainer from '@/features/student/kit/views/Stude
   <div class="av-col av-gap-md">
     <ValorizedDeclaredSkillsContainer />
     <ValorizedDeclaredExperiencesContainer />
+    <ValorizedDeclaredProgramsContainer />
   </div>
 </template>

--- a/src/features/student/kit/views/StudentToolsKitView/components/ValorizedDeclaredProgramItem/ValorizedDeclaredProgramItem.stub.ts
+++ b/src/features/student/kit/views/StudentToolsKitView/components/ValorizedDeclaredProgramItem/ValorizedDeclaredProgramItem.stub.ts
@@ -1,0 +1,10 @@
+import type { DeclaredProgramViewDTO } from '@/api/avenir-esr'
+import type { PropType } from 'vue'
+
+export const ValorizedDeclaredProgramItemStub = defineComponent({
+  name: 'ValorizedDeclaredProgramItem',
+  template: '<div data-testid="valorized-declared-program-item-stub" />',
+  props: {
+    declaredProgram: { type: Object as PropType<DeclaredProgramViewDTO>, required: true }
+  }
+})

--- a/src/features/student/kit/views/StudentToolsKitView/components/ValorizedDeclaredProgramItem/ValorizedDeclaredProgramItem.test.ts
+++ b/src/features/student/kit/views/StudentToolsKitView/components/ValorizedDeclaredProgramItem/ValorizedDeclaredProgramItem.test.ts
@@ -1,0 +1,150 @@
+import type { DeclaredProgramViewDTO } from '@/api/avenir-esr'
+import type { VueWrapper } from '@vue/test-utils'
+import { EProgramStatus } from '@/api/avenir-esr'
+import { ROUTES } from '@/common/constants'
+import ValorizedDeclaredProgramItem from '@/features/student/kit/views/StudentToolsKitView/components/ValorizedDeclaredProgramItem/ValorizedDeclaredProgramItem.vue'
+import { AvBadgeStub, AvButtonStub, AvTooltipStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { flushPromises } from '@vue/test-utils'
+import { mountComponent } from 'tests/utils'
+
+const BASE_DECLARED_PROGRAM: DeclaredProgramViewDTO = {
+  id: 'c1e6a6f0-1c2d-4f3e-9a1b-3f2b1c0d4e5f',
+  title: 'Master en Informatique',
+  organization: 'Université Paris-Saclay',
+  description: 'Formation approfondie en développement logiciel et intelligence artificielle',
+  status: EProgramStatus.IN_PROGRESS,
+  result: 'Mention Très Bien',
+  startDate: '2025-09-01',
+  endDate: '2027-06-01',
+  valorized: true
+}
+
+const stubs = {
+  AvButton: AvButtonStub,
+  AvTooltip: AvTooltipStub,
+  AvBadge: AvBadgeStub
+}
+
+function mountValorizedDeclaredProgramItem (declaredProgram: DeclaredProgramViewDTO) {
+  return mountComponent(ValorizedDeclaredProgramItem, {
+    props: { declaredProgram },
+    global: { stubs }
+  })
+}
+
+BddTest().given('a valorized declared program item', () => {
+  let wrapper: VueWrapper<InstanceType<typeof ValorizedDeclaredProgramItem>>
+
+  BddTest().when('the component is mounted', () => {
+    beforeEach(async () => {
+      wrapper = mountValorizedDeclaredProgramItem(BASE_DECLARED_PROGRAM)
+      await flushPromises()
+    })
+
+    BddTest().then('it should render the wrapped ValorizedItem with the program title', () => {
+      expect(wrapper.find('[data-testid="valorized-item"]').exists()).toBe(true)
+      expect(wrapper.find('.title').text()).toBe(BASE_DECLARED_PROGRAM.title)
+    })
+
+    BddTest().then('it should render the access button pointing to the declared program route', () => {
+      const button = wrapper.findComponent(AvButtonStub)
+      expect(button.props('to')).toEqual({
+        name: ROUTES.STUDENT.PERSONAL_CAREER_DECLARED_PROGRAM_DETAILED.name,
+        params: { id: BASE_DECLARED_PROGRAM.id }
+      })
+    })
+
+    BddTest().then('it should render the organization badge combined with the period', () => {
+      const labels = wrapper.findAllComponents(AvBadgeStub).map(badge => badge.props('label'))
+      expect(labels).toContain(`${BASE_DECLARED_PROGRAM.organization} • 2025 - 2027`)
+    })
+
+    BddTest().then('it should render the description', () => {
+      expect(wrapper.text()).toContain(BASE_DECLARED_PROGRAM.description)
+    })
+
+    BddTest().then('it should render the status badge', () => {
+      const labels = wrapper.findAllComponents(AvBadgeStub).map(badge => badge.props('label'))
+      expect(labels).toContain('En cours')
+    })
+
+    BddTest().then('it should render the result badge', () => {
+      const labels = wrapper.findAllComponents(AvBadgeStub).map(badge => badge.props('label'))
+      expect(labels).toContain(BASE_DECLARED_PROGRAM.result)
+    })
+  })
+
+  BddTest().when('the program has no description', () => {
+    beforeEach(async () => {
+      wrapper = mountValorizedDeclaredProgramItem({
+        ...BASE_DECLARED_PROGRAM,
+        description: undefined
+      })
+      await flushPromises()
+    })
+
+    BddTest().then('it should not render a description', () => {
+      expect(wrapper.text()).not.toContain(BASE_DECLARED_PROGRAM.description)
+    })
+  })
+
+  BddTest().when('the program has no status', () => {
+    beforeEach(async () => {
+      wrapper = mountValorizedDeclaredProgramItem({
+        ...BASE_DECLARED_PROGRAM,
+        status: undefined
+      } as unknown as DeclaredProgramViewDTO)
+      await flushPromises()
+    })
+
+    BddTest().then('it should not render the status badge', () => {
+      const labels = wrapper.findAllComponents(AvBadgeStub).map(badge => badge.props('label'))
+      expect(labels).not.toContain('En cours')
+    })
+  })
+
+  BddTest().when('the program has no result', () => {
+    beforeEach(async () => {
+      wrapper = mountValorizedDeclaredProgramItem({
+        ...BASE_DECLARED_PROGRAM,
+        result: undefined
+      })
+      await flushPromises()
+    })
+
+    BddTest().then('it should not render the result badge', () => {
+      const labels = wrapper.findAllComponents(AvBadgeStub).map(badge => badge.props('label'))
+      expect(labels).not.toContain(BASE_DECLARED_PROGRAM.result)
+    })
+  })
+
+  BddTest().when('the program has no start date', () => {
+    beforeEach(async () => {
+      wrapper = mountValorizedDeclaredProgramItem({
+        ...BASE_DECLARED_PROGRAM,
+        startDate: undefined
+      })
+      await flushPromises()
+    })
+
+    BddTest().then('it should render the organization badge without a period', () => {
+      const labels = wrapper.findAllComponents(AvBadgeStub).map(badge => badge.props('label'))
+      expect(labels).toContain(BASE_DECLARED_PROGRAM.organization)
+    })
+  })
+
+  BddTest().when('the program has a start date but no end date', () => {
+    beforeEach(async () => {
+      wrapper = mountValorizedDeclaredProgramItem({
+        ...BASE_DECLARED_PROGRAM,
+        endDate: undefined
+      })
+      await flushPromises()
+    })
+
+    BddTest().then('it should render the period as ongoing', () => {
+      const labels = wrapper.findAllComponents(AvBadgeStub).map(badge => badge.props('label'))
+      expect(labels).toContain(`${BASE_DECLARED_PROGRAM.organization} • 2025 - En cours`)
+    })
+  })
+})

--- a/src/features/student/kit/views/StudentToolsKitView/components/ValorizedDeclaredProgramItem/ValorizedDeclaredProgramItem.vue
+++ b/src/features/student/kit/views/StudentToolsKitView/components/ValorizedDeclaredProgramItem/ValorizedDeclaredProgramItem.vue
@@ -1,0 +1,60 @@
+<script lang="ts" setup>
+import type { DeclaredProgramViewDTO } from '@/api/avenir-esr'
+import type { AvLocale } from '@/types'
+import { formatDateToYearLocalized } from '@/common/utils'
+import { ValorizedItemType } from '@/features/student/kit/types/valorized.types'
+import ValorizedItem from '@/features/student/kit/views/StudentToolsKitView/components/ValorizedItem/ValorizedItem.vue'
+import { DeclaredProgramOrganizationBadge, DeclaredProgramResultBadge, DeclaredProgramStatusBadge } from '@/features/student/personalCareer'
+import { useI18n } from 'vue-i18n'
+
+export interface ValorizedDeclaredProgramItemProps {
+  declaredProgram: DeclaredProgramViewDTO
+}
+
+const { declaredProgram } = defineProps<ValorizedDeclaredProgramItemProps>()
+
+const { t, locale } = useI18n()
+const currentLocale = computed(() => locale.value as AvLocale)
+
+const period = computed(() => {
+  if (!declaredProgram.startDate) {
+    return undefined
+  }
+
+  const start = formatDateToYearLocalized(declaredProgram.startDate, currentLocale.value)
+  const end = declaredProgram.endDate
+    ? formatDateToYearLocalized(declaredProgram.endDate, currentLocale.value)
+    : t('global.dates.ongoing')
+
+  return `${start} - ${end}`
+})
+</script>
+
+<template>
+  <ValorizedItem
+    :title="declaredProgram.title"
+    :item-id="declaredProgram.id"
+    :type="ValorizedItemType.DECLARED_PROGRAM"
+  >
+    <DeclaredProgramOrganizationBadge
+      :organization="declaredProgram.organization"
+      :period="period"
+    />
+    <span
+      v-if="declaredProgram.description"
+      class="b2-regular av-max-lines"
+    >
+      {{ declaredProgram.description }}
+    </span>
+    <div class="av-row av-align-center av-wrap av-gap-xs">
+      <DeclaredProgramStatusBadge
+        v-if="declaredProgram.status"
+        :status="declaredProgram.status"
+      />
+      <DeclaredProgramResultBadge
+        v-if="declaredProgram.result"
+        :result="declaredProgram.result"
+      />
+    </div>
+  </ValorizedItem>
+</template>

--- a/src/features/student/kit/views/StudentToolsKitView/components/ValorizedDeclaredProgramsContainer/ValorizedDeclaredProgramsContainer.stub.ts
+++ b/src/features/student/kit/views/StudentToolsKitView/components/ValorizedDeclaredProgramsContainer/ValorizedDeclaredProgramsContainer.stub.ts
@@ -1,0 +1,4 @@
+export const ValorizedDeclaredProgramsContainerStub = defineComponent({
+  name: 'ValorizedDeclaredProgramsContainer',
+  template: '<div data-testid="valorized-declared-programs-container-stub" />',
+})

--- a/src/features/student/kit/views/StudentToolsKitView/components/ValorizedDeclaredProgramsContainer/ValorizedDeclaredProgramsContainer.test.ts
+++ b/src/features/student/kit/views/StudentToolsKitView/components/ValorizedDeclaredProgramsContainer/ValorizedDeclaredProgramsContainer.test.ts
@@ -1,0 +1,121 @@
+import type { GetDeclaredProgramsParams } from '@/api/avenir-esr'
+import type { VueWrapper } from '@vue/test-utils'
+import { createMockedDeclaredProgramsPagedResponse } from '@/__mocks__/fixtures/student/declaredPrograms.fixtures'
+import { createDeclaredProgramsViewHandler, declaredProgramsQueryErrorHandler } from '@/__mocks__/msw/handlers/student/declaredPrograms.handlers'
+import { server } from '@/__mocks__/msw/server'
+import { ValorizedElementsCardContainerStub } from '@/features/student/kit/components/cards/ValorizedElementsCardContainer/ValorizedElementsCardContainer.stub'
+import { ValorizedDeclaredProgramItemStub } from '@/features/student/kit/views/StudentToolsKitView/components/ValorizedDeclaredProgramItem/ValorizedDeclaredProgramItem.stub'
+import ValorizedDeclaredProgramsContainer from '@/features/student/kit/views/StudentToolsKitView/components/ValorizedDeclaredProgramsContainer/ValorizedDeclaredProgramsContainer.vue'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { mountComponent } from 'tests/utils'
+import { vi } from 'vitest'
+
+BddTest().given('a valorized declared programs container', () => {
+  let wrapper: VueWrapper<InstanceType<typeof ValorizedDeclaredProgramsContainer>>
+  let requestedParams: GetDeclaredProgramsParams
+
+  const stubs = {
+    ValorizedElementsCardContainer: ValorizedElementsCardContainerStub,
+    ValorizedDeclaredProgramItem: ValorizedDeclaredProgramItemStub
+  }
+
+  const mountDeclaredProgramsContainer = async () => {
+    wrapper = mountComponent(ValorizedDeclaredProgramsContainer, { global: { stubs } })
+    await vi.waitFor(() => {
+      expect(wrapper.findComponent(ValorizedElementsCardContainerStub).props('isLoading')).toBe(false)
+    })
+  }
+
+  BddTest().when('the request succeeds with 3 declared programs', () => {
+    const mockedResponse = createMockedDeclaredProgramsPagedResponse(100, 3, 0)
+
+    beforeEach(async () => {
+      server.use(createDeclaredProgramsViewHandler(mockedResponse, (params) => {
+        requestedParams = params
+      }))
+
+      await mountDeclaredProgramsContainer()
+    })
+
+    BddTest().then('it should fetch declared programs with isValorized true and pageSize 100', () => {
+      expect(requestedParams.isValorized).toBe(true)
+      expect(requestedParams.pageSize).toBe(100)
+    })
+
+    BddTest().then('it should render the title with the total elements count', () => {
+      const container = wrapper.findComponent(ValorizedElementsCardContainerStub)
+      expect(container.exists()).toBe(true)
+      expect(container.props('title')).toBe('Formations (3)')
+    })
+
+    BddTest().then('it should not be loading, have no error and not be empty once fetched', () => {
+      const container = wrapper.findComponent(ValorizedElementsCardContainerStub)
+      expect(container.props('isLoading')).toBe(false)
+      expect(container.props('error')).toBe(null)
+      expect(container.props('isEmpty')).toBe(false)
+    })
+
+    BddTest().then('it should render one ValorizedDeclaredProgramItem per declared program', () => {
+      const items = wrapper.findAllComponents(ValorizedDeclaredProgramItemStub)
+      expect(items).toHaveLength(3)
+      mockedResponse.data.forEach((declaredProgram, index) => {
+        expect(items[index].props('declaredProgram')).toEqual(declaredProgram)
+      })
+    })
+
+    BddTest().then('it should pass the empty state message and see all link to the exhaustive declared programs list', () => {
+      const container = wrapper.findComponent(ValorizedElementsCardContainerStub)
+      expect(container.props('emptyStateMessage')).toBe('Vous n\'avez pas encore valorisé ce type de contenu, ajoutez et valorisez une formation afin de constituer votre kit')
+      expect(container.props('seeAllLabel')).toBe('Voir toutes mes formations')
+      expect(container.props('seeAllTo')).toEqual({ name: 'personal-career-declared-programs' })
+    })
+  })
+
+  BddTest().when('the request succeeds with a single declared program', () => {
+    const mockedResponse = createMockedDeclaredProgramsPagedResponse(100, 1, 0)
+
+    beforeEach(async () => {
+      server.use(createDeclaredProgramsViewHandler(mockedResponse))
+
+      await mountDeclaredProgramsContainer()
+    })
+
+    BddTest().then('it should render the title in the singular form', () => {
+      expect(wrapper.findComponent(ValorizedElementsCardContainerStub).props('title')).toBe('Formation (1)')
+    })
+
+    BddTest().then('it should render a single ValorizedDeclaredProgramItem', () => {
+      expect(wrapper.findAllComponents(ValorizedDeclaredProgramItemStub)).toHaveLength(1)
+    })
+  })
+
+  BddTest().when('the request succeeds with 0 declared programs', () => {
+    const mockedResponse = createMockedDeclaredProgramsPagedResponse(100, 0, 0)
+
+    beforeEach(async () => {
+      server.use(createDeclaredProgramsViewHandler(mockedResponse))
+
+      await mountDeclaredProgramsContainer()
+    })
+
+    BddTest().then('it should render no ValorizedDeclaredProgramItem', () => {
+      expect(wrapper.findAllComponents(ValorizedDeclaredProgramItemStub)).toHaveLength(0)
+    })
+
+    BddTest().then('it should mark the container as empty', () => {
+      expect(wrapper.findComponent(ValorizedElementsCardContainerStub).props('isEmpty')).toBe(true)
+    })
+  })
+
+  BddTest().when('the request fails', () => {
+    beforeEach(async () => {
+      server.use(declaredProgramsQueryErrorHandler)
+
+      await mountDeclaredProgramsContainer()
+    })
+
+    BddTest().then('it should forward the error to the card container', () => {
+      expect(wrapper.findComponent(ValorizedElementsCardContainerStub).props('error')).toBeTruthy()
+    })
+  })
+})

--- a/src/features/student/kit/views/StudentToolsKitView/components/ValorizedDeclaredProgramsContainer/ValorizedDeclaredProgramsContainer.vue
+++ b/src/features/student/kit/views/StudentToolsKitView/components/ValorizedDeclaredProgramsContainer/ValorizedDeclaredProgramsContainer.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+import { useGetDeclaredPrograms } from '@/api/avenir-esr'
+import { ROUTES } from '@/common/constants'
+import ValorizedElementsCardContainer from '@/features/student/kit/components/cards/ValorizedElementsCardContainer/ValorizedElementsCardContainer.vue'
+import ValorizedDeclaredProgramItem from '@/features/student/kit/views/StudentToolsKitView/components/ValorizedDeclaredProgramItem/ValorizedDeclaredProgramItem.vue'
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
+
+const { data, error, isFetching } = useGetDeclaredPrograms(
+  { isValorized: true, pageSize: 100 }
+)
+
+const declaredPrograms = computed(() => data.value?.data ?? [])
+const totalElements = computed(() => data.value?.page?.totalElements ?? 0)
+const isEmpty = computed(() => totalElements.value === 0)
+const declaredProgramsRoute = { name: ROUTES.STUDENT.PERSONAL_CAREER_DECLARED_PROGRAMS.name }
+const emptyStateMessage = computed(() => t(
+  'student.kit.cards.ValorizedElementsCardContainer.emptyState',
+  { item: t('student.kit.views.StudentToolsKitView.valorizedDeclaredProgramsContainer.emptyStateItemLabel') }
+))
+</script>
+
+<template>
+  <ValorizedElementsCardContainer
+    :title="t('student.kit.views.StudentToolsKitView.valorizedDeclaredProgramsContainer.title', { count: totalElements })"
+    :error="error"
+    :is-loading="isFetching"
+    :is-empty="isEmpty"
+    :empty-state-message="emptyStateMessage"
+    :see-all-label="t('student.kit.views.StudentToolsKitView.valorizedDeclaredProgramsContainer.seeAll')"
+    :see-all-to="declaredProgramsRoute"
+    data-testid="valorized-declared-programs-container"
+    collapsed
+  >
+    <ValorizedDeclaredProgramItem
+      v-for="declaredProgram in declaredPrograms"
+      :key="declaredProgram.id"
+      :declared-program="declaredProgram"
+    />
+  </ValorizedElementsCardContainer>
+</template>

--- a/src/features/student/personalCareer/components/badges/DeclaredProgramOrganizationBadge/DeclaredProgramOrganizationBadge.stub.ts
+++ b/src/features/student/personalCareer/components/badges/DeclaredProgramOrganizationBadge/DeclaredProgramOrganizationBadge.stub.ts
@@ -1,0 +1,8 @@
+export const DeclaredProgramOrganizationBadgeStub = defineComponent({
+  name: 'DeclaredProgramOrganizationBadge',
+  props: {
+    organization: { type: String, required: true },
+    period: { type: String, default: undefined }
+  },
+  template: '<div data-testid="declared-program-organization-badge-stub">{{ organization }}</div>'
+})

--- a/src/features/student/personalCareer/components/badges/DeclaredProgramOrganizationBadge/DeclaredProgramOrganizationBadge.test.ts
+++ b/src/features/student/personalCareer/components/badges/DeclaredProgramOrganizationBadge/DeclaredProgramOrganizationBadge.test.ts
@@ -1,0 +1,50 @@
+import DeclaredProgramOrganizationBadge
+  from '@/features/student/personalCareer/components/badges/DeclaredProgramOrganizationBadge/DeclaredProgramOrganizationBadge.vue'
+import { MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
+import { AvBadgeStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { mount, type VueWrapper } from '@vue/test-utils'
+
+const stubs = {
+  AvBadge: AvBadgeStub
+}
+
+BddTest().given('a declared program organization badge', () => {
+  let wrapper: VueWrapper<InstanceType<typeof DeclaredProgramOrganizationBadge>>
+
+  BddTest().when('mounted with only an organization', () => {
+    beforeEach(() => {
+      wrapper = mount(DeclaredProgramOrganizationBadge, {
+        props: { organization: 'Université Paris-Saclay' },
+        global: { stubs }
+      })
+    })
+
+    BddTest().then('it should render the badge with the organization as label', () => {
+      const badge = wrapper.findComponent(AvBadgeStub)
+      expect(badge.exists()).toBe(true)
+      expect(badge.props('label')).toBe('Université Paris-Saclay')
+    })
+
+    BddTest().then('it should render the badge with correct props', () => {
+      const badge = wrapper.findComponent(AvBadgeStub)
+      expect(badge.props('icon')).toBe(MDI_ICONS.BUILDING)
+      expect(badge.props('color')).toBe('var(--text1)')
+      expect(badge.props('backgroundColor')).toBe('transparent')
+      expect(badge.props('ellipsis')).toBe(true)
+    })
+  })
+
+  BddTest().when('mounted with an organization and a period', () => {
+    beforeEach(() => {
+      wrapper = mount(DeclaredProgramOrganizationBadge, {
+        props: { organization: 'Université Paris-Saclay', period: '2025 - 2027' },
+        global: { stubs }
+      })
+    })
+
+    BddTest().then('it should render the badge with the organization and period combined as label', () => {
+      const badge = wrapper.findComponent(AvBadgeStub)
+      expect(badge.props('label')).toBe('Université Paris-Saclay • 2025 - 2027')
+    })
+  })
+})

--- a/src/features/student/personalCareer/components/badges/DeclaredProgramOrganizationBadge/DeclaredProgramOrganizationBadge.vue
+++ b/src/features/student/personalCareer/components/badges/DeclaredProgramOrganizationBadge/DeclaredProgramOrganizationBadge.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+import { AvBadge, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
+
+export interface DeclaredProgramOrganizationBadgeProps {
+  organization: string
+  period?: string
+}
+
+const { organization, period } = defineProps<DeclaredProgramOrganizationBadgeProps>()
+
+const label = computed(() => period ? `${organization} • ${period}` : organization)
+</script>
+
+<template>
+  <AvBadge
+    :label="label"
+    :icon="MDI_ICONS.BUILDING"
+    color="var(--text1)"
+    background-color="transparent"
+    ellipsis
+    data-testid="declared-program-organization-badge"
+  />
+</template>

--- a/src/features/student/personalCareer/components/badges/DeclaredProgramResultBadge/DeclaredProgramResultBadge.stub.ts
+++ b/src/features/student/personalCareer/components/badges/DeclaredProgramResultBadge/DeclaredProgramResultBadge.stub.ts
@@ -1,0 +1,7 @@
+export const DeclaredProgramResultBadgeStub = defineComponent({
+  name: 'DeclaredProgramResultBadge',
+  props: {
+    result: { type: String, required: true }
+  },
+  template: '<div data-testid="declared-program-result-badge-stub">{{ result }}</div>'
+})

--- a/src/features/student/personalCareer/components/badges/DeclaredProgramResultBadge/DeclaredProgramResultBadge.test.ts
+++ b/src/features/student/personalCareer/components/badges/DeclaredProgramResultBadge/DeclaredProgramResultBadge.test.ts
@@ -1,0 +1,36 @@
+import DeclaredProgramResultBadge
+  from '@/features/student/personalCareer/components/badges/DeclaredProgramResultBadge/DeclaredProgramResultBadge.vue'
+import { RI_ICONS } from '@avenirs-esr/avenirs-dsav'
+import { AvBadgeStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { mount, type VueWrapper } from '@vue/test-utils'
+
+const stubs = {
+  AvBadge: AvBadgeStub
+}
+
+BddTest().given('a declared program result badge', () => {
+  let wrapper: VueWrapper<InstanceType<typeof DeclaredProgramResultBadge>>
+
+  BddTest().when('mounted with a result', () => {
+    beforeEach(() => {
+      wrapper = mount(DeclaredProgramResultBadge, {
+        props: { result: 'Mention Très Bien' },
+        global: { stubs }
+      })
+    })
+
+    BddTest().then('it should render the badge with the result as label', () => {
+      const badge = wrapper.findComponent(AvBadgeStub)
+      expect(badge.exists()).toBe(true)
+      expect(badge.props('label')).toBe('Mention Très Bien')
+    })
+
+    BddTest().then('it should render the badge with correct props', () => {
+      const badge = wrapper.findComponent(AvBadgeStub)
+      expect(badge.props('icon')).toBe(RI_ICONS.LAYOUT_6_LINE)
+      expect(badge.props('color')).toBe('var(--card2)')
+      expect(badge.props('backgroundColor')).toBe('var(--dark-background-primary1)')
+      expect(badge.props('ellipsis')).toBe(true)
+    })
+  })
+})

--- a/src/features/student/personalCareer/components/badges/DeclaredProgramResultBadge/DeclaredProgramResultBadge.vue
+++ b/src/features/student/personalCareer/components/badges/DeclaredProgramResultBadge/DeclaredProgramResultBadge.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+import { AvBadge, RI_ICONS } from '@avenirs-esr/avenirs-dsav'
+
+export interface DeclaredProgramResultBadgeProps {
+  result: string
+}
+
+const { result } = defineProps<DeclaredProgramResultBadgeProps>()
+</script>
+
+<template>
+  <AvBadge
+    :label="result"
+    :icon="RI_ICONS.LAYOUT_6_LINE"
+    color="var(--card2)"
+    background-color="var(--dark-background-primary1)"
+    ellipsis
+    data-testid="declared-program-result-badge"
+  />
+</template>

--- a/src/features/student/personalCareer/components/badges/DeclaredProgramStatusBadge/DeclaredProgramStatusBadge.stub.ts
+++ b/src/features/student/personalCareer/components/badges/DeclaredProgramStatusBadge/DeclaredProgramStatusBadge.stub.ts
@@ -1,0 +1,13 @@
+import type { EProgramStatus } from '@/api/avenir-esr'
+import type { PropType } from 'vue'
+
+export const DeclaredProgramStatusBadgeStub = defineComponent({
+  name: 'DeclaredProgramStatusBadge',
+  props: {
+    status: {
+      type: String as PropType<EProgramStatus>,
+      required: true
+    }
+  },
+  template: '<div data-testid="declared-program-status-badge-stub">{{ status }}</div>'
+})

--- a/src/features/student/personalCareer/components/badges/DeclaredProgramStatusBadge/DeclaredProgramStatusBadge.test.ts
+++ b/src/features/student/personalCareer/components/badges/DeclaredProgramStatusBadge/DeclaredProgramStatusBadge.test.ts
@@ -1,0 +1,96 @@
+import { EProgramStatus } from '@/api/avenir-esr'
+import DeclaredProgramStatusBadge
+  from '@/features/student/personalCareer/components/badges/DeclaredProgramStatusBadge/DeclaredProgramStatusBadge.vue'
+import { ICONS_DATA_URL, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
+import { AvBadgeStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { beforeEach, expect, vi } from 'vitest'
+
+BddTest().given('a declared program status badge', () => {
+  let wrapper: VueWrapper
+  let badge: VueWrapper<InstanceType<typeof AvBadgeStub>>
+
+  const stubs = { AvBadge: AvBadgeStub }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  BddTest().when('the component is mounted with NOT_STARTED status', () => {
+    beforeEach(() => {
+      wrapper = mount(DeclaredProgramStatusBadge, {
+        props: { status: EProgramStatus.NOT_STARTED },
+        global: { stubs }
+      })
+      badge = wrapper.findComponent(AvBadgeStub) as VueWrapper<InstanceType<typeof AvBadgeStub>>
+    })
+
+    BddTest().then('it should display the not started label', () => {
+      expect(badge.props('label')).toBe('Non démarrée')
+    })
+
+    BddTest().then('it should apply the light neutral background color', () => {
+      expect(badge.props('backgroundColor')).toBe('var(--light-background-neutral)')
+    })
+
+    BddTest().then('it should apply the text1 color', () => {
+      expect(badge.props('color')).toBe('var(--text1)')
+    })
+
+    BddTest().then('it should use the hourglass icon', () => {
+      expect(badge.props('icon')).toBe(ICONS_DATA_URL.MDI_HOURGLASS)
+    })
+  })
+
+  BddTest().when('the component is mounted with IN_PROGRESS status', () => {
+    beforeEach(() => {
+      wrapper = mount(DeclaredProgramStatusBadge, {
+        props: { status: EProgramStatus.IN_PROGRESS },
+        global: { stubs }
+      })
+      badge = wrapper.findComponent(AvBadgeStub) as VueWrapper<InstanceType<typeof AvBadgeStub>>
+    })
+
+    BddTest().then('it should display the in progress label', () => {
+      expect(badge.props('label')).toBe('En cours')
+    })
+
+    BddTest().then('it should apply the light primary2 background color', () => {
+      expect(badge.props('backgroundColor')).toBe('var(--light-background-primary2)')
+    })
+
+    BddTest().then('it should apply the light foreground primary1 color', () => {
+      expect(badge.props('color')).toBe('var(--light-foreground-primary1)')
+    })
+
+    BddTest().then('it should use the hourglass icon', () => {
+      expect(badge.props('icon')).toBe(ICONS_DATA_URL.MDI_HOURGLASS)
+    })
+  })
+
+  BddTest().when('the component is mounted with COMPLETED status', () => {
+    beforeEach(() => {
+      wrapper = mount(DeclaredProgramStatusBadge, {
+        props: { status: EProgramStatus.COMPLETED },
+        global: { stubs }
+      })
+      badge = wrapper.findComponent(AvBadgeStub) as VueWrapper<InstanceType<typeof AvBadgeStub>>
+    })
+
+    BddTest().then('it should display the completed label', () => {
+      expect(badge.props('label')).toBe('Terminée')
+    })
+
+    BddTest().then('it should apply the light neutral background color', () => {
+      expect(badge.props('backgroundColor')).toBe('var(--light-background-neutral)')
+    })
+
+    BddTest().then('it should apply the text1 color', () => {
+      expect(badge.props('color')).toBe('var(--text1)')
+    })
+
+    BddTest().then('it should use the check circle icon', () => {
+      expect(badge.props('icon')).toBe(MDI_ICONS.CHECK_CIRCLE)
+    })
+  })
+})

--- a/src/features/student/personalCareer/components/badges/DeclaredProgramStatusBadge/DeclaredProgramStatusBadge.vue
+++ b/src/features/student/personalCareer/components/badges/DeclaredProgramStatusBadge/DeclaredProgramStatusBadge.vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+import type { EProgramStatus } from '@/api/avenir-esr'
+import { AvBadge, ICONS_DATA_URL, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
+import { useI18n } from 'vue-i18n'
+
+export interface DeclaredProgramStatusBadgeProps {
+  status: EProgramStatus
+}
+
+const { status } = defineProps<DeclaredProgramStatusBadgeProps>()
+
+const { t } = useI18n()
+
+const statusColorMap: Record<EProgramStatus, string> = {
+  NOT_STARTED: 'var(--light-background-neutral)',
+  IN_PROGRESS: 'var(--light-background-primary2)',
+  COMPLETED: 'var(--light-background-neutral)'
+}
+
+const statusIconMap: Record<EProgramStatus, string> = {
+  NOT_STARTED: ICONS_DATA_URL.MDI_HOURGLASS,
+  IN_PROGRESS: ICONS_DATA_URL.MDI_HOURGLASS,
+  COMPLETED: MDI_ICONS.CHECK_CIRCLE
+}
+
+const statusTextColorMap: Record<EProgramStatus, string> = {
+  NOT_STARTED: 'var(--text1)',
+  IN_PROGRESS: 'var(--light-foreground-primary1)',
+  COMPLETED: 'var(--text1)'
+}
+
+const statusBadgeProps = computed(() => ({
+  label: t(`student.personalCareer.declaredProgramStatus.${status}`),
+  backgroundColor: statusColorMap[status],
+  icon: statusIconMap[status],
+  color: statusTextColorMap[status],
+}))
+</script>
+
+<template>
+  <AvBadge
+    v-bind="statusBadgeProps"
+    data-testid="declared-program-status-badge"
+  />
+</template>

--- a/src/features/student/personalCareer/components/cards/DeclaredProgramCard/DeclaredProgramCard.test.ts
+++ b/src/features/student/personalCareer/components/cards/DeclaredProgramCard/DeclaredProgramCard.test.ts
@@ -1,8 +1,14 @@
 import { type DeclaredProgramViewDTO, EProgramStatus } from '@/api/avenir-esr'
 import { FloatingIconCardStub } from '@/features/student/global/components/cards/FloatingIconCard/FloatingIconCard.stub'
+import { DeclaredProgramOrganizationBadgeStub }
+  from '@/features/student/personalCareer/components/badges/DeclaredProgramOrganizationBadge/DeclaredProgramOrganizationBadge.stub'
+import { DeclaredProgramResultBadgeStub }
+  from '@/features/student/personalCareer/components/badges/DeclaredProgramResultBadge/DeclaredProgramResultBadge.stub'
+import { DeclaredProgramStatusBadgeStub }
+  from '@/features/student/personalCareer/components/badges/DeclaredProgramStatusBadge/DeclaredProgramStatusBadge.stub'
 import DeclaredProgramCard from '@/features/student/personalCareer/components/cards/DeclaredProgramCard/DeclaredProgramCard.vue'
-import { ICONS_DATA_URL, MDI_ICONS, RI_ICONS } from '@avenirs-esr/avenirs-dsav'
-import { AvBadgeStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { mount, RouterLinkStub, type VueWrapper } from '@vue/test-utils'
 import { beforeEach, expect, vi } from 'vitest'
 
@@ -11,15 +17,18 @@ BddTest().given('a declared program card', () => {
 
   const stubs = {
     FloatingIconCard: FloatingIconCardStub,
-    AvBadge: AvBadgeStub,
-    RouterLink: RouterLinkStub
+    RouterLink: RouterLinkStub,
+    DeclaredProgramStatusBadge: DeclaredProgramStatusBadgeStub,
+    DeclaredProgramResultBadge: DeclaredProgramResultBadgeStub,
+    DeclaredProgramOrganizationBadge: DeclaredProgramOrganizationBadgeStub
   }
 
-  const baseDeclaredProgram: Omit<DeclaredProgramViewDTO, 'status'> = {
+  const baseDeclaredProgram: DeclaredProgramViewDTO = {
     id: '1',
     title: 'Master en Informatique',
     organization: 'Université Paris-Saclay',
     result: 'Mention Très Bien',
+    status: EProgramStatus.IN_PROGRESS,
     valorized: false
   }
 
@@ -32,12 +41,7 @@ BddTest().given('a declared program card', () => {
 
     beforeEach(() => {
       wrapper = mount(DeclaredProgramCard, {
-        props: {
-          declaredProgram: {
-            ...baseDeclaredProgram,
-            status: EProgramStatus.IN_PROGRESS
-          }
-        },
+        props: { declaredProgram: baseDeclaredProgram },
         global: { stubs }
       })
       floatingCard = wrapper.findComponent({ name: 'FloatingIconCard' }) as VueWrapper<InstanceType<typeof FloatingIconCardStub>>
@@ -96,170 +100,50 @@ BddTest().given('a declared program card', () => {
     })
 
     BddTest().and('the status badge is rendered', () => {
-      BddTest().then('it should exist', () => {
-        const badges = wrapper.findAllComponents({ name: 'AvBadge' })
-        const statusBadge = badges.find(badge => badge.props('label') === 'En cours')
-        expect(statusBadge).toBeDefined()
+      BddTest().then('it should receive the status', () => {
+        expect(wrapper.findComponent(DeclaredProgramStatusBadgeStub).props('status')).toBe(baseDeclaredProgram.status)
       })
     })
 
     BddTest().and('the organization badge is rendered', () => {
-      let organizationBadge: VueWrapper<InstanceType<typeof AvBadgeStub>> | undefined
-
-      beforeEach(() => {
-        const badges = wrapper.findAllComponents({ name: 'AvBadge' })
-        organizationBadge = badges.find(badge => badge.props('label') === baseDeclaredProgram.organization) as VueWrapper<InstanceType<typeof AvBadgeStub>>
-      })
-
-      BddTest().then('it should exist', () => {
-        expect(organizationBadge).toBeDefined()
-      })
-
-      BddTest().then('it should have building icon', () => {
-        expect(organizationBadge?.props('icon')).toBe(MDI_ICONS.BUILDING)
-      })
-
-      BddTest().then('it should have correct colors', () => {
-        expect(organizationBadge?.props('color')).toBe('var(--text1)')
-        expect(organizationBadge?.props('backgroundColor')).toBe('transparent')
-      })
-
-      BddTest().then('it should have ellipsis enabled', () => {
-        expect(organizationBadge?.props('ellipsis')).toBe(true)
+      BddTest().then('it should receive the organization', () => {
+        expect(wrapper.findComponent(DeclaredProgramOrganizationBadgeStub).props('organization')).toBe(baseDeclaredProgram.organization)
       })
     })
 
     BddTest().and('the result badge is rendered', () => {
-      let resultBadge: VueWrapper<InstanceType<typeof AvBadgeStub>> | undefined
+      let resultBadge: VueWrapper<InstanceType<typeof DeclaredProgramResultBadgeStub>>
 
       beforeEach(() => {
-        const badges = wrapper.findAllComponents({ name: 'AvBadge' })
-        resultBadge = badges.find(badge => badge.props('label') === baseDeclaredProgram.result) as VueWrapper<InstanceType<typeof AvBadgeStub>>
+        resultBadge = wrapper.findComponent(DeclaredProgramResultBadgeStub) as VueWrapper<InstanceType<typeof DeclaredProgramResultBadgeStub>>
       })
 
-      BddTest().then('it should exist', () => {
-        expect(resultBadge).toBeDefined()
-      })
-
-      BddTest().then('it should have layout icon', () => {
-        expect(resultBadge?.props('icon')).toBe(RI_ICONS.LAYOUT_6_LINE)
-      })
-
-      BddTest().then('it should have correct colors', () => {
-        expect(resultBadge?.props('color')).toBe('var(--card2)')
-        expect(resultBadge?.props('backgroundColor')).toBe('var(--dark-background-primary1)')
-      })
-
-      BddTest().then('it should have ellipsis enabled', () => {
-        expect(resultBadge?.props('ellipsis')).toBe(true)
+      BddTest().then('it should receive the result', () => {
+        expect(resultBadge.props('result')).toBe(baseDeclaredProgram.result)
       })
 
       BddTest().then('it should have responsive visibility classes', () => {
-        expect(resultBadge?.classes()).toContain('av-hidden')
-        expect(resultBadge?.classes()).toContain('av-unhidden--md')
+        expect(resultBadge.classes()).toContain('av-hidden')
+        expect(resultBadge.classes()).toContain('av-unhidden--md')
       })
     })
   })
 
-  BddTest().when('the component is mounted with NOT_STARTED status', () => {
-    let statusBadge: VueWrapper<InstanceType<typeof AvBadgeStub>> | undefined
-
+  BddTest().when('the declared program has no status, result or organization', () => {
     beforeEach(() => {
       wrapper = mount(DeclaredProgramCard, {
         props: {
           declaredProgram: {
             ...baseDeclaredProgram,
-            status: EProgramStatus.NOT_STARTED
+            result: undefined
           }
         },
         global: { stubs }
       })
-      const badges = wrapper.findAllComponents({ name: 'AvBadge' })
-      statusBadge = badges.find(badge => badge.props('label') === 'Non démarrée') as VueWrapper<InstanceType<typeof AvBadgeStub>>
     })
 
-    BddTest().then('it should display not started status label', () => {
-      expect(statusBadge).toBeDefined()
-    })
-
-    BddTest().then('it should apply light neutral background color', () => {
-      expect(statusBadge?.props('backgroundColor')).toBe('var(--light-background-neutral)')
-    })
-
-    BddTest().then('it should apply text1 color for not started status', () => {
-      expect(statusBadge?.props('color')).toBe('var(--text1)')
-    })
-
-    BddTest().then('it should use hourglass icon', () => {
-      expect(statusBadge?.props('icon')).toBe(ICONS_DATA_URL.MDI_HOURGLASS)
-    })
-  })
-
-  BddTest().when('the component is mounted with IN_PROGRESS status', () => {
-    let statusBadge: VueWrapper<InstanceType<typeof AvBadgeStub>> | undefined
-
-    beforeEach(() => {
-      wrapper = mount(DeclaredProgramCard, {
-        props: {
-          declaredProgram: {
-            ...baseDeclaredProgram,
-            status: EProgramStatus.IN_PROGRESS
-          }
-        },
-        global: { stubs }
-      })
-      const badges = wrapper.findAllComponents({ name: 'AvBadge' })
-      statusBadge = badges.find(badge => badge.props('label') === 'En cours') as VueWrapper<InstanceType<typeof AvBadgeStub>>
-    })
-
-    BddTest().then('it should display in progress status label', () => {
-      expect(statusBadge).toBeDefined()
-    })
-
-    BddTest().then('it should apply light primary2 background color', () => {
-      expect(statusBadge?.props('backgroundColor')).toBe('var(--light-background-primary2)')
-    })
-
-    BddTest().then('it should apply light foreground primary1 color', () => {
-      expect(statusBadge?.props('color')).toBe('var(--light-foreground-primary1)')
-    })
-
-    BddTest().then('it should use hourglass icon from ICONS_DATA_URL', () => {
-      expect(statusBadge?.props('icon')).toBe(ICONS_DATA_URL.MDI_HOURGLASS)
-    })
-  })
-
-  BddTest().when('the component is mounted with COMPLETED status', () => {
-    let statusBadge: VueWrapper<InstanceType<typeof AvBadgeStub>> | undefined
-
-    beforeEach(() => {
-      wrapper = mount(DeclaredProgramCard, {
-        props: {
-          declaredProgram: {
-            ...baseDeclaredProgram,
-            status: EProgramStatus.COMPLETED
-          }
-        },
-        global: { stubs }
-      })
-      const badges = wrapper.findAllComponents({ name: 'AvBadge' })
-      statusBadge = badges.find(badge => badge.props('label') === 'Terminée') as VueWrapper<InstanceType<typeof AvBadgeStub>>
-    })
-
-    BddTest().then('it should display completed status label', () => {
-      expect(statusBadge).toBeDefined()
-    })
-
-    BddTest().then('it should apply light neutral background color', () => {
-      expect(statusBadge?.props('backgroundColor')).toBe('var(--light-background-neutral)')
-    })
-
-    BddTest().then('it should apply text1 color for completed status', () => {
-      expect(statusBadge?.props('color')).toBe('var(--text1)')
-    })
-
-    BddTest().then('it should use check outline icon', () => {
-      expect(statusBadge?.props('icon')).toBe(MDI_ICONS.CHECK_CIRCLE)
+    BddTest().then('it should not render the result badge', () => {
+      expect(wrapper.findComponent(DeclaredProgramResultBadgeStub).exists()).toBe(false)
     })
   })
 })

--- a/src/features/student/personalCareer/components/cards/DeclaredProgramCard/DeclaredProgramCard.vue
+++ b/src/features/student/personalCareer/components/cards/DeclaredProgramCard/DeclaredProgramCard.vue
@@ -1,13 +1,16 @@
 <script setup lang="ts">
-import type { DeclaredProgramViewDTO, EProgramStatus } from '@/api/avenir-esr'
+import type { DeclaredProgramViewDTO } from '@/api/avenir-esr'
 import { ROUTES } from '@/common/constants'
 import FloatingIconCard from '@/features/student/global/components/cards/FloatingIconCard/FloatingIconCard.vue'
-import { AvBadge, ICONS_DATA_URL, MDI_ICONS, RI_ICONS } from '@avenirs-esr/avenirs-dsav'
-import { useI18n } from 'vue-i18n'
+import DeclaredProgramOrganizationBadge
+  from '@/features/student/personalCareer/components/badges/DeclaredProgramOrganizationBadge/DeclaredProgramOrganizationBadge.vue'
+import DeclaredProgramResultBadge
+  from '@/features/student/personalCareer/components/badges/DeclaredProgramResultBadge/DeclaredProgramResultBadge.vue'
+import DeclaredProgramStatusBadge
+  from '@/features/student/personalCareer/components/badges/DeclaredProgramStatusBadge/DeclaredProgramStatusBadge.vue'
+import { MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
 
 const { declaredProgram } = defineProps<{ declaredProgram: DeclaredProgramViewDTO }>()
-
-const { t } = useI18n()
 
 const iconOptions = {
   name: MDI_ICONS.SCHOOL_OUTLINE,
@@ -16,35 +19,6 @@ const iconOptions = {
   bottom: 'calc(-1 * 3.3rem)',
   borderColor: 'var(--other-border-skill-card)'
 }
-
-const statusColorMap: Record<EProgramStatus, string> = {
-  NOT_STARTED: 'var(--light-background-neutral)',
-  IN_PROGRESS: 'var(--light-background-primary2)',
-  COMPLETED: 'var(--light-background-neutral)'
-}
-
-const statusIconMap: Record<EProgramStatus, string> = {
-  NOT_STARTED: ICONS_DATA_URL.MDI_HOURGLASS,
-  IN_PROGRESS: ICONS_DATA_URL.MDI_HOURGLASS,
-  COMPLETED: MDI_ICONS.CHECK_CIRCLE
-}
-
-const statusTextColorMap: Record<EProgramStatus, string> = {
-  NOT_STARTED: 'var(--text1)',
-  IN_PROGRESS: 'var(--light-foreground-primary1)',
-  COMPLETED: 'var(--text1)'
-}
-
-const statusBadgeProps = computed(() => {
-  const status = declaredProgram.status
-
-  return {
-    label: status ? t(`student.personalCareer.declaredProgramStatus.${status}`) : t(`student.personalCareer.declaredProgramStatus.NOT_STARTED`),
-    backgroundColor: status ? statusColorMap[status] : statusColorMap.NOT_STARTED,
-    icon: status ? statusIconMap[status] : statusIconMap.NOT_STARTED,
-    color: status ? statusTextColorMap[status] : statusTextColorMap.NOT_STARTED,
-  }
-})
 </script>
 
 <template>
@@ -66,27 +40,19 @@ const statusBadgeProps = computed(() => {
       <template #body>
         <div class="av-col av-pr-4xl--md av-pt-xl av-pt-none--md">
           <div class="av-col av-row--md av-align-end av-justify-end--md av-gap-sm">
-            <AvBadge
+            <DeclaredProgramStatusBadge
               v-if="declaredProgram.status"
-              v-bind="statusBadgeProps"
+              :status="declaredProgram.status"
             />
-            <AvBadge
+            <DeclaredProgramResultBadge
               v-if="declaredProgram.result"
               class="av-hidden av-unhidden--md"
-              :label="declaredProgram.result"
-              :icon="RI_ICONS.LAYOUT_6_LINE"
-              color="var(--card2)"
-              background-color="var(--dark-background-primary1)"
-              ellipsis
+              :result="declaredProgram.result"
             />
 
-            <AvBadge
+            <DeclaredProgramOrganizationBadge
               v-if="declaredProgram.organization"
-              :label="declaredProgram.organization"
-              :icon="MDI_ICONS.BUILDING"
-              color="var(--text1)"
-              background-color="transparent"
-              ellipsis
+              :organization="declaredProgram.organization"
             />
           </div>
         </div>

--- a/src/features/student/personalCareer/index.ts
+++ b/src/features/student/personalCareer/index.ts
@@ -4,6 +4,15 @@ export { default as DeclaredExperienceOrganizationBadge }
 export { default as DeclaredExperienceTypeBadge }
   from '@/features/student/personalCareer/components/badges/DeclaredExperienceTypeBadge/DeclaredExperienceTypeBadge.vue'
 
+export { default as DeclaredProgramOrganizationBadge }
+  from '@/features/student/personalCareer/components/badges/DeclaredProgramOrganizationBadge/DeclaredProgramOrganizationBadge.vue'
+
+export { default as DeclaredProgramResultBadge }
+  from '@/features/student/personalCareer/components/badges/DeclaredProgramResultBadge/DeclaredProgramResultBadge.vue'
+
+export { default as DeclaredProgramStatusBadge }
+  from '@/features/student/personalCareer/components/badges/DeclaredProgramStatusBadge/DeclaredProgramStatusBadge.vue'
+
 export { default as AssociatedDeclaredExperiencesCard }
   from '@/features/student/personalCareer/components/cards/AssociatedDeclaredExperiencesCard/AssociatedDeclaredExperiencesCard.vue'
 

--- a/src/features/student/personalCareer/views/PersonalCareerView/sections/ProgramsSection/components/DeleteDeclaredProgramsModal/DeleteDeclaredProgramsModal.test.ts
+++ b/src/features/student/personalCareer/views/PersonalCareerView/sections/ProgramsSection/components/DeleteDeclaredProgramsModal/DeleteDeclaredProgramsModal.test.ts
@@ -1,5 +1,5 @@
 import type { VueWrapper } from '@vue/test-utils'
-import { declaredProgramsQueryEmptyHandler, declaredProgramsQueryErrorHandler, declaredProgramsQueryHandler } from '@/__mocks__/msw/handlers/student/declaredPrograms.handlers'
+import { declaredProgramsQueryEmptyHandler, declaredProgramsQueryErrorHandler } from '@/__mocks__/msw/handlers/student/declaredPrograms.handlers'
 import { server } from '@/__mocks__/msw/server'
 import { LoaderStub } from '@/common/components/Loader/Loader.stub'
 import { DeleteDeclaredProgramConfirmModalStub } from '@/features/student/personalCareer/components/overlays/DeleteDeclaredProgramConfirmModal/DeleteDeclaredProgramConfirmModal.stub'
@@ -93,7 +93,6 @@ BddTest().given('a delete declared programs modal', () => {
 
   BddTest().when('the component is mounted and the query returns declared programs', () => {
     beforeEach(() => {
-      server.use(declaredProgramsQueryHandler)
       wrapper = mountComponent(DeleteDeclaredProgramsModal, { props: { show: true, totalCount: 10 }, global: { stubs } })
     })
 


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
This PR introduces valorized declared programs display in the kit view, building upon the previously added declared experiences functionality. It includes new components for displaying declared programs and experiences in the kit, along with supporting badges for program status, result, and organization information.

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/2151

---

### Documentation
- Updated API specification (`api-specs/avenir-esr.swagger.json`) with new program and experience endpoints
- Added internationalization (i18n) for kit view components in both English and French
- Component structure follows established patterns with stubs for testing

---

### Target Branch
`develop`

---

### Additional Notes
- Added comprehensive test coverage for all new components (ValorizedDeclaredProgramItem, ValorizedDeclaredExperiencesContainer, ValorizedDeclaredProgramsContainer, etc.)
- Created reusable badges for displaying program status, result, and organization information
- Added date utility functions to support date formatting across the application
- Integrated with existing kit view architecture and valorized elements card container
- Updated MSW handlers to support declared programs and experiences mocking

---

### Known Limitations or Side Effects
None identified.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [x] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [x] i18n handled (texts are translated)
- [x] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [x] Semantic Versioning respected
- [x] Add to `CHANGELOG.md` file all properties and database change and detaiils for the update process