### PR TITLE
feat(2153): display self-knowledge elements in kit view

### DIFF
--- a/src/features/student/kit/locales/en.json
+++ b/src/features/student/kit/locales/en.json
@@ -58,6 +58,11 @@
               "emptyStateItemLabel": "an interest",
               "seeAll": "See all my interests",
               "title": "My interest (1) | My interests ({count})"
+            },
+            "OTHERS": {
+              "emptyStateItemLabel": "an information",
+              "seeAll": "See all my other information",
+              "title": "Other information (1) | Other information ({count})"
             }
           }
         }

--- a/src/features/student/kit/locales/fr.json
+++ b/src/features/student/kit/locales/fr.json
@@ -58,6 +58,11 @@
               "emptyStateItemLabel": "un centre d'intérêt",
               "seeAll": "Voir tous mes centres d'intérêt",
               "title": "Centre d'intérêt (1) | Centres d'intérêt ({count})"
+            },
+            "OTHERS": {
+              "emptyStateItemLabel": "une information",
+              "seeAll": "Voir toutes mes autres informations",
+              "title": "Autre information (1) | Autres informations ({count})"
             }
           }
         }

--- a/src/features/student/kit/views/StudentToolsKitView/components/KitTextContentTab/KitTextContentTab.test.ts
+++ b/src/features/student/kit/views/StudentToolsKitView/components/KitTextContentTab/KitTextContentTab.test.ts
@@ -12,7 +12,7 @@ const stubs = {
   ValorizedDeclaredSkillsContainer: ValorizedDeclaredSkillsContainerStub,
   ValorizedDeclaredExperiencesContainer: ValorizedDeclaredExperiencesContainerStub,
   ValorizedDeclaredProgramsContainer: ValorizedDeclaredProgramsContainerStub,
-  ValorizedSelfKnowledgeInterestsContainer: ValorizedSelfKnowledgeContainerStub
+  ValorizedSelfKnowledgeContainer: ValorizedSelfKnowledgeContainerStub
 }
 
 BddTest().given('a kit text content tab', () => {
@@ -39,8 +39,14 @@ BddTest().given('a kit text content tab', () => {
       expect(wrapper.findComponent(ValorizedDeclaredProgramsContainerStub).exists()).toBe(true)
     })
 
-    BddTest().then('it should render the valorized self knowledge interests container', () => {
-      expect(wrapper.findComponent(ValorizedSelfKnowledgeContainerStub).exists()).toBe(true)
+    BddTest().then('it should render the interests self knowledge container then the other information one', () => {
+      const containers = wrapper.findAllComponents(ValorizedSelfKnowledgeContainerStub)
+      expect(containers.map(container => container.props('interestsOnly'))).toEqual([true, false])
+    })
+
+    BddTest().then('it should render both self knowledge containers with their own test id', () => {
+      expect(wrapper.find('[data-testid="valorized-self-knowledge-interests-container-stub"]').exists()).toBe(true)
+      expect(wrapper.find('[data-testid="valorized-self-knowledge-others-container-stub"]').exists()).toBe(true)
     })
   })
 })

--- a/src/features/student/kit/views/StudentToolsKitView/components/KitTextContentTab/KitTextContentTab.vue
+++ b/src/features/student/kit/views/StudentToolsKitView/components/KitTextContentTab/KitTextContentTab.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { EExperienceType, ESelfKnowledgeCategory } from '@/api/avenir-esr'
+import { EExperienceType } from '@/api/avenir-esr'
 import ValorizedDeclaredExperiencesContainer from '@/features/student/kit/views/StudentToolsKitView/components/ValorizedDeclaredExperiencesContainer/ValorizedDeclaredExperiencesContainer.vue'
 import ValorizedDeclaredProgramsContainer from '@/features/student/kit/views/StudentToolsKitView/components/ValorizedDeclaredProgramsContainer/ValorizedDeclaredProgramsContainer.vue'
 import ValorizedDeclaredSkillsContainer from '@/features/student/kit/views/StudentToolsKitView/components/ValorizedDeclaredSkillsContainer/ValorizedDeclaredSkillsContainer.vue'
@@ -12,6 +12,7 @@ import ValorizedSelfKnowledgeContainer from '@/features/student/kit/views/Studen
     <ValorizedDeclaredExperiencesContainer :experience-type="EExperienceType.PROFESSIONAL" />
     <ValorizedDeclaredExperiencesContainer :experience-type="EExperienceType.PERSONAL" />
     <ValorizedDeclaredProgramsContainer />
-    <ValorizedSelfKnowledgeContainer :category="ESelfKnowledgeCategory.INTERESTS" />
+    <ValorizedSelfKnowledgeContainer interests-only />
+    <ValorizedSelfKnowledgeContainer />
   </div>
 </template>

--- a/src/features/student/kit/views/StudentToolsKitView/components/ValorizedSelfKnowledgeContainer/ValorizedSelfKnowledgeContainer.stub.ts
+++ b/src/features/student/kit/views/StudentToolsKitView/components/ValorizedSelfKnowledgeContainer/ValorizedSelfKnowledgeContainer.stub.ts
@@ -1,4 +1,7 @@
 export const ValorizedSelfKnowledgeContainerStub = defineComponent({
   name: 'ValorizedSelfKnowledgeContainer',
-  template: '<div data-testid="valorized-self-knowledge-interests-container-stub" />',
+  props: {
+    interestsOnly: { type: Boolean, default: false }
+  },
+  template: '<div :data-testid="interestsOnly ? \'valorized-self-knowledge-interests-container-stub\' : \'valorized-self-knowledge-others-container-stub\'" />',
 })

--- a/src/features/student/kit/views/StudentToolsKitView/components/ValorizedSelfKnowledgeContainer/ValorizedSelfKnowledgeContainer.test.ts
+++ b/src/features/student/kit/views/StudentToolsKitView/components/ValorizedSelfKnowledgeContainer/ValorizedSelfKnowledgeContainer.test.ts
@@ -1,120 +1,262 @@
-import type { GetSelfKnowledgeElementsParams } from '@/api/avenir-esr'
+import type { GetSelfKnowledgeElementsParams, PagedResponseSelfKnowledgeElementViewDTO } from '@/api/avenir-esr'
 import { createMockedPagedResponseSelfKnowledgeElementViewDTO } from '@/__mocks__/fixtures/student/self-knowledge.fixtures'
 import { createSelfKnowledgeElementsHandler, selfKnowledgeCategoryElementsErrorHandler } from '@/__mocks__/msw/handlers/student/self-knowledge.handlers'
 import { server } from '@/__mocks__/msw/server'
 import { ESelfKnowledgeCategory } from '@/api/avenir-esr'
 import { ROUTES } from '@/common/constants'
+import { ProjectTrajectoryItems } from '@/features/student/global/views/StudentProjectTrajectoriesView/types'
 import { ValorizedElementsCardContainerStub } from '@/features/student/kit/components/cards/ValorizedElementsCardContainer/ValorizedElementsCardContainer.stub'
 import ValorizedSelfKnowledgeContainer from '@/features/student/kit/views/StudentToolsKitView/components/ValorizedSelfKnowledgeContainer/ValorizedSelfKnowledgeContainer.vue'
+import { ValorizedSelfKnowledgeItemStub } from '@/features/student/kit/views/StudentToolsKitView/components/ValorizedSelfKnowledgeItem/ValorizedSelfKnowledgeItem.stub'
 import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { flushPromises, type VueWrapper } from '@vue/test-utils'
 import { mountComponent } from 'tests/utils'
 
-BddTest().given('a valorized self knowledge interests container', () => {
+const otherCategories = [
+  ESelfKnowledgeCategory.STRENGTHS,
+  ESelfKnowledgeCategory.VALUES,
+  ESelfKnowledgeCategory.ASPIRATIONS,
+  ESelfKnowledgeCategory.MOTIVATION,
+  ESelfKnowledgeCategory.IMPROVEMENT,
+  ESelfKnowledgeCategory.INSPIRATIONS,
+  ESelfKnowledgeCategory.OBLIGATIONS,
+  ESelfKnowledgeCategory.TESTIMONIALS
+]
+
+function createMixedCategoriesResponse (categories: ESelfKnowledgeCategory[]): PagedResponseSelfKnowledgeElementViewDTO {
+  return {
+    data: categories.map((type, index) => ({
+      id: `element-${index}`,
+      title: `Élément ${index}`,
+      description: `Description ${index}`,
+      category: { type, mandatory: true }
+    })),
+    page: { page: 0, pageSize: 100, totalElements: categories.length, totalPages: 1 }
+  }
+}
+
+BddTest().given('a valorized self knowledge container', () => {
   let wrapper: VueWrapper<InstanceType<typeof ValorizedSelfKnowledgeContainer>>
   let requestedParams: GetSelfKnowledgeElementsParams
 
   const stubs = {
     ValorizedElementsCardContainer: ValorizedElementsCardContainerStub,
-    ValorizedItem: { template: '<div data-testid="valorized-item-stub" />' }
+    ValorizedSelfKnowledgeItem: ValorizedSelfKnowledgeItemStub
   }
 
-  const mountInterestsContainer = async () => {
-    wrapper = mountComponent(ValorizedSelfKnowledgeContainer, { props: { category: ESelfKnowledgeCategory.INTERESTS }, global: { stubs } })
+  const mountContainer = async (interestsOnly: boolean) => {
+    wrapper = mountComponent(ValorizedSelfKnowledgeContainer, { props: { interestsOnly }, global: { stubs } })
     await flushPromises()
   }
 
-  BddTest().when('the self knowledge elements request succeeds with 3 interests', () => {
-    const mockedResponse = createMockedPagedResponseSelfKnowledgeElementViewDTO(ESelfKnowledgeCategory.INTERESTS, 100, 3, 0)
+  BddTest().given('the interests only variant', () => {
+    BddTest().when('the self knowledge elements request succeeds with 3 interests', () => {
+      const mockedResponse = createMockedPagedResponseSelfKnowledgeElementViewDTO(ESelfKnowledgeCategory.INTERESTS, 100, 3, 0)
 
-    beforeEach(async () => {
-      server.use(createSelfKnowledgeElementsHandler(mockedResponse, (params) => {
-        requestedParams = params
-      }))
+      beforeEach(async () => {
+        server.use(createSelfKnowledgeElementsHandler(mockedResponse, (params) => {
+          requestedParams = params
+        }))
 
-      await mountInterestsContainer()
+        await mountContainer(true)
+      })
+
+      BddTest().then('it should fetch self knowledge elements with the interests category only, isValorized true and pageSize 100', () => {
+        expect(requestedParams.selfKnowledgeCategories).toEqual([ESelfKnowledgeCategory.INTERESTS])
+        expect(requestedParams.isValorized).toBe(true)
+        expect(requestedParams.pageSize).toBe(100)
+      })
+
+      BddTest().then('it should render the title with the total elements count', () => {
+        const container = wrapper.findComponent(ValorizedElementsCardContainerStub)
+        expect(container.exists()).toBe(true)
+        expect(container.props('title')).toBe('Centres d\'intérêt (3)')
+      })
+
+      BddTest().then('it should not be loading and have no error once fetched', () => {
+        const container = wrapper.findComponent(ValorizedElementsCardContainerStub)
+        expect(container.props('isLoading')).toBe(false)
+        expect(container.props('error')).toBe(null)
+      })
+
+      BddTest().then('it should render one item per interest without the category badge', () => {
+        const items = wrapper.findAllComponents(ValorizedSelfKnowledgeItemStub)
+        expect(items).toHaveLength(3)
+        expect(items.every(item => item.props('showCategoryBadge') === false)).toBe(true)
+      })
+
+      BddTest().then('it should not be empty and pass the empty state message and see all link to the interests category', () => {
+        const container = wrapper.findComponent(ValorizedElementsCardContainerStub)
+        expect(container.props('isEmpty')).toBe(false)
+        expect(container.props('emptyStateMessage')).toBe('Vous n\'avez pas encore valorisé ce type de contenu, ajoutez et valorisez un centre d\'intérêt afin de constituer votre kit')
+        expect(container.props('seeAllLabel')).toBe('Voir tous mes centres d\'intérêt')
+        expect(container.props('seeAllTo')).toEqual({
+          name: ROUTES.STUDENT.SELFKNOWLEDGE_CATEGORY.name,
+          params: { id: ESelfKnowledgeCategory.INTERESTS }
+        })
+      })
+
+      BddTest().then('it should expose the interests container test id', () => {
+        expect(wrapper.find('[data-testid="valorized-self-knowledge-interests-container"]').exists()).toBe(true)
+      })
     })
 
-    BddTest().then('it should fetch self knowledge elements with INTERESTS category, isValorized true and pageSize 100', () => {
-      expect(requestedParams.selfKnowledgeCategories).toContain(ESelfKnowledgeCategory.INTERESTS)
-      expect(requestedParams.isValorized).toBe(true)
-      expect(requestedParams.pageSize).toBe(100)
+    BddTest().when('the self knowledge elements request succeeds with a single interest', () => {
+      const mockedResponse = createMockedPagedResponseSelfKnowledgeElementViewDTO(ESelfKnowledgeCategory.INTERESTS, 100, 1, 0)
+
+      beforeEach(async () => {
+        server.use(createSelfKnowledgeElementsHandler(mockedResponse))
+
+        await mountContainer(true)
+      })
+
+      BddTest().then('it should render the title in the singular form', () => {
+        expect(wrapper.findComponent(ValorizedElementsCardContainerStub).props('title')).toBe('Centre d\'intérêt (1)')
+      })
+
+      BddTest().then('it should render a single item', () => {
+        expect(wrapper.findAllComponents(ValorizedSelfKnowledgeItemStub)).toHaveLength(1)
+      })
     })
 
-    BddTest().then('it should render the title with the total elements count', () => {
-      const container = wrapper.findComponent(ValorizedElementsCardContainerStub)
-      expect(container.exists()).toBe(true)
-      expect(container.props('title')).toBe('Centres d\'intérêt (3)')
+    BddTest().when('the self knowledge elements request succeeds with 0 interests', () => {
+      const mockedResponse = createMockedPagedResponseSelfKnowledgeElementViewDTO(ESelfKnowledgeCategory.INTERESTS, 100, 0, 0)
+
+      beforeEach(async () => {
+        server.use(createSelfKnowledgeElementsHandler(mockedResponse))
+
+        await mountContainer(true)
+      })
+
+      BddTest().then('it should render no item', () => {
+        expect(wrapper.findAllComponents(ValorizedSelfKnowledgeItemStub)).toHaveLength(0)
+      })
+
+      BddTest().then('it should mark the container as empty', () => {
+        expect(wrapper.findComponent(ValorizedElementsCardContainerStub).props('isEmpty')).toBe(true)
+      })
+
+      BddTest().then('it should fall back to the self knowledge section link', () => {
+        expect(wrapper.findComponent(ValorizedElementsCardContainerStub).props('seeAllTo')).toEqual({
+          name: ROUTES.STUDENT.PROJECT_TRAJECTORIES.name,
+          query: { section: ProjectTrajectoryItems.SELF_KNOWLEDGE }
+        })
+      })
     })
 
-    BddTest().then('it should not be loading and have no error once fetched', () => {
-      const container = wrapper.findComponent(ValorizedElementsCardContainerStub)
-      expect(container.props('isLoading')).toBe(false)
-      expect(container.props('error')).toBe(null)
-    })
+    BddTest().when('the self knowledge elements request fails', () => {
+      beforeEach(async () => {
+        server.use(selfKnowledgeCategoryElementsErrorHandler)
 
-    BddTest().then('it should render one ValorizedItem per interest', () => {
-      const items = wrapper.findAll('[data-testid="valorized-item-stub"]')
-      expect(items).toHaveLength(3)
-    })
+        await mountContainer(true)
+      })
 
-    BddTest().then('it should not be empty and pass the empty state message and see all link to the interests category', () => {
-      const container = wrapper.findComponent(ValorizedElementsCardContainerStub)
-      expect(container.props('isEmpty')).toBe(false)
-      expect(container.props('emptyStateMessage')).toBe('Vous n\'avez pas encore valorisé ce type de contenu, ajoutez et valorisez un centre d\'intérêt afin de constituer votre kit')
-      expect(container.props('seeAllLabel')).toBe('Voir tous mes centres d\'intérêt')
-      expect(container.props('seeAllTo')).toEqual({
-        name: ROUTES.STUDENT.SELFKNOWLEDGE_CATEGORY.name,
-        params: { id: ESelfKnowledgeCategory.INTERESTS }
+      BddTest().then('it should forward the error to the card container', () => {
+        expect(wrapper.findComponent(ValorizedElementsCardContainerStub).props('error')).toBeTruthy()
       })
     })
   })
 
-  BddTest().when('the self knowledge elements request succeeds with a single interest', () => {
-    const mockedResponse = createMockedPagedResponseSelfKnowledgeElementViewDTO(ESelfKnowledgeCategory.INTERESTS, 100, 1, 0)
+  BddTest().given('the other information variant', () => {
+    BddTest().when('the self knowledge elements request succeeds with 3 elements of mixed categories', () => {
+      const mockedResponse = createMixedCategoriesResponse([
+        ESelfKnowledgeCategory.VALUES,
+        ESelfKnowledgeCategory.STRENGTHS,
+        ESelfKnowledgeCategory.MOTIVATION
+      ])
 
-    beforeEach(async () => {
-      server.use(createSelfKnowledgeElementsHandler(mockedResponse))
+      beforeEach(async () => {
+        server.use(createSelfKnowledgeElementsHandler(mockedResponse, (params) => {
+          requestedParams = params
+        }))
 
-      await mountInterestsContainer()
+        await mountContainer(false)
+      })
+
+      BddTest().then('it should fetch every category but interests, with isValorized true and pageSize 100', () => {
+        expect(requestedParams.selfKnowledgeCategories).toEqual(otherCategories)
+        expect(requestedParams.selfKnowledgeCategories).not.toContain(ESelfKnowledgeCategory.INTERESTS)
+        expect(requestedParams.isValorized).toBe(true)
+        expect(requestedParams.pageSize).toBe(100)
+      })
+
+      BddTest().then('it should render the title with the total elements count', () => {
+        expect(wrapper.findComponent(ValorizedElementsCardContainerStub).props('title')).toBe('Autres informations (3)')
+      })
+
+      BddTest().then('it should render one item per element with the category badge, in the api order', () => {
+        const items = wrapper.findAllComponents(ValorizedSelfKnowledgeItemStub)
+        expect(items).toHaveLength(3)
+        expect(items.every(item => item.props('showCategoryBadge') === true)).toBe(true)
+        expect(items.map(item => item.props('element').category.type)).toEqual([
+          ESelfKnowledgeCategory.VALUES,
+          ESelfKnowledgeCategory.STRENGTHS,
+          ESelfKnowledgeCategory.MOTIVATION
+        ])
+      })
+
+      BddTest().then('it should pass the empty state message and see all link to the self knowledge section', () => {
+        const container = wrapper.findComponent(ValorizedElementsCardContainerStub)
+        expect(container.props('isEmpty')).toBe(false)
+        expect(container.props('emptyStateMessage')).toBe('Vous n\'avez pas encore valorisé ce type de contenu, ajoutez et valorisez une information afin de constituer votre kit')
+        expect(container.props('seeAllLabel')).toBe('Voir toutes mes autres informations')
+        expect(container.props('seeAllTo')).toEqual({
+          name: ROUTES.STUDENT.PROJECT_TRAJECTORIES.name,
+          query: { section: ProjectTrajectoryItems.SELF_KNOWLEDGE }
+        })
+      })
+
+      BddTest().then('it should expose the other information container test id', () => {
+        expect(wrapper.find('[data-testid="valorized-self-knowledge-others-container"]').exists()).toBe(true)
+      })
     })
 
-    BddTest().then('it should render the title in the singular form', () => {
-      expect(wrapper.findComponent(ValorizedElementsCardContainerStub).props('title')).toBe('Centre d\'intérêt (1)')
+    BddTest().when('the self knowledge elements request succeeds with a single element', () => {
+      const mockedResponse = createMixedCategoriesResponse([ESelfKnowledgeCategory.TESTIMONIALS])
+
+      beforeEach(async () => {
+        server.use(createSelfKnowledgeElementsHandler(mockedResponse))
+
+        await mountContainer(false)
+      })
+
+      BddTest().then('it should render the title in the singular form', () => {
+        expect(wrapper.findComponent(ValorizedElementsCardContainerStub).props('title')).toBe('Autre information (1)')
+      })
+
+      BddTest().then('it should render a single item', () => {
+        expect(wrapper.findAllComponents(ValorizedSelfKnowledgeItemStub)).toHaveLength(1)
+      })
     })
 
-    BddTest().then('it should render a single ValorizedItem', () => {
-      expect(wrapper.findAll('[data-testid="valorized-item-stub"]')).toHaveLength(1)
-    })
-  })
+    BddTest().when('the self knowledge elements request succeeds with 0 element', () => {
+      const mockedResponse = createMixedCategoriesResponse([])
 
-  BddTest().when('the self knowledge elements request succeeds with 0 interests', () => {
-    const mockedResponse = createMockedPagedResponseSelfKnowledgeElementViewDTO(ESelfKnowledgeCategory.INTERESTS, 100, 0, 0)
+      beforeEach(async () => {
+        server.use(createSelfKnowledgeElementsHandler(mockedResponse))
 
-    beforeEach(async () => {
-      server.use(createSelfKnowledgeElementsHandler(mockedResponse))
+        await mountContainer(false)
+      })
 
-      await mountInterestsContainer()
-    })
+      BddTest().then('it should render no item', () => {
+        expect(wrapper.findAllComponents(ValorizedSelfKnowledgeItemStub)).toHaveLength(0)
+      })
 
-    BddTest().then('it should render no ValorizedItem', () => {
-      expect(wrapper.findAll('[data-testid="valorized-item-stub"]')).toHaveLength(0)
-    })
-
-    BddTest().then('it should mark the container as empty', () => {
-      expect(wrapper.findComponent(ValorizedElementsCardContainerStub).props('isEmpty')).toBe(true)
-    })
-  })
-
-  BddTest().when('the self knowledge elements request fails', () => {
-    beforeEach(async () => {
-      server.use(selfKnowledgeCategoryElementsErrorHandler)
-
-      await mountInterestsContainer()
+      BddTest().then('it should mark the container as empty', () => {
+        expect(wrapper.findComponent(ValorizedElementsCardContainerStub).props('isEmpty')).toBe(true)
+      })
     })
 
-    BddTest().then('it should forward the error to the card container', () => {
-      expect(wrapper.findComponent(ValorizedElementsCardContainerStub).props('error')).toBeTruthy()
+    BddTest().when('the self knowledge elements request fails', () => {
+      beforeEach(async () => {
+        server.use(selfKnowledgeCategoryElementsErrorHandler)
+
+        await mountContainer(false)
+      })
+
+      BddTest().then('it should forward the error to the card container', () => {
+        expect(wrapper.findComponent(ValorizedElementsCardContainerStub).props('error')).toBeTruthy()
+      })
     })
   })
 })

--- a/src/features/student/kit/views/StudentToolsKitView/components/ValorizedSelfKnowledgeContainer/ValorizedSelfKnowledgeContainer.vue
+++ b/src/features/student/kit/views/StudentToolsKitView/components/ValorizedSelfKnowledgeContainer/ValorizedSelfKnowledgeContainer.vue
@@ -1,22 +1,27 @@
 <script setup lang="ts">
-import type { ESelfKnowledgeCategory } from '@/api/avenir-esr'
-import { useGetSelfKnowledgeElements } from '@/api/avenir-esr'
+import { ESelfKnowledgeCategory, useGetSelfKnowledgeElements } from '@/api/avenir-esr'
 import { ROUTES } from '@/common/constants'
 import { ProjectTrajectoryItems } from '@/features/student/global/views/StudentProjectTrajectoriesView/types'
 import ValorizedElementsCardContainer from '@/features/student/kit/components/cards/ValorizedElementsCardContainer/ValorizedElementsCardContainer.vue'
-import ValorizedItem from '@/features/student/kit/views/StudentToolsKitView/components/ValorizedItem/ValorizedItem.vue'
+import ValorizedSelfKnowledgeItem from '@/features/student/kit/views/StudentToolsKitView/components/ValorizedSelfKnowledgeItem/ValorizedSelfKnowledgeItem.vue'
 import { useI18n } from 'vue-i18n'
 
-export interface ValorizedSelfKnowledgeInterestsContainerProps {
-  category: ESelfKnowledgeCategory
+export interface ValorizedSelfKnowledgeContainerProps {
+  interestsOnly?: boolean
 }
 
-const { category } = defineProps<ValorizedSelfKnowledgeInterestsContainerProps>()
+const { interestsOnly = false } = defineProps<ValorizedSelfKnowledgeContainerProps>()
 
 const { t } = useI18n()
 
+const categories = computed(() => interestsOnly
+  ? [ESelfKnowledgeCategory.INTERESTS]
+  : Object.values(ESelfKnowledgeCategory).filter(category => category !== ESelfKnowledgeCategory.INTERESTS))
+
+const i18nKey = computed(() => interestsOnly ? ESelfKnowledgeCategory.INTERESTS : 'OTHERS')
+
 const { data, error, isFetching } = useGetSelfKnowledgeElements(
-  { selfKnowledgeCategories: [category], isValorized: true, pageSize: 100 }
+  computed(() => ({ selfKnowledgeCategories: categories.value, isValorized: true, pageSize: 100 }))
 )
 
 const elements = computed(() => data.value?.data ?? [])
@@ -24,11 +29,11 @@ const totalElements = computed(() => data.value?.page?.totalElements ?? 0)
 const isEmpty = computed(() => totalElements.value === 0)
 
 const seeAllTo = computed(() => {
-  if (totalElements.value > 0) {
+  if (interestsOnly && totalElements.value > 0) {
     return {
       name: ROUTES.STUDENT.SELFKNOWLEDGE_CATEGORY.name,
       params: {
-        id: category
+        id: ESelfKnowledgeCategory.INTERESTS
       }
     }
   }
@@ -43,29 +48,31 @@ const seeAllTo = computed(() => {
 
 const emptyStateMessage = computed(() => t(
   'student.kit.cards.ValorizedElementsCardContainer.emptyState',
-  { item: t(`student.kit.views.StudentToolsKitView.valorizedSelfKnowledgeContainer.${category}.emptyStateItemLabel`) }
+  { item: t(`student.kit.views.StudentToolsKitView.valorizedSelfKnowledgeContainer.${i18nKey.value}.emptyStateItemLabel`) }
 ))
+
+const dataTestId = computed(() => interestsOnly
+  ? 'valorized-self-knowledge-interests-container'
+  : 'valorized-self-knowledge-others-container')
 </script>
 
 <template>
   <ValorizedElementsCardContainer
-    :title="t(`student.kit.views.StudentToolsKitView.valorizedSelfKnowledgeContainer.${category}.title`, { count: totalElements })"
+    :title="t(`student.kit.views.StudentToolsKitView.valorizedSelfKnowledgeContainer.${i18nKey}.title`, { count: totalElements })"
     :error="error"
     :is-loading="isFetching"
     :is-empty="isEmpty"
     :empty-state-message="emptyStateMessage"
-    :see-all-label="t(`student.kit.views.StudentToolsKitView.valorizedSelfKnowledgeContainer.${category}.seeAll`)"
+    :see-all-label="t(`student.kit.views.StudentToolsKitView.valorizedSelfKnowledgeContainer.${i18nKey}.seeAll`)"
     :see-all-to="seeAllTo"
-    data-testid="valorized-self-knowledge-interests-container"
+    :data-testid="dataTestId"
     collapsed
   >
-    <ValorizedItem
-      v-for="interest in elements"
-      :key="interest.id"
-      :title="interest.title"
-      :item-id="interest.id"
-      :parent-id="category"
-      :type="category"
+    <ValorizedSelfKnowledgeItem
+      v-for="element in elements"
+      :key="element.id"
+      :element="element"
+      :show-category-badge="!interestsOnly"
     />
   </ValorizedElementsCardContainer>
 </template>

--- a/src/features/student/kit/views/StudentToolsKitView/components/ValorizedSelfKnowledgeItem/ValorizedSelfKnowledgeItem.stub.ts
+++ b/src/features/student/kit/views/StudentToolsKitView/components/ValorizedSelfKnowledgeItem/ValorizedSelfKnowledgeItem.stub.ts
@@ -1,0 +1,8 @@
+export const ValorizedSelfKnowledgeItemStub = defineComponent({
+  name: 'ValorizedSelfKnowledgeItem',
+  props: {
+    element: { type: Object, required: true },
+    showCategoryBadge: { type: Boolean, default: false }
+  },
+  template: '<div data-testid="valorized-self-knowledge-item-stub" />'
+})

--- a/src/features/student/kit/views/StudentToolsKitView/components/ValorizedSelfKnowledgeItem/ValorizedSelfKnowledgeItem.test.ts
+++ b/src/features/student/kit/views/StudentToolsKitView/components/ValorizedSelfKnowledgeItem/ValorizedSelfKnowledgeItem.test.ts
@@ -1,0 +1,78 @@
+import type { SelfKnowledgeElementViewDTO } from '@/api/avenir-esr'
+import type { VueWrapper } from '@vue/test-utils'
+import { ESelfKnowledgeCategory } from '@/api/avenir-esr'
+import { ROUTES } from '@/common/constants'
+import ValorizedSelfKnowledgeItem
+  from '@/features/student/kit/views/StudentToolsKitView/components/ValorizedSelfKnowledgeItem/ValorizedSelfKnowledgeItem.vue'
+import { AvBadgeStub, AvButtonStub, AvTooltipStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { flushPromises } from '@vue/test-utils'
+import { mountComponent } from 'tests/utils'
+
+const element: SelfKnowledgeElementViewDTO = {
+  id: 'element-1',
+  title: 'Travail d\'équipe',
+  description: 'Je travaille efficacement avec les autres',
+  rating: 4,
+  category: { type: ESelfKnowledgeCategory.VALUES, mandatory: true }
+}
+
+BddTest().given('a valorized self knowledge item', () => {
+  let wrapper: VueWrapper<InstanceType<typeof ValorizedSelfKnowledgeItem>>
+
+  const stubs = {
+    AvBadge: AvBadgeStub,
+    AvButton: AvButtonStub,
+    AvTooltip: AvTooltipStub
+  }
+
+  const mountItem = async (showCategoryBadge: boolean) => {
+    wrapper = mountComponent(ValorizedSelfKnowledgeItem, {
+      props: { element, showCategoryBadge },
+      global: { stubs }
+    })
+    await flushPromises()
+  }
+
+  BddTest().when('the category badge is displayed', () => {
+    beforeEach(async () => {
+      await mountItem(true)
+    })
+
+    BddTest().then('it should render the element title', () => {
+      expect(wrapper.text()).toContain('Travail d\'équipe')
+    })
+
+    BddTest().then('it should render the category badge with the singular category label', () => {
+      const badge = wrapper.find('[data-testid="self-knowledge-category-badge"]')
+      expect(badge.exists()).toBe(true)
+      expect(badge.text()).toBe('# valeur')
+    })
+
+    BddTest().then('it should link to the element inside its own category', () => {
+      expect(wrapper.findComponent(AvButtonStub).props('to')).toEqual({
+        name: ROUTES.STUDENT.SELFKNOWLEDGE_CATEGORY.name,
+        params: { id: ESelfKnowledgeCategory.VALUES },
+        query: { elementId: 'element-1' }
+      })
+    })
+
+    BddTest().then('it should not render the element description nor its rating', () => {
+      expect(wrapper.text()).not.toContain('Je travaille efficacement avec les autres')
+      expect(wrapper.text()).not.toContain('4')
+    })
+  })
+
+  BddTest().when('the category badge is hidden', () => {
+    beforeEach(async () => {
+      await mountItem(false)
+    })
+
+    BddTest().then('it should render the element title', () => {
+      expect(wrapper.text()).toContain('Travail d\'équipe')
+    })
+
+    BddTest().then('it should not render the category badge', () => {
+      expect(wrapper.find('[data-testid="self-knowledge-category-badge"]').exists()).toBe(false)
+    })
+  })
+})

--- a/src/features/student/kit/views/StudentToolsKitView/components/ValorizedSelfKnowledgeItem/ValorizedSelfKnowledgeItem.vue
+++ b/src/features/student/kit/views/StudentToolsKitView/components/ValorizedSelfKnowledgeItem/ValorizedSelfKnowledgeItem.vue
@@ -1,0 +1,28 @@
+<script lang="ts" setup>
+import type { SelfKnowledgeElementViewDTO } from '@/api/avenir-esr'
+import ValorizedItem from '@/features/student/kit/views/StudentToolsKitView/components/ValorizedItem/ValorizedItem.vue'
+import { SelfKnowledgeCategoryBadge } from '@/features/student/selfKnowledge'
+
+export interface ValorizedSelfKnowledgeItemProps {
+  element: SelfKnowledgeElementViewDTO
+  showCategoryBadge?: boolean
+}
+
+const { element, showCategoryBadge = false } = defineProps<ValorizedSelfKnowledgeItemProps>()
+</script>
+
+<template>
+  <ValorizedItem
+    :title="element.title"
+    :item-id="element.id"
+    :parent-id="element.category.type"
+    :type="element.category.type"
+  >
+    <div
+      v-if="showCategoryBadge"
+      class="av-row av-align-center av-wrap av-gap-xs"
+    >
+      <SelfKnowledgeCategoryBadge :category-type="element.category.type" />
+    </div>
+  </ValorizedItem>
+</template>

--- a/src/features/student/selfKnowledge/components/badges/SelfKnowledgeCategoryBadge/SelfKnowledgeCategoryBadge.stub.ts
+++ b/src/features/student/selfKnowledge/components/badges/SelfKnowledgeCategoryBadge/SelfKnowledgeCategoryBadge.stub.ts
@@ -1,0 +1,5 @@
+export const SelfKnowledgeCategoryBadgeStub = defineComponent({
+  name: 'SelfKnowledgeCategoryBadge',
+  props: ['categoryType'],
+  template: '<div data-testid="self-knowledge-category-badge-stub">{{ categoryType }}</div>'
+})

--- a/src/features/student/selfKnowledge/components/badges/SelfKnowledgeCategoryBadge/SelfKnowledgeCategoryBadge.test.ts
+++ b/src/features/student/selfKnowledge/components/badges/SelfKnowledgeCategoryBadge/SelfKnowledgeCategoryBadge.test.ts
@@ -1,0 +1,62 @@
+import type { VueWrapper } from '@vue/test-utils'
+import { ESelfKnowledgeCategory } from '@/api/avenir-esr'
+import SelfKnowledgeCategoryBadge
+  from '@/features/student/selfKnowledge/components/badges/SelfKnowledgeCategoryBadge/SelfKnowledgeCategoryBadge.vue'
+import { AvBadgeStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { mount } from '@vue/test-utils'
+
+BddTest().given('a self knowledge category badge', () => {
+  let wrapper: VueWrapper
+
+  const stubs = { AvBadge: AvBadgeStub }
+
+  const mountBadge = (categoryType: ESelfKnowledgeCategory) => {
+    wrapper = mount(SelfKnowledgeCategoryBadge, {
+      props: { categoryType },
+      global: { stubs }
+    })
+  }
+
+  BddTest().when('the component is mounted with the values category', () => {
+    beforeEach(() => {
+      mountBadge(ESelfKnowledgeCategory.VALUES)
+    })
+
+    BddTest().then('it should display the singular category label prefixed by a hash', () => {
+      expect(wrapper.findComponent(AvBadgeStub).props('label')).toBe('# valeur')
+    })
+
+    BddTest().then('it should apply the light primary1 background and the dark primary1 text color', () => {
+      const badge = wrapper.findComponent(AvBadgeStub)
+      expect(badge.props('backgroundColor')).toBe('var(--light-background-primary1)')
+      expect(badge.props('color')).toBe('var(--dark-background-primary1)')
+    })
+
+    BddTest().then('it should render a small ellipsed badge exposing its test id', () => {
+      const badge = wrapper.findComponent(AvBadgeStub)
+      expect(badge.props('small')).toBe(true)
+      expect(badge.props('ellipsis')).toBe(true)
+      expect(wrapper.find('[data-testid="self-knowledge-category-badge"]').exists()).toBe(true)
+    })
+  })
+
+  BddTest().when('the component is mounted with the strengths category', () => {
+    beforeEach(() => {
+      mountBadge(ESelfKnowledgeCategory.STRENGTHS)
+    })
+
+    BddTest().then('it should display the singular strengths label', () => {
+      expect(wrapper.findComponent(AvBadgeStub).props('label')).toBe('# point fort')
+    })
+  })
+
+  BddTest().when('the component is mounted with the improvement category', () => {
+    beforeEach(() => {
+      mountBadge(ESelfKnowledgeCategory.IMPROVEMENT)
+    })
+
+    BddTest().then('it should display the singular improvement label', () => {
+      expect(wrapper.findComponent(AvBadgeStub).props('label')).toBe('# axe d\'amélioration')
+    })
+  })
+})

--- a/src/features/student/selfKnowledge/components/badges/SelfKnowledgeCategoryBadge/SelfKnowledgeCategoryBadge.vue
+++ b/src/features/student/selfKnowledge/components/badges/SelfKnowledgeCategoryBadge/SelfKnowledgeCategoryBadge.vue
@@ -1,0 +1,26 @@
+<script setup lang="ts">
+import type { ESelfKnowledgeCategory } from '@/api/avenir-esr'
+import { AvBadge } from '@avenirs-esr/avenirs-dsav'
+import { useI18n } from 'vue-i18n'
+
+export interface SelfKnowledgeCategoryBadgeProps {
+  categoryType: ESelfKnowledgeCategory
+}
+
+const { categoryType } = defineProps<SelfKnowledgeCategoryBadgeProps>()
+
+const { t } = useI18n()
+
+const label = computed(() => `# ${t(`student.selfKnowledge.categoryType.${categoryType}`)}`)
+</script>
+
+<template>
+  <AvBadge
+    :label="label"
+    color="var(--dark-background-primary1)"
+    background-color="var(--light-background-primary1)"
+    data-testid="self-knowledge-category-badge"
+    small
+    ellipsis
+  />
+</template>

--- a/src/features/student/selfKnowledge/index.ts
+++ b/src/features/student/selfKnowledge/index.ts
@@ -1,3 +1,5 @@
+export { default as SelfKnowledgeCategoryBadge } from '@/features/student/selfKnowledge/components/badges/SelfKnowledgeCategoryBadge/SelfKnowledgeCategoryBadge.vue'
+
 export { default as SelfKnowledgeMainSection } from '@/features/student/selfKnowledge/components/SelfKnowledgeMainSection/SelfKnowledgeMainSection.vue'
 
 export { studentSelfKnowledgeCategoryRoute, studentSelfKnowledgeElementUpdateRoute } from '@/features/student/selfKnowledge/routes'


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> This PR implements the valorized self-knowledge elements container and item components for the kit view, following the same pattern used for valorized traces in the StudentToolsKitView. The implementation includes:
>
> - **ValorizedSelfKnowledgeContainer**: Main container component that displays self-knowledge elements in the kit view
> - **ValorizedSelfKnowledgeItem**: Individual item component for self-knowledge elements
> - **SelfKnowledgeCategoryBadge**: Badge component to display self-knowledge category labels
> - Integration with KitTextContentTab to display self-knowledge elements

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/2153

---

### Documentation
> - Updated locale files (en.json, fr.json) with new translation keys for self-knowledge elements display
> - Components follow the established feature-based architecture with proper barrel file exports

---

### Target Branch
> `develop`

---

### Additional Notes
> - Components are based on the valorized traces pattern to ensure consistency
> - Full TypeScript coverage with proper type definitions
> - Tests included for all components
> - Proper accessibility and i18n handling

---

### Known Limitations or Side Effects
> None identified.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [x] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [x] i18n handled (texts are translated)
- [x] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [x] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and detaiils for the update process
