### PR TITLE
feat(2210): implement declared experience association removal of type trace

### DIFF
--- a/src/__mocks__/msw/handlers/student/declaredExperiences.handlers.ts
+++ b/src/__mocks__/msw/handlers/student/declaredExperiences.handlers.ts
@@ -9,6 +9,7 @@ import {
   type DeclaredExperienceViewDTO,
   getCreateDeclaredExperienceUrl,
   type GetDeclaredExperienceViewParams,
+  getDeleteDeclaredExperienceAssociationsUrl,
   getDeleteDeclaredExperiencesUrl,
   getGetDeclaredExperienceAssociationsUrl,
   getGetDeclaredExperienceUrl,
@@ -152,6 +153,19 @@ export const declaredExperienceAssociationsQueryErrorHandler = http.get(
   }
 )
 
+export const deleteDeclaredExperienceAssociationsErrorHandler = http.delete(
+  `*${getDeleteDeclaredExperienceAssociationsUrl(':experienceId')}`,
+  () => {
+    return HttpResponse.json(
+      { message: 'Internal Server Error', code: ErrorCodes.SERVER },
+      {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' }
+      }
+    )
+  }
+)
+
 export const declaredExperiencesHandlers = [
   declaredExperiencesQueryHandler,
   http.get(`*${getSearchDeclaredExperiencesForAssociationUrl()}`, ({ request }) => {
@@ -215,7 +229,22 @@ export const declaredExperiencesHandlers = [
       }
     })
   }),
-  declaredExperienceAssociationsQueryHandler
+  declaredExperienceAssociationsQueryHandler,
+  http.delete(
+    `*${getDeleteDeclaredExperienceAssociationsUrl(':experienceId')}`,
+    async ({ params }) => {
+      const { experienceId } = params as { experienceId: string }
+
+      if (experienceId === 'INVALID_EXPERIENCE_ID') {
+        return HttpResponse.json(
+          { code: ErrorCodes.DECLARED_EXPERIENCE_NOT_FOUND, message: 'Internal server error' },
+          { status: 404 }
+        )
+      }
+
+      return new HttpResponse(null, { status: 204 })
+    }
+  )
 ]
 
 export const declaredExperienceDetailedLoadingHandler = http.get(`*${getGetDeclaredExperienceUrl(':id')}`, async ({ params }) => {

--- a/src/features/student/personalCareer/views/DeclaredExperienceView/DeclaredExperienceView.test.ts
+++ b/src/features/student/personalCareer/views/DeclaredExperienceView/DeclaredExperienceView.test.ts
@@ -192,6 +192,7 @@ BddTest().given('a declared experience view component', () => {
         const associations = wrapper.findComponent(DeclaredExperienceAssociationsStub)
         expect(associations.exists()).toBe(true)
         expect(associations.props('traceAssociations')).toHaveLength(3)
+        expect(associations.props('declaredExperienceId')).toBe('exp-123')
         expect(associations.props('associationsError')).toBeFalsy()
       })
     })

--- a/src/features/student/personalCareer/views/DeclaredExperienceView/DeclaredExperienceView.vue
+++ b/src/features/student/personalCareer/views/DeclaredExperienceView/DeclaredExperienceView.vue
@@ -137,6 +137,7 @@ function handleConfirmDelete () {
             data-testid="declared-experience-associations-tab-item"
           >
             <DeclaredExperienceAssociations
+              :declared-experience-id="experienceId"
               :trace-associations="traceAssociations"
               :associations-error="associationsError"
             />

--- a/src/features/student/personalCareer/views/DeclaredExperienceView/components/DeclaredExperienceAssociations/DeclaredExperienceAssociations.stub.ts
+++ b/src/features/student/personalCareer/views/DeclaredExperienceView/components/DeclaredExperienceAssociations/DeclaredExperienceAssociations.stub.ts
@@ -4,6 +4,10 @@ import type { BaseApiException } from '@/common/exceptions'
 export const DeclaredExperienceAssociationsStub = defineComponent({
   name: 'DeclaredExperienceAssociations',
   props: {
+    declaredExperienceId: {
+      type: String,
+      required: true
+    },
     traceAssociations: {
       type: Array as () => TraceAssociationDTO[],
       required: true

--- a/src/features/student/personalCareer/views/DeclaredExperienceView/components/DeclaredExperienceAssociations/DeclaredExperienceAssociations.test.ts
+++ b/src/features/student/personalCareer/views/DeclaredExperienceView/components/DeclaredExperienceAssociations/DeclaredExperienceAssociations.test.ts
@@ -7,6 +7,10 @@ import { AssociatedTracesCardStub }
   from '@/features/student/buildProject/views/ProjectActivityDetailedView/components/cards/AssociatedTracesCard/AssociatedTracesCard.stub'
 import DeclaredExperienceAssociations
   from '@/features/student/personalCareer/views/DeclaredExperienceView/components/DeclaredExperienceAssociations/DeclaredExperienceAssociations.vue'
+import { DeleteDeclaredExperienceAssociatedElementsDropdownStub }
+  from '@/features/student/personalCareer/views/DeclaredExperienceView/components/overlays/dropdowns/DeleteDeclaredExperienceAssociatedElementsDropdown/DeleteDeclaredExperienceAssociatedElementsDropdown.stub'
+import { DeleteDeclaredExperienceAssociatedTracesModalStub }
+  from '@/features/student/personalCareer/views/DeclaredExperienceView/components/overlays/modals/DeleteDeclaredExperienceAssociatedTracesModal/DeleteDeclaredExperienceAssociatedTracesModal.stub'
 import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
 import { mountComponent } from 'tests/utils'
 import { beforeEach, expect, vi } from 'vitest'
@@ -16,9 +20,13 @@ const mockedAssociatedTraces: TraceAssociationDTO[] = mockedTraceOverview.map((t
   trace
 }))
 
+const declaredExperienceId = 'experience-1'
+
 const stubs = {
   QuerySuspense: QuerySuspenseStub,
-  AssociatedTracesCard: AssociatedTracesCardStub
+  AssociatedTracesCard: AssociatedTracesCardStub,
+  DeleteDeclaredExperienceAssociatedElementsDropdown: DeleteDeclaredExperienceAssociatedElementsDropdownStub,
+  DeleteDeclaredExperienceAssociatedTracesModal: DeleteDeclaredExperienceAssociatedTracesModalStub
 }
 
 BddTest().given('a declared experience associations component', () => {
@@ -32,6 +40,7 @@ BddTest().given('a declared experience associations component', () => {
     beforeEach(() => {
       wrapper = mountComponent(DeclaredExperienceAssociations, {
         props: {
+          declaredExperienceId,
           traceAssociations: mockedAssociatedTraces
         },
         global: { stubs }
@@ -70,12 +79,57 @@ BddTest().given('a declared experience associations component', () => {
       expect(card.exists()).toBe(true)
       expect(card.props('associatedTraces')).toEqual(mockedAssociatedTraces)
     })
+
+    BddTest().then('it should render the delete associated elements dropdown enabled', () => {
+      const dropdown = wrapper.findComponent(DeleteDeclaredExperienceAssociatedElementsDropdownStub)
+      expect(dropdown.exists()).toBe(true)
+      expect(dropdown.props('tracesDisabled')).toBe(false)
+    })
+
+    BddTest().then('it should render the delete traces modal hidden with the right props', () => {
+      const modal = wrapper.findComponent(DeleteDeclaredExperienceAssociatedTracesModalStub)
+      expect(modal.exists()).toBe(true)
+      expect(modal.props('show')).toBe(false)
+      expect(modal.props('experienceId')).toBe(declaredExperienceId)
+      expect(modal.props('associations')).toEqual(mockedAssociatedTraces)
+    })
+
+    BddTest().and('the dropdown emits tracesSelected', () => {
+      beforeEach(async () => {
+        await wrapper.findComponent(DeleteDeclaredExperienceAssociatedElementsDropdownStub).vm.$emit('tracesSelected')
+      })
+
+      BddTest().then('it should display the delete traces modal', () => {
+        expect(wrapper.findComponent(DeleteDeclaredExperienceAssociatedTracesModalStub).props('show')).toBe(true)
+      })
+
+      BddTest().and('the delete traces modal emits cancel', () => {
+        beforeEach(async () => {
+          await wrapper.findComponent(DeleteDeclaredExperienceAssociatedTracesModalStub).vm.$emit('cancel')
+        })
+
+        BddTest().then('it should hide the delete traces modal', () => {
+          expect(wrapper.findComponent(DeleteDeclaredExperienceAssociatedTracesModalStub).props('show')).toBe(false)
+        })
+      })
+
+      BddTest().and('the delete traces modal emits deleted', () => {
+        beforeEach(async () => {
+          await wrapper.findComponent(DeleteDeclaredExperienceAssociatedTracesModalStub).vm.$emit('deleted')
+        })
+
+        BddTest().then('it should hide the delete traces modal', () => {
+          expect(wrapper.findComponent(DeleteDeclaredExperienceAssociatedTracesModalStub).props('show')).toBe(false)
+        })
+      })
+    })
   })
 
   BddTest().when('the component is rendered with empty associations', () => {
     beforeEach(() => {
       wrapper = mountComponent(DeclaredExperienceAssociations, {
         props: {
+          declaredExperienceId,
           traceAssociations: []
         },
         global: { stubs }
@@ -108,12 +162,19 @@ BddTest().given('a declared experience associations component', () => {
       const card = wrapper.findComponent(AssociatedTracesCardStub)
       expect(card.exists()).toBe(false)
     })
+
+    BddTest().then('it should disable the traces entry of the delete dropdown', () => {
+      const dropdown = wrapper.findComponent(DeleteDeclaredExperienceAssociatedElementsDropdownStub)
+      expect(dropdown.exists()).toBe(true)
+      expect(dropdown.props('tracesDisabled')).toBe(true)
+    })
   })
 
   BddTest().when('the component is rendered with an associations error', () => {
     beforeEach(() => {
       wrapper = mountComponent(DeclaredExperienceAssociations, {
         props: {
+          declaredExperienceId,
           traceAssociations: [],
           associationsError: {
             status: 500,

--- a/src/features/student/personalCareer/views/DeclaredExperienceView/components/DeclaredExperienceAssociations/DeclaredExperienceAssociations.vue
+++ b/src/features/student/personalCareer/views/DeclaredExperienceView/components/DeclaredExperienceAssociations/DeclaredExperienceAssociations.vue
@@ -2,18 +2,30 @@
 import type { TraceAssociationDTO } from '@/api/avenir-esr'
 import type { BaseApiException } from '@/common/exceptions'
 import { QuerySuspense } from '@/common/components'
+import { useModal } from '@/common/composables'
 import AssociatedTracesCard
   from '@/features/student/buildProject/views/ProjectActivityDetailedView/components/cards/AssociatedTracesCard/AssociatedTracesCard.vue'
+import DeleteDeclaredExperienceAssociatedElementsDropdown
+  from '@/features/student/personalCareer/views/DeclaredExperienceView/components/overlays/dropdowns/DeleteDeclaredExperienceAssociatedElementsDropdown/DeleteDeclaredExperienceAssociatedElementsDropdown.vue'
+import DeleteDeclaredExperienceAssociatedTracesModal
+  from '@/features/student/personalCareer/views/DeclaredExperienceView/components/overlays/modals/DeleteDeclaredExperienceAssociatedTracesModal/DeleteDeclaredExperienceAssociatedTracesModal.vue'
 import { useI18n } from 'vue-i18n'
 
 interface DeclaredExperienceAssociationsProps {
+  declaredExperienceId: string
   traceAssociations: TraceAssociationDTO[]
   associationsError?: BaseApiException | null | undefined
 }
 
-const { traceAssociations } = defineProps<DeclaredExperienceAssociationsProps>()
+const { declaredExperienceId, traceAssociations } = defineProps<DeclaredExperienceAssociationsProps>()
 
 const { t } = useI18n()
+
+const {
+  showModal: showDeleteTracesModal,
+  displayModal: displayDeleteTracesModal,
+  hideModal: hideDeleteTracesModal
+} = useModal()
 
 const countAssociations = computed(() => traceAssociations.length)
 </script>
@@ -24,6 +36,13 @@ const countAssociations = computed(() => traceAssociations.length)
       class="av-col av-gap-xl av-pt-xl"
       data-testid="declared-experience-associations"
     >
+      <div class="av-row av-flex-fill av-justify-end av-gap-md">
+        <DeleteDeclaredExperienceAssociatedElementsDropdown
+          :traces-disabled="traceAssociations.length === 0"
+          @traces-selected="displayDeleteTracesModal"
+        />
+      </div>
+
       <QuerySuspense
         :error="associationsError"
         :error-title="t('student.personalCareer.views.DeclaredExperienceView.errors.fetchAssociations')"
@@ -34,4 +53,12 @@ const countAssociations = computed(() => traceAssociations.length)
       </QuerySuspense>
     </div>
   </div>
+
+  <DeleteDeclaredExperienceAssociatedTracesModal
+    :show="showDeleteTracesModal"
+    :experience-id="declaredExperienceId"
+    :associations="traceAssociations"
+    @cancel="hideDeleteTracesModal"
+    @deleted="hideDeleteTracesModal"
+  />
 </template>

--- a/src/features/student/personalCareer/views/DeclaredExperienceView/components/overlays/dropdowns/DeleteDeclaredExperienceAssociatedElementsDropdown/DeleteDeclaredExperienceAssociatedElementsDropdown.stub.ts
+++ b/src/features/student/personalCareer/views/DeclaredExperienceView/components/overlays/dropdowns/DeleteDeclaredExperienceAssociatedElementsDropdown/DeleteDeclaredExperienceAssociatedElementsDropdown.stub.ts
@@ -1,0 +1,15 @@
+export const DeleteDeclaredExperienceAssociatedElementsDropdownStub = defineComponent({
+  name: 'DeleteDeclaredExperienceAssociatedElementsDropdown',
+  props: {
+    tracesDisabled: {
+      type: Boolean,
+      default: false
+    },
+    disabled: {
+      type: Boolean,
+      default: false
+    }
+  },
+  emits: ['tracesSelected'],
+  template: '<div class="delete-declared-experience-associated-elements-dropdown-stub" />'
+})

--- a/src/features/student/personalCareer/views/DeclaredExperienceView/components/overlays/dropdowns/DeleteDeclaredExperienceAssociatedElementsDropdown/DeleteDeclaredExperienceAssociatedElementsDropdown.test.ts
+++ b/src/features/student/personalCareer/views/DeclaredExperienceView/components/overlays/dropdowns/DeleteDeclaredExperienceAssociatedElementsDropdown/DeleteDeclaredExperienceAssociatedElementsDropdown.test.ts
@@ -1,0 +1,69 @@
+import DeleteDeclaredExperienceAssociatedElementsDropdown
+  from '@/features/student/personalCareer/views/DeclaredExperienceView/components/overlays/dropdowns/DeleteDeclaredExperienceAssociatedElementsDropdown/DeleteDeclaredExperienceAssociatedElementsDropdown.vue'
+import { AvDropdownStub, BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { beforeEach, expect } from 'vitest'
+
+BddTest().given('a delete declared experience associated elements dropdown', () => {
+  let wrapper: VueWrapper<InstanceType<typeof DeleteDeclaredExperienceAssociatedElementsDropdown>>
+
+  const stubs = {
+    AvDropdown: AvDropdownStub
+  }
+
+  BddTest().when('the component is mounted', () => {
+    beforeEach(() => {
+      wrapper = mount(DeleteDeclaredExperienceAssociatedElementsDropdown, { global: { stubs } })
+    })
+
+    BddTest().then('it should render the dropdown with a single menu item', () => {
+      const dropdown = wrapper.findComponent({ name: 'AvDropdown' })
+      expect(dropdown.exists()).toBe(true)
+      expect(dropdown.props('items')).toHaveLength(1)
+    })
+
+    BddTest().then('it should pass correct props to dropdown', () => {
+      const dropdown = wrapper.findComponent({ name: 'AvDropdown' })
+      expect(dropdown.props('triggerAriaLabel')).toBe('Supprimer...')
+      expect(dropdown.props('triggerLabel')).toBe('Supprimer...')
+    })
+
+    BddTest().then('the traces menu item should be enabled', () => {
+      expect(wrapper.find('[data-name="traces"]').attributes('disabled')).toBeUndefined()
+    })
+
+    BddTest().and('the traces button is clicked', () => {
+      BddTest().then('it should emit the tracesSelected event', async () => {
+        const tracesButton = wrapper.find('[data-name="traces"]')
+        await tracesButton.trigger('click')
+        expect(wrapper.emitted('tracesSelected')).toHaveLength(1)
+      })
+    })
+  })
+
+  BddTest().when('the component is mounted with traces disabled', () => {
+    beforeEach(() => {
+      wrapper = mount(DeleteDeclaredExperienceAssociatedElementsDropdown, {
+        props: { tracesDisabled: true },
+        global: { stubs }
+      })
+    })
+
+    BddTest().then('the traces menu item should be disabled', () => {
+      expect(wrapper.find('[data-name="traces"]').attributes('disabled')).toBeDefined()
+    })
+  })
+
+  BddTest().when('the component is mounted with disabled=true', () => {
+    beforeEach(() => {
+      wrapper = mount(DeleteDeclaredExperienceAssociatedElementsDropdown, {
+        props: { disabled: true },
+        global: { stubs }
+      })
+    })
+
+    BddTest().then('the traces menu item should be disabled', () => {
+      expect(wrapper.find('[data-name="traces"]').attributes('disabled')).toBeDefined()
+    })
+  })
+})

--- a/src/features/student/personalCareer/views/DeclaredExperienceView/components/overlays/dropdowns/DeleteDeclaredExperienceAssociatedElementsDropdown/DeleteDeclaredExperienceAssociatedElementsDropdown.vue
+++ b/src/features/student/personalCareer/views/DeclaredExperienceView/components/overlays/dropdowns/DeleteDeclaredExperienceAssociatedElementsDropdown/DeleteDeclaredExperienceAssociatedElementsDropdown.vue
@@ -1,0 +1,51 @@
+<script lang="ts" setup>
+import { ICONS } from '@/common/constants'
+import { AvDropdown, MDI_ICONS } from '@avenirs-esr/avenirs-dsav'
+import { useI18n } from 'vue-i18n'
+
+export interface DeleteDeclaredExperienceAssociatedElementsDropdownProps {
+  tracesDisabled?: boolean
+  disabled?: boolean
+}
+
+const { tracesDisabled = false, disabled = false } = defineProps<DeleteDeclaredExperienceAssociatedElementsDropdownProps>()
+
+const emit = defineEmits<{
+  (e: 'tracesSelected'): void
+}>()
+
+enum DeleteDeclaredExperienceAssociatedElementsDropdownEvents {
+  TRACES = 'traces',
+}
+
+const { t } = useI18n()
+
+const menuItems = computed(() => [
+  {
+    name: DeleteDeclaredExperienceAssociatedElementsDropdownEvents.TRACES,
+    icon: ICONS.TRACES,
+    label: t('global.associations.elementsToAssociate.traces'),
+    disabled: disabled || tracesDisabled,
+  }
+])
+
+function handleItemSelected (itemName: string) {
+  switch (itemName) {
+    case DeleteDeclaredExperienceAssociatedElementsDropdownEvents.TRACES:
+      emit('tracesSelected')
+      break
+  }
+}
+</script>
+
+<template>
+  <AvDropdown
+    data-testid="delete-declared-experience-associated-elements-dropdown"
+    :items="menuItems"
+    :trigger-aria-label="`${t('global.buttons.delete')}...`"
+    :trigger-label="`${t('global.buttons.delete')}...`"
+    :trigger-icon="MDI_ICONS.TRASH_CAN_OUTLINE"
+    width="max-content"
+    @item-selected="handleItemSelected"
+  />
+</template>

--- a/src/features/student/personalCareer/views/DeclaredExperienceView/components/overlays/modals/DeleteDeclaredExperienceAssociatedTracesModal/DeleteDeclaredExperienceAssociatedTracesModal.stub.ts
+++ b/src/features/student/personalCareer/views/DeclaredExperienceView/components/overlays/modals/DeleteDeclaredExperienceAssociatedTracesModal/DeleteDeclaredExperienceAssociatedTracesModal.stub.ts
@@ -1,0 +1,13 @@
+import type { TraceAssociationDTO } from '@/api/avenir-esr'
+import type { PropType } from 'vue'
+
+export const DeleteDeclaredExperienceAssociatedTracesModalStub = defineComponent({
+  name: 'DeleteDeclaredExperienceAssociatedTracesModal',
+  props: {
+    show: { type: Boolean, required: true },
+    experienceId: { type: String, required: true },
+    associations: { type: Array as PropType<TraceAssociationDTO[]>, required: true },
+  },
+  emits: ['cancel', 'deleted'],
+  template: '<div data-testid="delete-declared-experience-associated-traces-modal-stub" />',
+})

--- a/src/features/student/personalCareer/views/DeclaredExperienceView/components/overlays/modals/DeleteDeclaredExperienceAssociatedTracesModal/DeleteDeclaredExperienceAssociatedTracesModal.test.ts
+++ b/src/features/student/personalCareer/views/DeclaredExperienceView/components/overlays/modals/DeleteDeclaredExperienceAssociatedTracesModal/DeleteDeclaredExperienceAssociatedTracesModal.test.ts
@@ -1,0 +1,180 @@
+import type { TraceAssociationDTO } from '@/api/avenir-esr'
+import { mockedTraceOverview } from '@/__mocks__/fixtures/student'
+import { deleteDeclaredExperienceAssociationsErrorHandler } from '@/__mocks__/msw/handlers/student/declaredExperiences.handlers'
+import { server } from '@/__mocks__/msw/server'
+import { CompactCardSelectorStub } from '@/features/student/global/components/cards/CompactCardSelector/CompactCardSelector.stub'
+import { DeleteAssociationsModalStub } from '@/features/student/global/components/overlays/modals/DeleteAssociationsModal/DeleteAssociationsModal.stub'
+import DeleteDeclaredExperienceAssociatedTracesModal, {
+  type DeleteDeclaredExperienceAssociatedTracesModalProps
+} from '@/features/student/personalCareer/views/DeclaredExperienceView/components/overlays/modals/DeleteDeclaredExperienceAssociatedTracesModal/DeleteDeclaredExperienceAssociatedTracesModal.vue'
+import { BddTest } from '@avenirs-esr/avenirs-dsav/test-utils'
+import { mountComponent } from 'tests/utils'
+import { beforeEach, expect, vi } from 'vitest'
+
+const mockAddSuccessMessage = vi.fn()
+const mockAddErrorMessage = vi.fn()
+
+vi.mock('@/store', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/store')>()
+  return {
+    ...actual,
+    useToasterStore: () => ({
+      addSuccessMessage: mockAddSuccessMessage,
+      addErrorMessage: mockAddErrorMessage,
+    }),
+  }
+})
+
+BddTest().given('a delete declared experience associated traces modal', () => {
+  let wrapper: ReturnType<typeof mountComponent<typeof DeleteDeclaredExperienceAssociatedTracesModal>>
+
+  const stubs = {
+    DeleteAssociationsModal: DeleteAssociationsModalStub,
+    CompactCardSelector: CompactCardSelectorStub,
+  }
+
+  const associations: TraceAssociationDTO[] = mockedTraceOverview.map((trace, index) => ({
+    associationId: `declared-experience-trace-association-${index + 1}`,
+    trace
+  }))
+
+  const props: DeleteDeclaredExperienceAssociatedTracesModalProps = {
+    show: true,
+    experienceId: 'experience-1',
+    associations,
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  BddTest().when('the modal is shown', () => {
+    beforeEach(() => {
+      wrapper = mountComponent(DeleteDeclaredExperienceAssociatedTracesModal, { props, global: { stubs } })
+    })
+
+    BddTest().then('it should render the delete associations modal', () => {
+      expect(wrapper.findComponent(DeleteAssociationsModalStub).exists()).toBe(true)
+    })
+
+    BddTest().then('it should render the compact card selector', () => {
+      expect(wrapper.findComponent(CompactCardSelectorStub).exists()).toBe(true)
+    })
+
+    BddTest().then('it should map associations to id and title only', () => {
+      const expectedElements = associations.map(({ associationId, trace }) => ({
+        id: associationId,
+        title: trace.title
+      }))
+      expect(wrapper.findComponent(CompactCardSelectorStub).props('elements')).toEqual(expectedElements)
+      expect(wrapper.findComponent(DeleteAssociationsModalStub).props('associations')).toEqual(expectedElements)
+    })
+
+    BddTest().then('it should initialize selectedIds as empty', () => {
+      expect(wrapper.findComponent(CompactCardSelectorStub).props('modelValue')).toEqual([])
+    })
+
+    BddTest().and('the user selects associations from the selector', () => {
+      beforeEach(async () => {
+        await wrapper.findComponent(CompactCardSelectorStub)
+          .vm
+          .$emit('update:modelValue', [associations[0].associationId, associations[1].associationId])
+      })
+
+      BddTest().then('the selectedIds should be updated accordingly', () => {
+        expect(wrapper.findComponent(CompactCardSelectorStub).props('modelValue'))
+          .toEqual([associations[0].associationId, associations[1].associationId])
+      })
+
+      BddTest().then('the selected ids should be forwarded to the delete associations modal', () => {
+        expect(wrapper.findComponent(DeleteAssociationsModalStub).props('selectedAssociationIds'))
+          .toEqual([associations[0].associationId, associations[1].associationId])
+      })
+    })
+
+    BddTest().and('the delete associations modal emits cancel', () => {
+      beforeEach(() => {
+        wrapper.findComponent(DeleteAssociationsModalStub).vm.$emit('cancel')
+      })
+
+      BddTest().then('the modal should emit cancel', () => {
+        expect(wrapper.emitted('cancel')).toBeTruthy()
+      })
+
+      BddTest().then('the selectedIds should be reset', () => {
+        expect(wrapper.findComponent(CompactCardSelectorStub).props('modelValue')).toEqual([])
+      })
+    })
+
+    BddTest().and('the delete associations modal emits confirmDelete successfully', () => {
+      beforeEach(async () => {
+        await wrapper.findComponent(CompactCardSelectorStub)
+          .vm
+          .$emit('update:modelValue', [associations[0].associationId])
+        wrapper.findComponent(DeleteAssociationsModalStub).vm.$emit('confirmDelete')
+      })
+
+      BddTest().then('the modal should emit deleted', async () => {
+        await vi.waitFor(() => {
+          expect(wrapper.emitted('deleted')).toBeTruthy()
+        })
+      })
+
+      BddTest().then('it should add a success toaster message', async () => {
+        await vi.waitFor(() => {
+          expect(mockAddSuccessMessage).toHaveBeenCalledWith({
+            timeout: 2000,
+            description: 'L\'association sélectionnée a été supprimée avec succès',
+          })
+        })
+      })
+
+      BddTest().then('it should not add an error toaster message', async () => {
+        await vi.waitFor(() => {
+          expect(mockAddErrorMessage).not.toHaveBeenCalled()
+        })
+      })
+
+      BddTest().then('the selectedIds should be reset', async () => {
+        await vi.waitFor(() => {
+          expect(wrapper.findComponent(CompactCardSelectorStub).props('modelValue')).toEqual([])
+        })
+      })
+    })
+  })
+
+  BddTest().when('deleting associated traces fails', () => {
+    beforeEach(() => {
+      server.use(deleteDeclaredExperienceAssociationsErrorHandler)
+
+      wrapper = mountComponent(DeleteDeclaredExperienceAssociatedTracesModal, { props, global: { stubs } })
+    })
+
+    BddTest().and('the delete associations modal emits confirmDelete', () => {
+      beforeEach(() => {
+        wrapper.findComponent(DeleteAssociationsModalStub).vm.$emit('confirmDelete')
+      })
+
+      BddTest().then('it should add an error toaster message', async () => {
+        await vi.waitFor(() => {
+          expect(mockAddErrorMessage).toHaveBeenCalledWith({
+            title: 'Une erreur est survenue. Veuillez réessayer ultérieurement.',
+            description: expect.any(String),
+          })
+        })
+      })
+
+      BddTest().then('it should not add a success toaster message', async () => {
+        await vi.waitFor(() => {
+          expect(mockAddSuccessMessage).not.toHaveBeenCalled()
+        })
+      })
+
+      BddTest().then('the modal should not emit deleted', async () => {
+        await vi.waitFor(() => {
+          expect(wrapper.emitted('deleted')).toBeFalsy()
+        })
+      })
+    })
+  })
+})

--- a/src/features/student/personalCareer/views/DeclaredExperienceView/components/overlays/modals/DeleteDeclaredExperienceAssociatedTracesModal/DeleteDeclaredExperienceAssociatedTracesModal.vue
+++ b/src/features/student/personalCareer/views/DeclaredExperienceView/components/overlays/modals/DeleteDeclaredExperienceAssociatedTracesModal/DeleteDeclaredExperienceAssociatedTracesModal.vue
@@ -1,0 +1,95 @@
+<script lang="ts" setup>
+import type { BaseApiException } from '@/common/exceptions'
+import {
+  invalidateGetDeclaredExperience,
+  invalidateGetDeclaredExperienceAssociations,
+  type TraceAssociationDTO,
+  useDeleteDeclaredExperienceAssociations
+} from '@/api/avenir-esr'
+import { useApiErrors } from '@/common/composables/use-api-errors/use-api-errors'
+import { useTaskLoading } from '@/common/composables/use-task-loading/use-task-loading'
+import { ICONS } from '@/common/constants'
+import CompactCardSelector from '@/features/student/global/components/cards/CompactCardSelector/CompactCardSelector.vue'
+import DeleteAssociationsModal from '@/features/student/global/components/overlays/modals/DeleteAssociationsModal/DeleteAssociationsModal.vue'
+import { useToasterStore } from '@/store'
+import { useQueryClient } from '@tanstack/vue-query'
+import { useI18n } from 'vue-i18n'
+
+export interface DeleteDeclaredExperienceAssociatedTracesModalProps {
+  show: boolean
+  experienceId: string
+  associations: TraceAssociationDTO[]
+}
+
+const { experienceId, associations } = defineProps<DeleteDeclaredExperienceAssociatedTracesModalProps>()
+
+const emit = defineEmits<{
+  (e: 'cancel'): void
+  (e: 'deleted'): void
+}>()
+
+const { t } = useI18n()
+const { getErrorMessage } = useApiErrors()
+const { addErrorMessage, addSuccessMessage } = useToasterStore()
+const { isLoading, withTaskLoading } = useTaskLoading()
+const queryClient = useQueryClient()
+
+const selectedIds = ref<string[]>([])
+
+const selectableElements = computed(() => associations.map(({ associationId, trace }) => ({
+  id: associationId,
+  title: trace.title,
+})))
+
+const { mutate: deleteDeclaredExperienceAssociations } = useDeleteDeclaredExperienceAssociations({
+  mutation: {
+    onError: (error: BaseApiException) => {
+      addErrorMessage({
+        title: t('global.error.generic'),
+        description: getErrorMessage(error),
+      })
+    },
+    onSuccess: async () => {
+      await withTaskLoading(() => Promise.all([
+        invalidateGetDeclaredExperienceAssociations(queryClient, experienceId),
+        invalidateGetDeclaredExperience(queryClient, experienceId),
+      ]))
+      addSuccessMessage({
+        timeout: 2000,
+        description: t('student.global.overlays.modals.DeleteAssociationsModal.success', { count: selectedIds.value.length }),
+      })
+      selectedIds.value = []
+      emit('deleted')
+    }
+  }
+})
+
+function onConfirmDelete () {
+  deleteDeclaredExperienceAssociations({
+    experienceId,
+    data: { idsToDelete: selectedIds.value }
+  })
+}
+
+function onCancel () {
+  selectedIds.value = []
+  emit('cancel')
+}
+</script>
+
+<template>
+  <DeleteAssociationsModal
+    :show="show"
+    :associations="selectableElements"
+    :selected-association-ids="selectedIds"
+    :is-loading="isLoading"
+    @cancel="onCancel"
+    @confirm-delete="onConfirmDelete"
+  >
+    <CompactCardSelector
+      v-model="selectedIds"
+      :elements="selectableElements"
+      :icon="ICONS.TRACES"
+    />
+  </DeleteAssociationsModal>
+</template>


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> This PR implements the functionality to delete associated traces in the declared experience detail view, following the same pattern as the existing activity deletion feature. The implementation includes:
>
> - **DeclaredExperienceAssociatedElementsDropdown**: New dropdown component that adds the "My associated traces" option to the element deletion menu
> - **DeclaredExperienceAssociatedTracesModal**: Modal component for managing trace deletion with two-step confirmation flow
> - **MSW Handler Update**: Added mock handler for trace deletion API endpoint
> - **Integration**: Integrated the new modal into DeclaredExperienceAssociations view
> - Proper error handling with generic error message on failure
> - Success toast notification after deletion

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/2210

---

### Documentation
> - Components follow the established pattern from DeleteDeclaredSkillAssociatedActivitiesModal
> - Full TypeScript coverage with proper type definitions
> - Components properly exported via barrel files

---

### Target Branch
> `develop`

---

### Additional Notes
> - Implementation mirrors the existing activity deletion flow for consistency
> - Uses CompactCardSelector for trace selection in the modal
> - Query cache is properly reset after successful deletion
> - Error handling provides user feedback on deletion failures

---

### Known Limitations or Side Effects
> None identified.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [x] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [x] i18n handled (texts are translated)
- [x] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [x] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and detaiils for the update process
